### PR TITLE
Add agent process spawning for Claude Code, Codex, and Pi

### DIFF
--- a/backend/foreman.py
+++ b/backend/foreman.py
@@ -1,0 +1,493 @@
+"""
+ForemanService: the AI orchestrator that lives in the backend.
+
+Triggered by:
+  - Chat messages directed to "foreman"
+  - agent-done notifications from completed worker subprocesses
+
+Uses the Claude API (tool use) to:
+  - Reply to the human
+  - Assign tasks to worker agents
+  - Manage a GitHub Projects v2 board (create issues, move cards, comment)
+"""
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+import anthropic
+import httpx
+
+logger = logging.getLogger(__name__)
+
+FOREMAN_MODEL = "claude-opus-4-7"
+MAX_HISTORY = 60   # messages to keep in memory before trimming oldest pairs
+IDLE_TIMEOUT = 600  # seconds before the loop exits (restarts on next trigger)
+
+TOOLS = [
+    {
+        "name": "reply",
+        "description": "Send a message back to the human in the session chat.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "The message to display in chat."}
+            },
+            "required": ["content"],
+        },
+    },
+    {
+        "name": "list_agents",
+        "description": "Return the current list of registered worker agents and their states.",
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "assign_task",
+        "description": (
+            "Start an AI coding agent on a task. The agent streams its output to its terminal pane. "
+            "Call list_agents first to find an idle agent."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {"type": "string", "description": "ID of the worker agent to use."},
+                "tool": {
+                    "type": "string",
+                    "enum": ["claude", "codex", "pi"],
+                    "description": "Which AI coding tool to run.",
+                },
+                "prompt": {"type": "string", "description": "The task prompt for the agent."},
+                "model": {"type": "string", "description": "Optional model override (e.g. claude-opus-4-7)."},
+            },
+            "required": ["agent_id", "tool", "prompt"],
+        },
+    },
+    {
+        "name": "github_create_issue",
+        "description": "Create a GitHub issue in the configured repository. Returns the issue number and node_id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "body": {"type": "string", "description": "Markdown body. Include task details, acceptance criteria, etc."},
+                "labels": {"type": "array", "items": {"type": "string"}, "description": "Optional label names."},
+            },
+            "required": ["title", "body"],
+        },
+    },
+    {
+        "name": "github_add_to_project",
+        "description": "Add a GitHub issue to the session's configured project board. Returns the project item ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "issue_node_id": {"type": "string", "description": "The node_id returned by github_create_issue."}
+            },
+            "required": ["issue_node_id"],
+        },
+    },
+    {
+        "name": "github_set_status",
+        "description": (
+            "Set the Status field of a project board item. "
+            "Common values: 'Todo', 'In Progress', 'Done'. "
+            "The exact option names depend on the project's configuration."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "item_id": {"type": "string", "description": "Project item ID from github_add_to_project."},
+                "status": {"type": "string", "description": "Status option name."},
+            },
+            "required": ["item_id", "status"],
+        },
+    },
+    {
+        "name": "github_comment_issue",
+        "description": "Add a comment to a GitHub issue (e.g. agent output summary, follow-up notes).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "issue_number": {"type": "integer"},
+                "body": {"type": "string", "description": "Markdown comment body."},
+            },
+            "required": ["issue_number", "body"],
+        },
+    },
+]
+
+
+def _system_prompt(agents: list[dict], config: dict) -> str:
+    agent_lines = "\n".join(
+        f"  - {a['name']} (id={a['id']}, state={a['state']})" for a in agents
+    ) or "  (none registered yet — ask the human to register workers)"
+
+    gh_parts = []
+    if config.get("github_token"):
+        if config.get("github_repo"):
+            gh_parts.append(f"repo={config['github_repo']}")
+        if config.get("github_project_id"):
+            gh_parts.append(f"project={config['github_project_id']}")
+    gh_status = ", ".join(gh_parts) if gh_parts else "not configured (session settings)"
+
+    return f"""\
+You are the Foreman of Pioneer Square, a software workshop that dispatches AI coding agents.
+
+Your responsibilities:
+1. Understand requests from the human and decompose them into concrete tasks.
+2. Track each task as a GitHub issue and move it through the project board.
+3. Assign tasks to idle worker agents with assign_task.
+4. When an agent reports completion, review its output summary and decide:
+   - Task complete → update status to Done, comment the summary, report to human.
+   - More work needed → assign follow-up tasks (same or different agent).
+   - Error → diagnose, retry if sensible, otherwise escalate to human.
+
+Registered worker agents:
+{agent_lines}
+
+GitHub: {gh_status}
+
+Guidelines:
+- Always reply to the human to acknowledge what you're doing.
+- Create a GitHub issue before assigning work so every task is tracked.
+- Keep chat replies concise; put detail in GitHub issue bodies/comments.
+- If GitHub is not configured, still manage work but note tracking is unavailable.
+- Prefer idle agents; do not double-assign a busy agent without asking.
+- If no agents are idle, tell the human and wait."""
+
+
+class ForemanService:
+    def __init__(
+        self,
+        session_id: str,
+        broadcast_fn: Callable,
+        get_db_fn: Callable,
+        spawn_agent_fn: Callable,  # async (session_id, agent_id, tool, prompt, model) -> None
+    ):
+        self.session_id = session_id
+        self._broadcast = broadcast_fn
+        self._get_db = get_db_fn
+        self._spawn_agent = spawn_agent_fn
+
+        self.messages: list[dict] = []
+        self._task: Optional[asyncio.Task] = None
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._gh_field_cache: dict = {}  # project_id -> {field_id, options}
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def notify(self, event: dict):
+        """Enqueue a trigger (chat or agent_done) and ensure the loop is running."""
+        self._queue.put_nowait(event)
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._loop())
+
+    # ------------------------------------------------------------------
+    # Internal loop
+    # ------------------------------------------------------------------
+
+    async def _loop(self):
+        while True:
+            try:
+                event = await asyncio.wait_for(self._queue.get(), timeout=IDLE_TIMEOUT)
+            except asyncio.TimeoutError:
+                break
+            try:
+                await self._process(event)
+            except Exception:
+                logger.exception("Foreman error processing event %s", event.get("type"))
+
+    async def _process(self, event: dict):
+        config = await self._get_config()
+        agents = await self._get_agents()
+
+        if event["type"] == "chat":
+            self.messages.append({"role": "user", "content": event["content"]})
+        elif event["type"] == "agent_done":
+            name = event.get("agent_name", event.get("agent_id", "?"))
+            tool = event.get("tool", "?")
+            ok = event.get("exit_code", 0) == 0
+            summary = event.get("summary", "(no output)")
+            outcome = "completed successfully" if ok else "finished with an error"
+            self.messages.append({
+                "role": "user",
+                "content": (
+                    f"[System] Agent '{name}' ({tool}) {outcome}.\n"
+                    f"Output summary:\n```\n{summary}\n```"
+                ),
+            })
+
+        await self._set_state("thinking")
+        try:
+            await self._run_turn(config, agents)
+        finally:
+            await self._set_state("idle")
+
+        # Trim history to avoid unbounded growth
+        if len(self.messages) > MAX_HISTORY:
+            self.messages = self.messages[-MAX_HISTORY:]
+
+    async def _run_turn(self, config: dict, agents: list[dict]):
+        client = anthropic.AsyncAnthropic(api_key=os.environ.get("ANTHROPIC_API_KEY", ""))
+        system = _system_prompt(agents, config)
+        messages = list(self.messages)
+
+        while True:
+            response = await client.messages.create(
+                model=FOREMAN_MODEL,
+                max_tokens=4096,
+                system=system,
+                tools=TOOLS,
+                messages=messages,
+            )
+
+            messages.append({"role": "assistant", "content": response.content})
+
+            if response.stop_reason != "tool_use":
+                break
+
+            tool_results = []
+            for block in response.content:
+                if block.type == "tool_use":
+                    result = await self._execute_tool(block.name, block.input, config)
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": json.dumps(result),
+                    })
+            messages.append({"role": "user", "content": tool_results})
+
+        self.messages = messages
+
+    # ------------------------------------------------------------------
+    # Tool execution
+    # ------------------------------------------------------------------
+
+    async def _execute_tool(self, name: str, inputs: dict, config: dict) -> dict:
+        try:
+            if name == "reply":
+                return await self._tool_reply(inputs["content"])
+            if name == "list_agents":
+                return {"agents": await self._get_agents()}
+            if name == "assign_task":
+                return await self._tool_assign(inputs, config)
+            if name == "github_create_issue":
+                return await self._gh_create_issue(config, inputs)
+            if name == "github_add_to_project":
+                return await self._gh_add_to_project(config, inputs)
+            if name == "github_set_status":
+                return await self._gh_set_status(config, inputs)
+            if name == "github_comment_issue":
+                return await self._gh_comment_issue(config, inputs)
+            return {"error": f"Unknown tool: {name}"}
+        except Exception as exc:
+            logger.exception("Tool %s failed", name)
+            return {"error": str(exc)}
+
+    async def _tool_reply(self, content: str) -> dict:
+        now = datetime.now(timezone.utc).isoformat()
+        await self._broadcast(self.session_id, {
+            "type": "chat",
+            "from": "foreman",
+            "to": "user",
+            "content": content,
+            "createdAt": now,
+        })
+        db = await self._get_db()
+        try:
+            await db.execute(
+                "INSERT INTO messages (session_id, from_agent, to_agent, content, message_type, created_at)"
+                " VALUES (?, 'foreman', 'user', ?, 'chat', ?)",
+                (self.session_id, content, now),
+            )
+            await db.commit()
+        finally:
+            await db.close()
+        return {"ok": True}
+
+    async def _tool_assign(self, inputs: dict, config: dict) -> dict:
+        agent_id = inputs["agent_id"]
+        tool = inputs["tool"]
+        prompt = inputs["prompt"]
+        model = inputs.get("model")
+        await self._spawn_agent(self.session_id, agent_id, tool, prompt, model)
+        return {"ok": True, "agent_id": agent_id, "tool": tool}
+
+    # ------------------------------------------------------------------
+    # GitHub helpers
+    # ------------------------------------------------------------------
+
+    def _gh_headers(self, token: str) -> dict:
+        return {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _require_gh(self, config: dict, need_project: bool = False) -> tuple[str, str]:
+        token = config.get("github_token", "")
+        repo = config.get("github_repo", "")
+        if not token or not repo:
+            raise ValueError("GitHub token and repo are not configured for this session.")
+        if need_project and not config.get("github_project_id"):
+            raise ValueError("GitHub project ID is not configured for this session.")
+        return token, repo
+
+    async def _gh_graphql(self, token: str, query: str, variables: dict | None = None) -> dict:
+        async with httpx.AsyncClient() as client:
+            r = await client.post(
+                "https://api.github.com/graphql",
+                headers={**self._gh_headers(token), "Content-Type": "application/json"},
+                json={"query": query, "variables": variables or {}},
+                timeout=20,
+            )
+            r.raise_for_status()
+            data = r.json()
+            if "errors" in data:
+                raise RuntimeError("; ".join(e["message"] for e in data["errors"]))
+            return data.get("data", {})
+
+    async def _gh_create_issue(self, config: dict, inputs: dict) -> dict:
+        token, repo = self._require_gh(config)
+        async with httpx.AsyncClient() as client:
+            r = await client.post(
+                f"https://api.github.com/repos/{repo}/issues",
+                headers=self._gh_headers(token),
+                json={
+                    "title": inputs["title"],
+                    "body": inputs.get("body", ""),
+                    "labels": inputs.get("labels", []),
+                },
+                timeout=20,
+            )
+            r.raise_for_status()
+            data = r.json()
+            return {"issue_number": data["number"], "node_id": data["node_id"], "url": data["html_url"]}
+
+    async def _gh_add_to_project(self, config: dict, inputs: dict) -> dict:
+        token, _ = self._require_gh(config, need_project=True)
+        project_id = config["github_project_id"]
+        data = await self._gh_graphql(token, """
+            mutation Add($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item { id }
+              }
+            }
+        """, {"projectId": project_id, "contentId": inputs["issue_node_id"]})
+        return {"item_id": data["addProjectV2ItemById"]["item"]["id"]}
+
+    async def _gh_set_status(self, config: dict, inputs: dict) -> dict:
+        token, _ = self._require_gh(config, need_project=True)
+        project_id = config["github_project_id"]
+
+        # Fetch and cache the Status field + option IDs for this project
+        if project_id not in self._gh_field_cache:
+            data = await self._gh_graphql(token, """
+                query Fields($id: ID!) {
+                  node(id: $id) {
+                    ... on ProjectV2 {
+                      fields(first: 30) {
+                        nodes {
+                          ... on ProjectV2SingleSelectField {
+                            id name
+                            options { id name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+            """, {"id": project_id})
+            fields = data["node"]["fields"]["nodes"]
+            status_field = next(
+                (f for f in fields if isinstance(f, dict) and f.get("name", "").lower() == "status"),
+                None,
+            )
+            if not status_field:
+                raise ValueError("No 'Status' single-select field found in the project.")
+            self._gh_field_cache[project_id] = {
+                "field_id": status_field["id"],
+                "options": {opt["name"].lower(): opt["id"] for opt in status_field["options"]},
+                "option_names": [opt["name"] for opt in status_field["options"]],
+            }
+
+        cached = self._gh_field_cache[project_id]
+        status_lower = inputs["status"].lower()
+        option_id = cached["options"].get(status_lower)
+        if not option_id:
+            return {"error": f"Status '{inputs['status']}' not found. Available: {cached['option_names']}"}
+
+        await self._gh_graphql(token, """
+            mutation SetStatus($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) { projectV2Item { id } }
+            }
+        """, {
+            "projectId": project_id,
+            "itemId": inputs["item_id"],
+            "fieldId": cached["field_id"],
+            "optionId": option_id,
+        })
+        return {"ok": True, "status": inputs["status"]}
+
+    async def _gh_comment_issue(self, config: dict, inputs: dict) -> dict:
+        token, repo = self._require_gh(config)
+        async with httpx.AsyncClient() as client:
+            r = await client.post(
+                f"https://api.github.com/repos/{repo}/issues/{inputs['issue_number']}/comments",
+                headers=self._gh_headers(token),
+                json={"body": inputs["body"]},
+                timeout=20,
+            )
+            r.raise_for_status()
+            return {"ok": True, "comment_id": r.json()["id"]}
+
+    # ------------------------------------------------------------------
+    # State / DB helpers
+    # ------------------------------------------------------------------
+
+    async def _set_state(self, state: str):
+        await self._broadcast(self.session_id, {
+            "type": "agent-state",
+            "agentId": "foreman",
+            "state": state,
+        })
+        db = await self._get_db()
+        try:
+            await db.execute(
+                "UPDATE agents SET state = ? WHERE id = 'foreman' AND session_id = ?",
+                (state, self.session_id),
+            )
+            await db.commit()
+        finally:
+            await db.close()
+
+    async def _get_config(self) -> dict:
+        db = await self._get_db()
+        try:
+            async with db.execute("SELECT * FROM sessions WHERE id = ?", (self.session_id,)) as cur:
+                row = await cur.fetchone()
+            return dict(row) if row else {}
+        finally:
+            await db.close()
+
+    async def _get_agents(self) -> list[dict]:
+        db = await self._get_db()
+        try:
+            async with db.execute(
+                "SELECT id, name, type, state FROM agents WHERE session_id = ? AND type != 'foreman'",
+                (self.session_id,),
+            ) as cur:
+                rows = await cur.fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            await db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,8 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
+from foreman import ForemanService
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
@@ -35,6 +37,9 @@ connections: Dict[str, List[WebSocket]] = {}
 # Running agent subprocesses: agent_id -> asyncio.subprocess.Process
 running_processes: Dict[str, asyncio.subprocess.Process] = {}
 
+# Active foreman services: session_id -> ForemanService
+foremans: Dict[str, ForemanService] = {}
+
 
 async def get_db():
     db = await aiosqlite.connect(DB_PATH)
@@ -48,9 +53,23 @@ async def init_db():
         CREATE TABLE IF NOT EXISTS sessions (
             id TEXT PRIMARY KEY,
             created_at TEXT NOT NULL,
-            name TEXT
+            name TEXT,
+            github_token TEXT,
+            github_repo TEXT,
+            github_project_id TEXT
         )
     """)
+    # Migrate existing sessions table if columns are missing
+    for col, typedef in [
+        ("github_token", "TEXT"),
+        ("github_repo", "TEXT"),
+        ("github_project_id", "TEXT"),
+    ]:
+        try:
+            await db.execute(f"ALTER TABLE sessions ADD COLUMN {col} {typedef}")
+        except Exception:
+            pass  # column already exists
+
     await db.execute("""
         CREATE TABLE IF NOT EXISTS agents (
             id TEXT PRIMARY KEY,
@@ -82,8 +101,18 @@ def generate_session_id():
     return ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
 
 
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
 class SessionCreate(BaseModel):
     name: Optional[str] = None
+
+
+class SessionConfig(BaseModel):
+    github_token: Optional[str] = None
+    github_repo: Optional[str] = None
+    github_project_id: Optional[str] = None
 
 
 class RunAgentRequest(BaseModel):
@@ -93,6 +122,10 @@ class RunAgentRequest(BaseModel):
     provider: Optional[str] = None   # pi only
 
 
+# ---------------------------------------------------------------------------
+# Session endpoints
+# ---------------------------------------------------------------------------
+
 @app.post("/sessions")
 async def create_session(data: Optional[SessionCreate] = None):
     if data is None:
@@ -100,7 +133,6 @@ async def create_session(data: Optional[SessionCreate] = None):
     created_at = datetime.now(timezone.utc).isoformat()
     db = await get_db()
     try:
-        # Retry on collision (UNIQUE constraint); negligible probability with 36^6 space
         for _ in range(5):
             session_id = generate_session_id()
             try:
@@ -154,8 +186,40 @@ async def get_session(session_id: str):
         await db.close()
 
 
+@app.patch("/sessions/{session_id}/config")
+async def update_session_config(session_id: str, config: SessionConfig):
+    """Update GitHub integration settings for a session."""
+    db = await get_db()
+    try:
+        async with db.execute("SELECT id FROM sessions WHERE id = ?", (session_id,)) as cur:
+            if not await cur.fetchone():
+                raise HTTPException(status_code=404, detail="Session not found")
+
+        fields = {k: v for k, v in config.model_dump().items() if v is not None}
+        if not fields:
+            return {"ok": True}
+
+        set_clause = ", ".join(f"{k} = ?" for k in fields)
+        await db.execute(
+            f"UPDATE sessions SET {set_clause} WHERE id = ?",
+            (*fields.values(), session_id),
+        )
+        await db.commit()
+
+        # Invalidate cached GitHub field IDs if the project changed
+        if "github_project_id" in fields and session_id in foremans:
+            foremans[session_id]._gh_field_cache.clear()
+
+        return {"ok": True}
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# WebSocket broadcast helper
+# ---------------------------------------------------------------------------
+
 async def broadcast(session_id: str, message: dict, exclude: WebSocket = None):
-    """Broadcast a message to all connections in a session."""
     if session_id not in connections:
         return
     dead = []
@@ -169,6 +233,57 @@ async def broadcast(session_id: str, message: dict, exclude: WebSocket = None):
     for ws in dead:
         connections[session_id].remove(ws)
 
+
+# ---------------------------------------------------------------------------
+# Foreman factory
+# ---------------------------------------------------------------------------
+
+def _get_or_create_foreman(session_id: str) -> ForemanService:
+    if session_id not in foremans:
+        async def _spawn(sid, agent_id, tool, prompt, model):
+            req = RunAgentRequest(tool=tool, prompt=prompt, model=model)
+            asyncio.create_task(_stream_agent(sid, agent_id, req))
+
+        foremans[session_id] = ForemanService(
+            session_id=session_id,
+            broadcast_fn=broadcast,
+            get_db_fn=get_db,
+            spawn_agent_fn=_spawn,
+        )
+    return foremans[session_id]
+
+
+async def _ensure_foreman_registered(session_id: str):
+    """Insert the foreman agent row if it doesn't already exist."""
+    db = await get_db()
+    try:
+        async with db.execute(
+            "SELECT id FROM agents WHERE id = 'foreman' AND session_id = ?", (session_id,)
+        ) as cur:
+            if await cur.fetchone():
+                return
+        joined_at = datetime.now(timezone.utc).isoformat()
+        await db.execute(
+            "INSERT INTO agents (id, session_id, name, type, state, joined_at)"
+            " VALUES ('foreman', ?, 'Foreman', 'foreman', 'idle', ?)",
+            (session_id, joined_at),
+        )
+        await db.commit()
+        await broadcast(session_id, {
+            "type": "agent-joined",
+            "agentId": "foreman",
+            "agentName": "Foreman",
+            "agentType": "foreman",
+            "state": "idle",
+            "joinedAt": joined_at,
+        })
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# WebSocket endpoint
+# ---------------------------------------------------------------------------
 
 @app.websocket("/ws/{session_id}")
 async def websocket_endpoint(websocket: WebSocket, session_id: str):
@@ -193,15 +308,14 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                     (agent_id, session_id, agent_name, agent_type, joined_at)
                 )
                 await db.commit()
-                broadcast_msg = {
+                await broadcast(session_id, {
                     "type": "agent-joined",
                     "agentId": agent_id,
                     "agentName": agent_name,
                     "agentType": agent_type,
                     "state": "idle",
                     "joinedAt": joined_at
-                }
-                await broadcast(session_id, broadcast_msg)
+                })
 
             elif msg_type == "agent-state":
                 agent_id = data.get("agentId")
@@ -223,7 +337,8 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                 content = data.get("content", "")
                 created_at = datetime.now(timezone.utc).isoformat()
                 await db.execute(
-                    "INSERT INTO messages (session_id, from_agent, to_agent, content, message_type, created_at) VALUES (?, ?, ?, ?, 'chat', ?)",
+                    "INSERT INTO messages (session_id, from_agent, to_agent, content, message_type, created_at)"
+                    " VALUES (?, ?, ?, ?, 'chat', ?)",
                     (session_id, from_agent, to_agent, content, created_at)
                 )
                 await db.commit()
@@ -235,12 +350,19 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                     "createdAt": created_at
                 })
 
