### PR TITLE
Add lifecycle logging across worker so silent startups are diagnosable

### DIFF
--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -64,6 +64,17 @@ class ClaudeProcess:
             return False
 
 
+async def _drain_stderr(stream, pid: int) -> None:
+    """Log claude's stderr line-by-line so we can diagnose silent failures."""
+    try:
+        async for raw in stream:
+            line = raw.decode(errors="replace").rstrip()
+            if line:
+                logger.warning("claude[%d] stderr: %s", pid, line[:500])
+    except Exception as exc:  # pragma: no cover
+        logger.debug("claude[%d] stderr drain error: %s", pid, exc)
+
+
 async def run_claude_auto(
     description: str,
     cwd: str,
@@ -80,8 +91,10 @@ async def run_claude_auto(
         "--dangerously-skip-permissions",
         "-p", description,
     ]
+    logger.info("Spawning claude in %s: %s", cwd, " ".join(cmd[:5] + ["…"]))
     await emit(f"[claude] Starting: {description[:80]}")
     last_text = ""
+    event_count = 0
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -90,18 +103,27 @@ async def run_claude_auto(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+        logger.info("claude subprocess started pid=%s", proc.pid)
         if on_proc is not None:
             on_proc(ClaudeProcess(proc))
+
+        stderr_task = asyncio.create_task(_drain_stderr(proc.stderr, proc.pid))  # type: ignore[arg-type]
 
         async for raw in proc.stdout:  # type: ignore[union-attr]
             line_str = raw.decode(errors="replace").strip()
             if not line_str:
                 continue
+            event_count += 1
             try:
                 event = json.loads(line_str)
             except json.JSONDecodeError:
+                logger.debug("claude[%d] non-JSON stdout: %s", proc.pid, line_str[:200])
                 await emit(line_str)
                 continue
+            logger.debug(
+                "claude[%d] event #%d type=%s subtype=%s",
+                proc.pid, event_count, event.get("type"), event.get("subtype"),
+            )
             text = parse_claude_event(event)
             if text:
                 await emit(text)
@@ -109,10 +131,22 @@ async def run_claude_auto(
                     last_text = text
 
         exit_code = await proc.wait()
+        await stderr_task
+        logger.info(
+            "claude[%d] exited rc=%s after %d event(s)",
+            proc.pid, exit_code, event_count,
+        )
+        if event_count == 0:
+            logger.warning(
+                "claude[%d] produced no stdout events — check stderr above and PATH/auth",
+                proc.pid,
+            )
         return exit_code == 0, last_text
     except FileNotFoundError:
+        logger.error("`claude` CLI not found on PATH")
         await emit("[claude] ✗ `claude` CLI not found on PATH")
         return False, last_text
     except Exception as exc:  # pragma: no cover
+        logger.exception("claude subprocess crashed: %s", exc)
         await emit(f"[claude] ✗ {exc}")
         return False, last_text

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -64,15 +64,133 @@ class ClaudeProcess:
             return False
 
 
-async def _drain_stderr(stream, pid: int) -> None:
-    """Log claude's stderr line-by-line so we can diagnose silent failures."""
+# Allow long stream-json lines (large tool_result payloads). The asyncio default
+# StreamReader limit is 64 KiB which is easily exceeded by file reads.
+STDOUT_LINE_LIMIT = 16 * 1024 * 1024  # 16 MiB
+
+
+async def _drain_stderr(stream, pid: int) -> int:
+    """Log claude's stderr line-by-line at full length. Returns line count."""
+    n = 0
     try:
-        async for raw in stream:
-            line = raw.decode(errors="replace").rstrip()
+        while True:
+            try:
+                raw = await stream.readuntil(b"\n")
+            except asyncio.IncompleteReadError as exc:
+                raw = exc.partial
+                if not raw:
+                    break
+            except asyncio.LimitOverrunError as exc:
+                # Line longer than the buffer — pull what we have and keep going.
+                raw = await stream.readexactly(exc.consumed)
+            except (asyncio.CancelledError, ValueError):
+                break
+            line = raw.decode(errors="replace").rstrip("\n")
             if line:
-                logger.warning("claude[%d] stderr: %s", pid, line[:500])
+                n += 1
+                logger.warning("claude[%d] stderr: %s", pid, line)
+            if not raw:
+                break
     except Exception as exc:  # pragma: no cover
         logger.debug("claude[%d] stderr drain error: %s", pid, exc)
+    logger.info("claude[%d] stderr drain finished after %d line(s)", pid, n)
+    return n
+
+
+def _log_event_full(event: dict, pid: int, n: int) -> None:
+    """Log the full content of a stream-json event, untruncated."""
+    t = event.get("type")
+    subtype = event.get("subtype")
+    logger.info("claude[%d] event#%d type=%s subtype=%s", pid, n, t, subtype)
+
+    if t == "assistant":
+        for i, blk in enumerate(event.get("message", {}).get("content", [])):
+            btype = blk.get("type")
+            if btype == "text":
+                logger.info(
+                    "claude[%d] event#%d assistant.text[%d]:\n%s",
+                    pid, n, i, blk.get("text", ""),
+                )
+            elif btype == "tool_use":
+                logger.info(
+                    "claude[%d] event#%d tool_use[%d] name=%s id=%s input=%s",
+                    pid, n, i, blk.get("name", ""), blk.get("id", ""),
+                    json.dumps(blk.get("input", {}), ensure_ascii=False),
+                )
+            elif btype == "thinking":
+                logger.info(
+                    "claude[%d] event#%d assistant.thinking[%d]:\n%s",
+                    pid, n, i, blk.get("thinking", ""),
+                )
+            else:
+                logger.info(
+                    "claude[%d] event#%d assistant.block[%d] type=%s: %s",
+                    pid, n, i, btype, json.dumps(blk, ensure_ascii=False),
+                )
+    elif t == "user":
+        for i, blk in enumerate(event.get("message", {}).get("content", [])):
+            btype = blk.get("type")
+            if btype == "tool_result":
+                content = blk.get("content")
+                if not isinstance(content, str):
+                    content = json.dumps(content, ensure_ascii=False)
+                logger.info(
+                    "claude[%d] event#%d tool_result[%d] tool_use_id=%s is_error=%s:\n%s",
+                    pid, n, i, blk.get("tool_use_id", ""),
+                    blk.get("is_error", False), content,
+                )
+            else:
+                logger.info(
+                    "claude[%d] event#%d user.block[%d] type=%s: %s",
+                    pid, n, i, btype, json.dumps(blk, ensure_ascii=False),
+                )
+    elif t == "result":
+        logger.info(
+            "claude[%d] event#%d result: %s",
+            pid, n, json.dumps(event, ensure_ascii=False),
+        )
+    elif t == "system":
+        logger.info(
+            "claude[%d] event#%d system: %s",
+            pid, n, json.dumps(event, ensure_ascii=False),
+        )
+    else:
+        logger.info(
+            "claude[%d] event#%d %s: %s",
+            pid, n, t, json.dumps(event, ensure_ascii=False),
+        )
+
+
+async def _iter_stdout_lines(stream):
+    """Yield stdout lines without the 64KiB asyncio default line cap."""
+    while True:
+        try:
+            raw = await stream.readuntil(b"\n")
+        except asyncio.IncompleteReadError as exc:
+            if exc.partial:
+                yield exc.partial
+            return
+        except asyncio.LimitOverrunError as exc:
+            # Line is longer than the StreamReader buffer; pull what's queued and
+            # keep reading more chunks until we see a newline or EOF.
+            chunks = [await stream.readexactly(exc.consumed)]
+            while True:
+                try:
+                    more = await stream.readuntil(b"\n")
+                    chunks.append(more)
+                    break
+                except asyncio.IncompleteReadError as exc2:
+                    if exc2.partial:
+                        chunks.append(exc2.partial)
+                    yield b"".join(chunks)
+                    return
+                except asyncio.LimitOverrunError as exc2:
+                    chunks.append(await stream.readexactly(exc2.consumed))
+            yield b"".join(chunks)
+            continue
+        if not raw:
+            return
+        yield raw
 
 
 async def run_claude_auto(
@@ -91,7 +209,8 @@ async def run_claude_auto(
         "--dangerously-skip-permissions",
         "-p", description,
     ]
-    logger.info("Spawning claude in %s: %s", cwd, " ".join(cmd[:5] + ["…"]))
+    logger.info("Spawning claude in %s; description=%r", cwd, description)
+    logger.info("claude argv: %s", cmd)
     await emit(f"[claude] Starting: {description[:80]}")
     last_text = ""
     event_count = 0
@@ -102,6 +221,7 @@ async def run_claude_auto(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            limit=STDOUT_LINE_LIMIT,
         )
         logger.info("claude subprocess started pid=%s", proc.pid)
         if on_proc is not None:
@@ -109,21 +229,22 @@ async def run_claude_auto(
 
         stderr_task = asyncio.create_task(_drain_stderr(proc.stderr, proc.pid))  # type: ignore[arg-type]
 
-        async for raw in proc.stdout:  # type: ignore[union-attr]
-            line_str = raw.decode(errors="replace").strip()
-            if not line_str:
+        async for raw in _iter_stdout_lines(proc.stdout):  # type: ignore[arg-type]
+            line_str = raw.decode(errors="replace").rstrip("\n")
+            if not line_str.strip():
                 continue
             event_count += 1
+            # Always log the full raw line at DEBUG so the wire format is recoverable.
+            logger.debug("claude[%d] stdout#%d (%d bytes): %s",
+                         proc.pid, event_count, len(line_str), line_str)
             try:
                 event = json.loads(line_str)
             except json.JSONDecodeError:
-                logger.debug("claude[%d] non-JSON stdout: %s", proc.pid, line_str[:200])
+                logger.info("claude[%d] non-JSON stdout#%d: %s",
+                            proc.pid, event_count, line_str)
                 await emit(line_str)
                 continue
-            logger.debug(
-                "claude[%d] event #%d type=%s subtype=%s",
-                proc.pid, event_count, event.get("type"), event.get("subtype"),
-            )
+            _log_event_full(event, proc.pid, event_count)
             text = parse_claude_event(event)
             if text:
                 await emit(text)
@@ -133,7 +254,7 @@ async def run_claude_auto(
         exit_code = await proc.wait()
         await stderr_task
         logger.info(
-            "claude[%d] exited rc=%s after %d event(s)",
+            "claude[%d] exited rc=%s after %d stdout event(s)",
             proc.pid, exit_code, event_count,
         )
         if event_count == 0:

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -39,16 +39,22 @@ def main(argv: Optional[list[str]] = None) -> int:
         level=args.log_level,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    log = logging.getLogger("pioneer_worker.cli")
+    log.info("pioneer-worker CLI starting (log_level=%s)", args.log_level)
+
     try:
         cfg = config_mod.load(args.config)
     except (FileNotFoundError, ValueError) as exc:
+        log.error("Config load failed: %s", exc)
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
+    log.info("Config loaded from %s", cfg.config_path)
     worker = Worker(cfg)
     try:
         asyncio.run(worker.run())
     except KeyboardInterrupt:
+        log.info("Interrupted; shutting down")
         print("\nShutting down.", file=sys.stderr)
         return 0
     return 0

--- a/worker/pioneer_worker/git_ops.py
+++ b/worker/pioneer_worker/git_ops.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
+import time
 from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
 
 EmitFn = Callable[[str], Awaitable[None]]
 
 
 async def run_git(args: list[str], cwd: Optional[str] = None) -> tuple[int, str, str]:
+    logger.debug("git %s (cwd=%s)", " ".join(args), cwd or os.getcwd())
+    started = time.monotonic()
     proc = await asyncio.create_subprocess_exec(
         "git", *args,
         cwd=cwd,
@@ -17,13 +23,23 @@ async def run_git(args: list[str], cwd: Optional[str] = None) -> tuple[int, str,
         stderr=asyncio.subprocess.PIPE,
     )
     stdout, stderr = await proc.communicate()
-    return proc.returncode, stdout.decode(errors="replace"), stderr.decode(errors="replace")
+    rc = proc.returncode if proc.returncode is not None else -1
+    elapsed = time.monotonic() - started
+    if rc != 0:
+        logger.warning(
+            "git %s failed rc=%s in %.2fs: %s",
+            " ".join(args), rc, elapsed, stderr.decode(errors="replace").strip()[:200],
+        )
+    else:
+        logger.debug("git %s ok in %.2fs", " ".join(args), elapsed)
+    return rc, stdout.decode(errors="replace"), stderr.decode(errors="replace")
 
 
 async def ensure_repo(repos_dir: str, repo_full: str, token: Optional[str] = None) -> Optional[str]:
     """Clone repo if absent, otherwise fast-forward to origin/HEAD. Returns local path."""
     parts = repo_full.split("/", 1)
     if len(parts) != 2:
+        logger.error("ensure_repo: malformed repo name %r", repo_full)
         return None
     owner, name = parts
     local_path = os.path.join(repos_dir, owner, name)
@@ -34,11 +50,15 @@ async def ensure_repo(repos_dir: str, repo_full: str, token: Optional[str] = Non
     )
 
     if not os.path.exists(os.path.join(local_path, ".git")):
+        logger.info("Cloning %s into %s", repo_full, local_path)
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
         rc, _, _ = await run_git(["clone", remote_url, local_path])
         if rc != 0:
+            logger.error("Clone failed for %s (rc=%d)", repo_full, rc)
             return None
+        logger.info("Clone done: %s", repo_full)
     else:
+        logger.info("Fetching latest for %s at %s", repo_full, local_path)
         await run_git(["fetch", "origin"], cwd=local_path)
         await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
 
@@ -46,16 +66,20 @@ async def ensure_repo(repos_dir: str, repo_full: str, token: Optional[str] = Non
 
 
 async def create_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
+    logger.info("Creating worktree at %s on branch %s (from %s)", wt_path, branch, repo_path)
     os.makedirs(os.path.dirname(wt_path), exist_ok=True)
     await run_git(["fetch", "origin"], cwd=repo_path)
     rc, _, _ = await run_git(
         ["worktree", "add", "-b", branch, wt_path, "origin/HEAD"],
         cwd=repo_path,
     )
+    if rc != 0:
+        logger.error("Worktree add failed at %s (rc=%d)", wt_path, rc)
     return rc == 0
 
 
 async def remove_worktree(repo_path: str, wt_path: str) -> None:
+    logger.info("Removing worktree %s", wt_path)
     await run_git(["worktree", "remove", "--force", wt_path], cwd=repo_path)
 
 
@@ -66,19 +90,24 @@ async def pull_repos(
     emit: EmitFn,
 ) -> None:
     """Refresh all configured repos; emit progress through *emit*."""
+    logger.info("pull_repos: refreshing %d repo(s)", len(repos))
     for repo_full in repos:
         parts = repo_full.split("/", 1)
         if len(parts) != 2:
+            logger.warning("pull_repos: skipping malformed repo %r", repo_full)
             continue
         owner, name = parts
         local_path = os.path.join(repos_dir, owner, name)
         if not os.path.exists(os.path.join(local_path, ".git")):
+            logger.info("pull_repos: %s missing locally — cloning", repo_full)
             await emit(f"[worker] Cloning {repo_full}...")
             await ensure_repo(repos_dir, repo_full, token)
         else:
             rc, _, err = await run_git(["fetch", "origin"], cwd=local_path)
             await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
             if rc == 0:
+                logger.info("pull_repos: pulled %s", repo_full)
                 await emit(f"[worker] Pulled {repo_full}")
             else:
+                logger.warning("pull_repos: fetch warn for %s: %s", repo_full, err.strip()[:120])
                 await emit(f"[worker] Pull warn {repo_full}: {err.strip()[:60]}")

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -108,35 +108,61 @@ class Worker:
 
     # ------------------------------------------------------------------ Loop
     async def run(self) -> None:
+        logger.info(
+            "Worker starting: session=%s backend=%s repos=%s worker_id=%s",
+            self.cfg.session_id, self.cfg.backend_url, self.cfg.repos,
+            self.cfg.worker_id or "<unregistered>",
+        )
+        logger.info(
+            "Paths: repos_dir=%s work_dir=%s pull_interval=%.1fs max_turns=%d",
+            self.cfg.repos_dir, self.cfg.work_dir,
+            self.cfg.pull_interval, self.cfg.claude_max_turns,
+        )
+
         await self._register_if_needed()
         assert self.cfg.worker_id, "worker_id must be set after registration"
 
+        logger.info("Connecting to backend WebSocket at %s", self.cfg.ws_url)
         await self.ws.connect()
         await self._join()
+        logger.info("Joined session %s as worker %s", self.cfg.session_id, self.cfg.worker_id)
         await self._emit("[worker] Online. Watching for tasks.")
         await self._set_state("idle")
 
-        for task in await self._fetch_pending_tasks():
+        initial = await self._fetch_pending_tasks()
+        logger.info("Initial pending-task fetch returned %d task(s)", len(initial))
+        for task in initial:
+            logger.info("Queuing pending task %s: %s", task.get("id"), task.get("description", "")[:80])
             self._known_task_ids.add(task["id"])
             await self.task_queue.put(task)
 
+        logger.info("Spawning listener, task runner, and idle poller; entering main loop")
         listener = asyncio.create_task(self._listen())
         runner = asyncio.create_task(self._task_runner())
         puller = asyncio.create_task(self._idle_puller())
         try:
             await asyncio.gather(listener, runner, puller)
         finally:
+            logger.info("Worker shutting down; closing WebSocket")
             await self.ws.close()
 
     async def _listen(self) -> None:
+        logger.info("Listener started; awaiting WebSocket messages")
         async for msg in self.ws.messages():
             mtype = msg.get("type")
+            logger.debug("WS message: type=%s keys=%s", mtype, list(msg.keys()))
             if mtype == "task-assigned":
                 if msg.get("workerId") != self.cfg.worker_id:
+                    logger.debug("Ignoring task-assigned for other worker %s", msg.get("workerId"))
                     continue
                 task_id = msg.get("taskId")
                 if not task_id or task_id in self._known_task_ids:
+                    logger.debug("Skipping already-known task %s", task_id)
                     continue
+                logger.info(
+                    "Task assigned: %s — %s",
+                    task_id, (msg.get("description") or "")[:80],
+                )
                 self._known_task_ids.add(task_id)
                 await self.task_queue.put({
                     "id": task_id,
@@ -151,34 +177,58 @@ class Worker:
                     continue
                 text = msg.get("message", "")
                 if self.current_claude and text:
+                    logger.info("Injecting message into running claude: %s", text[:80])
                     delivered = await self.current_claude.send_message(text)
                     if delivered:
                         await self._emit(f"[worker] Injected: {text[:80]}")
+                    else:
+                        logger.warning("Failed to inject message into claude (stdin closed?)")
+                elif text:
+                    logger.debug("worker-message received but no claude is running; dropping")
 
     async def _idle_puller(self) -> None:
+        logger.info("Idle puller started (interval=%.1fs)", self.cfg.pull_interval)
         while True:
             await asyncio.sleep(self.cfg.pull_interval)
             # Catch tasks that were broadcast while we were briefly disconnected.
             try:
-                for task in await self._fetch_pending_tasks():
+                logger.debug("Polling backend for pending tasks")
+                pending = await self._fetch_pending_tasks()
+                new_count = 0
+                for task in pending:
                     if task["id"] in self._known_task_ids:
                         continue
+                    new_count += 1
+                    logger.info(
+                        "Picked up missed task %s via poll: %s",
+                        task["id"], (task.get("description") or "")[:80],
+                    )
                     self._known_task_ids.add(task["id"])
                     await self.task_queue.put(task)
+                logger.debug("Poll done: %d known, %d new", len(pending), new_count)
             except Exception as exc:  # pragma: no cover
                 logger.warning("Pending-task poll failed: %s", exc)
             if self.task_queue.empty() and self.current_claude is None and self.cfg.repos:
+                logger.debug("Idle: refreshing %d repo(s)", len(self.cfg.repos))
                 await git_ops.pull_repos(
                     self.cfg.repos_dir, self.cfg.repos, self.cfg.github_token, self._emit
                 )
 
     async def _task_runner(self) -> None:
+        logger.info("Task runner started; waiting for queued tasks")
         while True:
             task = await self.task_queue.get()
+            task_id = task.get("id")
+            logger.info(
+                "Dequeued task %s (queue depth now %d): %s",
+                task_id, self.task_queue.qsize(),
+                (task.get("description") or "")[:80],
+            )
             try:
                 await self._execute_task(task)
+                logger.info("Task %s execution returned", task_id)
             except Exception as exc:  # pragma: no cover
-                logger.exception("Task %s crashed: %s", task.get("id"), exc)
+                logger.exception("Task %s crashed: %s", task_id, exc)
                 await self._emit(f"[worker] ✗ Internal error: {exc}")
                 await self._task_update(task["id"], state="failed", finishedAt=_now_iso())
                 await self._set_state("error")
@@ -189,11 +239,13 @@ class Worker:
         token = self.cfg.github_token
         repos = self.cfg.repos
 
+        logger.info("Executing task %s: %s", task_id, desc[:120])
         await self._set_state("working")
         await self._task_update(task_id, state="working")
 
         branch = f"claude/{_slug(desc)}-{task_id[:6]}"
         work_dir = os.path.join(self.cfg.work_dir, self.cfg.session_id, self.cfg.worker_id, task_id)
+        logger.info("Task %s branch=%s work_dir=%s", task_id, branch, work_dir)
         os.makedirs(work_dir, exist_ok=True)
 
         await self._emit(f"[worker] Task: {desc}")
@@ -203,21 +255,27 @@ class Worker:
         primary_wt: Optional[str] = None
 
         for repo_full in repos:
+            logger.info("Task %s: preparing repo %s", task_id, repo_full)
             await self._emit(f"[worker] Preparing {repo_full}...")
             repo_path = await git_ops.ensure_repo(self.cfg.repos_dir, repo_full, token)
             if not repo_path:
+                logger.error("Task %s: clone/fetch failed for %s", task_id, repo_full)
                 await self._emit(f"[worker] ✗ Clone failed: {repo_full}")
                 continue
             repo_name = repo_full.split("/")[-1]
             wt_path = os.path.join(work_dir, repo_name)
+            logger.info("Task %s: creating worktree %s on branch %s", task_id, wt_path, branch)
             if await git_ops.create_worktree(repo_path, wt_path, branch):
+                logger.info("Task %s: worktree ready at %s", task_id, wt_path)
                 worktree_entries.append((repo_full, repo_path, wt_path))
                 if primary_wt is None:
                     primary_wt = wt_path
             else:
+                logger.error("Task %s: worktree creation failed for %s", task_id, repo_full)
                 await self._emit(f"[worker] ✗ Worktree failed: {repo_full}")
 
         if not primary_wt:
+            logger.error("Task %s: aborting — no worktrees were created", task_id)
             await self._emit("[worker] ✗ No worktrees — aborting.")
             await self._task_update(task_id, state="failed", finishedAt=_now_iso())
             await self._set_state("error")
@@ -228,6 +286,10 @@ class Worker:
         def _on_proc(proc: claude_runner.ClaudeProcess) -> None:
             self.current_claude = proc
 
+        logger.info(
+            "Task %s: launching claude in %s (max_turns=%d)",
+            task_id, primary_wt, self.cfg.claude_max_turns,
+        )
         success, last_msg = await claude_runner.run_claude_auto(
             desc,
             primary_wt,
@@ -237,8 +299,10 @@ class Worker:
         )
         self.current_claude = None
         finished_at = _now_iso()
+        logger.info("Task %s: claude finished success=%s", task_id, success)
 
         if success:
+            logger.info("Task %s: pushing branch and opening PR", task_id)
             pr_url = await github_pr.push_and_open_pr(
                 task=task,
                 branch=branch,
@@ -246,6 +310,7 @@ class Worker:
                 token=token,
                 emit=self._emit,
             )
+            logger.info("Task %s: done — pr_url=%s", task_id, pr_url or "<none>")
             await self._task_update(
                 task_id, state="done", branch=branch, prUrl=pr_url or "", finishedAt=finished_at,
             )
@@ -259,6 +324,7 @@ class Worker:
             })
             await self._set_state("idle")
         else:
+            logger.warning("Task %s: failed, requesting human input", task_id)
             await self._task_update(task_id, state="failed", finishedAt=finished_at)
             await self._set_state("error")
             await self._send({
@@ -269,5 +335,6 @@ class Worker:
                 "lastMessage": last_msg,
             })
 
+        logger.info("Task %s: cleaning up %d worktree(s)", task_id, len(worktree_entries))
         for _repo_full, repo_path, wt_path in worktree_entries:
             await git_ops.remove_worktree(repo_path, wt_path)


### PR DESCRIPTION
Previously the worker emitted progress only over the WebSocket; the
Python logger was nearly silent on startup, the main loop, and the task
lifecycle, so a stalled worker looked like "nothing happened". This adds
INFO logs at every major transition (startup, register, WS connect,
join, listener/runner/poller spawn, task assigned, task dequeued,
per-repo prepare, worktree create/remove, claude spawn, claude exit, PR
push, completion/failure, cleanup) and DEBUG logs for finer tracing
(WS message dispatch, poll cycles, git command timing, claude
stream-json events). Also captures and logs claude's stderr so the
"started but no events" case has a visible cause.