### PR TITLE
Extract worker logic into standalone /worker package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,16 @@
 node_modules/
 dist/
+build/
 __pycache__/
 *.pyc
+*.egg-info/
 .venv/
 venv/
 *.sqlite
 *.db
 .env
 .DS_Store
+
+# Worker runtime state (auto-written next to pioneer-worker.toml)
+pioneer-worker.toml
+pioneer-worker.state.json

--- a/README.md
+++ b/README.md
@@ -36,11 +36,31 @@ npm run dev
 
 Open http://localhost:5173 — a new session will be created automatically.
 
+### Worker
+
+Worker agents run as standalone processes (one per worker) and connect to the
+backend over WebSocket. They can run on any machine that has `claude`, `git`,
+and access to the configured repos.
+
+```bash
+cd worker
+python -m venv venv
+source venv/bin/activate
+pip install -e .
+cp pioneer-worker.toml.example pioneer-worker.toml
+# edit pioneer-worker.toml: backend_url, session_id, repos, github token
+pioneer-worker
+```
+
+See [`worker/README.md`](worker/README.md) for details.
+
 ## Architecture
 
 - **Backend**: FastAPI + aiosqlite + WebSocket signaling
 - **Frontend**: Vue 3 + Pinia + Vue Router + WebRTC
-- **Database**: SQLite (sessions, agents, messages)
+- **Worker**: Standalone Python process (`pioneer-worker` CLI) that runs
+  Claude on assigned tasks and opens GitHub PRs.
+- **Database**: SQLite (sessions, agents, messages, workers, tasks)
 
 ## Connecting Agents
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,7 @@
 import asyncio
 import json
-import os
-import re
 import random
 import string
-import urllib.request
-import urllib.error
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
@@ -24,21 +20,8 @@ except ImportError:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
-    # Recover persisted workers (tokens are not stored — workers restart without push/PR capability
-    # until the human re-deploys or sets a token via the UI)
-    db = await get_db()
-    try:
-        async with db.execute("SELECT * FROM workers") as cur:
-            saved_workers = [dict(r) for r in await cur.fetchall()]
-    finally:
-        await db.close()
-    for w in saved_workers:
-        wid = w["id"]
-        sid = w["session_id"]
-        repos = json.loads(w.get("repos", "[]"))
-        worker_configs[wid] = {"session_id": sid, "repos": repos, "token": None}
-        worker_task_queues[wid] = asyncio.Queue()
-        worker_loops[wid] = asyncio.create_task(_worker_loop(sid, wid))
+    # Workers run as standalone processes (see /worker package) and connect over
+    # WebSocket; no in-process recovery is needed here.
     yield
 
 app = FastAPI(title="Pioneer Square", lifespan=lifespan)
@@ -52,19 +35,14 @@ app.add_middleware(
 )
 
 DB_PATH = "pioneer_square.db"
-REPOS_DIR = os.environ.get("PIONEER_REPOS", "/tmp/pioneer-repos")
-WORK_DIR  = os.environ.get("PIONEER_WORK",  "/tmp/pioneer-work")
 
 # In-memory WebSocket connections: session_id -> list of WebSocket
 connections: Dict[str, List[WebSocket]] = {}
 
 # Running agent subprocesses: agent_id -> asyncio.subprocess.Process
+# Used only by /agents/{id}/run (one-off claude/codex/pi invocations).
+# Worker subprocesses live in the standalone /worker process.
 running_processes: Dict[str, asyncio.subprocess.Process] = {}
-
-# Worker state (not persisted across restarts)
-worker_configs:     Dict[str, dict]           = {}   # worker_id -> {session_id, repos, token}
-worker_task_queues: Dict[str, asyncio.Queue]  = {}   # worker_id -> Queue[task_dict]
-worker_loops:       Dict[str, asyncio.Task]   = {}   # worker_id -> asyncio.Task
 
 # Foreman AI conversation history per session
 foreman_conversations: Dict[str, List[dict]] = {}    # session_id -> messages list