+                # Route chat messages addressed to the foreman
+                if to_agent == "foreman" and from_agent != "foreman":
+                    await _ensure_foreman_registered(session_id)
+                    foreman = _get_or_create_foreman(session_id)
+                    foreman.notify({"type": "chat", "content": content, "from": from_agent})
+
             elif msg_type == "terminal-output":
                 agent_id = data.get("agentId")
                 line = data.get("line", "")
                 created_at = datetime.now(timezone.utc).isoformat()
                 await db.execute(
-                    "INSERT INTO messages (session_id, from_agent, content, message_type, created_at) VALUES (?, ?, ?, 'terminal', ?)",
+                    "INSERT INTO messages (session_id, from_agent, content, message_type, created_at)"
+                    " VALUES (?, ?, ?, 'terminal', ?)",
                     (session_id, agent_id, line, created_at)
                 )
                 await db.commit()
@@ -252,11 +374,9 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                 })
 
             elif msg_type in ("offer", "answer", "ice-candidate"):
-                # WebRTC signaling - forward to all
                 await broadcast(session_id, data, exclude=websocket)
 
             else:
-                # Generic broadcast
                 await broadcast(session_id, data)
 
     except WebSocketDisconnect:
@@ -274,7 +394,6 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
 # ---------------------------------------------------------------------------
 
 async def _emit_terminal_line(session_id: str, agent_id: str, line: str):
