### PR TITLE
Load .env file in backend at startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,12 +4,22 @@ import random
 import string
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import aiosqlite
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+
+# Load .env (looked up from CWD upward, then alongside this file) before any
+# code reads os.environ, so ANTHROPIC_API_KEY etc. are available.
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+    load_dotenv(Path(__file__).resolve().parent / ".env")
+except ImportError:
+    pass
 
 try:
     import anthropic as _anthropic

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ websockets
 aiosqlite
 python-multipart
 anthropic
+python-dotenv


### PR DESCRIPTION
Adds python-dotenv as a dependency and calls load_dotenv() at module
import time so ANTHROPIC_API_KEY (and any other config) can be supplied
via a .env file in the working dir or alongside backend/main.py.

https://claude.ai/code/session_01SQdMnbm7VDyvEyqLHPPbMe