### PR TITLE
Add agent process spawning for Claude Code, Codex, and Pi

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,9 @@ DB_PATH = "pioneer_square.db"
 # In-memory WebSocket connections: session_id -> list of WebSocket
 connections: Dict[str, List[WebSocket]] = {}
 
+# Running agent subprocesses: agent_id -> asyncio.subprocess.Process
+running_processes: Dict[str, asyncio.subprocess.Process] = {}
+
 
 async def get_db():
     db = await aiosqlite.connect(DB_PATH)
@@ -81,6 +84,13 @@ def generate_session_id():
 
 class SessionCreate(BaseModel):
     name: Optional[str] = None
+
+
+class RunAgentRequest(BaseModel):
+    tool: str          # "claude" | "codex" | "pi"
+    prompt: str
+    model: Optional[str] = None
+    provider: Optional[str] = None   # pi only
 
 
 @app.post("/sessions")
@@ -252,8 +262,259 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
     except WebSocketDisconnect:
         if session_id in connections and websocket in connections[session_id]:
             connections[session_id].remove(websocket)
-    except Exception as e:
+    except Exception:
         if session_id in connections and websocket in connections[session_id]:
             connections[session_id].remove(websocket)
     finally:
         await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Agent process management
+# ---------------------------------------------------------------------------
+
+async def _emit_terminal_line(session_id: str, agent_id: str, line: str):
+    """Broadcast a terminal output line and persist it to the DB."""
+    now = datetime.now(timezone.utc).isoformat()
+    await broadcast(session_id, {
+        "type": "terminal-output",
+        "agentId": agent_id,
+        "line": line,
+        "timestamp": now,
+    })
+    db = await get_db()
+    try:
+        await db.execute(
+            "INSERT INTO messages (session_id, from_agent, content, message_type, created_at)"
+            " VALUES (?, ?, ?, 'terminal', ?)",
+            (session_id, agent_id, line, now),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def _set_agent_state(session_id: str, agent_id: str, state: str):
+    """Broadcast and persist an agent state change."""
+    await broadcast(session_id, {"type": "agent-state", "agentId": agent_id, "state": state})
+    db = await get_db()
+    try:
+        await db.execute(
+            "UPDATE agents SET state = ? WHERE id = ? AND session_id = ?",
+            (state, agent_id, session_id),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
+def _build_command(req: RunAgentRequest) -> tuple[list[str], bool]:
+    """Return (cmd_list, needs_stdin_prompt).
+
+    needs_stdin_prompt=True means we must write the RPC prompt to stdin
+    (Pi RPC mode) rather than passing it on the command line.
+    """
+    tool = req.tool.lower()
+
+    if tool == "claude":
+        cmd = ["claude", "-p", req.prompt, "--output-format", "stream-json", "--max-turns", "20"]
+        if req.model:
+            cmd += ["--model", req.model]
+        return cmd, False
+
+    if tool == "codex":
+        # codex exec --full-auto accepts a prompt as positional arg; --json for structured output
+        cmd = ["codex", "exec", "--json", req.prompt]
+        if req.model:
+            cmd += ["--model", req.model]
+        return cmd, False
+
+    if tool == "pi":
+        # Pi --mode rpc: bidirectional JSONL over stdin/stdout
+        cmd = ["pi", "--mode", "rpc", "--no-session"]
+        if req.provider:
+            cmd += ["--provider", req.provider]
+        if req.model:
+            cmd += ["--model", req.model]
+        return cmd, True
+
+    raise ValueError(f"Unknown tool: {req.tool!r}")
+
+
+async def _stream_agent(session_id: str, agent_id: str, req: RunAgentRequest):
+    """Spawn the agent subprocess and stream its output as terminal-output events."""
+    tool = req.tool.lower()
+
+    try:
+        cmd, needs_stdin = _build_command(req)
+    except ValueError as exc:
+        await _emit_terminal_line(session_id, agent_id, f"✗ {exc}")
+        return
+
+    stdin_pipe = asyncio.subprocess.PIPE if needs_stdin else asyncio.subprocess.DEVNULL
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=stdin_pipe,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    if needs_stdin:
+        # Pi RPC: send the initial prompt as a JSON command, then leave stdin open
+        rpc_msg = json.dumps({"type": "prompt", "content": req.prompt}) + "\n"
+        proc.stdin.write(rpc_msg.encode())
+        await proc.stdin.drain()
+
+    running_processes[agent_id] = proc
+    await _set_agent_state(session_id, agent_id, "working")
+
+    # For Pi message_update we track accumulated text to emit only deltas
+    pi_last_text = ""
+
+    try:
+        async for raw_line in proc.stdout:
+            line_str = raw_line.decode(errors="replace").strip()
+            if not line_str:
+                continue
+
+            try:
+                event = json.loads(line_str)
+            except json.JSONDecodeError:
+                await _emit_terminal_line(session_id, agent_id, line_str)
+                continue
+
+            text = _parse_event(tool, event, pi_last_text)
+
+            # Pi: update delta baseline
+            if tool == "pi" and event.get("type") == "message_update":
+                full = ""
+                for blk in event.get("message", {}).get("content", []):
+                    if isinstance(blk, dict) and blk.get("type") == "text":
+                        full += blk.get("text", "")
+                pi_last_text = full
+            elif tool == "pi" and event.get("type") == "agent_end":
+                pi_last_text = ""
+
+            if text:
+                await _emit_terminal_line(session_id, agent_id, text)
+
+    finally:
+        if needs_stdin and proc.stdin and not proc.stdin.is_closing():
+            proc.stdin.close()
+        exit_code = await proc.wait()
+        running_processes.pop(agent_id, None)
+        await _set_agent_state(session_id, agent_id, "idle" if exit_code == 0 else "error")
+
+
+def _parse_event(tool: str, event: dict, pi_last_text: str) -> Optional[str]:
+    """Extract a human-readable line from one stream-JSON / RPC event."""
+
+    if tool == "claude":
+        t = event.get("type")
+        if t == "assistant":
+            parts = []
+            for blk in event.get("message", {}).get("content", []):
+                if blk.get("type") == "text":
+                    txt = blk.get("text", "").strip()
+                    if txt:
+                        parts.append(txt)
+                elif blk.get("type") == "tool_use":
+                    name = blk.get("name", "")
+                    inp = blk.get("input", {})
+                    if name == "Bash":
+                        parts.append(f"▶ bash: {inp.get('command', '')[:120]}")
+                    elif name in ("Read", "Write", "Edit"):
+                        fp = inp.get("file_path", inp.get("path", ""))
+                        parts.append(f"▶ {name.lower()}: {fp}")
+                    else:
+                        parts.append(f"▶ {name}: {json.dumps(inp)[:80]}")
+            return "\n".join(parts) or None
+        if t == "result":
+            subtype = event.get("subtype", "success")
+            turns = event.get("num_turns", 0)
+            cost = event.get("cost_usd")
+            cost_str = f" (${cost:.4f})" if cost else ""
+            if subtype == "success":
+                return f"✓ Done in {turns} turns{cost_str}"
+            return f"✗ {subtype}: {event.get('error', '')}"
+        if t == "system" and event.get("subtype") == "init":
+            tools = event.get("tools", [])
+            return f"[claude] tools: {', '.join(tools[:6])}"
+
+    elif tool == "codex":
+        t = event.get("type")
+        if t == "message" and event.get("role") == "assistant":
+            return (event.get("content") or "").strip() or None
+        if t == "function_call":
+            name = event.get("name", "")
+            args = event.get("arguments", "")
+            return f"▶ {name}({args[:80]})"
+        if t == "function_result":
+            return f"  → {str(event.get('output', ''))[:200]}"
+        if t == "done":
+            return "✓ Done"
+        if t == "error":
+            return f"✗ {event.get('message', '')}"
+
+    elif tool == "pi":
+        t = event.get("type")
+        if t == "message_update":
+            full = ""
+            for blk in event.get("message", {}).get("content", []):
+                if isinstance(blk, dict) and blk.get("type") == "text":
+                    full += blk.get("text", "")
+            delta = full[len(pi_last_text):]
+            return delta if delta.strip() else None
+        if t == "tool_execution_start":
+            ti = event.get("tool", {})
+            name = ti.get("name", "")
+            inp = ti.get("input", {})
+            if name == "bash":
+                return f"▶ bash: {inp.get('command', '')[:120]}"
+            if name in ("read", "write", "edit"):
+                return f"▶ {name}: {inp.get('path', inp.get('file_path', ''))}"
+            return f"▶ {name}({json.dumps(inp)[:80]})"
+        if t == "tool_execution_end":
+            out = str(event.get("output", "")).strip()
+            if not out:
+                return None
+            lines = out.split("\n")
+            preview = lines[0][:120]
+            if len(lines) > 1:
+                preview += f" (+{len(lines) - 1} lines)"
+            return f"  → {preview}"
+        if t == "agent_end":
+            err = event.get("error")
+            return f"✗ {err}" if err else None
+        if t == "agent_start":
+            return "[pi] agent started"
+
+    return None
+
+
+@app.post("/sessions/{session_id}/agents/{agent_id}/run")
+async def start_agent_run(session_id: str, agent_id: str, req: RunAgentRequest):
+    """Spawn an AI coding agent subprocess and stream its output over WebSocket."""
+    # Kill any existing run for this agent
+    old = running_processes.get(agent_id)
+    if old:
+        try:
+            old.kill()
+        except ProcessLookupError:
+            pass
+
+    asyncio.create_task(_stream_agent(session_id, agent_id, req))
+    return {"status": "started", "agentId": agent_id, "tool": req.tool}
+
+
+@app.delete("/sessions/{session_id}/agents/{agent_id}/run")
+async def stop_agent_run(session_id: str, agent_id: str):
+    """Terminate a running agent subprocess."""
+    proc = running_processes.get(agent_id)
+    if not proc:
+        raise HTTPException(status_code=404, detail="No running process for this agent")
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        pass
+    return {"status": "stopped", "agentId": agent_id}

--- a/frontend/src/components/TerminalPane.vue
+++ b/frontend/src/components/TerminalPane.vue
@@ -14,6 +14,7 @@
         </span>
       </div>
     </div>
+
     <div class="terminal-body" ref="terminalEl">
       <div class="terminal-welcome">
         <pre>╔══════════════════════════════════════╗
@@ -26,7 +27,7 @@
       </div>
       <div v-for="(log, i) in logs" :key="i" class="terminal-line">
         <span class="log-time">{{ formatTime(log.timestamp) }}</span>
-        <span class="log-content">{{ log.line }}</span>
+        <span class="log-content" :class="lineClass(log.line)">{{ log.line }}</span>
       </div>
       <div class="terminal-prompt">
         <span class="prompt-user">agent@pioneer-square</span>
@@ -36,6 +37,52 @@
         <span class="cursor-blink">_</span>
       </div>
     </div>
+
+    <!-- Run command bar -->
+    <div class="run-bar">
+      <select v-model="runTool" class="tool-select" :disabled="isRunning">
+        <option value="claude">claude</option>
+        <option value="codex">codex</option>
+        <option value="pi">pi</option>
+      </select>
+      <input
+        v-model="runModel"
+        class="model-input"
+        :placeholder="modelPlaceholder"
+        :disabled="isRunning"
+        title="Model (optional)"
+      />
+      <input
+        v-if="runTool === 'pi'"
+        v-model="runProvider"
+        class="provider-input"
+        placeholder="provider"
+        :disabled="isRunning"
+        title="Provider (anthropic, openai, google…)"
+      />
+      <input
+        v-model="runPrompt"
+        class="prompt-input"
+        placeholder="Enter task prompt…"
+        :disabled="isRunning"
+        @keydown.enter.exact="handleRun"
+      />
+      <button
+        v-if="!isRunning"
+        class="run-btn pixel-btn"
+        :disabled="!runPrompt.trim()"
+        @click="handleRun"
+        title="Run agent"
+      >▶ RUN</button>
+      <button
+        v-else
+        class="stop-btn pixel-btn"
+        @click="handleStop"
+        title="Stop agent"
+      >■ STOP</button>
+    </div>
+
+    <div v-if="runError" class="run-error">{{ runError }}</div>
   </div>
 </template>
 
@@ -55,6 +102,19 @@ const terminalEl = ref(null)
 
 const agent = computed(() => agentsStore.agents.find(a => a.id === props.agentId))
 const logs = computed(() => agent.value?.logs || [])
+const isRunning = computed(() => agent.value?.state === 'working' || agent.value?.state === 'thinking' || agent.value?.state === 'busy')
+
+const runTool = ref('claude')
+const runPrompt = ref('')
+const runModel = ref('')
+const runProvider = ref('')
+const runError = ref('')
+
+const modelPlaceholder = computed(() => {
+  if (runTool.value === 'claude') return 'claude-opus-4-7'
+  if (runTool.value === 'codex') return 'o4-mini'
+  return 'model (optional)'
+})
 
 function padName(name) {
   if (!name) return ''.padEnd(20)
@@ -65,6 +125,41 @@ function formatTime(isoStr) {
   if (!isoStr) return '00:00:00'
   const d = new Date(isoStr)
   return d.toLocaleTimeString('en-US', { hour12: false })
+}
+
+function lineClass(line) {
+  if (!line) return ''
+  if (line.startsWith('✓')) return 'log-success'
+  if (line.startsWith('✗')) return 'log-error'
+  if (line.startsWith('▶')) return 'log-tool'
+  if (line.startsWith('  →')) return 'log-result'
+  if (line.startsWith('[')) return 'log-meta'
+  return ''
+}
+
+async function handleRun() {
+  if (!runPrompt.value.trim() || isRunning.value) return
+  runError.value = ''
+  try {
+    await agentsStore.runAgent(props.agentId, {
+      tool: runTool.value,
+      prompt: runPrompt.value.trim(),
+      model: runModel.value.trim(),
+      provider: runProvider.value.trim()
+    })
+    runPrompt.value = ''
+  } catch (e) {
+    runError.value = e.message
+  }
+}
+
+async function handleStop() {
+  runError.value = ''
+  try {
+    await agentsStore.stopAgent(props.agentId)
+  } catch (e) {
+    runError.value = e.message
+  }
 }
 
 watch(logs, async () => {
@@ -122,17 +217,16 @@ watch(logs, async () => {
   letter-spacing: 1px;
 }
 
-.agent-state-badge.idle { background: rgba(154,128,96,0.2); color: var(--color-text-dim); }
-.agent-state-badge.thinking { background: rgba(68,153,255,0.2); color: var(--color-blue); }
-.agent-state-badge.working { background: rgba(0,255,136,0.2); color: var(--color-green); }
-.agent-state-badge.busy { background: rgba(255,136,68,0.2); color: var(--color-orange); }
-.agent-state-badge.error { background: rgba(255,51,51,0.2); color: var(--color-red); }
+.agent-state-badge.idle    { background: rgba(154,128,96,0.2); color: var(--color-text-dim); }
+.agent-state-badge.thinking{ background: rgba(68,153,255,0.2); color: var(--color-blue); }
+.agent-state-badge.working { background: rgba(0,255,136,0.2);  color: var(--color-green); }
+.agent-state-badge.busy    { background: rgba(255,136,68,0.2); color: var(--color-orange); }
+.agent-state-badge.error   { background: rgba(255,51,51,0.2);  color: var(--color-red); }
 
 .live-indicator {
   font-size: 11px;
   color: var(--color-text-dim);
 }
-
 .live-indicator.active {
   color: var(--color-green);
   animation: livePulse 1.5s infinite;
@@ -140,7 +234,7 @@ watch(logs, async () => {
 
 @keyframes livePulse {
   0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  50%       { opacity: 0.4; }
 }
 
 .terminal-body {
@@ -180,10 +274,12 @@ watch(logs, async () => {
   font-size: 11px;
 }
 
-.log-content {
-  color: var(--color-green);
-  word-break: break-all;
-}
+.log-content         { color: var(--color-green);    word-break: break-all; }
+.log-content.log-success { color: var(--color-teal); }
+.log-content.log-error   { color: var(--color-red);  }
+.log-content.log-tool    { color: var(--color-amber); }
+.log-content.log-result  { color: var(--color-text-dim); }
+.log-content.log-meta    { color: var(--color-brass-dark); }
 
 .terminal-prompt {
   margin-top: 8px;
@@ -193,9 +289,9 @@ watch(logs, async () => {
   gap: 2px;
 }
 
-.prompt-user { color: var(--color-green); }
-.prompt-sep { color: var(--color-text-dim); }
-.prompt-path { color: var(--color-blue); }
+.prompt-user   { color: var(--color-green); }
+.prompt-sep    { color: var(--color-text-dim); }
+.prompt-path   { color: var(--color-blue); }
 .prompt-dollar { color: var(--color-text); margin: 0 4px; }
 
 .cursor-blink {
@@ -205,6 +301,123 @@ watch(logs, async () => {
 
 @keyframes blink {
   0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
+  50%       { opacity: 0; }
+}
+
+/* ── Run bar ──────────────────────────────────────────────────── */
+.run-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: #0c0700;
+  border-top: 2px solid #2a1a05;
+  flex-shrink: 0;
+}
+
+.tool-select {
+  background: var(--color-bg);
+  border: 2px solid var(--color-brass-dark);
+  color: var(--color-amber);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 5px 6px;
+  outline: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.tool-select:focus {
+  border-color: var(--color-brass);
+}
+
+.model-input,
+.provider-input {
+  background: var(--color-bg);
+  border: 2px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 5px 8px;
+  outline: none;
+  width: 120px;
+  flex-shrink: 0;
+}
+.model-input:focus,
+.provider-input:focus {
+  border-color: var(--color-brass);
+}
+.model-input::placeholder,
+.provider-input::placeholder {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+
+.prompt-input {
+  flex: 1;
+  background: var(--color-bg);
+  border: 2px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 5px 10px;
+  outline: none;
+  min-width: 0;
+}
+.prompt-input:focus {
+  border-color: var(--color-brass);
+  box-shadow: 0 0 8px rgba(232, 170, 0, 0.25);
+}
+.prompt-input::placeholder {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+.prompt-input:disabled,
+.model-input:disabled,
+.provider-input:disabled,
+.tool-select:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.run-btn {
+  padding: 5px 12px;
+  font-size: 10px;
+  color: var(--color-green);
+  border-color: var(--color-green);
+  flex-shrink: 0;
+}
+.run-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.run-btn:not(:disabled):hover {
+  background: rgba(0, 255, 136, 0.12);
+  box-shadow: 0 0 8px rgba(0, 255, 136, 0.3);
+}
+
+.stop-btn {
+  padding: 5px 12px;
+  font-size: 10px;
+  color: var(--color-red);
+  border-color: var(--color-red);
+  flex-shrink: 0;
+  animation: stopPulse 1.2s infinite;
+}
+.stop-btn:hover {
+  background: rgba(255, 51, 51, 0.12);
+}
+
+@keyframes stopPulse {
+  0%, 100% { box-shadow: 0 0 0 rgba(255,51,51,0); }
+  50%       { box-shadow: 0 0 8px rgba(255,51,51,0.4); }
+}
+
+.run-error {
+  padding: 4px 12px 6px;
+  font-size: 11px;
+  color: var(--color-red);
+  background: rgba(255, 51, 51, 0.07);
+  border-top: 1px solid rgba(255, 51, 51, 0.2);
+  flex-shrink: 0;
 }
 </style>

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -2,6 +2,8 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useSessionStore } from './session'
 
+const API_BASE = 'http://localhost:8000'
+
 export const useAgentsStore = defineStore('agents', () => {
   const agents = ref([])
 
@@ -45,6 +47,38 @@ export const useAgentsStore = defineStore('agents', () => {
     })
   }
 
+  async function runAgent(agentId, { tool, prompt, model, provider }) {
+    const sessionStore = useSessionStore()
+    const sessionId = sessionStore.currentSession?.id
+    if (!sessionId) throw new Error('No active session')
+
+    const res = await fetch(`${API_BASE}/sessions/${sessionId}/agents/${agentId}/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool, prompt, model: model || undefined, provider: provider || undefined })
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.detail || `HTTP ${res.status}`)
+    }
+    return res.json()
+  }
+
+  async function stopAgent(agentId) {
+    const sessionStore = useSessionStore()
+    const sessionId = sessionStore.currentSession?.id
+    if (!sessionId) throw new Error('No active session')
+
+    const res = await fetch(`${API_BASE}/sessions/${sessionId}/agents/${agentId}/run`, {
+      method: 'DELETE'
+    })
+    if (!res.ok && res.status !== 404) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.detail || `HTTP ${res.status}`)
+    }
+    return res.json()
+  }
+
   function handleWebSocketMessage(data) {
     if (data.type === 'agent-joined') {
       registerAgent(data)
@@ -61,6 +95,8 @@ export const useAgentsStore = defineStore('agents', () => {
     updateAgentState,
     addLog,
     sendMessage,
+    runAgent,
+    stopAgent,
     handleWebSocketMessage
   }
 })


### PR DESCRIPTION
- backend: POST /sessions/{id}/agents/{id}/run spawns subprocess for
  the chosen tool (claude -p --output-format stream-json, codex exec --json,
  or pi --mode rpc --no-session) and streams JSONL events as terminal-output
  WebSocket messages; DELETE endpoint kills the process
- backend: _parse_event maps each tool's native event format to a
  human-readable line (text deltas, tool calls, results, errors)
- agents store: runAgent/stopAgent actions call the new HTTP endpoints
- TerminalPane: run bar with tool selector, optional model/provider fields,
  prompt input, and RUN/STOP button; log lines colour-coded by type

No PTY or tmux needed — all three tools support structured non-interactive
output over plain stdin/stdout pipes.

https://claude.ai/code/session_01V5t65ufryeCCUkuGst4WrD