-    """Broadcast a terminal output line and persist it to the DB."""
     now = datetime.now(timezone.utc).isoformat()
     await broadcast(session_id, {
         "type": "terminal-output",
@@ -295,7 +414,6 @@ async def _emit_terminal_line(session_id: str, agent_id: str, line: str):
 
 
 async def _set_agent_state(session_id: str, agent_id: str, state: str):
-    """Broadcast and persist an agent state change."""
     await broadcast(session_id, {"type": "agent-state", "agentId": agent_id, "state": state})
     db = await get_db()
     try:
@@ -309,11 +427,7 @@ async def _set_agent_state(session_id: str, agent_id: str, state: str):
 
 
 def _build_command(req: RunAgentRequest) -> tuple[list[str], bool]:
-    """Return (cmd_list, needs_stdin_prompt).
-
-    needs_stdin_prompt=True means we must write the RPC prompt to stdin
-    (Pi RPC mode) rather than passing it on the command line.
-    """
+    """Return (cmd_list, needs_stdin_prompt)."""
     tool = req.tool.lower()
 
     if tool == "claude":
@@ -323,14 +437,12 @@ def _build_command(req: RunAgentRequest) -> tuple[list[str], bool]:
         return cmd, False
 
     if tool == "codex":
-        # codex exec --full-auto accepts a prompt as positional arg; --json for structured output
         cmd = ["codex", "exec", "--json", req.prompt]
         if req.model:
             cmd += ["--model", req.model]
         return cmd, False
 
     if tool == "pi":
-        # Pi --mode rpc: bidirectional JSONL over stdin/stdout
         cmd = ["pi", "--mode", "rpc", "--no-session"]
         if req.provider:
             cmd += ["--provider", req.provider]
@@ -342,7 +454,6 @@ def _build_command(req: RunAgentRequest) -> tuple[list[str], bool]:
 
 
 async def _stream_agent(session_id: str, agent_id: str, req: RunAgentRequest):
-    """Spawn the agent subprocess and stream its output as terminal-output events."""
     tool = req.tool.lower()
 
     try:
@@ -350,6 +461,15 @@ async def _stream_agent(session_id: str, agent_id: str, req: RunAgentRequest):
     except ValueError as exc:
         await _emit_terminal_line(session_id, agent_id, f"✗ {exc}")
         return
+
+    # Look up agent name for the done notification
+    db = await get_db()
+    try:
+        async with db.execute("SELECT name FROM agents WHERE id = ?", (agent_id,)) as cur:
+            row = await cur.fetchone()
+        agent_name = row["name"] if row else agent_id
+    finally:
+        await db.close()
 
     stdin_pipe = asyncio.subprocess.PIPE if needs_stdin else asyncio.subprocess.DEVNULL
     proc = await asyncio.create_subprocess_exec(
@@ -360,7 +480,6 @@ async def _stream_agent(session_id: str, agent_id: str, req: RunAgentRequest):
     )
 
     if needs_stdin:
-        # Pi RPC: send the initial prompt as a JSON command, then leave stdin open
         rpc_msg = json.dumps({"type": "prompt", "content": req.prompt}) + "\n"
         proc.stdin.write(rpc_msg.encode())
         await proc.stdin.drain()
@@ -368,8 +487,8 @@ async def _stream_agent(session_id: str, agent_id: str, req: RunAgentRequest):
     running_processes[agent_id] = proc
     await _set_agent_state(session_id, agent_id, "working")
 
-    # For Pi message_update we track accumulated text to emit only deltas
     pi_last_text = ""
+    output_lines: list[str] = []  # collect for agent-done summary
 
     try:
         async for raw_line in proc.stdout:
@@ -381,11 +500,11 @@ async def _stream_agent(session_id: str, agent_id: str, req: RunAgentRequest):
                 event = json.loads(line_str)
             except json.JSONDecodeError:
                 await _emit_terminal_line(session_id, agent_id, line_str)
+                output_lines.append(line_str)
                 continue
 
             text = _parse_event(tool, event, pi_last_text)
 
-            # Pi: update delta baseline
             if tool == "pi" and event.get("type") == "message_update":
                 full = ""
                 for blk in event.get("message", {}).get("content", []):
@@ -397,18 +516,44 @@ async def _stream_agent(session_id: str, agent_id: str, req: RunAgentRequest):
 
             if text:
                 await _emit_terminal_line(session_id, agent_id, text)
+                output_lines.append(text)
 
     finally:
         if needs_stdin and proc.stdin and not proc.stdin.is_closing():
             proc.stdin.close()
         exit_code = await proc.wait()
         running_processes.pop(agent_id, None)
-        await _set_agent_state(session_id, agent_id, "idle" if exit_code == 0 else "error")
+        final_state = "idle" if exit_code == 0 else "error"
+        await _set_agent_state(session_id, agent_id, final_state)
+
+        # Build a summary for the foreman (last 30 non-empty lines)
+        summary_lines = [l for l in output_lines if l.strip()][-30:]
+        summary = "\n".join(summary_lines)
+
+        # Broadcast agent-done so the UI can show a notification
+        await broadcast(session_id, {
+            "type": "agent-done",
+            "agentId": agent_id,
+            "agentName": agent_name,
+            "tool": tool,
+            "exitCode": exit_code,
+            "summary": summary,
+        })
+
+        # Notify the foreman so it can review and follow up
+        if session_id in foremans or exit_code == 0:
+            foreman = _get_or_create_foreman(session_id)
+            foreman.notify({
+                "type": "agent_done",
+                "agent_id": agent_id,
+                "agent_name": agent_name,
+                "tool": tool,
+                "exit_code": exit_code,
+                "summary": summary,
+            })
 
 
 def _parse_event(tool: str, event: dict, pi_last_text: str) -> Optional[str]:
-    """Extract a human-readable line from one stream-JSON / RPC event."""
-
     if tool == "claude":
         t = event.get("type")
         if t == "assistant":
@@ -438,17 +583,14 @@ def _parse_event(tool: str, event: dict, pi_last_text: str) -> Optional[str]:
                 return f"✓ Done in {turns} turns{cost_str}"
             return f"✗ {subtype}: {event.get('error', '')}"
         if t == "system" and event.get("subtype") == "init":
-            tools = event.get("tools", [])
-            return f"[claude] tools: {', '.join(tools[:6])}"
+            return f"[claude] tools: {', '.join(event.get('tools', [])[:6])}"
 
     elif tool == "codex":
         t = event.get("type")
         if t == "message" and event.get("role") == "assistant":
             return (event.get("content") or "").strip() or None
         if t == "function_call":
-            name = event.get("name", "")
-            args = event.get("arguments", "")
-            return f"▶ {name}({args[:80]})"
+            return f"▶ {event.get('name', '')}({str(event.get('arguments', ''))[:80]})"
         if t == "function_result":
             return f"  → {str(event.get('output', ''))[:200]}"
         if t == "done":
@@ -479,9 +621,7 @@ def _parse_event(tool: str, event: dict, pi_last_text: str) -> Optional[str]:
             if not out:
                 return None
             lines = out.split("\n")
-            preview = lines[0][:120]
-            if len(lines) > 1:
-                preview += f" (+{len(lines) - 1} lines)"
+            preview = lines[0][:120] + (f" (+{len(lines) - 1} lines)" if len(lines) > 1 else "")
             return f"  → {preview}"
         if t == "agent_end":
             err = event.get("error")
@@ -492,24 +632,26 @@ def _parse_event(tool: str, event: dict, pi_last_text: str) -> Optional[str]:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Run / stop endpoints
+# ---------------------------------------------------------------------------
+
 @app.post("/sessions/{session_id}/agents/{agent_id}/run")
 async def start_agent_run(session_id: str, agent_id: str, req: RunAgentRequest):
-    """Spawn an AI coding agent subprocess and stream its output over WebSocket."""
-    # Kill any existing run for this agent
     old = running_processes.get(agent_id)
     if old:
         try:
             old.kill()
         except ProcessLookupError:
             pass
-
+    # Register the foreman so it receives the agent-done notification
+    await _ensure_foreman_registered(session_id)
     asyncio.create_task(_stream_agent(session_id, agent_id, req))
     return {"status": "started", "agentId": agent_id, "tool": req.tool}
 
 
 @app.delete("/sessions/{session_id}/agents/{agent_id}/run")
 async def stop_agent_run(session_id: str, agent_id: str):
-    """Terminate a running agent subprocess."""
     proc = running_processes.get(agent_id)
     if not proc:
         raise HTTPException(status_code=404, detail="No running process for this agent")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]
 websockets
 aiosqlite
 python-multipart
+anthropic>=0.40.0
+httpx>=0.27.0

--- a/frontend/src/components/SessionSidebar.vue
+++ b/frontend/src/components/SessionSidebar.vue
@@ -4,6 +4,7 @@
       <span class="sidebar-title">Sessions</span>
       <button class="pixel-btn new-btn" @click="newSession">+ New</button>
     </div>
+
     <div class="session-list">
       <div
         v-for="session in sessions"
@@ -18,6 +19,44 @@
       </div>
       <div v-if="sessions.length === 0" class="no-sessions">No sessions yet</div>
     </div>
+
+    <!-- GitHub config for the active session -->
+    <div v-if="currentSession" class="gh-config">
+      <div class="gh-config-header" @click="ghOpen = !ghOpen">
+        <span class="gh-icon">⬡</span>
+        <span class="gh-title">GitHub</span>
+        <span class="gh-status-dot" :class="ghConfigured ? 'ok' : 'off'"></span>
+        <span class="gh-toggle">{{ ghOpen ? '▲' : '▼' }}</span>
+      </div>
+
+      <div v-if="ghOpen" class="gh-config-body">
+        <label class="gh-label">Token
+          <input
+            v-model="ghToken"
+            class="gh-input"
+            type="password"
+            placeholder="ghp_…"
+            autocomplete="off"
+          />
+        </label>
+        <label class="gh-label">Repo
+          <input v-model="ghRepo" class="gh-input" placeholder="owner/repo" />
+        </label>
+        <label class="gh-label">Project ID
+          <input v-model="ghProjectId" class="gh-input" placeholder="PVT_…" />
+        </label>
+        <div class="gh-hint">Project node ID from GitHub Projects v2 URL</div>
+        <div class="gh-actions">
+          <button class="pixel-btn gh-save-btn" :disabled="saving" @click="saveConfig">
+            {{ saving ? '…' : 'Save' }}
+          </button>
+          <span v-if="saveMsg" class="gh-save-msg" :class="saveError ? 'err' : 'ok'">
+            {{ saveMsg }}
+          </span>
+        </div>
+      </div>
+    </div>
+
     <div class="sidebar-footer">
       <div class="connection-status" :class="{ connected: isConnected }">
         <span class="status-dot"></span>
@@ -28,7 +67,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSessionStore } from '../stores/session.js'
 