@@ -166,311 +144,9 @@ class TaskCreate(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Git helpers
+# Worker tasks live in the standalone /worker package; this backend only
+# persists worker/task state and dispatches assignments over WebSocket.
 # ---------------------------------------------------------------------------
-
-async def _run_git(args: list, cwd: str = None) -> tuple[int, str, str]:
-    proc = await asyncio.create_subprocess_exec(
-        "git", *args,
-        cwd=cwd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await proc.communicate()
-    return proc.returncode, stdout.decode(errors="replace"), stderr.decode(errors="replace")
-
-
-async def _ensure_repo(repo_full: str, token: str = None) -> Optional[str]:
-    """Clone repo if not present; otherwise pull latest main. Returns local path or None."""
-    parts = repo_full.split("/", 1)
-    if len(parts) != 2:
-        return None
-    owner, name = parts
-    local_path = os.path.join(REPOS_DIR, owner, name)
-
-    if token:
-        remote_url = f"https://{token}@github.com/{repo_full}.git"
-    else:
-        remote_url = f"https://github.com/{repo_full}.git"
-
-    if not os.path.exists(os.path.join(local_path, ".git")):
-        os.makedirs(os.path.dirname(local_path), exist_ok=True)
-        rc, _, err = await _run_git(["clone", remote_url, local_path])
-        if rc != 0:
-            return None
-    else:
-        # Fetch + fast-forward default branch
-        await _run_git(["fetch", "origin"], cwd=local_path)
-        await _run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
-
-    return local_path
-
-
-async def _create_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
-    """Create a git worktree at wt_path on a new branch from origin/HEAD."""
-    os.makedirs(os.path.dirname(wt_path), exist_ok=True)
-    # Fetch so origin/HEAD is current
-    await _run_git(["fetch", "origin"], cwd=repo_path)
-    rc, _, _ = await _run_git(
-        ["worktree", "add", "-b", branch, wt_path, "origin/HEAD"],
-        cwd=repo_path,
-    )
-    return rc == 0
-
-
-async def _pull_repos(session_id: str, worker_id: str, repos: list, token: str = None):
-    for repo_full in repos:
-        parts = repo_full.split("/", 1)
-        if len(parts) != 2:
-            continue
-        owner, name = parts
-        local_path = os.path.join(REPOS_DIR, owner, name)
-        if not os.path.exists(os.path.join(local_path, ".git")):
-            await _emit_terminal_line(session_id, worker_id, f"[worker] Cloning {repo_full}...")
-            await _ensure_repo(repo_full, token)
-        else:
-            rc, _, err = await _run_git(["fetch", "origin"], cwd=local_path)
-            await _run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
-            msg = f"[worker] Pulled {repo_full}" if rc == 0 else f"[worker] Pull warn {repo_full}: {err.strip()[:60]}"
-            await _emit_terminal_line(session_id, worker_id, msg)
-
-
-# ---------------------------------------------------------------------------
-# Claude auto-mode runner
-# ---------------------------------------------------------------------------
-
-async def _run_claude_auto(
-    session_id: str, worker_id: str, task_id: str, description: str, cwd: str
-) -> tuple[bool, str]:
-    """Run `claude --dangerously-skip-permissions` on *description* in *cwd*.
-    Streams output as terminal lines. Returns (success, last_assistant_text)."""
-    cmd = [
-        "claude",
-        "--output-format", "stream-json",
-        "--max-turns", "50",
-        "--dangerously-skip-permissions",
-        "-p", description,
-    ]
-    await _emit_terminal_line(session_id, worker_id, f"[claude] Starting: {description[:80]}")
-    key = f"{worker_id}:{task_id}"
-    last_text = ""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=cwd,
-            stdin=asyncio.subprocess.PIPE,   # keep open so foreman can inject messages
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        running_processes[key] = proc
-
-        async for raw in proc.stdout:
-            line_str = raw.decode(errors="replace").strip()
-            if not line_str:
-                continue
-            try:
-                event = json.loads(line_str)
-                text = _parse_event("claude", event, "")
-                if text:
-                    await _emit_terminal_line(session_id, worker_id, text)
-                    # Track last substantive assistant message for escalation context
-                    if not text.startswith(("▶", "✓", "✗", "[")):
-                        last_text = text
-            except json.JSONDecodeError:
-                await _emit_terminal_line(session_id, worker_id, line_str)
-
-        exit_code = await proc.wait()
-        return exit_code == 0, last_text
-    except Exception as exc:
-        await _emit_terminal_line(session_id, worker_id, f"[claude] ✗ {exc}")
-        return False, last_text
-    finally:
-        running_processes.pop(key, None)
-
-
-# ---------------------------------------------------------------------------
-# Git push + GitHub PR creation
-# ---------------------------------------------------------------------------
-
-async def _push_and_pr(
-    session_id: str,
-    worker_id: str,
-    task: dict,
-    branch: str,
-    worktree_path: str,
-    token: str = None,
-) -> Optional[str]:
-    """Push branch to origin, create a GitHub PR. Returns PR URL or None."""
-    await _emit_terminal_line(session_id, worker_id, f"[worker] Pushing {branch}...")
-    rc, _, err = await _run_git(["push", "-u", "origin", branch], cwd=worktree_path)
-    if rc != 0:
-        await _emit_terminal_line(session_id, worker_id, f"[worker] ✗ Push failed: {err.strip()[:120]}")
-        return None
-    await _emit_terminal_line(session_id, worker_id, f"[worker] ✓ Pushed {branch}")
-
-    if not token:
-        return None
-
-    # Resolve repo from task or worktree remote
-    repo_full = task.get("issue_repo")
-    if not repo_full:
-        rc2, url, _ = await _run_git(["remote", "get-url", "origin"], cwd=worktree_path)
-        if rc2 == 0:
-            m = re.search(r"github\.com[:/](.+?/[^/\s]+?)(?:\.git)?$", url.strip())
-            if m:
-                repo_full = m.group(1)
-    if not repo_full:
-        return None
-
-    issue_ref = f"\n\nCloses #{task['issue_number']}" if task.get("issue_number") else ""
-    body = f"Automated by Pioneer Square worker agent.{issue_ref}"
-    payload = json.dumps({
-        "title": task["description"][:72],
-        "body": body,
-        "head": branch,
-        "base": "main",
-    }).encode()
-
-    def _create_pr():
-        req = urllib.request.Request(
-            f"https://api.github.com/repos/{repo_full}/pulls",
-            data=payload,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github.v3+json",
-                "Content-Type": "application/json",
-            },
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            return json.loads(resp.read())
-
-    try:
-        result = await asyncio.to_thread(_create_pr)
-        pr_url = result.get("html_url", "")
-        await _emit_terminal_line(session_id, worker_id, f"[worker] ✓ PR: {pr_url}")
-        await broadcast(session_id, {
-            "type": "task-complete",
-            "workerId": worker_id,
-            "taskId": task["id"],
-            "prUrl": pr_url,
-            "branch": branch,
-            "description": task["description"],
-        })
-        return pr_url
-    except Exception as exc:
-        await _emit_terminal_line(session_id, worker_id, f"[worker] PR failed: {exc}")
-        return None
-
-
-# ---------------------------------------------------------------------------
-# Worker loop + task execution
-# ---------------------------------------------------------------------------
-
-async def _execute_worker_task(session_id: str, worker_id: str, task: dict):
-    task_id   = task["id"]
-    desc      = task["description"]
-    config    = worker_configs.get(worker_id, {})
-    repos     = config.get("repos", [])
-    token     = config.get("token")
-
-    await _set_agent_state(session_id, worker_id, "working")
-    db = await get_db()
-    await db.execute("UPDATE tasks SET state='working' WHERE id=?", (task_id,))
-    await db.commit()
-    await db.close()
-
-    # Build branch name from description
-    slug   = re.sub(r"[^a-z0-9]+", "-", desc[:40].lower()).strip("-")
-    branch = f"claude/{slug}-{task_id[:6]}"
-
-    work_dir = os.path.join(WORK_DIR, session_id, worker_id, task_id)
-    os.makedirs(work_dir, exist_ok=True)
-
-    await _emit_terminal_line(session_id, worker_id, f"[worker] Task: {desc}")
-    await _emit_terminal_line(session_id, worker_id, f"[worker] Branch: {branch}")
-
-    # Clone/pull each repo and create a worktree
-    worktree_entries: list[tuple[str, str, str]] = []  # (repo_full, repo_path, wt_path)
-    primary_wt = None
-
-    for repo_full in repos:
-        await _emit_terminal_line(session_id, worker_id, f"[worker] Preparing {repo_full}...")
-        repo_path = await _ensure_repo(repo_full, token)
-        if not repo_path:
-            await _emit_terminal_line(session_id, worker_id, f"[worker] ✗ Clone failed: {repo_full}")
-            continue
-        repo_name = repo_full.split("/")[-1]
-        wt_path   = os.path.join(work_dir, repo_name)
-        ok        = await _create_worktree(repo_path, wt_path, branch)
-        if ok:
-            worktree_entries.append((repo_full, repo_path, wt_path))
-            if primary_wt is None:
-                primary_wt = wt_path
-        else:
-            await _emit_terminal_line(session_id, worker_id, f"[worker] ✗ Worktree failed: {repo_full}")
-
-    if not primary_wt:
-        await _emit_terminal_line(session_id, worker_id, "[worker] ✗ No worktrees — aborting.")
-        await _set_agent_state(session_id, worker_id, "error")
-        db = await get_db()
-        await db.execute(
-            "UPDATE tasks SET state='failed', finished_at=? WHERE id=?",
-            (datetime.now(timezone.utc).isoformat(), task_id),
-        )
-        await db.commit()
-        await db.close()
-        return
-
-    db = await get_db()
-    await db.execute(
-        "UPDATE tasks SET worktree_path=?, branch=? WHERE id=?",
-        (primary_wt, branch, task_id),
-    )
-    await db.commit()
-    await db.close()
-
-    success, last_msg = await _run_claude_auto(session_id, worker_id, task_id, desc, primary_wt)
-    finished_at = datetime.now(timezone.utc).isoformat()
-
-    if success:
-        pr_url = await _push_and_pr(session_id, worker_id, task, branch, primary_wt, token)
-        db = await get_db()
-        await db.execute(
-            "UPDATE tasks SET state='done', pr_url=?, finished_at=? WHERE id=?",
-            (pr_url, finished_at, task_id),
-        )
-        await db.commit()
-        await db.close()
-        await _set_agent_state(session_id, worker_id, "idle")
-    else:
-        db = await get_db()
-        await db.execute(
-            "UPDATE tasks SET state='failed', finished_at=? WHERE id=?",
-            (finished_at, task_id),
-        )
-        await db.commit()
-        await db.close()
-        await _set_agent_state(session_id, worker_id, "error")
-        # Broadcast needs-input so the frontend surfaces it
-        await broadcast(session_id, {
-            "type": "needs-input",
-            "workerId": worker_id,
-            "taskId": task_id,
-            "description": desc,
-            "lastMessage": last_msg,
-        })
-        # Also route escalation through the foreman AI so it can advise the human
-        escalation = (
-            f"Worker {worker_id} failed on task: \"{desc}\""
-            + (f"\n\nLast output: {last_msg}" if last_msg else "")
-        )
-        asyncio.create_task(_run_foreman_ai(session_id, escalation,
-                                            extra_context=f"ESCALATION from worker {worker_id}"))
-
-    # Remove worktrees
-    for repo_full, repo_path, wt_path in worktree_entries:
-        await _run_git(["worktree", "remove", "--force", wt_path], cwd=repo_path)
 
 
 FOREMAN_SYSTEM = """\
@@ -542,43 +218,43 @@ async def _foreman_exec_tools(session_id: str, tool_uses: list) -> list:
             desc = inp["description"]
             task_id    = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
             created_at = datetime.now(timezone.utc).isoformat()
-            task = {
-                "id": task_id, "worker_id": wid, "session_id": session_id,
-                "description": desc,
-                "issue_number": inp.get("issue_number"),
-                "issue_repo": inp.get("issue_repo"),
-            }
             db = await get_db()
             try:
-                await db.execute(
-                    "INSERT INTO tasks (id, worker_id, session_id, description, issue_number,"
-                    " issue_repo, state, created_at) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)",
-                    (task_id, wid, session_id, desc, inp.get("issue_number"), inp.get("issue_repo"), created_at),
-                )
-                await db.commit()
+                async with db.execute(
+                    "SELECT 1 FROM workers WHERE id=? AND session_id=?", (wid, session_id)
+                ) as cur:
+                    worker_row = await cur.fetchone()
+                if not worker_row:
+                    result_text = f"Worker {wid} not found — task NOT queued."
+                else:
+                    await db.execute(
+                        "INSERT INTO tasks (id, worker_id, session_id, description, issue_number,"
+                        " issue_repo, state, created_at) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)",
+                        (task_id, wid, session_id, desc, inp.get("issue_number"), inp.get("issue_repo"), created_at),
+                    )
+                    await db.commit()
+                    await broadcast(session_id, {
+                        "type": "task-assigned",
+                        "workerId": wid,
+                        "taskId": task_id,
+                        "description": desc,
+                        "issueNumber": inp.get("issue_number"),
+                        "issueRepo": inp.get("issue_repo"),
+                    })
+                    result_text = f"Task {task_id} queued for {wid}."
             finally:
                 await db.close()
-            if wid in worker_task_queues:
-                await worker_task_queues[wid].put(task)
-                await broadcast(session_id, {"type": "task-assigned", "workerId": wid,
-                                             "taskId": task_id, "description": desc})
-                result_text = f"Task {task_id} queued for {wid}."
-            else:
-                result_text = f"Worker {wid} not found — task NOT queued."
 
         elif tu.name == "message_worker":
             wid = inp["worker_id"]
             msg = inp["message"]
             await _emit_terminal_line(session_id, wid, f"[foreman] {msg}")
-            # If worker has a running subprocess with an open stdin, inject the message
-            for key, proc in running_processes.items():
-                if key.startswith(wid + ":") and proc.stdin and not proc.stdin.is_closing():
-                    try:
-                        proc.stdin.write((msg + "\n").encode())
-                        await proc.stdin.drain()
-                    except Exception:
-                        pass
-                    break
+            # The worker process picks this up over its session WebSocket.
+            await broadcast(session_id, {
+                "type": "worker-message",
+                "workerId": wid,
+                "message": msg,
+            })
             result_text = f"Message delivered to {wid}."
 
         results.append({"type": "tool_result", "tool_use_id": tu.id, "content": result_text})
@@ -688,32 +364,6 @@ async def _run_foreman_ai(session_id: str, human_message: str, extra_context: st
             "type": "chat", "from": "foreman", "to": "user",
             "content": f"Foreman error: {exc}", "createdAt": now,
         })
-
-
-async def _worker_loop(session_id: str, worker_id: str):
-    """Persistent worker loop: process task queue; periodically pull repos."""
-    queue = worker_task_queues[worker_id]
-    PULL_INTERVAL = 300  # seconds
-    last_pull: float = 0.0
-
-    await _emit_terminal_line(session_id, worker_id, "[worker] Online. Watching for tasks.")
-
-    while True:
-        try:
-            task = await asyncio.wait_for(queue.get(), timeout=60.0)
-            await _execute_worker_task(session_id, worker_id, task)
-        except asyncio.TimeoutError:
-            loop_time = asyncio.get_event_loop().time()
-            if loop_time - last_pull >= PULL_INTERVAL:
-                config = worker_configs.get(worker_id, {})
-                repos  = config.get("repos", [])
-                token  = config.get("token")
-                if repos:
-                    await _pull_repos(session_id, worker_id, repos, token)
-                last_pull = loop_time
-        except asyncio.CancelledError:
-            await _emit_terminal_line(session_id, worker_id, "[worker] Shutting down.")
-            break
 
 
 @app.post("/sessions")
@@ -883,6 +533,38 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                     "line": line,
                     "timestamp": created_at
                 })
+
+            elif msg_type == "worker-register":
+                # A standalone worker process is announcing/refreshing its config.
+                worker_id = data.get("workerId")
+                repos = data.get("repos") or []
+                if worker_id:
+                    await db.execute(
+                        "UPDATE workers SET repos=? WHERE id=? AND session_id=?",
+                        (json.dumps(repos), worker_id, session_id),
+                    )
+                    await db.commit()
+
+            elif msg_type == "task-update":
+                # Worker is reporting a task state change; persist + rebroadcast.
+                task_id = data.get("taskId")
+                if task_id:
+                    fields: list[tuple[str, object]] = []
+                    for src, col in (
+                        ("state", "state"),
+                        ("branch", "branch"),
+                        ("worktreePath", "worktree_path"),
+                        ("prUrl", "pr_url"),
+                        ("finishedAt", "finished_at"),
+                    ):
+                        if src in data:
+                            fields.append((col, data[src]))
+                    if fields:
+                        sql = "UPDATE tasks SET " + ", ".join(f"{c}=?" for c, _ in fields) + " WHERE id=?"
+                        params = [v for _, v in fields] + [task_id]
+                        await db.execute(sql, params)
+                        await db.commit()
+                    await broadcast(session_id, data, exclude=websocket)
 
             elif msg_type in ("offer", "answer", "ice-candidate"):
                 # WebRTC signaling - forward to all
@@ -1159,7 +841,8 @@ async def stop_agent_run(session_id: str, agent_id: str):
 
 @app.post("/sessions/{session_id}/workers")
 async def create_worker(session_id: str, data: WorkerCreate):
-    """Register a worker agent and start its persistent loop."""
+    """Register a worker agent. The actual worker process must connect via WebSocket
+    using the returned id (see the standalone /worker package)."""
     worker_id   = "w-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
     created_at  = datetime.now(timezone.utc).isoformat()
     worker_name = f"Worker-{worker_id[2:6]}"
@@ -1172,27 +855,19 @@ async def create_worker(session_id: str, data: WorkerCreate):
         )
         await db.execute(
             "INSERT OR REPLACE INTO agents (id, session_id, name, type, state, joined_at)"
-            " VALUES (?, ?, ?, 'worker', 'idle', ?)",
+            " VALUES (?, ?, ?, 'worker', 'offline', ?)",
             (worker_id, session_id, worker_name, created_at),
         )
         await db.commit()
     finally:
         await db.close()
 
-    worker_configs[worker_id] = {
-        "session_id": session_id,
-        "repos": data.repos,
-        "token": data.github_token,
-    }
-    worker_task_queues[worker_id] = asyncio.Queue()
-    worker_loops[worker_id] = asyncio.create_task(_worker_loop(session_id, worker_id))
-
     await broadcast(session_id, {
         "type": "agent-joined",
         "agentId": worker_id,
         "agentName": worker_name,
         "agentType": "worker",
-        "state": "idle",
+        "state": "offline",
         "joinedAt": created_at,
     })
     return {"id": worker_id, "name": worker_name, "repos": data.repos, "created_at": created_at}
@@ -1213,12 +888,17 @@ async def list_workers(session_id: str):
 
 @app.post("/sessions/{session_id}/workers/{worker_id}/tasks")
 async def assign_task(session_id: str, worker_id: str, data: TaskCreate):
-    """Queue a task for the specified worker."""
+    """Persist a task and broadcast a task-assigned event for the worker process."""
     task_id    = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
     created_at = datetime.now(timezone.utc).isoformat()
 
     db = await get_db()
     try:
+        async with db.execute(
+            "SELECT 1 FROM workers WHERE id=? AND session_id=?", (worker_id, session_id)
+        ) as cur:
+            if not await cur.fetchone():
+                raise HTTPException(status_code=404, detail="Worker not found")
         await db.execute(
             "INSERT INTO tasks (id, worker_id, session_id, description, issue_number, issue_repo, state, created_at)"
             " VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)",
@@ -1228,23 +908,14 @@ async def assign_task(session_id: str, worker_id: str, data: TaskCreate):
     finally:
         await db.close()
 
-    task = {
-        "id": task_id,
-        "worker_id": worker_id,
-        "session_id": session_id,
+    await broadcast(session_id, {
+        "type": "task-assigned",
+        "workerId": worker_id,
+        "taskId": task_id,
         "description": data.description,
-        "issue_number": data.issue_number,
-        "issue_repo": data.issue_repo,
-    }
-
-    if worker_id in worker_task_queues:
-        await worker_task_queues[worker_id].put(task)
-        await broadcast(session_id, {
-            "type": "task-assigned",
-            "workerId": worker_id,
-            "taskId": task_id,
-            "description": data.description,
-        })
+        "issueNumber": data.issue_number,
+        "issueRepo": data.issue_repo,
+    })
 
     return {"id": task_id, "worker_id": worker_id, "state": "pending"}
 
@@ -1269,23 +940,15 @@ class WorkerMessage(BaseModel):
 
 @app.post("/sessions/{session_id}/workers/{worker_id}/message")
 async def message_worker(session_id: str, worker_id: str, data: WorkerMessage):
-    """Send a message to a worker's terminal; inject into stdin if a task is running."""
+    """Forward a message to a worker process via its session WebSocket."""
     text = data.message.strip()
     if not text:
         raise HTTPException(status_code=400, detail="Empty message")
 
     await _emit_terminal_line(session_id, worker_id, f"[foreman → worker] {text}")
-
-    # Try to write to an active claude subprocess stdin
-    injected = False
-    for key, proc in running_processes.items():
-        if key.startswith(worker_id + ":") and proc.stdin and not proc.stdin.is_closing():
-            try:
-                proc.stdin.write((text + "\n").encode())
-                await proc.stdin.drain()
-                injected = True
-            except Exception:
-                pass
-            break
-
-    return {"status": "delivered", "injected": injected}
+    await broadcast(session_id, {
+        "type": "worker-message",
+        "workerId": worker_id,
+        "message": text,
+    })
+    return {"status": "delivered"}

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,79 @@
+# Pioneer Square Worker
+
+Standalone worker agent for [Pioneer Square](../README.md). Connects to a backend
+session over WebSocket, listens for task assignments, runs
+`claude --dangerously-skip-permissions` against a fresh git worktree, then
+pushes the result and opens a GitHub PR.
+
+The worker is a separate process from the backend so it can run on a different
+machine — typically one with the cloned repos, a `claude` CLI install, and a
+GitHub token.
+
+## Install
+
+```bash
+cd worker
+python -m venv venv
+source venv/bin/activate
+pip install -e .
+```
+
+This installs the `pioneer-worker` console script.
+
+## Configure
+
+Copy the example config and edit it:
+
+```bash
+cp pioneer-worker.toml.example pioneer-worker.toml
+$EDITOR pioneer-worker.toml
+```
+
+Required keys:
+
+- `backend_url` — `http://host:port` (or `ws://...`); the worker derives the
+  WebSocket URL automatically.
+- `session_id` — the 6-char session id from the Pioneer Square UI.
+- `[github] repos` — list of `owner/repo` strings the worker may operate on.
+
+Optional:
+
+- `worker_id` — pre-existing worker id from the backend. If omitted, the worker
+  registers itself on first launch and writes the assigned id to
+  `.pioneer-worker.state.json` next to the config.
+- `[github] token` — inline token, or `"env:VAR"` to read from the environment.
+  Required to push and open PRs against private repos.
+
+## Run
+
+```bash
+pioneer-worker                       # reads ./pioneer-worker.toml
+pioneer-worker --config /path.toml   # explicit path
+pioneer-worker --log-level DEBUG     # verbose
+```
+
+The worker stays running, reconnecting if the backend restarts.
+
+## How it works
+
+1. On startup, registers (or claims) a worker id with the backend.
+2. Opens a WebSocket to `/ws/{session_id}` and announces itself with `join`
+   and `worker-register` messages.
+3. Fetches any pending tasks via REST so it can resume work across restarts.
+4. Listens for `task-assigned` messages whose `workerId` matches its own id.
+5. For each task: clones the configured repos under `repos_dir`, creates a
+   worktree under `work_dir`, runs `claude` in the worktree, then pushes the
+   branch and opens a PR via the GitHub API.
+6. Reports state changes (`working`, `done`, `failed`, branch, PR url) back
+   to the backend via `task-update` WebSocket messages.
+
+## Multiple workers
+
+Run more than one worker against the same session by giving each its own
+config directory (so the sidecar state file doesn't collide):
+
+```bash
+mkdir -p ~/.pioneer/builder ~/.pioneer/tester
+pioneer-worker --config ~/.pioneer/builder/pioneer-worker.toml &
+pioneer-worker --config ~/.pioneer/tester/pioneer-worker.toml  &
+```

--- a/worker/README.md
+++ b/worker/README.md
@@ -40,7 +40,7 @@ Optional:
 
 - `worker_id` — pre-existing worker id from the backend. If omitted, the worker
   registers itself on first launch and writes the assigned id to
-  `.pioneer-worker.state.json` next to the config.
+  `pioneer-worker.state.json` next to the config.
 - `[github] token` — inline token, or `"env:VAR"` to read from the environment.
   Required to push and open PRs against private repos.
 

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -12,7 +12,7 @@ session_id = "abc123"
 # worker_name = "Builder"
 
 # Optional pre-assigned worker id. If omitted, the worker registers with the
-# backend on startup and writes the assigned id to .pioneer-worker.state.json.
+# backend on startup and writes the assigned id to pioneer-worker.state.json.
 # worker_id = "w-myname"
 
 # Pull repos in the background every N seconds while idle.

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -1,0 +1,34 @@
+# Example Pioneer Square worker configuration.
+# Copy to pioneer-worker.toml and edit for your environment.
+
+# Backend URL (http or ws scheme; the worker derives the WebSocket URL automatically).
+backend_url = "http://localhost:8000"
+
+# Session this worker joins. Create a session via the UI (or POST /sessions)
+# and paste the 6-char id here.
+session_id = "abc123"
+
+# Optional human-readable name shown in the UI. Auto-generated if absent.
+# worker_name = "Builder"
+
+# Optional pre-assigned worker id. If omitted, the worker registers with the
+# backend on startup and writes the assigned id to .pioneer-worker.state.json.
+# worker_id = "w-myname"
+
+# Pull repos in the background every N seconds while idle.
+pull_interval = 300
+
+[github]
+# Repos this worker will clone and operate on.
+repos = ["owner/repo"]
+
+# GitHub token for cloning private repos and opening pull requests.
+# Use "env:VAR_NAME" to read from an environment variable instead of inlining.
+token = "env:GITHUB_TOKEN"
+
+[paths]
+repos_dir = "/tmp/pioneer-repos"
+work_dir = "/tmp/pioneer-work"
+
+[claude]
+max_turns = 50

--- a/worker/pioneer_worker/__init__.py
+++ b/worker/pioneer_worker/__init__.py
@@ -1,0 +1,9 @@
+"""Pioneer Square worker agent.
+
+Standalone process that connects to a Pioneer Square backend over WebSocket,
+listens for task assignments, clones the configured repos into git worktrees,
+runs `claude --dangerously-skip-permissions` on each task, and pushes the
+result as a GitHub pull request.
+"""
+
+__version__ = "0.1.0"

--- a/worker/pioneer_worker/__main__.py
+++ b/worker/pioneer_worker/__main__.py
@@ -1,0 +1,4 @@
+from pioneer_worker.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -1,0 +1,118 @@
+"""Run `claude --dangerously-skip-permissions` on a task and stream output."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+EmitFn = Callable[[str], Awaitable[None]]
+
+
+def parse_claude_event(event: dict) -> Optional[str]:
+    """Extract a human-readable line from one stream-JSON event."""
+    t = event.get("type")
+    if t == "assistant":
+        parts: list[str] = []
+        for blk in event.get("message", {}).get("content", []):
+            if blk.get("type") == "text":
+                txt = blk.get("text", "").strip()
+                if txt:
+                    parts.append(txt)
+            elif blk.get("type") == "tool_use":
+                name = blk.get("name", "")
+                inp = blk.get("input", {})
+                if name == "Bash":
+                    parts.append(f"▶ bash: {inp.get('command', '')[:120]}")
+                elif name in ("Read", "Write", "Edit"):
+                    fp = inp.get("file_path", inp.get("path", ""))
+                    parts.append(f"▶ {name.lower()}: {fp}")
+                else:
+                    parts.append(f"▶ {name}: {json.dumps(inp)[:80]}")
+        return "\n".join(parts) or None
+    if t == "result":
+        subtype = event.get("subtype", "success")
+        turns = event.get("num_turns", 0)
+        cost = event.get("cost_usd")
+        cost_str = f" (${cost:.4f})" if cost else ""
+        if subtype == "success":
+            return f"✓ Done in {turns} turns{cost_str}"
+        return f"✗ {subtype}: {event.get('error', '')}"
+    if t == "system" and event.get("subtype") == "init":
+        tools = event.get("tools", [])
+        return f"[claude] tools: {', '.join(tools[:6])}"
+    return None
+
+
+class ClaudeProcess:
+    """Wraps a running claude subprocess so the worker can inject stdin messages."""
+
+    def __init__(self, proc: asyncio.subprocess.Process) -> None:
+        self.proc = proc
+
+    async def send_message(self, text: str) -> bool:
+        if self.proc.stdin is None or self.proc.stdin.is_closing():
+            return False
+        try:
+            self.proc.stdin.write((text + "\n").encode())
+            await self.proc.stdin.drain()
+            return True
+        except Exception:
+            return False
+
+
+async def run_claude_auto(
+    description: str,
+    cwd: str,
+    *,
+    max_turns: int,
+    emit: EmitFn,
+    on_proc: Optional[Callable[[ClaudeProcess], None]] = None,
+) -> tuple[bool, str]:
+    """Run claude on *description* in *cwd*. Returns (success, last_assistant_text)."""
+    cmd = [
+        "claude",
+        "--output-format", "stream-json",
+        "--max-turns", str(max_turns),
+        "--dangerously-skip-permissions",
+        "-p", description,
+    ]
+    await emit(f"[claude] Starting: {description[:80]}")
+    last_text = ""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=cwd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        if on_proc is not None:
+            on_proc(ClaudeProcess(proc))
+
+        async for raw in proc.stdout:  # type: ignore[union-attr]
+            line_str = raw.decode(errors="replace").strip()
+            if not line_str:
+                continue
+            try:
+                event = json.loads(line_str)
+            except json.JSONDecodeError:
+                await emit(line_str)
+                continue
+            text = parse_claude_event(event)
+            if text:
+                await emit(text)
+                if not text.startswith(("▶", "✓", "✗", "[")):
+                    last_text = text
+
+        exit_code = await proc.wait()
+        return exit_code == 0, last_text
+    except FileNotFoundError:
+        await emit("[claude] ✗ `claude` CLI not found on PATH")
+        return False, last_text
+    except Exception as exc:  # pragma: no cover
+        await emit(f"[claude] ✗ {exc}")
+        return False, last_text

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -1,0 +1,58 @@
+"""Pioneer Square worker CLI entry point."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from typing import Optional
+
+from . import __version__, config as config_mod
+from .worker import Worker
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pioneer-worker",
+        description="Run a Pioneer Square worker agent that connects to the backend over WebSocket.",
+    )
+    parser.add_argument(
+        "--config", "-c",
+        help="Path to the TOML config file (default: ./pioneer-worker.toml).",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging verbosity (default: INFO).",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"pioneer-worker {__version__}",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=args.log_level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    try:
+        cfg = config_mod.load(args.config)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    worker = Worker(cfg)
+    try:
+        asyncio.run(worker.run())
+    except KeyboardInterrupt:
+        print("\nShutting down.", file=sys.stderr)
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -1,0 +1,129 @@
+"""Configuration for the Pioneer Square worker.
+
+Reads a TOML file (default: ``./pioneer-worker.toml``) and a sidecar JSON
+state file (``.pioneer-worker.state.json`` next to the config) used to
+persist runtime values like the worker id assigned by the backend.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse, urlunparse
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+
+DEFAULT_CONFIG_NAME = "pioneer-worker.toml"
+STATE_SUFFIX = ".state.json"
+
+
+@dataclass
+class Config:
+    backend_url: str
+    session_id: str
+    repos: list[str] = field(default_factory=list)
+    worker_id: Optional[str] = None
+    worker_name: Optional[str] = None
+    github_token: Optional[str] = None
+    repos_dir: str = "/tmp/pioneer-repos"
+    work_dir: str = "/tmp/pioneer-work"
+    pull_interval: float = 300.0
+    claude_max_turns: int = 50
+
+    config_path: Path = field(default_factory=Path)
+    state_path: Path = field(default_factory=Path)
+
+    @property
+    def http_url(self) -> str:
+        """Backend HTTP URL derived from backend_url."""
+        parsed = urlparse(self.backend_url)
+        scheme = {"ws": "http", "wss": "https"}.get(parsed.scheme, parsed.scheme or "http")
+        return urlunparse((scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+
+    @property
+    def ws_url(self) -> str:
+        """Backend WebSocket URL for this session."""
+        parsed = urlparse(self.backend_url)
+        scheme = {"http": "ws", "https": "wss"}.get(parsed.scheme, parsed.scheme or "ws")
+        base = urlunparse((scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+        return f"{base}/ws/{self.session_id}"
+
+
+def _resolve_config_path(explicit: Optional[str]) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    return Path.cwd() / DEFAULT_CONFIG_NAME
+
+
+def load(explicit_path: Optional[str] = None) -> Config:
+    """Load config from TOML, layered with optional sidecar state and env vars."""
+    cfg_path = _resolve_config_path(explicit_path)
+    if not cfg_path.exists():
+        raise FileNotFoundError(
+            f"Worker config not found at {cfg_path}. "
+            "Create one (see pioneer-worker.toml.example) or pass --config."
+        )
+
+    with cfg_path.open("rb") as fh:
+        raw = tomllib.load(fh)
+
+    state_path = cfg_path.with_name(cfg_path.stem + STATE_SUFFIX)
+    state: dict = {}
+    if state_path.exists():
+        try:
+            state = json.loads(state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            state = {}
+
+    backend_url = raw.get("backend_url") or os.environ.get("PIONEER_BACKEND_URL")
+    session_id = raw.get("session_id") or os.environ.get("PIONEER_SESSION_ID")
+    if not backend_url:
+        raise ValueError("backend_url is required (in config or PIONEER_BACKEND_URL).")
+    if not session_id:
+        raise ValueError("session_id is required (in config or PIONEER_SESSION_ID).")
+
+    github_block = raw.get("github") or {}
+    paths_block = raw.get("paths") or {}
+    claude_block = raw.get("claude") or {}
+
+    token = github_block.get("token")
+    if isinstance(token, str) and token.startswith("env:"):
+        token = os.environ.get(token[4:].strip()) or None
+    elif token is None:
+        token = os.environ.get("PIONEER_GITHUB_TOKEN")
+
+    return Config(
+        backend_url=backend_url.rstrip("/"),
+        session_id=session_id,
+        repos=list(github_block.get("repos") or raw.get("repos") or []),
+        worker_id=state.get("worker_id") or raw.get("worker_id"),
+        worker_name=raw.get("worker_name"),
+        github_token=token,
+        repos_dir=paths_block.get("repos_dir", "/tmp/pioneer-repos"),
+        work_dir=paths_block.get("work_dir", "/tmp/pioneer-work"),
+        pull_interval=float(raw.get("pull_interval", 300.0)),
+        claude_max_turns=int(claude_block.get("max_turns", 50)),
+        config_path=cfg_path,
+        state_path=state_path,
+    )
+
+
+def save_worker_id(cfg: Config, worker_id: str) -> None:
+    """Persist the assigned worker_id to the sidecar state file."""
+    state: dict = {}
+    if cfg.state_path.exists():
+        try:
+            state = json.loads(cfg.state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            state = {}
+    state["worker_id"] = worker_id
+    cfg.state_path.write_text(json.dumps(state, indent=2) + "\n")
+    cfg.worker_id = worker_id

--- a/worker/pioneer_worker/git_ops.py
+++ b/worker/pioneer_worker/git_ops.py
@@ -1,0 +1,84 @@
+"""Async git helpers used by the worker."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Awaitable, Callable, Optional
+
+EmitFn = Callable[[str], Awaitable[None]]
+
+
+async def run_git(args: list[str], cwd: Optional[str] = None) -> tuple[int, str, str]:
+    proc = await asyncio.create_subprocess_exec(
+        "git", *args,
+        cwd=cwd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    return proc.returncode, stdout.decode(errors="replace"), stderr.decode(errors="replace")
+
+
+async def ensure_repo(repos_dir: str, repo_full: str, token: Optional[str] = None) -> Optional[str]:
+    """Clone repo if absent, otherwise fast-forward to origin/HEAD. Returns local path."""
+    parts = repo_full.split("/", 1)
+    if len(parts) != 2:
+        return None
+    owner, name = parts
+    local_path = os.path.join(repos_dir, owner, name)
+
+    remote_url = (
+        f"https://{token}@github.com/{repo_full}.git" if token
+        else f"https://github.com/{repo_full}.git"
+    )
+
+    if not os.path.exists(os.path.join(local_path, ".git")):
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        rc, _, _ = await run_git(["clone", remote_url, local_path])
+        if rc != 0:
+            return None
+    else:
+        await run_git(["fetch", "origin"], cwd=local_path)
+        await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
+
+    return local_path
+
+
+async def create_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
+    os.makedirs(os.path.dirname(wt_path), exist_ok=True)
+    await run_git(["fetch", "origin"], cwd=repo_path)
+    rc, _, _ = await run_git(
+        ["worktree", "add", "-b", branch, wt_path, "origin/HEAD"],
+        cwd=repo_path,
+    )
+    return rc == 0
+
+
+async def remove_worktree(repo_path: str, wt_path: str) -> None:
+    await run_git(["worktree", "remove", "--force", wt_path], cwd=repo_path)
+
+
+async def pull_repos(
+    repos_dir: str,
+    repos: list[str],
+    token: Optional[str],
+    emit: EmitFn,
+) -> None:
+    """Refresh all configured repos; emit progress through *emit*."""
+    for repo_full in repos:
+        parts = repo_full.split("/", 1)
+        if len(parts) != 2:
+            continue
+        owner, name = parts
+        local_path = os.path.join(repos_dir, owner, name)
+        if not os.path.exists(os.path.join(local_path, ".git")):
+            await emit(f"[worker] Cloning {repo_full}...")
+            await ensure_repo(repos_dir, repo_full, token)
+        else:
+            rc, _, err = await run_git(["fetch", "origin"], cwd=local_path)
+            await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
+            if rc == 0:
+                await emit(f"[worker] Pulled {repo_full}")
+            else:
+                await emit(f"[worker] Pull warn {repo_full}: {err.strip()[:60]}")

--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -1,0 +1,76 @@
+"""Push a branch and open a GitHub pull request."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import urllib.error
+import urllib.request
+from typing import Awaitable, Callable, Optional
+
+from . import git_ops
+
+EmitFn = Callable[[str], Awaitable[None]]
+
+
+async def push_and_open_pr(
+    *,
+    task: dict,
+    branch: str,
+    worktree_path: str,
+    token: Optional[str],
+    emit: EmitFn,
+) -> Optional[str]:
+    """Push *branch* and create a PR. Returns PR URL or None on failure."""
+    await emit(f"[worker] Pushing {branch}...")
+    rc, _, err = await git_ops.run_git(["push", "-u", "origin", branch], cwd=worktree_path)
+    if rc != 0:
+        await emit(f"[worker] ✗ Push failed: {err.strip()[:120]}")
+        return None
+    await emit(f"[worker] ✓ Pushed {branch}")
+
+    if not token:
+        return None
+
+    repo_full = task.get("issue_repo")
+    if not repo_full:
+        rc2, url, _ = await git_ops.run_git(["remote", "get-url", "origin"], cwd=worktree_path)
+        if rc2 == 0:
+            m = re.search(r"github\.com[:/](.+?/[^/\s]+?)(?:\.git)?$", url.strip())
+            if m:
+                repo_full = m.group(1)
+    if not repo_full:
+        return None
+
+    issue_ref = f"\n\nCloses #{task['issue_number']}" if task.get("issue_number") else ""
+    body = f"Automated by Pioneer Square worker agent.{issue_ref}"
+    payload = json.dumps({
+        "title": task["description"][:72],
+        "body": body,
+        "head": branch,
+        "base": "main",
+    }).encode()
+
+    def _create_pr() -> dict:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo_full}/pulls",
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.v3+json",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+
+    try:
+        result = await asyncio.to_thread(_create_pr)
+        pr_url = result.get("html_url", "")
+        await emit(f"[worker] ✓ PR: {pr_url}")
+        return pr_url
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+        await emit(f"[worker] PR failed: {exc}")
+        return None

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1,0 +1,273 @@
+"""Main worker loop: register, listen for tasks over WebSocket, execute, report."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import random
+import re
+import string
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+
+from . import claude_runner, config as config_mod, git_ops, github_pr
+from .ws_client import WSClient
+
+logger = logging.getLogger(__name__)
+
+
+def _gen_task_id() -> str:
+    return "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text[:40].lower()).strip("-")
+
+
+class Worker:
+    def __init__(self, cfg: config_mod.Config) -> None:
+        self.cfg = cfg
+        self.ws = WSClient(cfg.ws_url)
+        self.task_queue: asyncio.Queue[dict] = asyncio.Queue()
+        self.current_claude: Optional[claude_runner.ClaudeProcess] = None
+        self._known_task_ids: set[str] = set()
+
+    # ------------------------------------------------------------------ HTTP
+    async def _http(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(base_url=self.cfg.http_url, timeout=30.0)
+
+    async def _register_if_needed(self) -> None:
+        if self.cfg.worker_id:
+            return
+        async with await self._http() as client:
+            resp = await client.post(
+                f"/sessions/{self.cfg.session_id}/workers",
+                json={"repos": self.cfg.repos, "github_token": None},
+            )
+            resp.raise_for_status()
+            wid = resp.json()["id"]
+        config_mod.save_worker_id(self.cfg, wid)
+        logger.info("Registered new worker id %s", wid)
+
+    async def _fetch_pending_tasks(self) -> list[dict]:
+        async with await self._http() as client:
+            resp = await client.get(
+                f"/sessions/{self.cfg.session_id}/workers/{self.cfg.worker_id}/tasks"
+            )
+            resp.raise_for_status()
+            tasks = resp.json()
+        return [t for t in tasks if t.get("state") in ("pending", "working")]
+
+    # ------------------------------------------------------------------ WS
+    async def _send(self, payload: dict) -> None:
+        await self.ws.send(payload)
+
+    async def _emit(self, line: str) -> None:
+        await self._send({
+            "type": "terminal-output",
+            "agentId": self.cfg.worker_id,
+            "line": line,
+            "timestamp": _now_iso(),
+        })
+
+    async def _set_state(self, state: str) -> None:
+        await self._send({
+            "type": "agent-state",
+            "agentId": self.cfg.worker_id,
+            "state": state,
+        })
+
+    async def _join(self) -> None:
+        name = self.cfg.worker_name or f"Worker-{self.cfg.worker_id[2:6]}"
+        await self._send({
+            "type": "join",
+            "agentId": self.cfg.worker_id,
+            "agentName": name,
+            "agentType": "worker",
+        })
+        await self._send({
+            "type": "worker-register",
+            "workerId": self.cfg.worker_id,
+            "repos": self.cfg.repos,
+        })
+
+    async def _task_update(self, task_id: str, **fields: object) -> None:
+        await self._send({
+            "type": "task-update",
+            "workerId": self.cfg.worker_id,
+            "taskId": task_id,
+            **fields,
+        })
+
+    # ------------------------------------------------------------------ Loop
+    async def run(self) -> None:
+        await self._register_if_needed()
+        assert self.cfg.worker_id, "worker_id must be set after registration"
+
+        await self.ws.connect()
+        await self._join()
+        await self._emit("[worker] Online. Watching for tasks.")
+        await self._set_state("idle")
+
+        for task in await self._fetch_pending_tasks():
+            self._known_task_ids.add(task["id"])
+            await self.task_queue.put(task)
+
+        listener = asyncio.create_task(self._listen())
+        runner = asyncio.create_task(self._task_runner())
+        puller = asyncio.create_task(self._idle_puller())
+        try:
+            await asyncio.gather(listener, runner, puller)
+        finally:
+            await self.ws.close()
+
+    async def _listen(self) -> None:
+        async for msg in self.ws.messages():
+            mtype = msg.get("type")
+            if mtype == "task-assigned":
+                if msg.get("workerId") != self.cfg.worker_id:
+                    continue
+                task_id = msg.get("taskId")
+                if not task_id or task_id in self._known_task_ids:
+                    continue
+                self._known_task_ids.add(task_id)
+                await self.task_queue.put({
+                    "id": task_id,
+                    "worker_id": self.cfg.worker_id,
+                    "session_id": self.cfg.session_id,
+                    "description": msg.get("description", ""),
+                    "issue_number": msg.get("issueNumber"),
+                    "issue_repo": msg.get("issueRepo"),
+                })
+            elif mtype == "worker-message":
+                if msg.get("workerId") != self.cfg.worker_id:
+                    continue
+                text = msg.get("message", "")
+                if self.current_claude and text:
+                    delivered = await self.current_claude.send_message(text)
+                    if delivered:
+                        await self._emit(f"[worker] Injected: {text[:80]}")
+
+    async def _idle_puller(self) -> None:
+        while True:
+            await asyncio.sleep(self.cfg.pull_interval)
+            # Catch tasks that were broadcast while we were briefly disconnected.
+            try:
+                for task in await self._fetch_pending_tasks():
+                    if task["id"] in self._known_task_ids:
+                        continue
+                    self._known_task_ids.add(task["id"])
+                    await self.task_queue.put(task)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Pending-task poll failed: %s", exc)
+            if self.task_queue.empty() and self.current_claude is None and self.cfg.repos:
+                await git_ops.pull_repos(
+                    self.cfg.repos_dir, self.cfg.repos, self.cfg.github_token, self._emit
+                )
+
+    async def _task_runner(self) -> None:
+        while True:
+            task = await self.task_queue.get()
+            try:
+                await self._execute_task(task)
+            except Exception as exc:  # pragma: no cover
+                logger.exception("Task %s crashed: %s", task.get("id"), exc)
+                await self._emit(f"[worker] ✗ Internal error: {exc}")
+                await self._task_update(task["id"], state="failed", finishedAt=_now_iso())
+                await self._set_state("error")
+
+    async def _execute_task(self, task: dict) -> None:
+        task_id = task["id"]
+        desc = task["description"]
+        token = self.cfg.github_token
+        repos = self.cfg.repos
+
+        await self._set_state("working")
+        await self._task_update(task_id, state="working")
+
+        branch = f"claude/{_slug(desc)}-{task_id[:6]}"
+        work_dir = os.path.join(self.cfg.work_dir, self.cfg.session_id, self.cfg.worker_id, task_id)
+        os.makedirs(work_dir, exist_ok=True)
+
+        await self._emit(f"[worker] Task: {desc}")
+        await self._emit(f"[worker] Branch: {branch}")
+
+        worktree_entries: list[tuple[str, str, str]] = []
+        primary_wt: Optional[str] = None
+
+        for repo_full in repos:
+            await self._emit(f"[worker] Preparing {repo_full}...")
+            repo_path = await git_ops.ensure_repo(self.cfg.repos_dir, repo_full, token)
+            if not repo_path:
+                await self._emit(f"[worker] ✗ Clone failed: {repo_full}")
+                continue
+            repo_name = repo_full.split("/")[-1]
+            wt_path = os.path.join(work_dir, repo_name)
+            if await git_ops.create_worktree(repo_path, wt_path, branch):
+                worktree_entries.append((repo_full, repo_path, wt_path))
+                if primary_wt is None:
+                    primary_wt = wt_path
+            else:
+                await self._emit(f"[worker] ✗ Worktree failed: {repo_full}")
+
+        if not primary_wt:
+            await self._emit("[worker] ✗ No worktrees — aborting.")
+            await self._task_update(task_id, state="failed", finishedAt=_now_iso())
+            await self._set_state("error")
+            return
+
+        await self._task_update(task_id, branch=branch, worktreePath=primary_wt)
+
+        def _on_proc(proc: claude_runner.ClaudeProcess) -> None:
+            self.current_claude = proc
+
+        success, last_msg = await claude_runner.run_claude_auto(
+            desc,
+            primary_wt,
+            max_turns=self.cfg.claude_max_turns,
+            emit=self._emit,
+            on_proc=_on_proc,
+        )
+        self.current_claude = None
+        finished_at = _now_iso()
+
+        if success:
+            pr_url = await github_pr.push_and_open_pr(
+                task=task,
+                branch=branch,
+                worktree_path=primary_wt,
+                token=token,
+                emit=self._emit,
+            )
+            await self._task_update(
+                task_id, state="done", branch=branch, prUrl=pr_url or "", finishedAt=finished_at,
+            )
+            await self._send({
+                "type": "task-complete",
+                "workerId": self.cfg.worker_id,
+                "taskId": task_id,
+                "prUrl": pr_url,
+                "branch": branch,
+                "description": desc,
+            })
+            await self._set_state("idle")
+        else:
+            await self._task_update(task_id, state="failed", finishedAt=finished_at)
+            await self._set_state("error")
+            await self._send({
+                "type": "needs-input",
+                "workerId": self.cfg.worker_id,
+                "taskId": task_id,
+                "description": desc,
+                "lastMessage": last_msg,
+            })
+
+        for _repo_full, repo_path, wt_path in worktree_entries:
+            await git_ops.remove_worktree(repo_path, wt_path)

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -1,0 +1,80 @@
+"""Resilient WebSocket client wrapper used by the worker.
+
+Provides ``connect()``, ``send()``, ``recv()`` with automatic reconnection
+on transport errors. Higher-level message dispatch is the caller's job.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import AsyncIterator, Optional
+
+import websockets
+from websockets.client import WebSocketClientProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class WSClient:
+    def __init__(self, url: str, *, max_backoff: float = 30.0) -> None:
+        self.url = url
+        self.max_backoff = max_backoff
+        self._ws: Optional[WebSocketClientProtocol] = None
+        self._lock = asyncio.Lock()
+
+    async def connect(self) -> WebSocketClientProtocol:
+        """Connect (or reconnect) with exponential backoff."""
+        async with self._lock:
+            if self._ws is not None and not self._ws.closed:
+                return self._ws
+            backoff = 1.0
+            while True:
+                try:
+                    logger.info("Connecting to %s", self.url)
+                    self._ws = await websockets.connect(
+                        self.url, ping_interval=20, ping_timeout=20, max_size=8 * 1024 * 1024
+                    )
+                    logger.info("WebSocket connected")
+                    return self._ws
+                except (OSError, websockets.WebSocketException) as exc:
+                    logger.warning("WS connect failed: %s — retrying in %.1fs", exc, backoff)
+                    await asyncio.sleep(backoff)
+                    backoff = min(self.max_backoff, backoff * 2)
+
+    async def send(self, payload: dict) -> None:
+        ws = await self.connect()
+        try:
+            await ws.send(json.dumps(payload))
+        except websockets.WebSocketException as exc:
+            logger.warning("WS send failed (%s); reconnecting", exc)
+            await self.close()
+            ws = await self.connect()
+            await ws.send(json.dumps(payload))
+
+    async def messages(self) -> AsyncIterator[dict]:
+        """Yield JSON messages forever, reconnecting transparently."""
+        while True:
+            ws = await self.connect()
+            try:
+                async for raw in ws:
+                    try:
+                        yield json.loads(raw)
+                    except json.JSONDecodeError:
+                        logger.debug("Non-JSON WS frame ignored: %r", raw[:120])
+            except websockets.ConnectionClosed as exc:
+                logger.warning("WS closed (%s); reconnecting", exc)
+                await self.close()
+            except Exception as exc:  # pragma: no cover
+                logger.exception("WS recv error: %s", exc)
+                await self.close()
+                await asyncio.sleep(1.0)
+
+    async def close(self) -> None:
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -12,22 +12,30 @@ import logging
 from typing import AsyncIterator, Optional
 
 import websockets
-from websockets.client import WebSocketClientProtocol
+from websockets.protocol import State
 
 logger = logging.getLogger(__name__)
+
+
+def _is_open(ws) -> bool:
+    state = getattr(ws, "state", None)
+    if state is not None:
+        return state is State.OPEN
+    # Older websockets versions exposed `.closed`.
+    return not getattr(ws, "closed", True)
 
 
 class WSClient:
     def __init__(self, url: str, *, max_backoff: float = 30.0) -> None:
         self.url = url
         self.max_backoff = max_backoff
-        self._ws: Optional[WebSocketClientProtocol] = None
+        self._ws = None
         self._lock = asyncio.Lock()
 
-    async def connect(self) -> WebSocketClientProtocol:
+    async def connect(self):
         """Connect (or reconnect) with exponential backoff."""
         async with self._lock:
-            if self._ws is not None and not self._ws.closed:
+            if self._ws is not None and _is_open(self._ws):
                 return self._ws
             backoff = 1.0
             while True:
@@ -47,7 +55,7 @@ class WSClient:
         ws = await self.connect()
         try:
             await ws.send(json.dumps(payload))
-        except websockets.WebSocketException as exc:
+        except (websockets.WebSocketException, ConnectionError) as exc:
             logger.warning("WS send failed (%s); reconnecting", exc)
             await self.close()
             ws = await self.connect()

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pioneer-worker"
+version = "0.1.0"
+description = "Standalone worker agent for Pioneer Square: clones repos, runs Claude on tasks, opens PRs."
+requires-python = ">=3.11"
+dependencies = [
+    "websockets>=12.0",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+toml = ["tomli>=2.0; python_version < '3.11'"]
+
+[project.scripts]
+pioneer-worker = "pioneer_worker.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["pioneer_worker*"]


### PR DESCRIPTION
## Summary

Refactor Pioneer Square to move worker task execution out of the backend process into a standalone `/worker` package. Workers now run as separate processes that connect to the backend over WebSocket, enabling them to run on different machines and survive backend restarts independently.

## Key Changes

- **Backend (`backend/main.py`)**:
  - Removed all worker task execution logic: `_run_git()`, `_ensure_repo()`, `_create_worktree()`, `_pull_repos()`, `_run_claude_auto()`, `_push_and_pr()`, `_execute_worker_task()`
  - Removed in-memory worker state dictionaries (`worker_configs`, `worker_task_queues`, `worker_loops`)
  - Removed worker recovery from database on startup (workers now connect over WebSocket instead)
  - Removed environment variables `PIONEER_REPOS` and `PIONEER_WORK` (moved to worker config)
  - Updated task assignment to validate worker exists and broadcast `task-assigned` messages over WebSocket instead of queuing locally
  - Simplified lifespan to only initialize the database

- **New Worker Package (`worker/`)**:
  - **`pioneer_worker/worker.py`**: Main worker loop that registers with backend, listens for task assignments over WebSocket, executes tasks, and reports state changes
  - **`pioneer_worker/config.py`**: Configuration loader (TOML + sidecar JSON state file) with support for environment variable overrides
  - **`pioneer_worker/claude_runner.py`**: Extracted Claude subprocess execution with stream-JSON parsing and stdin injection support
  - **`pioneer_worker/git_ops.py`**: Extracted git helpers (clone, fetch, worktree management)
  - **`pioneer_worker/github_pr.py`**: Extracted GitHub PR creation logic
  - **`pioneer_worker/ws_client.py`**: Resilient WebSocket client with automatic reconnection and exponential backoff
  - **`pioneer_worker/cli.py`**: CLI entry point with config path and log-level arguments
  - **`pyproject.toml`**: Package metadata and dependencies (websockets, httpx)
  - **`pioneer-worker.toml.example`**: Example configuration file
  - **`README.md`**: Worker setup and usage documentation

## Notable Implementation Details

- Workers persist their assigned ID in a sidecar JSON state file (`.pioneer-worker.state.json`) so they can resume work across restarts
- WebSocket client implements transparent reconnection with exponential backoff (max 30s)
- Worker fetches pending tasks on startup via REST to resume work across backend restarts
- Claude subprocess stdin remains open so the foreman can inject messages during execution
- Configuration supports reading GitHub token from environment variables via `"env:VAR"` syntax
- Multiple workers can run against the same session by using separate config directories
- Backend now only persists worker/task state and dispatches assignments; execution logic is entirely in the worker process

https://claude.ai/code/session_01PabsQApFzrzMcD4m2aVrhL