### PR TITLE
Replace GitHub PAT with OAuth; store tokens in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,35 @@ A real-time multi-agent workspace with a colorful pixel-art factory floor UI.
 
 ## Setup
 
+### GitHub OAuth App
+
+Pioneer Square uses GitHub OAuth instead of personal access tokens. You need to create a GitHub OAuth App and set the credentials as environment variables before starting the backend.
+
+1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
+   (direct link: https://github.com/settings/applications/new)
+2. Fill in:
+   - **Application name**: Pioneer Square (or anything you like)
+   - **Homepage URL**: `http://localhost:5173`
+   - **Authorization callback URL**: `http://localhost:8000/auth/github/callback`
+3. Click **Register application**, then generate a **Client secret**.
+
+Set the credentials before running the backend:
+
+```bash
+export GITHUB_CLIENT_ID=your_client_id_here
+export GITHUB_CLIENT_SECRET=your_client_secret_here
+# Optional overrides (defaults shown):
+# export GITHUB_REDIRECT_URI=http://localhost:8000/auth/github/callback
+# export FRONTEND_URL=http://localhost:5173
+```
+
+Or put them in `backend/.env`:
+
+```
+GITHUB_CLIENT_ID=your_client_id_here
+GITHUB_CLIENT_SECRET=your_client_secret_here
+```
+
 ### Backend
 
 ```bash
@@ -48,7 +77,9 @@ python -m venv venv
 source venv/bin/activate
 pip install -e .
 cp pioneer-worker.toml.example pioneer-worker.toml
-# edit pioneer-worker.toml: backend_url, session_id, repos, github token
+# edit pioneer-worker.toml: backend_url, session_id, repos
+# github_token is optional — if omitted, the worker fetches the OAuth token
+# stored in the backend DB (set after the user connects via GitHub OAuth)
 pioneer-worker
 ```
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,15 +1,21 @@
 import asyncio
 import json
+import os
 import random
+import secrets
 import string
+import urllib.error
+import urllib.parse
+import urllib.request
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import aiosqlite
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
@@ -45,6 +51,15 @@ app.add_middleware(
 )
 
 DB_PATH = "pioneer_square.db"
+
+# GitHub OAuth config (set via environment variables)
+GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID", "")
+GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "")
+GITHUB_REDIRECT_URI = os.environ.get("GITHUB_REDIRECT_URI", "http://localhost:8000/auth/github/callback")
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
+
+# In-memory: state token -> session_id (short-lived, for OAuth CSRF protection)
+oauth_states: Dict[str, str] = {}
 
 # In-memory WebSocket connections: session_id -> list of WebSocket
 connections: Dict[str, List[WebSocket]] = {}
@@ -123,6 +138,22 @@ async def init_db():
             FOREIGN KEY (worker_id) REFERENCES workers(id)
         )
     """)
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS github_tokens (
+            github_user_id TEXT PRIMARY KEY,
+            github_username TEXT,
+            access_token TEXT NOT NULL,
+            token_type TEXT NOT NULL DEFAULT 'bearer',
+            scope TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+    """)
+    # Add github_user_id to sessions if it doesn't exist yet (migration)
+    try:
+        await db.execute("ALTER TABLE sessions ADD COLUMN github_user_id TEXT")
+    except aiosqlite.OperationalError:
+        pass
     await db.commit()
     await db.close()
 
@@ -374,6 +405,184 @@ async def _run_foreman_ai(session_id: str, human_message: str, extra_context: st
             "type": "chat", "from": "foreman", "to": "user",
             "content": f"Foreman error: {exc}", "createdAt": now,
         })