@@ -38,6 +77,47 @@ const sessionStore = useSessionStore()
 const sessions = computed(() => sessionStore.sessions)
 const currentSession = computed(() => sessionStore.currentSession)
 const isConnected = computed(() => sessionStore.isConnected)
+
+// GitHub config fields — synced from currentSession
+const ghOpen = ref(false)
+const ghToken = ref('')
+const ghRepo = ref('')
+const ghProjectId = ref('')
+const saving = ref(false)
+const saveMsg = ref('')
+const saveError = ref(false)
+
+const ghConfigured = computed(() =>
+  !!(currentSession.value?.github_token && currentSession.value?.github_repo)
+)
+
+// Populate inputs when the active session changes
+watch(currentSession, (session) => {
+  if (!session) return
+  ghToken.value = session.github_token || ''
+  ghRepo.value = session.github_repo || ''
+  ghProjectId.value = session.github_project_id || ''
+}, { immediate: true })
+
+async function saveConfig() {
+  saving.value = true
+  saveMsg.value = ''
+  saveError.value = false
+  try {
+    await sessionStore.updateSessionConfig({
+      githubToken: ghToken.value.trim(),
+      githubRepo: ghRepo.value.trim(),
+      githubProjectId: ghProjectId.value.trim(),
+    })
+    saveMsg.value = 'Saved'
+  } catch (e) {
+    saveMsg.value = e.message
+    saveError.value = true
+  } finally {
+    saving.value = false
+    setTimeout(() => { saveMsg.value = '' }, 3000)
+  }
+}
 
 async function newSession() {
   const session = await sessionStore.createSession()
@@ -139,6 +219,118 @@ function formatTime(isoStr) {
   font-size: 11px;
 }
 
+/* ── GitHub config panel ─────────────────────────────────────── */
+.gh-config {
+  border-top: 2px solid var(--color-brass-dark);
+  flex-shrink: 0;
+}
+
+.gh-config-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  cursor: pointer;
+  background: var(--color-bg-tertiary);
+  user-select: none;
+  transition: background 0.12s;
+}
+
+.gh-config-header:hover {
+  background: rgba(232, 170, 0, 0.06);
+}
+
+.gh-icon {
+  font-size: 12px;
+  color: var(--color-brass-dark);
+}
+
+.gh-title {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-text-dim);
+  letter-spacing: 1px;
+  flex: 1;
+}
+
+.gh-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.gh-status-dot.ok  { background: var(--color-green); }
+.gh-status-dot.off { background: var(--color-text-dim); }
+
+.gh-toggle {
+  font-size: 9px;
+  color: var(--color-text-dim);
+}
+
+.gh-config-body {
+  padding: 8px 12px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-bg-tertiary);
+}
+
+.gh-label {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 9px;
+  color: var(--color-text-dim);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.gh-input {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 4px 6px;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+.gh-input:focus {
+  border-color: var(--color-brass);
+}
+.gh-input::placeholder {
+  color: var(--color-text-dim);
+  opacity: 0.5;
+}
+
+.gh-hint {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.gh-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.gh-save-btn {
+  font-size: 8px;
+  padding: 4px 10px;
+}
+
+.gh-save-msg {
+  font-size: 10px;
+}
+.gh-save-msg.ok  { color: var(--color-green); }
+.gh-save-msg.err { color: var(--color-red); }
+
+/* ── Footer ──────────────────────────────────────────────────── */
 .sidebar-footer {
   padding: 10px 12px;
   border-top: 2px solid var(--color-brass-dark);
@@ -171,6 +363,6 @@ function formatTime(isoStr) {
 
 @keyframes pulse {
   0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  50%       { opacity: 0.3; }
 }
 </style>

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -19,7 +19,8 @@ export const useAgentsStore = defineStore('agents', () => {
         type: agentData.agentType || 'worker',
         state: agentData.state || 'idle',
         logs: [],
-        joinedAt: agentData.joinedAt || new Date().toISOString()
+        joinedAt: agentData.joinedAt || new Date().toISOString(),
+        lastDone: null,
       })
     }
   }
@@ -34,6 +35,13 @@ export const useAgentsStore = defineStore('agents', () => {
     if (agent) {
       agent.logs.push({ line, timestamp: timestamp || new Date().toISOString() })
       if (agent.logs.length > 500) agent.logs.shift()
+    }
+  }
+
+  function markDone(agentId, { tool, exitCode, summary }) {
+    const agent = agents.value.find(a => a.id === agentId)
+    if (agent) {
+      agent.lastDone = { tool, exitCode, summary, at: new Date().toISOString() }
     }
   }
 
@@ -86,6 +94,13 @@ export const useAgentsStore = defineStore('agents', () => {
       updateAgentState(data.agentId, data.state)
     } else if (data.type === 'terminal-output') {
       addLog(data.agentId, data.line, data.timestamp)
+    } else if (data.type === 'agent-done') {
+      markDone(data.agentId, {
+        tool: data.tool,
+        exitCode: data.exitCode,
+        summary: data.summary,
+      })
+      // state is already updated to idle/error by agent-state event
     }
   }
 
@@ -94,6 +109,7 @@ export const useAgentsStore = defineStore('agents', () => {
     registerAgent,
     updateAgentState,
     addLog,
+    markDone,
     sendMessage,
     runAgent,
     stopAgent,

--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -45,6 +45,31 @@ export const useSessionStore = defineStore('session', () => {
     }
   }
 
+  async function updateSessionConfig({ githubToken, githubRepo, githubProjectId }) {
+    const sessionId = currentSession.value?.id
+    if (!sessionId) throw new Error('No active session')
+
+    const body = {}
+    if (githubToken !== undefined) body.github_token = githubToken || null
+    if (githubRepo !== undefined) body.github_repo = githubRepo || null
+    if (githubProjectId !== undefined) body.github_project_id = githubProjectId || null
+
+    const res = await fetch(`${API_BASE}/sessions/${sessionId}/config`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+
+    // Reflect changes locally so the UI updates immediately
+    if (currentSession.value) {
+      if (githubToken !== undefined) currentSession.value.github_token = githubToken
+      if (githubRepo !== undefined) currentSession.value.github_repo = githubRepo
+      if (githubProjectId !== undefined) currentSession.value.github_project_id = githubProjectId
+    }
+    return res.json()
+  }
+
   function connectWebSocket(sessionId, onMessage, retryCount = 0) {
     const MAX_RETRIES = 10
     if (ws) {
@@ -96,6 +121,7 @@ export const useSessionStore = defineStore('session', () => {
     loadSessions,
     createSession,
     joinSession,
+    updateSessionConfig,
     connectWebSocket,
     sendMessage,
     addMessageHandler,


### PR DESCRIPTION
- backend: POST /sessions/{id}/agents/{id}/run spawns subprocess for
  the chosen tool (claude -p --output-format stream-json, codex exec --json,
  or pi --mode rpc --no-session) and streams JSONL events as terminal-output
  WebSocket messages; DELETE endpoint kills the process
- backend: _parse_event maps each tool's native event format to a
  human-readable line (text deltas, tool calls, results, errors)
- agents store: runAgent/stopAgent actions call the new HTTP endpoints
- TerminalPane: run bar with tool selector, optional model/provider fields,
  prompt input, and RUN/STOP button; log lines colour-coded by type

No PTY or tmux needed — all three tools support structured non-interactive
output over plain stdin/stdout pipes.

https://claude.ai/code/session_01V5t65ufryeCCUkuGst4WrD