### PR TITLE
Mark agents offline when their websocket disconnects

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -456,6 +456,8 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
     if session_id not in connections:
         connections[session_id] = []
     connections[session_id].append(websocket)
+    # Agents that joined via this websocket; marked offline when it disconnects.
+    joined_agents: set[str] = set()
     db = await get_db()
     try:
         while True:
@@ -473,6 +475,8 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                     (agent_id, session_id, agent_name, agent_type, joined_at)
                 )
                 await db.commit()
+                if agent_id:
+                    joined_agents.add(agent_id)
                 broadcast_msg = {
                     "type": "agent-joined",
                     "agentId": agent_id,
@@ -581,7 +585,22 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
         if session_id in connections and websocket in connections[session_id]:
             connections[session_id].remove(websocket)
     finally:
-        await db.close()
+        try:
+            for agent_id in joined_agents:
+                await db.execute(
+                    "UPDATE agents SET state = 'offline' WHERE id = ? AND session_id = ?",
+                    (agent_id, session_id),
+                )
+            if joined_agents:
+                await db.commit()
+            for agent_id in joined_agents:
+                await broadcast(session_id, {
+                    "type": "agent-state",
+                    "agentId": agent_id,
+                    "state": "offline",
+                })
+        finally:
+            await db.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The websocket endpoint previously only removed the dead connection from
the in-memory registry on disconnect, leaving agent rows in whatever
state they last reported (often 'idle' or 'working'). Now we track the
agentIds that joined on each socket and flip them to 'offline' on
disconnect, broadcasting an 'agent-state' so connected clients update.