+
+
+# ---------------------------------------------------------------------------
+# GitHub OAuth helpers
+# ---------------------------------------------------------------------------
+
+def _gh_exchange_code(code: str) -> dict:
+    payload = urllib.parse.urlencode({
+        "client_id": GITHUB_CLIENT_ID,
+        "client_secret": GITHUB_CLIENT_SECRET,
+        "code": code,
+        "redirect_uri": GITHUB_REDIRECT_URI,
+    }).encode()
+    req = urllib.request.Request(
+        "https://github.com/login/oauth/access_token",
+        data=payload,
+        headers={"Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+def _gh_get_user(token: str) -> dict:
+    req = urllib.request.Request(
+        "https://api.github.com/user",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3+json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+# ---------------------------------------------------------------------------
+# GitHub OAuth endpoints
+# ---------------------------------------------------------------------------
+
+@app.get("/auth/github/login")
+async def github_login(session_id: str = Query(...)):
+    """Start the GitHub OAuth flow. Returns the authorization URL."""
+    if not GITHUB_CLIENT_ID:
+        raise HTTPException(status_code=500, detail="GitHub OAuth not configured (missing GITHUB_CLIENT_ID)")
+    state = secrets.token_urlsafe(16)
+    oauth_states[state] = session_id
+    params = urllib.parse.urlencode({
+        "client_id": GITHUB_CLIENT_ID,
+        "redirect_uri": GITHUB_REDIRECT_URI,
+        "scope": "repo read:org read:project",
+        "state": state,
+    })
+    return {"url": f"https://github.com/login/oauth/authorize?{params}"}
+
+
+@app.get("/auth/github/callback")
+async def github_callback(code: str = Query(...), state: str = Query(...)):
+    """Handle the GitHub OAuth callback, store token in DB, redirect to frontend."""
+    session_id = oauth_states.pop(state, None)
+    if session_id is None:
+        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
+
+    try:
+        token_data = await asyncio.to_thread(_gh_exchange_code, code)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"GitHub token exchange failed: {exc}")
+
+    access_token = token_data.get("access_token")
+    if not access_token:
+        raise HTTPException(status_code=502, detail=f"No access_token in GitHub response: {token_data}")
+
+    try:
+        user_data = await asyncio.to_thread(_gh_get_user, access_token)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"GitHub user fetch failed: {exc}")
+
+    github_user_id = str(user_data["id"])
+    github_username = user_data.get("login", "")
+    now = datetime.now(timezone.utc).isoformat()
+
+    db = await get_db()
+    try:
+        await db.execute(
+            """
+            INSERT INTO github_tokens (github_user_id, github_username, access_token, token_type, scope, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(github_user_id) DO UPDATE SET
+                github_username=excluded.github_username,
+                access_token=excluded.access_token,
+                token_type=excluded.token_type,
+                scope=excluded.scope,
+                updated_at=excluded.updated_at
+            """,
+            (
+                github_user_id, github_username, access_token,
+                token_data.get("token_type", "bearer"),
+                token_data.get("scope", ""),
+                now, now,
+            ),
+        )
+        await db.execute(
+            "UPDATE sessions SET github_user_id=? WHERE id=?",
+            (github_user_id, session_id),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+    # Redirect back to the frontend session with OAuth result in query params
+    qs = urllib.parse.urlencode({
+        "gh_token": access_token,
+        "gh_user_id": github_user_id,
+        "gh_login": github_username,
+        "gh_name": user_data.get("name") or "",
+        "gh_avatar": user_data.get("avatar_url") or "",
+    })
+    return RedirectResponse(url=f"{FRONTEND_URL}/{session_id}?{qs}")
+
+
+@app.get("/auth/github/token")
+async def get_github_token(session_id: str = Query(...)):
+    """Return the stored OAuth token for the session's linked GitHub user. Used by workers."""
+    db = await get_db()
+    try:
+        async with db.execute(
+            "SELECT github_user_id FROM sessions WHERE id=?", (session_id,)
+        ) as cur:
+            session_row = await cur.fetchone()
+        if not session_row or not session_row["github_user_id"]:
+            raise HTTPException(status_code=404, detail="No GitHub account linked to this session")
+        async with db.execute(
+            "SELECT access_token, github_username FROM github_tokens WHERE github_user_id=?",
+            (session_row["github_user_id"],),
+        ) as cur:
+            token_row = await cur.fetchone()
+        if not token_row:
+            raise HTTPException(status_code=404, detail="GitHub token not found")
+        return {"access_token": token_row["access_token"], "username": token_row["github_username"]}
+    finally:
+        await db.close()
+
+
+@app.get("/auth/github/user")
+async def get_github_user(session_id: str = Query(...)):
+    """Return the GitHub user linked to this session (no token exposed)."""
+    db = await get_db()
+    try:
+        async with db.execute(
+            "SELECT s.github_user_id, t.github_username, t.scope "
+            "FROM sessions s LEFT JOIN github_tokens t ON t.github_user_id = s.github_user_id "
+            "WHERE s.id=?",
+            (session_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if not row or not row["github_user_id"]:
+            return {"authenticated": False}
+        return {
+            "authenticated": True,
+            "github_user_id": row["github_user_id"],
+            "github_username": row["github_username"],
+            "scope": row["scope"],
+        }
+    finally:
+        await db.close()
+
+
+@app.delete("/auth/github/logout")
+async def github_logout(session_id: str = Query(...)):
+    """Unlink the GitHub account from this session."""
+    db = await get_db()
+    try:
+        await db.execute(
+            "UPDATE sessions SET github_user_id=NULL WHERE id=?", (session_id,)
+        )
+        await db.commit()
+    finally:
+        await db.close()
+    return {"status": "logged_out"}
 
 
 @app.post("/sessions")

--- a/backend/main.py
+++ b/backend/main.py
@@ -112,11 +112,13 @@ async def init_db():
         CREATE TABLE IF NOT EXISTS agents (
             id TEXT PRIMARY KEY,
             guild_id TEXT NOT NULL,
+            worker_id TEXT,
             name TEXT NOT NULL,
             type TEXT NOT NULL DEFAULT 'worker',
             state TEXT NOT NULL DEFAULT 'idle',
             joined_at TEXT NOT NULL,
-            FOREIGN KEY (guild_id) REFERENCES guilds(id)
+            FOREIGN KEY (guild_id) REFERENCES guilds(id),
+            FOREIGN KEY (worker_id) REFERENCES workers(id)
         )
     """)
     await db.execute("""
@@ -180,6 +182,7 @@ async def init_db():
     """)
     for col_sql in [
         "ALTER TABLE guilds ADD COLUMN github_user_id TEXT",
+        "ALTER TABLE agents ADD COLUMN worker_id TEXT REFERENCES workers(id)",
     ]:
         try:
             await db.execute(col_sql)
@@ -367,8 +370,18 @@ async def _run_foreman_ai(guild_id: str, human_message: str, extra_context: str 
     db = await get_db()
     try:
         async with db.execute(
-            "SELECT w.id, w.repos, a.state FROM workers w"
-            " LEFT JOIN agents a ON a.id = w.id WHERE w.guild_id=?", (guild_id,)
+            "SELECT w.id, w.repos, w.state as worker_state,"
+            " COUNT(a.id) as agent_count,"
+            " GROUP_CONCAT(a.id || ':' || a.state) as agents"
+            " FROM workers w"
+            " LEFT JOIN agents a ON a.worker_id = w.id AND a.state != 'offline'"
+            " WHERE w.guild_id=?"
+            " GROUP BY w.id"
+            " UNION ALL"
+            " SELECT a.id, '[]', a.state, 1, a.id || ':' || a.state"
+            " FROM agents a"
+            " WHERE a.guild_id=? AND a.type='worker' AND a.worker_id IS NULL AND a.state != 'offline'",
+            (guild_id, guild_id)
         ) as cur:
             worker_rows = [dict(r) for r in await cur.fetchall()]
         async with db.execute(
@@ -380,8 +393,9 @@ async def _run_foreman_ai(guild_id: str, human_message: str, extra_context: str 
         await db.close()
 
     workers_block = json.dumps(
-        [{"id": r["id"], "state": r["state"] or "idle",
-          "repos": json.loads(r["repos"] or "[]")} for r in worker_rows],
+        [{"id": r["id"], "state": r["worker_state"] or "idle",
+          "repos": json.loads(r["repos"] or "[]"),
+          "agent_count": r["agent_count"] or 0} for r in worker_rows],
         indent=2,
     )
     tasks_block = json.dumps(task_rows[:6], indent=2)
@@ -527,7 +541,7 @@ async def github_login():
     params = urllib.parse.urlencode({
         "client_id": GITHUB_CLIENT_ID,
         "redirect_uri": GITHUB_REDIRECT_URI,
-        "scope": "repo read:org read:project",
+        "scope": "repo read:org project",
         "state": state,
     })
     return {"url": f"https://github.com/login/oauth/authorize?{params}"}
@@ -764,11 +778,12 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 agent_id = data.get("agentId")
                 agent_name = data.get("agentName", "Unknown")
                 agent_type = data.get("agentType", "worker")
+                worker_id = data.get("workerId")
                 joined_at = datetime.now(timezone.utc).isoformat()
                 await db.execute(
-                    """INSERT OR REPLACE INTO agents (id, guild_id, name, type, state, joined_at)
-                       VALUES (?, ?, ?, ?, 'idle', ?)""",
-                    (agent_id, guild_id, agent_name, agent_type, joined_at)
+                    """INSERT OR REPLACE INTO agents (id, guild_id, worker_id, name, type, state, joined_at)
+                       VALUES (?, ?, ?, ?, ?, 'idle', ?)""",
+                    (agent_id, guild_id, worker_id, agent_name, agent_type, joined_at)
                 )
                 await db.commit()
                 if agent_id:
@@ -1191,9 +1206,9 @@ async def create_worker(guild_id: str, data: WorkerCreate):
             (worker_id, guild_id, json.dumps(data.repos), created_at),
         )
         await db.execute(
-            "INSERT OR REPLACE INTO agents (id, guild_id, name, type, state, joined_at)"
-            " VALUES (?, ?, ?, 'worker', 'offline', ?)",
-            (worker_id, guild_id, worker_name, created_at),
+            "INSERT OR REPLACE INTO agents (id, guild_id, worker_id, name, type, state, joined_at)"
+            " VALUES (?, ?, ?, ?, 'worker', 'offline', ?)",
+            (worker_id, guild_id, worker_id, worker_name, created_at),
         )
         await db.commit()
     finally:

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,9 +13,10 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import aiosqlite
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Query
+from fastapi import Depends, FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
@@ -58,8 +59,10 @@ GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "")
 GITHUB_REDIRECT_URI = os.environ.get("GITHUB_REDIRECT_URI", "http://localhost:8000/auth/github/callback")
 FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
 
-# In-memory: state token -> session_id (short-lived, for OAuth CSRF protection)
-oauth_states: Dict[str, str] = {}
+# In-memory: short-lived state tokens for OAuth CSRF protection
+oauth_states: set[str] = set()
+
+_http_bearer = HTTPBearer(auto_error=False)
 
 # In-memory WebSocket connections: session_id -> list of WebSocket
 connections: Dict[str, List[WebSocket]] = {}
@@ -149,11 +152,22 @@ async def init_db():
             updated_at TEXT NOT NULL
         )
     """)
-    # Add github_user_id to sessions if it doesn't exist yet (migration)
-    try:
-        await db.execute("ALTER TABLE sessions ADD COLUMN github_user_id TEXT")
-    except aiosqlite.OperationalError:
-        pass
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS user_sessions (
+            token TEXT PRIMARY KEY,
+            github_user_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (github_user_id) REFERENCES github_tokens(github_user_id)
+        )
+    """)
+    # Migrations: add columns if they don't exist yet
+    for col_sql in [
+        "ALTER TABLE sessions ADD COLUMN github_user_id TEXT",
+    ]:
+        try:
+            await db.execute(col_sql)
+        except aiosqlite.OperationalError:
+            pass
     await db.commit()
     await db.close()
 
@@ -441,16 +455,40 @@ def _gh_get_user(token: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Auth dependency
+# ---------------------------------------------------------------------------
+
+async def require_user(
+    credentials: HTTPAuthorizationCredentials = Depends(_http_bearer),
+) -> str:
+    """FastAPI dependency: validates the login_token and returns github_user_id."""
+    if not credentials:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    token = credentials.credentials
+    db = await get_db()
+    try:
+        async with db.execute(
+            "SELECT github_user_id FROM user_sessions WHERE token=?", (token,)
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=401, detail="Invalid or expired session token")
+        return row["github_user_id"]
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
 # GitHub OAuth endpoints
 # ---------------------------------------------------------------------------
 
 @app.get("/auth/github/login")
-async def github_login(session_id: str = Query(...)):
+async def github_login():
     """Start the GitHub OAuth flow. Returns the authorization URL."""
     if not GITHUB_CLIENT_ID:
         raise HTTPException(status_code=500, detail="GitHub OAuth not configured (missing GITHUB_CLIENT_ID)")
     state = secrets.token_urlsafe(16)
-    oauth_states[state] = session_id
+    oauth_states.add(state)
     params = urllib.parse.urlencode({
         "client_id": GITHUB_CLIENT_ID,
         "redirect_uri": GITHUB_REDIRECT_URI,
@@ -462,10 +500,10 @@ async def github_login(session_id: str = Query(...)):
 
 @app.get("/auth/github/callback")
 async def github_callback(code: str = Query(...), state: str = Query(...)):
-    """Handle the GitHub OAuth callback, store token in DB, redirect to frontend."""
-    session_id = oauth_states.pop(state, None)
-    if session_id is None:
+    """Handle the GitHub OAuth callback: store token, issue a login_token, redirect to frontend."""
+    if state not in oauth_states:
         raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
+    oauth_states.discard(state)
 
     try:
         token_data = await asyncio.to_thread(_gh_exchange_code, code)
@@ -483,6 +521,7 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
 
     github_user_id = str(user_data["id"])
     github_username = user_data.get("login", "")
+    login_token = secrets.token_urlsafe(32)
     now = datetime.now(timezone.utc).isoformat()
 
     db = await get_db()
@@ -506,22 +545,23 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
             ),
         )
         await db.execute(
-            "UPDATE sessions SET github_user_id=? WHERE id=?",
-            (github_user_id, session_id),
+            "INSERT INTO user_sessions (token, github_user_id, created_at) VALUES (?, ?, ?)",
+            (login_token, github_user_id, now),
         )
         await db.commit()
     finally:
         await db.close()
 
-    # Redirect back to the frontend session with OAuth result in query params
+    # Redirect to the frontend landing page with the login_token and GitHub info
     qs = urllib.parse.urlencode({
+        "login_token": login_token,
         "gh_token": access_token,
         "gh_user_id": github_user_id,
         "gh_login": github_username,
         "gh_name": user_data.get("name") or "",
         "gh_avatar": user_data.get("avatar_url") or "",
     })
-    return RedirectResponse(url=f"{FRONTEND_URL}/{session_id}?{qs}")
+    return RedirectResponse(url=f"{FRONTEND_URL}/?{qs}")
 
 
 @app.get("/auth/github/token")
@@ -547,22 +587,19 @@ async def get_github_token(session_id: str = Query(...)):
         await db.close()
 
 
-@app.get("/auth/github/user")
-async def get_github_user(session_id: str = Query(...)):
-    """Return the GitHub user linked to this session (no token exposed)."""
+@app.get("/auth/me")
+async def get_me(github_user_id: str = Depends(require_user)):
+    """Return the currently authenticated user's info."""
     db = await get_db()
     try:
         async with db.execute(
-            "SELECT s.github_user_id, t.github_username, t.scope "
-            "FROM sessions s LEFT JOIN github_tokens t ON t.github_user_id = s.github_user_id "
-            "WHERE s.id=?",
-            (session_id,),
+            "SELECT github_user_id, github_username, scope FROM github_tokens WHERE github_user_id=?",
+            (github_user_id,),
         ) as cur:
             row = await cur.fetchone()
-        if not row or not row["github_user_id"]:
-            return {"authenticated": False}
+        if not row:
+            raise HTTPException(status_code=404, detail="User not found")
         return {
-            "authenticated": True,
             "github_user_id": row["github_user_id"],
             "github_username": row["github_username"],
             "scope": row["scope"],
@@ -571,34 +608,35 @@ async def get_github_user(session_id: str = Query(...)):
         await db.close()
 
 
-@app.delete("/auth/github/logout")
-async def github_logout(session_id: str = Query(...)):
-    """Unlink the GitHub account from this session."""
-    db = await get_db()
-    try:
-        await db.execute(
-            "UPDATE sessions SET github_user_id=NULL WHERE id=?", (session_id,)
-        )
-        await db.commit()
-    finally:
-        await db.close()
+@app.delete("/auth/logout")
+async def logout(credentials: HTTPAuthorizationCredentials = Depends(_http_bearer)):
+    """Invalidate the current login_token."""
+    if credentials:
+        db = await get_db()
+        try:
+            await db.execute("DELETE FROM user_sessions WHERE token=?", (credentials.credentials,))
+            await db.commit()
+        finally:
+            await db.close()
     return {"status": "logged_out"}
 
 
 @app.post("/sessions")
-async def create_session(data: Optional[SessionCreate] = None):
+async def create_session(
+    data: Optional[SessionCreate] = None,
+    github_user_id: str = Depends(require_user),
+):
     if data is None:
         data = SessionCreate()
     created_at = datetime.now(timezone.utc).isoformat()
     db = await get_db()
     try:
-        # Retry on collision (UNIQUE constraint); negligible probability with 36^6 space
         for _ in range(5):
             session_id = generate_session_id()
             try:
                 await db.execute(
-                    "INSERT INTO sessions (id, created_at, name) VALUES (?, ?, ?)",
-                    (session_id, created_at, data.name or f"Session {session_id}")
+                    "INSERT INTO sessions (id, created_at, name, github_user_id) VALUES (?, ?, ?, ?)",
+                    (session_id, created_at, data.name or f"Session {session_id}", github_user_id)
                 )
                 await db.commit()
                 break
@@ -612,7 +650,8 @@ async def create_session(data: Optional[SessionCreate] = None):
 
 
 @app.get("/sessions")
-async def list_sessions():
+async def list_sessions(github_user_id: str = Depends(require_user)):
+    """List sessions belonging to the authenticated user."""
     db = await get_db()
     try:
         async with db.execute("""
@@ -620,9 +659,10 @@ async def list_sessions():
                    COUNT(a.id) as agent_count
             FROM sessions s
             LEFT JOIN agents a ON a.session_id = s.id AND a.type != 'foreman'
+            WHERE s.github_user_id = ?
             GROUP BY s.id
             ORDER BY s.created_at DESC
-        """) as cursor:
+        """, (github_user_id,)) as cursor:
             rows = await cursor.fetchall()
         return [dict(row) for row in rows]
     finally:

--- a/frontend/src/components/DeployWorkerModal.vue
+++ b/frontend/src/components/DeployWorkerModal.vue
@@ -7,8 +7,8 @@
       </div>
 
       <div class="modal-body">
-        <div v-if="!ghStore.isConfigured" class="warn-block">
-          Configure GitHub first (sidebar footer) to enable repo tracking and PR creation.
+        <div v-if="!authStore.isLoggedIn" class="warn-block">
+          Sign in with GitHub first to enable repo tracking and PR creation.
         </div>
 
         <div class="section-label">REPOSITORIES TO WATCH</div>
@@ -64,12 +64,14 @@
 <script setup>
 import { ref } from 'vue'
 import { useGitHubStore } from '../stores/github.js'
+import { useAuthStore } from '../stores/auth.js'
 import { useAgentsStore } from '../stores/agents.js'
 import { useSessionStore } from '../stores/session.js'
 
 const emit = defineEmits(['close', 'deployed'])
 
 const ghStore = useGitHubStore()
+const authStore = useAuthStore()
 const agentsStore = useAgentsStore()
 const sessionStore = useSessionStore()
 
@@ -94,7 +96,6 @@ async function deploy() {
   try {
     const worker = await agentsStore.deployWorker({
       repos: selectedRepos.value,
-      githubToken: ghStore.token || undefined,
     })
     emit('deployed', worker)
     emit('close')

--- a/frontend/src/components/GitHubConfigModal.vue
+++ b/frontend/src/components/GitHubConfigModal.vue
@@ -50,18 +50,11 @@
         <!-- Not logged in state -->
         <template v-else>
           <div class="auth-section">
-            <div class="section-label">PERSONAL ACCESS TOKEN</div>
+            <div class="section-label">CONNECT GITHUB ACCOUNT</div>
             <div class="token-hint">
-              Create a token at github.com/settings/tokens with
-              <code>repo</code>, <code>read:org</code>, and <code>read:project</code> scopes.
+              Authorize Pioneer Square to access your repositories via GitHub OAuth.
+              Requires <code>repo</code>, <code>read:org</code>, and <code>read:project</code> scopes.
             </div>
-            <input
-              v-model="tokenInput"
-              type="password"
-              class="field-input"
-              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
-              @keydown.enter="connect"
-            />
             <div v-if="ghStore.error" class="error-msg">{{ ghStore.error }}</div>
           </div>
         </template>
@@ -78,10 +71,10 @@
           <button class="pixel-btn cancel-btn" @click="$emit('close')">Cancel</button>
           <button
             class="pixel-btn connect-btn"
-            @click="connect"
-            :disabled="ghStore.loading || !tokenInput.trim()"
+            @click="connectOAuth"
+            :disabled="ghStore.loading"
           >
-            {{ ghStore.loading ? 'Connecting...' : 'CONNECT' }}
+            {{ ghStore.loading ? 'Redirecting...' : 'CONNECT WITH GITHUB' }}
           </button>
         </template>
       </div>
@@ -92,11 +85,12 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useGitHubStore } from '../stores/github.js'
+import { useSessionStore } from '../stores/session.js'
 
 const emit = defineEmits(['close'])
 const ghStore = useGitHubStore()
+const sessionStore = useSessionStore()
 
-const tokenInput = ref('')
 const loadingRepos = ref(false)
 const localSelected = ref([...ghStore.selectedRepos])
 
@@ -123,15 +117,13 @@ function toggleRepo(fullName) {
   }
 }
 
-async function connect() {
-  if (!tokenInput.value.trim() || ghStore.loading) return
-  const result = await ghStore.authenticate(tokenInput.value.trim())
-  if (result.success) {
-    tokenInput.value = ''
-    loadingRepos.value = true
-    await ghStore.fetchRepos()
-    loadingRepos.value = false
+async function connectOAuth() {
+  const sessionId = sessionStore.currentSession?.id
+  if (!sessionId) {
+    ghStore.error = 'No active session — open a session first.'
+    return
   }
+  await ghStore.loginWithOAuth(sessionId)
 }
 
 async function save() {
@@ -144,7 +136,6 @@ async function save() {
 
 async function logout() {
   ghStore.logout()
-  tokenInput.value = ''
   localSelected.value = []
 }
 </script>

--- a/frontend/src/components/GitHubConfigModal.vue
+++ b/frontend/src/components/GitHubConfigModal.vue
@@ -7,76 +7,51 @@
       </div>
 
       <div class="modal-body">
+        <div class="user-card">
+          <img :src="authStore.user?.avatar_url" class="avatar" alt="avatar" />
+          <div class="user-info">
+            <div class="user-name">{{ authStore.user?.login }}</div>
+            <div class="user-label">{{ authStore.user?.name || 'GitHub User' }}</div>
+          </div>
+        </div>
 
-        <!-- Logged in state -->
-        <template v-if="ghStore.isConfigured">
-          <div class="user-card">
-            <img :src="ghStore.user.avatar_url" class="avatar" alt="avatar" />
-            <div class="user-info">
-              <div class="user-name">{{ ghStore.user.login }}</div>
-              <div class="user-label">{{ ghStore.user.name || 'GitHub User' }}</div>
-            </div>
-            <button class="pixel-btn logout-btn" @click="logout">Disconnect</button>
+        <div class="divider"></div>
+
+        <div class="repos-section">
+          <div class="section-label">WATCHED REPOSITORIES</div>
+          <div class="repo-hint">Select repos for agents to work on and issue tracking.</div>
+
+          <div v-if="loadingRepos" class="loading-row">Loading repos...</div>
+
+          <div v-else-if="ghStore.repos.length === 0" class="loading-row">
+            No repositories found.
           </div>
 
-          <div class="divider"></div>
-
-          <div class="repos-section">
-            <div class="section-label">WATCHED REPOSITORIES</div>
-            <div class="repo-hint">Select repos for agents to work on and issue tracking.</div>
-
-            <div v-if="loadingRepos" class="loading-row">Loading repos...</div>
-
-            <div v-else class="repo-list">
-              <label
-                v-for="repo in ghStore.repos"
-                :key="repo.full_name"
-                class="repo-row"
-                :class="{ selected: isSelected(repo.full_name) }"
-              >
-                <input
-                  type="checkbox"
-                  :checked="isSelected(repo.full_name)"
-                  @change="toggleRepo(repo.full_name)"
-                  class="repo-check"
-                />
-                <span class="repo-name">{{ repo.full_name }}</span>
-                <span class="repo-lang" v-if="repo.language">{{ repo.language }}</span>
-              </label>
-            </div>
+          <div v-else class="repo-list">
+            <label
+              v-for="repo in ghStore.repos"
+              :key="repo.full_name"
+              class="repo-row"
+              :class="{ selected: isSelected(repo.full_name) }"
+            >
+              <input
+                type="checkbox"
+                :checked="isSelected(repo.full_name)"
+                @change="toggleRepo(repo.full_name)"
+                class="repo-check"
+              />
+              <span class="repo-name">{{ repo.full_name }}</span>
+              <span class="repo-lang" v-if="repo.language">{{ repo.language }}</span>
+            </label>
           </div>
-        </template>
-
-        <!-- Not logged in state -->
-        <template v-else>
-          <div class="auth-section">
-            <div class="section-label">CONNECT GITHUB ACCOUNT</div>
-            <div class="token-hint">
-              Authorize Pioneer Square to access your repositories via GitHub OAuth.
-              Requires <code>repo</code>, <code>read:org</code>, and <code>read:project</code> scopes.
-            </div>
-            <div v-if="ghStore.error" class="error-msg">{{ ghStore.error }}</div>
-          </div>
-        </template>
+        </div>
       </div>
 
       <div class="modal-footer">
-        <template v-if="ghStore.isConfigured">
-          <div class="selected-count">
-            {{ selectedCount }} repo{{ selectedCount !== 1 ? 's' : '' }} selected
-          </div>
-          <button class="pixel-btn" @click="save">SAVE</button>
-        </template>
-        <template v-else>
-          <button class="pixel-btn cancel-btn" @click="$emit('close')">Cancel</button>
-          <button
-            class="pixel-btn connect-btn"
-            @click="connectOAuth"
-            :disabled="ghStore.loading"
-          >
-            {{ ghStore.loading ? 'Redirecting...' : 'CONNECT WITH GITHUB' }}
-          </button>
-        </template>
+        <div class="selected-count">
+          {{ selectedCount }} repo{{ selectedCount !== 1 ? 's' : '' }} selected
+        </div>
+        <button class="pixel-btn" @click="save">SAVE</button>
       </div>
     </div>
   </div>
@@ -85,11 +60,11 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useGitHubStore } from '../stores/github.js'
-import { useSessionStore } from '../stores/session.js'
+import { useAuthStore } from '../stores/auth.js'
 
 const emit = defineEmits(['close'])
 const ghStore = useGitHubStore()
-const sessionStore = useSessionStore()
+const authStore = useAuthStore()
 
 const loadingRepos = ref(false)
 const localSelected = ref([...ghStore.selectedRepos])
@@ -97,7 +72,7 @@ const localSelected = ref([...ghStore.selectedRepos])
 const selectedCount = computed(() => localSelected.value.length)
 
 onMounted(async () => {
-  if (ghStore.isConfigured && ghStore.repos.length === 0) {
+  if (ghStore.repos.length === 0 && ghStore.token) {
     loadingRepos.value = true
     await ghStore.fetchRepos()
     loadingRepos.value = false
@@ -117,26 +92,12 @@ function toggleRepo(fullName) {
   }
 }
 
-async function connectOAuth() {
-  const sessionId = sessionStore.currentSession?.id
-  if (!sessionId) {
-    ghStore.error = 'No active session — open a session first.'
-    return
-  }
-  await ghStore.loginWithOAuth(sessionId)
-}
-
 async function save() {
   ghStore.setSelectedRepos(localSelected.value)
   if (localSelected.value.length > 0) {
     await ghStore.fetchIssues()
   }
   emit('close')
-}
-
-async function logout() {
-  ghStore.logout()
-  localSelected.value = []
 }
 </script>
 
@@ -201,7 +162,6 @@ async function logout() {
   gap: 16px;
 }
 
-/* ── User card ── */
 .user-card {
   display: flex;
   align-items: center;
@@ -235,28 +195,12 @@ async function logout() {
   color: var(--color-text-dim);
 }
 
-.logout-btn {
-  font-size: 7px;
-  padding: 5px 8px;
-  background: transparent;
-  border-color: var(--color-text-dim);
-  color: var(--color-text-dim);
-}
-
-.logout-btn:hover {
-  border-color: var(--color-red);
-  color: var(--color-red);
-  box-shadow: none;
-}
-
-/* ── Divider ── */
 .divider {
   height: 1px;
   background: var(--color-brass-dark);
   opacity: 0.5;
 }
 
-/* ── Section ── */
 .section-label {
   font-family: var(--font-pixel);
   font-size: 6px;
@@ -265,57 +209,6 @@ async function logout() {
   margin-bottom: 6px;
 }
 
-/* ── Auth section ── */
-.auth-section {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.token-hint {
-  font-size: 11px;
-  color: var(--color-text-dim);
-  line-height: 1.5;
-}
-
-.token-hint code {
-  background: var(--color-bg-tertiary);
-  border: 1px solid var(--color-brass-dark);
-  padding: 1px 5px;
-  font-family: var(--font-mono);
-  color: var(--color-brass-light);
-  font-size: 10px;
-}
-
-.field-input {
-  background: var(--color-bg);
-  border: 2px solid var(--color-brass-dark);
-  color: var(--color-text);
-  font-family: var(--font-mono);
-  font-size: 13px;
-  padding: 8px 10px;
-  outline: none;
-  width: 100%;
-}
-
-.field-input:focus {
-  border-color: var(--color-brass);
-  box-shadow: 0 0 8px rgba(232, 170, 0, 0.3);
-}
-
-.field-input::placeholder {
-  color: var(--color-text-dim);
-}
-
-.error-msg {
-  font-size: 11px;
-  color: var(--color-red);
-  padding: 6px 8px;
-  background: rgba(238, 51, 34, 0.1);
-  border: 1px solid rgba(238, 51, 34, 0.3);
-}
-
-/* ── Repos section ── */
 .repos-section {
   display: flex;
   flex-direction: column;
@@ -381,7 +274,6 @@ async function logout() {
   border: 1px solid var(--color-brass-dark);
 }
 
-/* ── Footer ── */
 .modal-footer {
   display: flex;
   align-items: center;
@@ -397,22 +289,5 @@ async function logout() {
   flex: 1;
   font-size: 11px;
   color: var(--color-text-dim);
-}
-
-.cancel-btn {
-  background: transparent;
-  border-color: var(--color-brass-dark);
-  color: var(--color-text-dim);
-}
-
-.cancel-btn:hover {
-  background: rgba(255, 255, 255, 0.05);
-  box-shadow: none;
-}
-
-.connect-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  pointer-events: none;
 }
 </style>

--- a/frontend/src/components/SessionSidebar.vue
+++ b/frontend/src/components/SessionSidebar.vue
@@ -36,14 +36,14 @@
       >+ WORKER</button>
 
       <!-- GitHub identity block -->
-      <div class="gh-block" @click="showGitHubModal = true" :title="ghStore.isConfigured ? 'GitHub: ' + ghStore.user.login : 'Configure GitHub'">
-        <div class="gh-inner" :class="{ configured: ghStore.isConfigured }">
-          <img v-if="ghStore.isConfigured" :src="ghStore.user.avatar_url" class="gh-avatar" alt="gh" />
+      <div class="gh-block" @click="showGitHubModal = true" :title="authStore.user ? 'GitHub: ' + authStore.user.login : 'Configure GitHub'">
+        <div class="gh-inner" :class="{ configured: authStore.isLoggedIn }">
+          <img v-if="authStore.isLoggedIn" :src="authStore.user?.avatar_url" class="gh-avatar" alt="gh" />
           <span v-else class="gh-icon">⚙</span>
           <div class="gh-text">
-            <span v-if="ghStore.isConfigured" class="gh-login">{{ ghStore.user.login }}</span>
+            <span v-if="authStore.isLoggedIn" class="gh-login">{{ authStore.user?.login }}</span>
             <span v-else class="gh-setup">Connect GitHub</span>
-            <span class="gh-repos" v-if="ghStore.isConfigured && ghStore.selectedRepos.length > 0">
+            <span class="gh-repos" v-if="authStore.isLoggedIn && ghStore.selectedRepos.length > 0">
               {{ ghStore.selectedRepos.length }} repo{{ ghStore.selectedRepos.length !== 1 ? 's' : '' }}
             </span>
           </div>
@@ -66,12 +66,14 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSessionStore } from '../stores/session.js'
 import { useGitHubStore } from '../stores/github.js'
+import { useAuthStore } from '../stores/auth.js'
 import GitHubConfigModal from './GitHubConfigModal.vue'
 import DeployWorkerModal from './DeployWorkerModal.vue'
 
 const router = useRouter()
 const sessionStore = useSessionStore()
 const ghStore = useGitHubStore()
+const authStore = useAuthStore()
 
 const showGitHubModal = ref(false)
 const showDeployModal = ref(false)

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useSessionStore } from './session'
+import { useAuthStore } from './auth.js'
 
 const API_BASE = 'http://localhost:8000'
 
@@ -47,6 +48,10 @@ export const useAgentsStore = defineStore('agents', () => {
     })
   }
 
+  function _authHeaders() {
+    return useAuthStore().authHeaders()
+  }
+
   async function runAgent(agentId, { tool, prompt, model, provider }) {
     const sessionStore = useSessionStore()
     const sessionId = sessionStore.currentSession?.id
@@ -54,7 +59,7 @@ export const useAgentsStore = defineStore('agents', () => {
 
     const res = await fetch(`${API_BASE}/sessions/${sessionId}/agents/${agentId}/run`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ tool, prompt, model: model || undefined, provider: provider || undefined })
     })
     if (!res.ok) {
@@ -70,7 +75,8 @@ export const useAgentsStore = defineStore('agents', () => {
     if (!sessionId) throw new Error('No active session')
 
     const res = await fetch(`${API_BASE}/sessions/${sessionId}/agents/${agentId}/run`, {
-      method: 'DELETE'
+      method: 'DELETE',
+      headers: _authHeaders(),
     })
     if (!res.ok && res.status !== 404) {
       const err = await res.json().catch(() => ({}))
@@ -79,15 +85,15 @@ export const useAgentsStore = defineStore('agents', () => {
     return res.json()
   }
 
-  async function deployWorker({ repos, githubToken }) {
+  async function deployWorker({ repos }) {
     const sessionStore = useSessionStore()
     const sessionId = sessionStore.currentSession?.id
     if (!sessionId) throw new Error('No active session')
 
     const res = await fetch(`${API_BASE}/sessions/${sessionId}/workers`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ repos, github_token: githubToken || null })
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
+      body: JSON.stringify({ repos, github_token: null })
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
@@ -103,7 +109,7 @@ export const useAgentsStore = defineStore('agents', () => {
 
     const res = await fetch(`${API_BASE}/sessions/${sessionId}/workers/${workerId}/tasks`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({
         description,
         issue_number: issueNumber || null,
@@ -124,7 +130,7 @@ export const useAgentsStore = defineStore('agents', () => {
 
     const res = await fetch(`${API_BASE}/sessions/${sessionId}/workers/${workerId}/message`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ message })
     })
     if (!res.ok) {

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,0 +1,67 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+const API_BASE = 'http://localhost:8000'
+
+export const useAuthStore = defineStore('auth', () => {
+  const loginToken = ref(localStorage.getItem('auth_token') || '')
+  const user = ref(JSON.parse(localStorage.getItem('auth_user') || 'null'))
+
+  const isLoggedIn = computed(() => !!loginToken.value && !!user.value)
+
+  function authHeaders() {
+    return loginToken.value
+      ? { Authorization: `Bearer ${loginToken.value}` }
+      : {}
+  }
+
+  async function loginWithGitHub() {
+    const res = await fetch(`${API_BASE}/auth/github/login`)
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new Error(body.detail || `Server error ${res.status}`)
+    }
+    const { url } = await res.json()
+    window.location.href = url
+  }
+
+  // Called on landing page mount when GitHub redirects back with query params.
+  // Returns true if callback params were present and processed.
+  function restoreFromCallback(params) {
+    const token = params.get('login_token')
+    const login = params.get('gh_login')
+    const name = params.get('gh_name')
+    const avatar = params.get('gh_avatar')
+    const userId = params.get('gh_user_id')
+    if (!token || !login) return false
+
+    loginToken.value = token
+    user.value = { id: userId, login, name: name || login, avatar_url: avatar || '' }
+    localStorage.setItem('auth_token', token)
+    localStorage.setItem('auth_user', JSON.stringify(user.value))
+    return true
+  }
+
+  async function logout() {
+    if (loginToken.value) {
+      await fetch(`${API_BASE}/auth/logout`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      }).catch(() => {})
+    }
+    loginToken.value = ''
+    user.value = null
+    localStorage.removeItem('auth_token')
+    localStorage.removeItem('auth_user')
+  }
+
+  return {
+    loginToken,
+    user,
+    isLoggedIn,
+    authHeaders,
+    loginWithGitHub,
+    restoreFromCallback,
+    logout,
+  }
+})

--- a/frontend/src/stores/github.js
+++ b/frontend/src/stores/github.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 
 const GH_API = 'https://api.github.com'
+const API_BASE = 'http://localhost:8000'
 
 function ghHeaders(token) {
   return {
@@ -21,22 +22,42 @@ export const useGitHubStore = defineStore('github', () => {
 
   const isConfigured = computed(() => !!token.value && !!user.value)
 
-  async function authenticate(newToken) {
+  // Called after the OAuth callback redirects back with query params
+  function restoreFromOAuthCallback(params) {
+    const ghToken = params.get('gh_token')
+    const ghLogin = params.get('gh_login')
+    const ghName = params.get('gh_name')
+    const ghAvatar = params.get('gh_avatar')
+    const ghUserId = params.get('gh_user_id')
+    if (!ghToken || !ghLogin) return false
+
+    const userData = {
+      id: ghUserId,
+      login: ghLogin,
+      name: ghName || ghLogin,
+      avatar_url: ghAvatar || '',
+    }
+    token.value = ghToken
+    user.value = userData
+    localStorage.setItem('gh_token', ghToken)
+    localStorage.setItem('gh_user', JSON.stringify(userData))
+    return true
+  }
+
+  // Redirect to GitHub OAuth. sessionId is used by the backend to link the token.
+  async function loginWithOAuth(sessionId) {
     error.value = ''
     loading.value = true
     try {
-      const res = await fetch(`${GH_API}/user`, { headers: ghHeaders(newToken) })
-      if (!res.ok) throw new Error(res.status === 401 ? 'Invalid token' : `GitHub error ${res.status}`)
-      const userData = await res.json()
-      token.value = newToken
-      user.value = userData
-      localStorage.setItem('gh_token', newToken)
-      localStorage.setItem('gh_user', JSON.stringify(userData))
-      return { success: true, user: userData }
+      const res = await fetch(`${API_BASE}/auth/github/login?session_id=${sessionId}`)
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.detail || `Server error ${res.status}`)
+      }
+      const { url } = await res.json()
+      window.location.href = url
     } catch (e) {
       error.value = e.message
-      return { success: false, error: e.message }
-    } finally {
       loading.value = false
     }
   }
@@ -117,7 +138,8 @@ export const useGitHubStore = defineStore('github', () => {
     loading,
     error,
     isConfigured,
-    authenticate,
+    loginWithOAuth,
+    restoreFromOAuthCallback,
     fetchRepos,
     setSelectedRepos,
     fetchIssues,

--- a/frontend/src/stores/github.js
+++ b/frontend/src/stores/github.js
@@ -2,7 +2,6 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 
 const GH_API = 'https://api.github.com'
-const API_BASE = 'http://localhost:8000'
 
 function ghHeaders(token) {
   return {
@@ -13,53 +12,21 @@ function ghHeaders(token) {
 
 export const useGitHubStore = defineStore('github', () => {
   const token = ref(localStorage.getItem('gh_token') || '')
-  const user = ref(JSON.parse(localStorage.getItem('gh_user') || 'null'))
   const selectedRepos = ref(JSON.parse(localStorage.getItem('gh_repos') || '[]'))
   const repos = ref([])
   const issues = ref([])
   const loading = ref(false)
   const error = ref('')
 
-  const isConfigured = computed(() => !!token.value && !!user.value)
+  const isConfigured = computed(() => !!token.value)
 
-  // Called after the OAuth callback redirects back with query params
-  function restoreFromOAuthCallback(params) {
+  // Called after the OAuth callback redirects back with query params.
+  function restoreGitHubToken(params) {
     const ghToken = params.get('gh_token')
-    const ghLogin = params.get('gh_login')
-    const ghName = params.get('gh_name')
-    const ghAvatar = params.get('gh_avatar')
-    const ghUserId = params.get('gh_user_id')
-    if (!ghToken || !ghLogin) return false
-
-    const userData = {
-      id: ghUserId,
-      login: ghLogin,
-      name: ghName || ghLogin,
-      avatar_url: ghAvatar || '',
-    }
+    if (!ghToken) return false
     token.value = ghToken
-    user.value = userData
     localStorage.setItem('gh_token', ghToken)
-    localStorage.setItem('gh_user', JSON.stringify(userData))
     return true
-  }
-
-  // Redirect to GitHub OAuth. sessionId is used by the backend to link the token.
-  async function loginWithOAuth(sessionId) {
-    error.value = ''
-    loading.value = true
-    try {
-      const res = await fetch(`${API_BASE}/auth/github/login?session_id=${sessionId}`)
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        throw new Error(body.detail || `Server error ${res.status}`)
-      }
-      const { url } = await res.json()
-      window.location.href = url
-    } catch (e) {
-      error.value = e.message
-      loading.value = false
-    }
   }
 
   async function fetchRepos() {
@@ -119,27 +86,23 @@ export const useGitHubStore = defineStore('github', () => {
 
   function logout() {
     token.value = ''
-    user.value = null
     selectedRepos.value = []
     repos.value = []
     issues.value = []
     error.value = ''
     localStorage.removeItem('gh_token')
-    localStorage.removeItem('gh_user')
     localStorage.removeItem('gh_repos')
   }
 
   return {
     token,
-    user,
     repos,
     selectedRepos,
     issues,
     loading,
     error,
     isConfigured,
-    loginWithOAuth,
-    restoreFromOAuthCallback,
+    restoreGitHubToken,
     fetchRepos,
     setSelectedRepos,
     fetchIssues,

--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { useAuthStore } from './auth.js'
 
 const API_BASE = 'http://localhost:8000'
 
@@ -11,9 +12,15 @@ export const useSessionStore = defineStore('session', () => {
   let ws = null
   const messageHandlers = ref([])
 
+  function _authHeaders() {
+    const authStore = useAuthStore()
+    return authStore.authHeaders()
+  }
+
   async function loadSessions() {
     try {
-      const res = await fetch(`${API_BASE}/sessions`)
+      const res = await fetch(`${API_BASE}/sessions`, { headers: _authHeaders() })
+      if (!res.ok) { sessions.value = []; return }
       sessions.value = await res.json()
     } catch (e) {
       console.error('Failed to load sessions', e)
@@ -23,7 +30,7 @@ export const useSessionStore = defineStore('session', () => {
   async function createSession(name) {
     const res = await fetch(`${API_BASE}/sessions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ name })
     })
     const session = await res.json()

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -8,9 +8,10 @@
 
 <script setup>
 import { onMounted, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useSessionStore } from '../stores/session.js'
 import { useAgentsStore } from '../stores/agents.js'
+import { useAuthStore } from '../stores/auth.js'
 import { useGitHubStore } from '../stores/github.js'
 import SessionSidebar from '../components/SessionSidebar.vue'
 import MainView from '../components/MainView.vue'
@@ -18,10 +19,10 @@ import ChatPane from '../components/ChatPane.vue'
 
 const props = defineProps({ sessionId: String })
 
-const route = useRoute()
 const router = useRouter()
 const sessionStore = useSessionStore()
 const agentsStore = useAgentsStore()
+const authStore = useAuthStore()
 const ghStore = useGitHubStore()
 
 function getClientId() {
@@ -34,6 +35,10 @@ function getClientId() {
 }
 
 async function initSession(sessionId) {
+  if (!authStore.isLoggedIn) {
+    router.replace('/')
+    return
+  }
   if (!sessionId) {
     router.replace('/')
     return
@@ -57,7 +62,7 @@ async function initSession(sessionId) {
 
   const clientId = getClientId()
   const suffix = clientId.slice(0, 4)
-  const foremanName = ghStore.user ? `${ghStore.user.login}-${suffix}` : `Foreman-${suffix}`
+  const foremanName = authStore.user ? `${authStore.user.login}-${suffix}` : `Foreman-${suffix}`
 
   sessionStore.connectWebSocket(sessionId, (data) => {
     agentsStore.handleWebSocketMessage(data)
@@ -80,18 +85,6 @@ async function initSession(sessionId) {
 onMounted(async () => {
   await sessionStore.loadSessions()
   await initSession(props.sessionId)
-
-  // Handle OAuth callback: GitHub redirects back here with gh_* query params
-  const urlParams = new URLSearchParams(window.location.search)
-  if (urlParams.has('gh_token')) {
-    const restored = ghStore.restoreFromOAuthCallback(urlParams)
-    if (restored && ghStore.repos.length === 0) {
-      ghStore.fetchRepos()
-    }
-    // Clean up the URL without reloading
-    const cleanUrl = window.location.pathname
-    window.history.replaceState({}, '', cleanUrl)
-  }
 })
 
 watch(() => props.sessionId, async (newId) => {

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -80,6 +80,18 @@ async function initSession(sessionId) {
 onMounted(async () => {
   await sessionStore.loadSessions()
   await initSession(props.sessionId)
+
+  // Handle OAuth callback: GitHub redirects back here with gh_* query params
+  const urlParams = new URLSearchParams(window.location.search)
+  if (urlParams.has('gh_token')) {
+    const restored = ghStore.restoreFromOAuthCallback(urlParams)
+    if (restored && ghStore.repos.length === 0) {
+      ghStore.fetchRepos()
+    }
+    // Clean up the URL without reloading
+    const cleanUrl = window.location.pathname
+    window.history.replaceState({}, '', cleanUrl)
+  }
 })
 
 watch(() => props.sessionId, async (newId) => {

--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -39,43 +39,64 @@
             <div class="logo-title">PIONEER SQUARE</div>
             <div class="logo-subtitle">Multi-Agent Coding Workshop</div>
           </div>
-          <div class="header-actions">
-            <button class="pixel-btn new-btn" @click="openNewSession">+ NEW SESSION</button>
-          </div>
-        </div>
-
-        <div class="sessions-section">
-        <div class="section-label">ACTIVE SESSIONS</div>
-
-        <div v-if="loading" class="loading-msg">Loading sessions...</div>
-
-        <div v-else-if="sessions.length === 0" class="empty-state">
-          <div class="empty-icon">⚙</div>
-          <div class="empty-text">No sessions running.</div>
-          <div class="empty-sub">Start one to begin coordinating agents.</div>
-          <button class="pixel-btn" @click="openNewSession">+ NEW SESSION</button>
-        </div>
-
-        <div v-else class="sessions-grid">
-          <div
-            v-for="session in sessions"
-            :key="session.id"
-            class="session-card"
-            @click="goToSession(session.id)"
-          >
-            <div class="card-top">
-              <span class="card-id">{{ session.id }}</span>
-              <span class="card-agents">
-                <span class="agent-dot" :class="session.agent_count > 0 ? 'active' : 'empty'"></span>
-                {{ session.agent_count || 0 }} agent{{ session.agent_count !== 1 ? 's' : '' }}
-              </span>
+          <div class="header-actions" v-if="authStore.isLoggedIn">
+            <div class="user-pill">
+              <img :src="authStore.user.avatar_url" class="user-avatar" alt="" />
+              <span class="user-login">{{ authStore.user.login }}</span>
             </div>
-            <div class="card-name">{{ session.name }}</div>
-            <div class="card-time">Created {{ formatTime(session.created_at) }}</div>
-            <div class="card-enter">ENTER →</div>
+            <button class="pixel-btn new-btn" @click="openNewSession">+ NEW SESSION</button>
+            <button class="pixel-btn logout-btn" @click="handleLogout">Sign out</button>
           </div>
         </div>
-      </div>
+
+        <!-- Login gate -->
+        <div v-if="!authStore.isLoggedIn" class="login-gate">
+          <div class="login-card">
+            <div class="login-icon">⚙</div>
+            <div class="login-title">SIGN IN TO GET STARTED</div>
+            <div class="login-sub">Connect your GitHub account to create sessions and run agents.</div>
+            <button class="pixel-btn login-btn" :disabled="loggingIn" @click="handleLogin">
+              {{ loggingIn ? 'Redirecting...' : 'SIGN IN WITH GITHUB' }}
+            </button>
+            <div v-if="loginError" class="login-error">{{ loginError }}</div>
+          </div>
+        </div>
+
+        <!-- Sessions list (only shown when logged in) -->
+        <template v-else>
+          <div class="sessions-section">
+            <div class="section-label">YOUR SESSIONS</div>
+
+            <div v-if="loading" class="loading-msg">Loading sessions...</div>
+
+            <div v-else-if="sessions.length === 0" class="empty-state">
+              <div class="empty-icon">⚙</div>
+              <div class="empty-text">No sessions yet.</div>
+              <div class="empty-sub">Start one to begin coordinating agents.</div>
+              <button class="pixel-btn" @click="openNewSession">+ NEW SESSION</button>
+            </div>
+
+            <div v-else class="sessions-grid">
+              <div
+                v-for="session in sessions"
+                :key="session.id"
+                class="session-card"
+                @click="goToSession(session.id)"
+              >
+                <div class="card-top">
+                  <span class="card-id">{{ session.id }}</span>
+                  <span class="card-agents">
+                    <span class="agent-dot" :class="session.agent_count > 0 ? 'active' : 'empty'"></span>
+                    {{ session.agent_count || 0 }} agent{{ session.agent_count !== 1 ? 's' : '' }}
+                  </span>
+                </div>
+                <div class="card-name">{{ session.name }}</div>
+                <div class="card-time">Created {{ formatTime(session.created_at) }}</div>
+                <div class="card-enter">ENTER →</div>
+              </div>
+            </div>
+          </div>
+        </template>
       </div><!-- end main-panel -->
     </div>
 
@@ -108,9 +129,13 @@
 import { ref, onMounted, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSessionStore } from '../stores/session.js'
+import { useAuthStore } from '../stores/auth.js'
+import { useGitHubStore } from '../stores/github.js'
 
 const router = useRouter()
 const sessionStore = useSessionStore()
+const authStore = useAuthStore()
+const ghStore = useGitHubStore()
 
 const loading = ref(true)
 const sessions = ref([])
@@ -118,15 +143,45 @@ const showNewModal = ref(false)
 const newSessionName = ref('')
 const creating = ref(false)
 const nameInput = ref(null)
+const loggingIn = ref(false)
+const loginError = ref('')
 
 onMounted(async () => {
-  await sessionStore.loadSessions()
-  sessions.value = sessionStore.sessions
+  // Handle the OAuth callback redirect: GitHub sends us back with query params
+  const params = new URLSearchParams(window.location.search)
+  if (params.has('login_token')) {
+    authStore.restoreFromCallback(params)
+    ghStore.restoreGitHubToken(params)
+    // Clean URL without reloading
+    window.history.replaceState({}, '', '/')
+  }
+
+  if (authStore.isLoggedIn) {
+    await sessionStore.loadSessions()
+    sessions.value = sessionStore.sessions
+  }
   loading.value = false
 })
 
 function goToSession(id) {
   router.push(`/${id}`)
+}
+
+async function handleLogin() {
+  loggingIn.value = true
+  loginError.value = ''
+  try {
+    await authStore.loginWithGitHub()
+  } catch (e) {
+    loginError.value = e.message
+    loggingIn.value = false
+  }
+}
+
+async function handleLogout() {
+  await authStore.logout()
+  ghStore.logout()
+  sessions.value = []
 }
 
 async function openNewSession() {
@@ -354,6 +409,104 @@ function sparkleStyle(n) {
 .new-btn {
   font-size: 9px;
   padding: 10px 16px;
+}
+
+.user-pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-brass-dark);
+}
+
+.user-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid var(--color-teal);
+}
+
+.user-login {
+  font-size: 11px;
+  color: var(--color-teal);
+}
+
+.logout-btn {
+  font-size: 9px;
+  padding: 6px 12px;
+  background: transparent;
+  border-color: var(--color-brass-dark);
+  color: var(--color-text-dim);
+}
+
+.logout-btn:hover {
+  border-color: var(--color-red);
+  color: var(--color-red);
+  box-shadow: none;
+}
+
+/* ── Login gate ── */
+.login-gate {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 0;
+}
+
+.login-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 48px 40px;
+  background: var(--color-bg-secondary);
+  border: 2px solid var(--color-brass-dark);
+  box-shadow: 0 0 32px rgba(232, 170, 0, 0.1);
+  max-width: 400px;
+  width: 100%;
+  text-align: center;
+}
+
+.login-icon {
+  font-size: 48px;
+  opacity: 0.4;
+  animation: spin 8s linear infinite;
+}
+
+.login-title {
+  font-family: var(--font-pixel);
+  font-size: 9px;
+  color: var(--color-brass-light);
+  letter-spacing: 2px;
+}
+
+.login-sub {
+  font-size: 12px;
+  color: var(--color-text-dim);
+  line-height: 1.6;
+}
+
+.login-btn {
+  font-size: 9px;
+  padding: 12px 24px;
+  margin-top: 8px;
+}
+
+.login-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.login-error {
+  font-size: 11px;
+  color: var(--color-red);
+  padding: 6px 10px;
+  background: rgba(238, 51, 34, 0.1);
+  border: 1px solid rgba(238, 51, 34, 0.3);
+  width: 100%;
 }
 
 /* ── Sessions ── */

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -4,16 +4,12 @@
 # Backend URL (http or ws scheme; the worker derives the WebSocket URL automatically).
 backend_url = "http://localhost:8000"
 
-# Session this worker joins. Create a session via the UI (or POST /sessions)
+# Guild this worker joins. Create a guild via the UI (or POST /guilds)
 # and paste the 6-char id here.
-session_id = "abc123"
+guild_id = "abc123"
 
 # Optional human-readable name shown in the UI. Auto-generated if absent.
 # worker_name = "Builder"
-
-# Optional pre-assigned worker id. If omitted, the worker registers with the
-# backend on startup and writes the assigned id to pioneer-worker.state.json.
-# worker_id = "w-myname"
 
 # Pull repos in the background every N seconds while idle.
 pull_interval = 300

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -27,7 +27,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--guild-id", help="Guild ID to join.")
 
     # Identity
-    parser.add_argument("--worker-id", help="Worker ID (overrides saved state).")
     parser.add_argument("--worker-name", help="Display name for this worker.")
 
     # GitHub
@@ -72,7 +71,6 @@ def main(argv: Optional[list[str]] = None) -> int:
     overrides = {k: v for k, v in {
         "backend_url": args.backend_url,
         "guild_id": args.guild_id,
-        "worker_id": args.worker_id,
         "worker_name": args.worker_name,
         "github_token": args.github_token,
         "repos": args.repos,

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -1,13 +1,10 @@
 """Configuration for the Pioneer Square worker.
 
-Reads a TOML file (default: ``./pioneer-worker.toml``) and a sidecar JSON
-state file (``.pioneer-worker.state.json`` next to the config) used to
-persist runtime values like the worker id assigned by the backend.
+Reads a TOML file (default: ``./pioneer-worker.toml``).
 """
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 from dataclasses import dataclass, field
@@ -22,7 +19,6 @@ else:  # pragma: no cover
 
 
 DEFAULT_CONFIG_NAME = "pioneer-worker.toml"
-STATE_SUFFIX = ".state.json"
 
 
 @dataclass
@@ -42,7 +38,6 @@ class Config:
     claude_max_turns: int = 50
 
     config_path: Path = field(default_factory=Path)
-    state_path: Path = field(default_factory=Path)
 
     @property
     def http_url(self) -> str:
@@ -67,10 +62,10 @@ def _resolve_config_path(explicit: Optional[str]) -> Path:
 
 
 def load(explicit_path: Optional[str] = None, overrides: Optional[dict] = None) -> Config:
-    """Load config from TOML, layered with optional sidecar state, env vars, and overrides.
+    """Load config from TOML layered with env vars and overrides.
 
     *overrides* keys map directly to Config field names and take highest priority.
-    If the config file is missing but overrides supply backend_url and session_id,
+    If the config file is missing but overrides supply backend_url and guild_id,
     the file is treated as empty (all other values fall back to defaults).
     """
     overrides = overrides or {}
@@ -89,14 +84,6 @@ def load(explicit_path: Optional[str] = None, overrides: Optional[dict] = None) 
                 "Create one (see pioneer-worker.toml.example), pass --config, "
                 "or supply --backend-url and --guild-id."
             )
-
-    state_path = cfg_path.with_name(cfg_path.stem + STATE_SUFFIX)
-    state: dict = {}
-    if state_path.exists():
-        try:
-            state = json.loads(state_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            state = {}
 
     backend_url = overrides.get("backend_url") or raw.get("backend_url") or os.environ.get("PIONEER_BACKEND_URL")
     guild_id = overrides.get("guild_id") or raw.get("guild_id") or os.environ.get("PIONEER_GUILD_ID")
@@ -121,7 +108,6 @@ def load(explicit_path: Optional[str] = None, overrides: Optional[dict] = None) 
         backend_url=backend_url.rstrip("/"),
         guild_id=guild_id,
         repos=list(overrides.get("repos") or github_block.get("repos") or raw.get("repos") or []),
-        worker_id=overrides.get("worker_id") or state.get("worker_id") or raw.get("worker_id"),
         worker_name=overrides.get("worker_name") or raw.get("worker_name"),
         github_token=token,
         repos_dir=os.path.abspath(overrides.get("repos_dir") or paths_block.get("repos_dir", "/tmp/pioneer-repos")),
@@ -132,18 +118,4 @@ def load(explicit_path: Optional[str] = None, overrides: Optional[dict] = None) 
         pull_interval=float(overrides.get("pull_interval") if overrides.get("pull_interval") is not None else raw.get("pull_interval", 300.0)),
         claude_max_turns=int(overrides.get("claude_max_turns") if overrides.get("claude_max_turns") is not None else claude_block.get("max_turns", 50)),
         config_path=cfg_path,
-        state_path=state_path,
     )
-
-
-def save_worker_id(cfg: Config, worker_id: str) -> None:
-    """Persist the assigned worker_id to the sidecar state file."""
-    state: dict = {}
-    if cfg.state_path.exists():
-        try:
-            state = json.loads(cfg.state_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            state = {}
-    state["worker_id"] = worker_id
-    cfg.state_path.write_text(json.dumps(state, indent=2) + "\n")
-    cfg.worker_id = worker_id

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -56,6 +56,25 @@ class Worker:
         config_mod.save_worker_id(self.cfg, wid)
         logger.info("Registered new worker id %s", wid)
 
+    async def _fetch_github_token_if_needed(self) -> None:
+        """If no token in config, try fetching the OAuth token stored in the backend DB."""
+        if self.cfg.github_token:
+            return
+        try:
+            async with await self._http() as client:
+                resp = await client.get(
+                    f"/auth/github/token",
+                    params={"session_id": self.cfg.session_id},
+                )
+            if resp.status_code == 200:
+                data = resp.json()
+                self.cfg.github_token = data.get("access_token")
+                logger.info("Fetched GitHub OAuth token from backend for user %s", data.get("username"))
+            else:
+                logger.warning("No GitHub token available from backend (status %d)", resp.status_code)
+        except Exception as exc:
+            logger.warning("Could not fetch GitHub token from backend: %s", exc)
+
     async def _fetch_pending_tasks(self) -> list[dict]:
         async with await self._http() as client:
             resp = await client.get(
@@ -121,6 +140,8 @@ class Worker:
 
         await self._register_if_needed()
         assert self.cfg.worker_id, "worker_id must be set after registration"
+
+        await self._fetch_github_token_if_needed()
 
         logger.info("Connecting to backend WebSocket at %s", self.cfg.ws_url)
         await self.ws.connect()

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -43,9 +43,7 @@ class Worker:
     async def _http(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(base_url=self.cfg.http_url, timeout=30.0)
 
-    async def _register_if_needed(self) -> None:
-        if self.cfg.worker_id:
-            return
+    async def _register(self) -> None:
         async with await self._http() as client:
             resp = await client.post(
                 f"/guilds/{self.cfg.guild_id}/workers",
@@ -53,8 +51,8 @@ class Worker:
             )
             resp.raise_for_status()
             wid = resp.json()["id"]
-        config_mod.save_worker_id(self.cfg, wid)
-        logger.info("Registered new worker id %s", wid)
+        self.cfg.worker_id = wid
+        logger.info("Registered as worker %s", wid)
 
     async def _fetch_github_token_if_needed(self) -> None:
         """If no token in config, try fetching the OAuth token stored in the backend DB."""
@@ -64,7 +62,7 @@ class Worker:
             async with await self._http() as client:
                 resp = await client.get(
                     f"/auth/github/token",
-                    params={"session_id": self.cfg.session_id},
+                    params={"guild_id": self.cfg.guild_id},
                 )
             if resp.status_code == 200:
                 data = resp.json()
@@ -113,6 +111,7 @@ class Worker:
             "agentId": self.cfg.worker_id,
             "agentName": name,
             "agentType": "worker",
+            "workerId": self.cfg.worker_id,
         })
         await self._send({
             "type": "worker-register",
@@ -143,7 +142,7 @@ class Worker:
             self.cfg.claude_path, self.cfg.codex_path, self.cfg.pi_path,
         )
 
-        await self._register_if_needed()
+        await self._register()
         assert self.cfg.worker_id, "worker_id must be set after registration"
 
         await self._fetch_github_token_if_needed()


### PR DESCRIPTION
- Backend: add github_tokens table (github_user_id, username, access_token,
  scope, timestamps). Add github_user_id FK column to sessions table.
  Add OAuth endpoints: GET /auth/github/login (returns authorization URL),
  GET /auth/github/callback (exchanges code, stores token, redirects to
  frontend), GET /auth/github/token (used by workers to retrieve the stored
  OAuth token for a session), GET /auth/github/user, DELETE /auth/github/logout.
  Configured via GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_REDIRECT_URI,
  and FRONTEND_URL env vars.

- Frontend: replace PAT input in GitHubConfigModal with "Connect with GitHub"
  OAuth button. github store adds loginWithOAuth() and restoreFromOAuthCallback().
  AppView reads gh_* query params on mount (set by the backend callback redirect)
  and clears them from the URL.

- Worker: on startup, if no github_token in config, fetch it from
  GET /auth/github/token?session_id=... so workers pick up the OAuth token
  stored in the DB without needing it hardcoded in the TOML.

https://claude.ai/code/session_01KzgnZNFspVerva9bkRp6i1