### PR TITLE
Propagate Claude result subtype as stop_reason through worker

### DIFF
--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -200,8 +200,13 @@ async def run_claude_auto(
     max_turns: int,
     emit: EmitFn,
     on_proc: Optional[Callable[[ClaudeProcess], None]] = None,
-) -> tuple[bool, str]:
-    """Run claude on *description* in *cwd*. Returns (success, last_assistant_text)."""
+) -> tuple[bool, str, str]:
+    """Run claude on *description* in *cwd*. Returns (success, stop_reason, last_assistant_text).
+
+    stop_reason is the result event subtype: "success", "max_turns",
+    "error_during_execution", "interrupted", or "no_events" when the process
+    produced no stream-json output at all.
+    """
     cmd = [
         "claude",
         "--output-format", "stream-json",
@@ -213,6 +218,7 @@ async def run_claude_auto(
     logger.info("claude argv: %s", cmd)
     await emit(f"[claude] Starting: {description[:80]}")
     last_text = ""
+    stop_reason = "no_events"
     event_count = 0
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -245,6 +251,8 @@ async def run_claude_auto(
                 await emit(line_str)
                 continue
             _log_event_full(event, proc.pid, event_count)
+            if event.get("type") == "result":
+                stop_reason = event.get("subtype", "success")
             text = parse_claude_event(event)
             if text:
                 await emit(text)
@@ -254,20 +262,20 @@ async def run_claude_auto(
         exit_code = await proc.wait()
         await stderr_task
         logger.info(
-            "claude[%d] exited rc=%s after %d stdout event(s)",
-            proc.pid, exit_code, event_count,
+            "claude[%d] exited rc=%s stop_reason=%s after %d stdout event(s)",
+            proc.pid, exit_code, stop_reason, event_count,
         )
         if event_count == 0:
             logger.warning(
                 "claude[%d] produced no stdout events — check stderr above and PATH/auth",
                 proc.pid,
             )
-        return exit_code == 0, last_text
+        return exit_code == 0, stop_reason, last_text
     except FileNotFoundError:
         logger.error("`claude` CLI not found on PATH")
         await emit("[claude] ✗ `claude` CLI not found on PATH")
-        return False, last_text
+        return False, "no_events", last_text
     except Exception as exc:  # pragma: no cover
         logger.exception("claude subprocess crashed: %s", exc)
         await emit(f"[claude] ✗ {exc}")
-        return False, last_text
+        return False, "error_during_execution", last_text

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -290,7 +290,7 @@ class Worker:
             "Task %s: launching claude in %s (max_turns=%d)",
             task_id, primary_wt, self.cfg.claude_max_turns,
         )
-        success, last_msg = await claude_runner.run_claude_auto(
+        success, stop_reason, last_msg = await claude_runner.run_claude_auto(
             desc,
             primary_wt,
             max_turns=self.cfg.claude_max_turns,
@@ -299,7 +299,7 @@ class Worker:
         )
         self.current_claude = None
         finished_at = _now_iso()
-        logger.info("Task %s: claude finished success=%s", task_id, success)
+        logger.info("Task %s: claude finished success=%s stop_reason=%s", task_id, success, stop_reason)
 
         if success:
             logger.info("Task %s: pushing branch and opening PR", task_id)
@@ -324,7 +324,7 @@ class Worker:
             })
             await self._set_state("idle")
         else:
-            logger.warning("Task %s: failed, requesting human input", task_id)
+            logger.warning("Task %s: failed stop_reason=%s, requesting human input", task_id, stop_reason)
             await self._task_update(task_id, state="failed", finishedAt=finished_at)
             await self._set_state("error")
             await self._send({
@@ -332,6 +332,7 @@ class Worker:
                 "workerId": self.cfg.worker_id,
                 "taskId": task_id,
                 "description": desc,
+                "stopReason": stop_reason,
                 "lastMessage": last_msg,
             })
 


### PR DESCRIPTION
run_claude_auto now returns (success, stop_reason, last_text) instead of
(success, last_text). stop_reason captures the stream-json result event's
subtype ("success", "max_turns", "error_during_execution", "interrupted",
"no_events") so callers can tell why Claude stopped rather than treating
all non-zero exits identically. The needs-input WebSocket message now
includes stopReason alongside lastMessage.

https://claude.ai/code/session_01GFTtzK3CTCWeYtxtQCj46U