### PR TITLE
feat: foreman task ownership, sticky follow-ups, task log persistence

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -193,6 +193,24 @@ async def init_db():
         await db.commit()
     except Exception:
         pass
+    for col_sql in [
+        "ALTER TABLE tasks ADD COLUMN name TEXT",
+        "ALTER TABLE tasks ADD COLUMN parent_task_id TEXT",
+        "ALTER TABLE tasks ADD COLUMN phase TEXT DEFAULT 'execute'",
+    ]:
+        try:
+            await db.execute(col_sql)
+        except aiosqlite.OperationalError:
+            pass
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS task_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            line TEXT NOT NULL,
+            FOREIGN KEY (task_id) REFERENCES tasks(id)
+        )
+    """)
     await db.commit()
     await db.close()
 
@@ -225,9 +243,12 @@ class WorkerCreate(BaseModel):
 
 class TaskCreate(BaseModel):
     description: str
+    name: Optional[str] = None
     tool: str = "claude"          # "claude" | "codex" | "pi"
     issue_number: Optional[int] = None
     issue_repo: Optional[str] = None
+    parent_task_id: Optional[str] = None
+    phase: Optional[str] = "execute"
 
 
 # ---------------------------------------------------------------------------
@@ -240,52 +261,138 @@ FOREMAN_SYSTEM = """\
 You are the Foreman AI in Pioneer Square, a multi-agent coding workshop.
 You coordinate worker agents that autonomously clone repos, write code, and open PRs.
 
-Your responsibilities:
-- Understand what the human wants done and break it into concrete tasks
-- Assign tasks to appropriate idle workers via assign_task
-- Message a specific worker to give it mid-task context via message_worker
-- Summarise worker status and recent task outcomes when asked
-- Escalate back to the human only when you genuinely cannot decide
+## Your responsibilities
+- Understand what the human wants and break it into named, tracked tasks
+- Always call create_task first to name the work and get a task_id; then assign_task to workers
+- After a worker finishes (task-complete), review the result and decide: send_followup for \
+additional work in the same worktree, or finalize_task when done
+- Message workers mid-task via message_worker for context
+- Summarise status and outcomes when asked
+- Escalate to the human only when genuinely stuck
 
-Workers are already configured with a list of repos. Prefer workers whose repo
-list covers the task. If multiple workers are idle, split work across them.
+## Multi-step flows
+For complex work use phases:
+1. **plan** — create_task(phase='plan'), assign a worker to produce an outline/spec
+2. **execute** — assign workers to implement
+3. **review** — assign a worker to verify correctness, run tests, check the PR
 
-Be concise — one short paragraph maximum per response unless detail is requested.\
+## Task ownership
+- create_task before assign_task so every job has a human-readable name in the sidebar
+- Set parent_task_id on worker tasks to link them to your foreman task
+- After task-complete: call send_followup for further work (update tests, fix lint, add docs),
+  or call finalize_task to mark it complete — don't leave tasks in limbo
+
+Workers are configured with repos. Prefer workers whose repos cover the task.
+Be concise — one short paragraph maximum unless detail is requested.\
 """
 
 FOREMAN_TOOLS = [
     {
+        "name": "create_task",
+        "description": (
+            "Create a named foreman task. Call this before assigning worker tasks — it gives the "
+            "work a human-readable name visible in the sidebar and returns a task_id to reference "
+            "in assign_task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Short human-readable name (≤60 chars), e.g. 'Implement OAuth login'.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Full description of the work to be done.",
+                },
+                "phase": {
+                    "type": "string",
+                    "enum": ["plan", "execute", "review"],
+                    "description": "Starting phase. Default: execute.",
+                },
+            },
+            "required": ["name", "description"],
+        },
+    },
+    {
         "name": "assign_task",
         "description": (
-            "Queue a coding task for a worker agent. The worker will create a git worktree, "
-            "run the chosen coding agent (claude, codex, or pi) on the task description, then push and "
-            "open a GitHub PR."
+            "Queue a coding task for a worker agent. The worker creates a git worktree, "
+            "runs the chosen coding agent on the description, then pushes the branch. "
+            "Link to a foreman task via parent_task_id."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "worker_id": {
                     "type": "string",
-                    "description": "Worker agent ID (e.g. w-abc123). Must be an idle worker.",
+                    "description": "Worker agent ID (e.g. w-abc123). Must be idle.",
                 },
                 "description": {
                     "type": "string",
-                    "description": "Detailed, self-contained task description the coding agent will receive.",
+                    "description": "Detailed, self-contained task description the coding agent receives.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Short task name shown in the sidebar (≤60 chars).",
                 },
                 "tool": {
                     "type": "string",
                     "enum": ["claude", "codex", "pi"],
-                    "description": "Which coding agent to use. Defaults to claude.",
+                    "description": "Coding agent to use. Default: claude.",
                 },
-                "issue_number": {"type": "integer", "description": "GitHub issue number to close (optional)."},
+                "parent_task_id": {
+                    "type": "string",
+                    "description": "Foreman task ID this worker task belongs to (optional).",
+                },
+                "phase": {
+                    "type": "string",
+                    "enum": ["plan", "execute", "review", "followup"],
+                    "description": "Phase of work.",
+                },
+                "issue_number": {"type": "integer", "description": "GitHub issue to close (optional)."},
                 "issue_repo": {"type": "string", "description": "owner/repo for the issue (optional)."},
             },
             "required": ["worker_id", "description"],
         },
     },
     {
+        "name": "send_followup",
+        "description": (
+            "Send follow-up instructions to a worker for a task that just completed. "
+            "The worker executes these in the same git worktree on the same branch — "
+            "ideal for 'update tests', 'fix type errors', 'add docs', etc. "
+            "Call after receiving a task-complete notification."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx)."},
+                "instructions": {
+                    "type": "string",
+                    "description": "Follow-up instructions to execute in the existing worktree.",
+                },
+            },
+            "required": ["task_id", "instructions"],
+        },
+    },
+    {
+        "name": "finalize_task",
+        "description": (
+            "Mark a task complete with no further follow-up needed. "
+            "Call after reviewing a completed task when no additional work is required."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID to finalize."},
+            },
+            "required": ["task_id"],
+        },
+    },
+    {
         "name": "message_worker",
-        "description": "Send a message to a specific worker's terminal — useful to provide mid-task context.",
+        "description": "Send a message to a worker's terminal — for mid-task context injection.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -304,14 +411,39 @@ async def _foreman_exec_tools(guild_id: str, tool_uses: list) -> list:
     for tu in tool_uses:
         inp = tu.input
         result_text = ""
+        db = await get_db()
+        try:
+            if tu.name == "create_task":
+                name = (inp.get("name") or "")[:80]
+                desc = inp.get("description", name)
+                phase = inp.get("phase", "execute")
+                task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+                created_at = datetime.now(timezone.utc).isoformat()
+                await db.execute(
+                    "INSERT INTO tasks (id, worker_id, guild_id, name, description, tool,"
+                    " state, phase, created_at) VALUES (?, 'foreman', ?, ?, ?, 'claude', 'planning', ?, ?)",
+                    (task_id, guild_id, name, desc, phase, created_at),
+                )
+                await db.commit()
+                await broadcast(guild_id, {
+                    "type": "task-created",
+                    "taskId": task_id,
+                    "name": name,
+                    "description": desc,
+                    "phase": phase,
+                    "state": "planning",
+                    "createdAt": created_at,
+                })
+                result_text = f"Task {task_id} created: '{name}'. Reference this task_id in assign_task."
 
-        if tu.name == "assign_task":
-            wid  = inp["worker_id"]
-            desc = inp["description"]
-            task_id    = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
-            created_at = datetime.now(timezone.utc).isoformat()
-            db = await get_db()
-            try:
+            elif tu.name == "assign_task":
+                wid = inp["worker_id"]
+                desc = inp["description"]
+                name = (inp.get("name") or desc[:60])
+                phase = inp.get("phase", "execute")
+                parent_task_id = inp.get("parent_task_id")
+                task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+                created_at = datetime.now(timezone.utc).isoformat()
                 async with db.execute(
                     "SELECT 1 FROM workers WHERE id=? AND guild_id=?", (wid, guild_id)
                 ) as cur:
@@ -321,35 +453,80 @@ async def _foreman_exec_tools(guild_id: str, tool_uses: list) -> list:
                 else:
                     tool = inp.get("tool", "claude")
                     await db.execute(
-                        "INSERT INTO tasks (id, worker_id, guild_id, description, tool, issue_number,"
-                        " issue_repo, state, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)",
-                        (task_id, wid, guild_id, desc, tool, inp.get("issue_number"), inp.get("issue_repo"), created_at),
+                        "INSERT INTO tasks (id, worker_id, guild_id, name, description, tool,"
+                        " issue_number, issue_repo, state, phase, parent_task_id, created_at)"
+                        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)",
+                        (task_id, wid, guild_id, name, desc, tool,
+                         inp.get("issue_number"), inp.get("issue_repo"),
+                         phase, parent_task_id, created_at),
                     )
                     await db.commit()
                     await broadcast(guild_id, {
                         "type": "task-assigned",
                         "workerId": wid,
                         "taskId": task_id,
+                        "name": name,
                         "description": desc,
                         "tool": tool,
+                        "phase": phase,
+                        "parentTaskId": parent_task_id,
                         "issueNumber": inp.get("issue_number"),
                         "issueRepo": inp.get("issue_repo"),
                     })
                     result_text = f"Task {task_id} queued for {wid}."
-            finally:
-                await db.close()
 
-        elif tu.name == "message_worker":
-            wid = inp["worker_id"]
-            msg = inp["message"]
-            await _emit_terminal_line(guild_id, wid, f"[foreman] {msg}")
-            # The worker process picks this up over its guild WebSocket.
-            await broadcast(guild_id, {
-                "type": "worker-message",
-                "workerId": wid,
-                "message": msg,
-            })
-            result_text = f"Message delivered to {wid}."
+            elif tu.name == "send_followup":
+                task_id = inp["task_id"]
+                instructions = inp["instructions"]
+                async with db.execute(
+                    "SELECT worker_id FROM tasks WHERE id=? AND guild_id=?", (task_id, guild_id)
+                ) as cur:
+                    row = await cur.fetchone()
+                if not row:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    await db.execute(
+                        "UPDATE tasks SET state='working', phase='followup' WHERE id=?", (task_id,)
+                    )
+                    await db.commit()
+                    await broadcast(guild_id, {
+                        "type": "task-followup",
+                        "workerId": row["worker_id"],
+                        "taskId": task_id,
+                        "instructions": instructions,
+                    })
+                    result_text = f"Follow-up sent to {row['worker_id']} for task {task_id}."
+
+            elif tu.name == "finalize_task":
+                task_id = inp["task_id"]
+                async with db.execute(
+                    "SELECT worker_id FROM tasks WHERE id=? AND guild_id=?", (task_id, guild_id)
+                ) as cur:
+                    row = await cur.fetchone()
+                if not row:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    await db.execute("UPDATE tasks SET state='done' WHERE id=?", (task_id,))
+                    await db.commit()
+                    await broadcast(guild_id, {
+                        "type": "task-finalize",
+                        "workerId": row["worker_id"],
+                        "taskId": task_id,
+                    })
+                    result_text = f"Task {task_id} finalized."
+
+            elif tu.name == "message_worker":
+                wid = inp["worker_id"]
+                msg = inp["message"]
+                await _emit_terminal_line(guild_id, wid, f"[foreman] {msg}")
+                await broadcast(guild_id, {
+                    "type": "worker-message",
+                    "workerId": wid,
+                    "message": msg,
+                })
+                result_text = f"Message delivered to {wid}."
+        finally:
+            await db.close()
 
         results.append({"type": "tool_result", "tool_use_id": tu.id, "content": result_text})
     return results
@@ -836,10 +1013,18 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
             elif msg_type == "terminal-output":
                 agent_id = data.get("agentId")
                 line = data.get("line", "")
+                task_id = data.get("taskId")
                 created_at = datetime.now(timezone.utc).isoformat()
+                if task_id and line:
+                    await db.execute(
+                        "INSERT INTO task_logs (task_id, timestamp, line) VALUES (?, ?, ?)",
+                        (task_id, created_at, line),
+                    )
+                    await db.commit()
                 await broadcast(guild_id, {
                     "type": "terminal-output",
                     "agentId": agent_id,
+                    "taskId": task_id,
                     "line": line,
                     "timestamp": created_at
                 })
@@ -875,6 +1060,44 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                         await db.execute(sql, params)
                         await db.commit()
                     await broadcast(guild_id, data, exclude=websocket)
+
+            elif msg_type == "task-complete":
+                task_id = data.get("taskId")
+                worker_id_msg = data.get("workerId", "")
+                desc = data.get("description", "")
+                branch = data.get("branch", "")
+                if task_id:
+                    await db.execute(
+                        "UPDATE tasks SET state='awaiting-review' WHERE id=? AND state='working'",
+                        (task_id,),
+                    )
+                    await db.commit()
+                await broadcast(guild_id, data, exclude=websocket)
+                if task_id:
+                    asyncio.create_task(_run_foreman_ai(
+                        guild_id,
+                        f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
+                        f"\"{desc[:80]}\" — branch: {branch}. "
+                        "Review this result. Call send_followup if additional work is needed "
+                        "(e.g. update tests, add docs, fix lint errors). "
+                        "Otherwise call finalize_task to mark it complete.",
+                    ))
+
+            elif msg_type == "task-followup-done":
+                task_id = data.get("taskId")
+                worker_id_msg = data.get("workerId", "")
+                if task_id:
+                    await db.execute(
+                        "UPDATE tasks SET state='awaiting-review' WHERE id=?", (task_id,)
+                    )
+                    await db.commit()
+                await broadcast(guild_id, data, exclude=websocket)
+                if task_id:
+                    asyncio.create_task(_run_foreman_ai(
+                        guild_id,
+                        f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
+                        "Decide: call send_followup for more work, or call finalize_task to mark it done.",
+                    ))
 
             elif msg_type in ("offer", "answer", "ice-candidate"):
                 # WebRTC signaling - forward to all
@@ -1251,10 +1474,14 @@ async def assign_task(guild_id: str, worker_id: str, data: TaskCreate):
         ) as cur:
             if not await cur.fetchone():
                 raise HTTPException(status_code=404, detail="Worker not found")
+        name = (data.name or data.description[:60])
         await db.execute(
-            "INSERT INTO tasks (id, worker_id, guild_id, description, tool, issue_number, issue_repo, state, created_at)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)",
-            (task_id, worker_id, guild_id, data.description, data.tool, data.issue_number, data.issue_repo, created_at),
+            "INSERT INTO tasks (id, worker_id, guild_id, name, description, tool, issue_number,"
+            " issue_repo, state, phase, parent_task_id, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)",
+            (task_id, worker_id, guild_id, name, data.description, data.tool,
+             data.issue_number, data.issue_repo, data.phase or "execute",
+             data.parent_task_id, created_at),
         )
         await db.commit()
     finally:
@@ -1264,8 +1491,11 @@ async def assign_task(guild_id: str, worker_id: str, data: TaskCreate):
         "type": "task-assigned",
         "workerId": worker_id,
         "taskId": task_id,
+        "name": name,
         "description": data.description,
         "tool": data.tool,
+        "phase": data.phase or "execute",
+        "parentTaskId": data.parent_task_id,
         "issueNumber": data.issue_number,
         "issueRepo": data.issue_repo,
     })
@@ -1305,3 +1535,99 @@ async def message_worker(guild_id: str, worker_id: str, data: WorkerMessage):
         "message": text,
     })
     return {"status": "delivered"}
+
+
+# ---------------------------------------------------------------------------
+# Task endpoints
+# ---------------------------------------------------------------------------
+
+@app.get("/guilds/{guild_id}/tasks")
+async def list_guild_tasks(guild_id: str):
+    """List all tasks for a guild, most recent first."""
+    db = await get_db()
+    try:
+        async with db.execute(
+            "SELECT id, worker_id, name, description, tool, state, phase,"
+            " parent_task_id, branch, pr_url, issue_number, issue_repo, created_at, finished_at"
+            " FROM tasks WHERE guild_id=? ORDER BY created_at DESC LIMIT 100",
+            (guild_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        await db.close()
+
+
+@app.get("/guilds/{guild_id}/tasks/{task_id}/logs")
+async def get_task_logs(guild_id: str, task_id: str):
+    """Get all saved log lines for a task."""
+    db = await get_db()
+    try:
+        async with db.execute(
+            "SELECT 1 FROM tasks WHERE id=? AND guild_id=?", (task_id, guild_id)
+        ) as cur:
+            if not await cur.fetchone():
+                raise HTTPException(status_code=404, detail="Task not found")
+        async with db.execute(
+            "SELECT timestamp, line FROM task_logs WHERE task_id=? ORDER BY id ASC",
+            (task_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        await db.close()
+
+
+class FollowupCreate(BaseModel):
+    instructions: str
+
+
+@app.post("/guilds/{guild_id}/tasks/{task_id}/followup")
+async def create_task_followup(guild_id: str, task_id: str, data: FollowupCreate):
+    """Send follow-up instructions to a worker — executed in the same worktree/branch."""
+    db = await get_db()
+    try:
+        async with db.execute(
+            "SELECT worker_id FROM tasks WHERE id=? AND guild_id=?", (task_id, guild_id)
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Task not found")
+        worker_id = row["worker_id"]
+        await db.execute(
+            "UPDATE tasks SET state='working', phase='followup' WHERE id=?", (task_id,)
+        )
+        await db.commit()
+    finally:
+        await db.close()
+    await broadcast(guild_id, {
+        "type": "task-followup",
+        "workerId": worker_id,
+        "taskId": task_id,
+        "instructions": data.instructions,
+    })
+    return {"status": "sent", "taskId": task_id}
+
+
+@app.post("/guilds/{guild_id}/tasks/{task_id}/finalize")
+async def finalize_task_endpoint(guild_id: str, task_id: str):
+    """Signal a worker to finalize a task — no more follow-ups."""
+    db = await get_db()
+    try:
+        async with db.execute(
+            "SELECT worker_id FROM tasks WHERE id=? AND guild_id=?", (task_id, guild_id)
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Task not found")
+        worker_id = row["worker_id"]
+        await db.execute("UPDATE tasks SET state='done' WHERE id=?", (task_id,))
+        await db.commit()
+    finally:
+        await db.close()
+    await broadcast(guild_id, {
+        "type": "task-finalize",
+        "workerId": worker_id,
+        "taskId": task_id,
+    })
+    return {"status": "finalized", "taskId": task_id}

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -26,6 +26,33 @@
       <div v-if="guilds.length === 0" class="no-sessions">No guilds yet</div>
     </div>
 
+    <!-- Tasks panel — visible when a guild is active -->
+    <div v-if="currentGuild" class="tasks-panel">
+      <div class="tasks-header">
+        <span class="tasks-title">Tasks</span>
+        <span class="tasks-count">{{ tasksStore.tasks.length }}</span>
+      </div>
+      <div class="tasks-list">
+        <div v-if="tasksStore.tasks.length === 0" class="tasks-empty">No tasks yet</div>
+        <div
+          v-for="task in tasksStore.tasks.slice(0, 20)"
+          :key="task.id"
+          class="task-item"
+          :class="{ selected: tasksStore.selectedTaskId === task.id }"
+          @click="openTask(task.id)"
+        >
+          <div class="task-item-top">
+            <span class="task-item-dot" :class="'dot-' + (task.state || 'pending').replace(/[^a-z]/g, '-')"></span>
+            <span class="task-item-name">{{ task.name || task.id }}</span>
+          </div>
+          <div class="task-item-meta">
+            <span class="task-item-phase">{{ task.phase || 'execute' }}</span>
+            <span class="task-item-state">{{ tasksStore.stateLabel(task.state) }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="sidebar-footer">
       <!-- Deploy worker — only when in an active guild -->
       <button
@@ -67,6 +94,7 @@ import { useRouter } from 'vue-router'
 import { useGuildStore } from '../stores/guild.js'
 import { useGitHubStore } from '../stores/github.js'
 import { useAuthStore } from '../stores/auth.js'
+import { useTasksStore } from '../stores/tasks.js'
 import GitHubConfigModal from './GitHubConfigModal.vue'
 import DeployWorkerModal from './DeployWorkerModal.vue'
 
@@ -74,6 +102,7 @@ const router = useRouter()
 const guildStore = useGuildStore()
 const ghStore = useGitHubStore()
 const authStore = useAuthStore()
+const tasksStore = useTasksStore()
 
 const showGitHubModal = ref(false)
 const showDeployModal = ref(false)
@@ -88,6 +117,10 @@ function goHome() {
 
 function goToSession(id) {
   router.push(`/${id}`)
+}
+
+function openTask(taskId) {
+  tasksStore.selectTask(taskId)
 }
 
 function formatTime(isoStr) {
@@ -139,6 +172,8 @@ function formatTime(isoStr) {
   flex: 1;
   overflow-y: auto;
   padding: 4px 0;
+  min-height: 80px;
+  max-height: 220px;
 }
 
 .session-item {
@@ -210,6 +245,120 @@ function formatTime(isoStr) {
   text-align: center;
   color: var(--color-text-dim);
   font-size: 11px;
+}
+
+/* ── Tasks panel ── */
+.tasks-panel {
+  border-top: 2px solid var(--color-brass-dark);
+  display: flex;
+  flex-direction: column;
+  max-height: 240px;
+  flex-shrink: 0;
+}
+
+.tasks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: var(--color-bg-tertiary);
+  border-bottom: 1px solid var(--color-brass-dark);
+  flex-shrink: 0;
+}
+
+.tasks-title {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-brass-light);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+.tasks-count {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  background: var(--color-bg);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+
+.tasks-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.tasks-empty {
+  padding: 12px;
+  text-align: center;
+  color: var(--color-text-dim);
+  font-size: 10px;
+  font-style: italic;
+}
+
+.task-item {
+  padding: 7px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-bg-tertiary);
+  transition: background 0.12s;
+}
+
+.task-item:hover {
+  background: rgba(232, 170, 0, 0.06);
+}
+
+.task-item.selected {
+  background: rgba(232, 170, 0, 0.12);
+  border-left: 3px solid var(--color-brass);
+}
+
+.task-item-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 3px;
+}
+
+.task-item-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.dot-pending { background: var(--color-text-dim); }
+.dot-planning { background: var(--color-blue); }
+.dot-working { background: var(--color-green); animation: pulse 0.5s infinite; }
+.dot-awaiting-review { background: var(--color-amber); animation: pulse 1.5s infinite; }
+.dot-done { background: var(--color-teal); }
+.dot-failed { background: var(--color-red); }
+.dot-follow-up { background: var(--color-orange); animation: pulse 0.8s infinite; }
+.dot-followup { background: var(--color-orange); animation: pulse 0.8s infinite; }
+
+.task-item-name {
+  font-size: 11px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.task-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-left: 12px;
+}
+
+.task-item-phase {
+  font-size: 9px;
+  color: var(--color-text-dim);
+}
+
+.task-item-state {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass-dark);
+  margin-left: auto;
 }
 
 /* ── Footer ── */

--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -19,23 +19,54 @@
         <span class="state-dot" :class="agent.state"></span>
         <span class="tab-label">{{ agent.name }}</span>
       </button>
+      <!-- Task tabs — shown for active/recent tasks -->
+      <button
+        v-for="task in visibleTaskTabs"
+        :key="'task-' + task.id"
+        class="tab task-tab"
+        :class="{ active: activeTab === 'task-' + task.id }"
+        @click="activeTab = 'task-' + task.id"
+      >
+        <span class="task-dot" :class="'task-dot-' + task.state.replace(/[^a-z]/g, '-')"></span>
+        <span class="tab-label">{{ task.name || task.id }}</span>
+      </button>
     </div>
     <div class="tab-content">
       <FactoryFloor v-if="activeTab === 'factory'" />
+      <TaskPane v-else-if="activeTab.startsWith('task-')" :taskId="activeTab.slice(5)" />
       <TerminalPane v-else :agentId="activeTab" />
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useAgentsStore } from '../stores/agents.js'
+import { useTasksStore } from '../stores/tasks.js'
 import FactoryFloor from './FactoryFloor.vue'
 import TerminalPane from './TerminalPane.vue'
+import TaskPane from './TaskPane.vue'
 
 const agentsStore = useAgentsStore()
+const tasksStore = useTasksStore()
 const agents = computed(() => agentsStore.agents)
 const activeTab = ref('factory')
+
+// Show tabs for tasks that are active or recently completed (last 8)
+const visibleTaskTabs = computed(() => {
+  const active = tasksStore.tasks.filter(t =>
+    ['pending', 'planning', 'working', 'awaiting-review', 'followup'].includes(t.state)
+  )
+  const done = tasksStore.tasks
+    .filter(t => t.state === 'done' || t.state === 'failed')
+    .slice(0, Math.max(0, 8 - active.length))
+  return [...active, ...done].slice(0, 8)
+})
+
+// Auto-open task tab when a new task becomes active
+watch(() => tasksStore.selectedTaskId, (id) => {
+  if (id) activeTab.value = 'task-' + id
+})
 </script>
 
 <style scoped>
@@ -105,6 +136,23 @@ const activeTab = ref('factory')
 .state-dot.working { background: var(--color-green); animation: dotPulse 0.5s infinite; }
 .state-dot.busy { background: var(--color-orange); animation: dotPulse 0.8s infinite; }
 .state-dot.error { background: var(--color-red); }
+
+.task-tab { border-left: 1px solid rgba(255,204,0,0.2); }
+
+.task-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.task-dot-pending { background: var(--color-text-dim); }
+.task-dot-planning { background: var(--color-blue); animation: dotPulse 1s infinite; }
+.task-dot-working { background: var(--color-green); animation: dotPulse 0.5s infinite; }
+.task-dot-awaiting-review { background: var(--color-amber); animation: dotPulse 1.5s infinite; }
+.task-dot-done { background: var(--color-teal); }
+.task-dot-failed { background: var(--color-red); }
+.task-dot-follow-up { background: var(--color-orange); animation: dotPulse 0.8s infinite; }
 
 @keyframes dotPulse {
   0%, 100% { opacity: 1; transform: scale(1); }

--- a/frontend/src/components/TaskPane.vue
+++ b/frontend/src/components/TaskPane.vue
@@ -1,0 +1,337 @@
+<template>
+  <div class="task-pane">
+    <div class="task-header">
+      <div class="task-title-row">
+        <span class="task-phase-badge" :class="task.phase">{{ task.phase || 'execute' }}</span>
+        <span class="task-name">{{ task.name || task.description?.slice(0, 60) }}</span>
+        <span class="task-state-badge" :class="stateClass">{{ tasksStore.stateLabel(task.state) }}</span>
+      </div>
+      <div class="task-meta">
+        <span class="task-id">{{ task.id }}</span>
+        <span v-if="task.branch" class="task-branch">⌥ {{ task.branch }}</span>
+        <a v-if="task.pr_url" :href="task.pr_url" target="_blank" rel="noopener" class="pr-link">PR →</a>
+        <span class="task-time">{{ formatTime(task.created_at) }}</span>
+      </div>
+    </div>
+
+    <div class="task-logs" ref="logsEl">
+      <div v-if="!logs.length" class="logs-empty">No logs yet — waiting for worker output…</div>
+      <div v-for="(entry, i) in logs" :key="i" class="log-line">
+        <span class="log-ts">{{ formatTs(entry.timestamp) }}</span>
+        <span class="log-text" :class="lineClass(entry.line)">{{ entry.line }}</span>
+      </div>
+    </div>
+
+    <!-- Follow-up panel — shown when task is awaiting review -->
+    <div v-if="task.state === 'awaiting-review'" class="followup-panel">
+      <div class="followup-header">FOREMAN FOLLOW-UP</div>
+      <div class="followup-row">
+        <textarea
+          v-model="followupText"
+          class="followup-input"
+          placeholder="Additional instructions (e.g. 'update tests', 'add docstrings')…"
+          rows="2"
+          @keydown.ctrl.enter="sendFollowup"
+        />
+      </div>
+      <div class="followup-actions">
+        <button class="pixel-btn followup-btn" @click="sendFollowup" :disabled="!followupText.trim()">
+          ↺ Follow-up
+        </button>
+        <button class="pixel-btn finalize-btn" @click="finalizeTask">
+          ✓ Finalize
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import { useTasksStore } from '../stores/tasks.js'
+import { useGuildStore } from '../stores/guild.js'
+
+const props = defineProps({ taskId: String })
+
+const tasksStore = useTasksStore()
+const guildStore = useGuildStore()
+
+const logsEl = ref(null)
+const followupText = ref('')
+
+const task = computed(() => tasksStore.tasks.find(t => t.id === props.taskId) || {})
+const logs = computed(() => tasksStore.taskLogs[props.taskId] || [])
+
+const stateClass = computed(() => `state-${(task.value.state || 'pending').replace(/[^a-z]/g, '-')}`)
+
+onMounted(async () => {
+  const guildId = guildStore.currentGuild?.id
+  if (guildId && props.taskId && !tasksStore.taskLogs[props.taskId]) {
+    await tasksStore.fetchTaskLogs(guildId, props.taskId)
+  }
+})
+
+watch(logs, async () => {
+  await nextTick()
+  if (logsEl.value) logsEl.value.scrollTop = logsEl.value.scrollHeight
+}, { deep: true })
+
+async function sendFollowup() {
+  const text = followupText.value.trim()
+  if (!text) return
+  const guildId = guildStore.currentGuild?.id
+  if (!guildId) return
+  try {
+    await tasksStore.sendFollowup(guildId, props.taskId, text)
+    followupText.value = ''
+  } catch (e) {
+    console.error('Follow-up failed', e)
+  }
+}
+
+async function finalizeTask() {
+  const guildId = guildStore.currentGuild?.id
+  if (!guildId) return
+  try {
+    await tasksStore.finalizeTask(guildId, props.taskId)
+  } catch (e) {
+    console.error('Finalize failed', e)
+  }
+}
+
+function lineClass(line) {
+  if (!line) return ''
+  if (line.startsWith('✓') || line.includes('Done')) return 'log-success'
+  if (line.startsWith('✗') || line.includes('error') || line.includes('Error')) return 'log-error'
+  if (line.startsWith('[worker]')) return 'log-worker'
+  if (line.startsWith('▶')) return 'log-tool'
+  if (line.startsWith('  →')) return 'log-result'
+  if (line.startsWith('[thinking]')) return 'log-thinking'
+  return ''
+}
+
+function formatTime(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function formatTs(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+</script>
+
+<style scoped>
+.task-pane {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--color-bg);
+}
+
+.task-header {
+  padding: 10px 14px 8px;
+  border-bottom: 2px solid var(--color-brass-dark);
+  background: var(--color-bg-secondary);
+  flex-shrink: 0;
+}
+
+.task-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 5px;
+}
+
+.task-name {
+  font-size: 13px;
+  color: var(--color-text);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.task-phase-badge {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  padding: 2px 5px;
+  border: 1px solid;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  flex-shrink: 0;
+}
+.task-phase-badge.plan { color: var(--color-blue); border-color: var(--color-blue); }
+.task-phase-badge.execute { color: var(--color-teal); border-color: var(--color-teal); }
+.task-phase-badge.review { color: var(--color-amber); border-color: var(--color-amber); }
+.task-phase-badge.followup { color: var(--color-orange); border-color: var(--color-orange); }
+
+.task-state-badge {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  padding: 2px 6px;
+  border: 1px solid;
+  flex-shrink: 0;
+}
+.state-pending { color: var(--color-text-dim); border-color: var(--color-text-dim); }
+.state-planning { color: var(--color-blue); border-color: var(--color-blue); }
+.state-working { color: var(--color-green); border-color: var(--color-green); animation: statePulse 1s infinite; }
+.state-awaiting-review { color: var(--color-amber); border-color: var(--color-amber); }
+.state-done { color: var(--color-teal); border-color: var(--color-teal); }
+.state-failed { color: var(--color-red); border-color: var(--color-red); }
+.state-follow-up { color: var(--color-orange); border-color: var(--color-orange); }
+
+@keyframes statePulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.task-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.task-id {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-text-dim);
+}
+
+.task-branch {
+  font-size: 10px;
+  color: var(--color-teal);
+  font-family: var(--font-mono);
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pr-link {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-teal);
+  text-decoration: none;
+  padding: 2px 6px;
+  border: 1px solid var(--color-teal);
+}
+.pr-link:hover { background: rgba(0,187,170,0.15); }
+
+.task-time {
+  font-size: 10px;
+  color: var(--color-text-dim);
+  margin-left: auto;
+}
+
+/* ── Logs ── */
+.task-logs {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.logs-empty {
+  color: var(--color-text-dim);
+  font-style: italic;
+  margin-top: 20px;
+  text-align: center;
+}
+
+.log-line {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.log-ts {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.log-text { word-break: break-all; }
+.log-success { color: var(--color-green); }
+.log-error { color: var(--color-red); }
+.log-worker { color: var(--color-brass); }
+.log-tool { color: var(--color-teal); }
+.log-result { color: var(--color-text-dim); }
+.log-thinking { color: var(--color-blue); font-style: italic; }
+
+/* ── Follow-up panel ── */
+.followup-panel {
+  flex-shrink: 0;
+  border-top: 2px solid var(--color-amber);
+  background: rgba(255, 204, 0, 0.04);
+  padding: 10px 14px;
+}
+
+.followup-header {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-amber);
+  letter-spacing: 2px;
+  margin-bottom: 8px;
+}
+
+.followup-row {
+  margin-bottom: 8px;
+}
+
+.followup-input {
+  width: 100%;
+  background: var(--color-bg);
+  border: 2px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 6px 10px;
+  outline: none;
+  resize: none;
+  box-sizing: border-box;
+}
+.followup-input:focus {
+  border-color: var(--color-amber);
+  box-shadow: 0 0 8px rgba(255,204,0,0.2);
+}
+.followup-input::placeholder { color: var(--color-text-dim); font-style: italic; }
+
+.followup-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.followup-btn {
+  background: linear-gradient(180deg, rgba(255,204,0,0.2) 0%, rgba(180,140,0,0.3) 100%);
+  border-color: var(--color-amber);
+  color: var(--color-amber);
+  font-size: 8px;
+  padding: 5px 12px;
+}
+.followup-btn:hover:not(:disabled) {
+  background: linear-gradient(180deg, rgba(255,204,0,0.4) 0%, rgba(200,160,0,0.5) 100%);
+  box-shadow: 0 0 8px rgba(255,204,0,0.3);
+}
+.followup-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+.finalize-btn {
+  background: linear-gradient(180deg, rgba(0,187,170,0.2) 0%, rgba(0,120,110,0.3) 100%);
+  border-color: var(--color-teal);
+  color: var(--color-teal);
+  font-size: 8px;
+  padding: 5px 12px;
+}
+.finalize-btn:hover {
+  background: linear-gradient(180deg, rgba(0,187,170,0.4) 0%, rgba(0,150,140,0.5) 100%);
+  box-shadow: 0 0 8px rgba(0,187,170,0.3);
+}
+</style>

--- a/frontend/src/stores/tasks.js
+++ b/frontend/src/stores/tasks.js
@@ -1,0 +1,158 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+const API_BASE = 'http://localhost:8000'
+
+const STATE_LABELS = {
+  pending: 'pending',
+  planning: 'planning',
+  working: 'working',
+  'awaiting-review': 'review',
+  done: 'done',
+  failed: 'failed',
+  followup: 'follow-up',
+}
+
+const STATE_COLORS = {
+  pending: 'dim',
+  planning: 'blue',
+  working: 'green',
+  'awaiting-review': 'amber',
+  done: 'teal',
+  failed: 'red',
+  followup: 'orange',
+}
+
+export const useTasksStore = defineStore('tasks', () => {
+  const tasks = ref([])
+  const taskLogs = ref({})   // task_id -> [{ line, timestamp }]
+  const selectedTaskId = ref(null)
+
+  async function fetchTasks(guildId) {
+    if (!guildId) return
+    try {
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks`)
+      if (res.ok) tasks.value = await res.json()
+    } catch (e) {
+      console.error('Failed to fetch tasks', e)
+    }
+  }
+
+  async function fetchTaskLogs(guildId, taskId) {
+    try {
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/logs`)
+      if (!res.ok) return []
+      const logs = await res.json()
+      taskLogs.value[taskId] = logs
+      return logs
+    } catch (e) {
+      console.error('Failed to fetch task logs', e)
+      return []
+    }
+  }
+
+  async function sendFollowup(guildId, taskId, instructions) {
+    const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/followup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ instructions }),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return res.json()
+  }
+
+  async function finalizeTask(guildId, taskId) {
+    const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/finalize`, {
+      method: 'POST',
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return res.json()
+  }
+
+  function _upsertTask(data) {
+    const idx = tasks.value.findIndex(t => t.id === data.id)
+    if (idx >= 0) {
+      Object.assign(tasks.value[idx], data)
+    } else {
+      tasks.value.unshift(data)
+    }
+  }
+
+  function handleWebSocketMessage(data) {
+    if (data.type === 'task-created') {
+      _upsertTask({
+        id: data.taskId,
+        name: data.name,
+        description: data.description,
+        phase: data.phase,
+        state: data.state,
+        worker_id: 'foreman',
+        created_at: data.createdAt,
+      })
+    } else if (data.type === 'task-assigned') {
+      _upsertTask({
+        id: data.taskId,
+        name: data.name || (data.description || '').slice(0, 60),
+        description: data.description,
+        phase: data.phase || 'execute',
+        state: 'pending',
+        worker_id: data.workerId,
+        parent_task_id: data.parentTaskId || null,
+        created_at: new Date().toISOString(),
+      })
+    } else if (data.type === 'task-update') {
+      const task = tasks.value.find(t => t.id === data.taskId)
+      if (task) {
+        if (data.state) task.state = data.state
+        if (data.branch) task.branch = data.branch
+        if (data.prUrl) task.pr_url = data.prUrl
+        if (data.finishedAt) task.finished_at = data.finishedAt
+        if (data.worktreePath) task.worktree_path = data.worktreePath
+      }
+    } else if (data.type === 'task-complete') {
+      const task = tasks.value.find(t => t.id === data.taskId)
+      if (task) {
+        task.state = 'awaiting-review'
+        if (data.branch) task.branch = data.branch
+      }
+    } else if (data.type === 'task-followup-done') {
+      const task = tasks.value.find(t => t.id === data.taskId)
+      if (task) task.state = 'awaiting-review'
+    } else if (data.type === 'terminal-output' && data.taskId) {
+      const { taskId, line, timestamp } = data
+      if (!taskLogs.value[taskId]) taskLogs.value[taskId] = []
+      for (const l of (line || '').split('\n')) {
+        if (l) taskLogs.value[taskId].push({ line: l, timestamp })
+        if (taskLogs.value[taskId].length > 2000) taskLogs.value[taskId].shift()
+      }
+    }
+  }
+
+  function selectTask(taskId) {
+    selectedTaskId.value = taskId
+  }
+
+  function clearTasks() {
+    tasks.value = []
+    taskLogs.value = {}
+    selectedTaskId.value = null
+  }
+
+  function stateLabel(state) { return STATE_LABELS[state] || state }
+  function stateColor(state) { return STATE_COLORS[state] || 'dim' }
+
+  return {
+    tasks,
+    taskLogs,
+    selectedTaskId,
+    fetchTasks,
+    fetchTaskLogs,
+    sendFollowup,
+    finalizeTask,
+    handleWebSocketMessage,
+    selectTask,
+    clearTasks,
+    stateLabel,
+    stateColor,
+  }
+})

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -13,6 +13,7 @@ import { useGuildStore } from '../stores/guild.js'
 import { useAgentsStore } from '../stores/agents.js'
 import { useAuthStore } from '../stores/auth.js'
 import { useGitHubStore } from '../stores/github.js'
+import { useTasksStore } from '../stores/tasks.js'
 import GuildSidebar from '../components/GuildSidebar.vue'
 import MainView from '../components/MainView.vue'
 import ChatPane from '../components/ChatPane.vue'
@@ -24,6 +25,7 @@ const guildStore = useGuildStore()
 const agentsStore = useAgentsStore()
 const authStore = useAuthStore()
 const ghStore = useGitHubStore()
+const tasksStore = useTasksStore()
 
 function getClientId() {
   let id = localStorage.getItem('client_id')
@@ -45,11 +47,14 @@ async function initGuild(guildId) {
   }
 
   agentsStore.clearAgents()
+  tasksStore.clearTasks()
   const guild = await guildStore.joinGuild(guildId)
   if (!guild) {
     router.replace('/')
     return
   }
+  // Load existing tasks for this guild
+  await tasksStore.fetchTasks(guildId)
 
   if (guild.agents) {
     guild.agents
@@ -69,6 +74,7 @@ async function initGuild(guildId) {
 
   guildStore.connectWebSocket(guildId, (data) => {
     agentsStore.handleWebSocketMessage(data)
+    tasksStore.handleWebSocketMessage(data)
   })
 
   setTimeout(() => {
@@ -91,6 +97,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   guildStore.disconnectWebSocket()
+  tasksStore.clearTasks()
 })
 
 watch(() => props.guildId, async (newId) => {

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -38,6 +38,8 @@ class Worker:
         self.task_queue: asyncio.Queue[dict] = asyncio.Queue()
         self.current_claude: Optional[claude_runner.ClaudeProcess] = None
         self._known_task_ids: set[str] = set()
+        # Per-task queues for follow-up instructions; None signals finalization
+        self._followup_queues: dict[str, asyncio.Queue] = {}
 
     # ------------------------------------------------------------------ HTTP
     async def _http(self) -> httpx.AsyncClient:
@@ -93,6 +95,18 @@ class Worker:
             "line": line,
             "timestamp": _now_iso(),
         })
+
+    def _task_emit(self, task_id: str):
+        """Return an async emit function that tags output with task_id for log persistence."""
+        async def _emit_task(line: str) -> None:
+            await self._send({
+                "type": "terminal-output",
+                "agentId": self.cfg.worker_id,
+                "taskId": task_id,
+                "line": line,
+                "timestamp": _now_iso(),
+            })
+        return _emit_task
 
     async def _set_state(self, state: str) -> None:
         await self._send({
@@ -212,6 +226,31 @@ class Worker:
                 elif text:
                     logger.debug("worker-message received but no claude is running; dropping")
 
+            elif mtype == "task-followup":
+                if msg.get("workerId") != self.cfg.worker_id:
+                    continue
+                task_id = msg.get("taskId")
+                instructions = msg.get("instructions", "")
+                q = self._followup_queues.get(task_id)
+                if q is not None:
+                    await q.put(instructions)
+                    logger.info("Follow-up queued for task %s: %s", task_id, instructions[:80])
+                else:
+                    logger.warning(
+                        "task-followup for %s but no queue (task may have finalized)", task_id
+                    )
+
+            elif mtype == "task-finalize":
+                if msg.get("workerId") != self.cfg.worker_id:
+                    continue
+                task_id = msg.get("taskId")
+                q = self._followup_queues.get(task_id)
+                if q is not None:
+                    await q.put(None)  # None = finalize signal
+                    logger.info("Finalize signal queued for task %s", task_id)
+                else:
+                    logger.debug("task-finalize for %s but no queue", task_id)
+
     async def _idle_puller(self) -> None:
         logger.info("Idle puller started (interval=%.1fs)", self.cfg.pull_interval)
         while True:
@@ -274,19 +313,21 @@ class Worker:
         logger.info("Task %s branch=%s work_dir=%s", task_id, branch, work_dir)
         os.makedirs(work_dir, exist_ok=True)
 
-        await self._emit(f"[worker] Task: {desc}")
-        await self._emit(f"[worker] Branch: {branch}")
+        # Task-scoped emit: tags terminal-output with taskId so backend persists to task_logs
+        emit = self._task_emit(task_id)
+        await emit(f"[worker] Task: {desc}")
+        await emit(f"[worker] Branch: {branch}")
 
         worktree_entries: list[tuple[str, str, str]] = []
         primary_wt: Optional[str] = None
 
         for repo_full in repos:
             logger.info("Task %s: preparing repo %s", task_id, repo_full)
-            await self._emit(f"[worker] Preparing {repo_full}...")
+            await emit(f"[worker] Preparing {repo_full}...")
             repo_path = await git_ops.ensure_repo(self.cfg.repos_dir, repo_full, token)
             if not repo_path:
                 logger.error("Task %s: clone/fetch failed for %s", task_id, repo_full)
-                await self._emit(f"[worker] ✗ Clone failed: {repo_full}")
+                await emit(f"[worker] ✗ Clone failed: {repo_full}")
                 continue
             repo_name = repo_full.split("/")[-1]
             wt_path = os.path.join(work_dir, repo_name)
@@ -298,11 +339,11 @@ class Worker:
                     primary_wt = wt_path
             else:
                 logger.error("Task %s: worktree creation failed for %s", task_id, repo_full)
-                await self._emit(f"[worker] ✗ Worktree failed: {repo_full}")
+                await emit(f"[worker] ✗ Worktree failed: {repo_full}")
 
         if not primary_wt:
             logger.error("Task %s: aborting — no worktrees were created", task_id)
-            await self._emit("[worker] ✗ No worktrees — aborting.")
+            await emit("[worker] ✗ No worktrees — aborting.")
             await self._task_update(task_id, state="failed", finishedAt=_now_iso())
             await self._set_state("error")
             return
@@ -317,18 +358,12 @@ class Worker:
         if tool == "codex":
             logger.info("Task %s: launching codex in %s", task_id, primary_wt)
             success, stop_reason, last_msg = await codex_runner.run_codex_auto(
-                desc,
-                primary_wt,
-                emit=self._emit,
-                codex_path=self.cfg.codex_path,
+                desc, primary_wt, emit=emit, codex_path=self.cfg.codex_path,
             )
         elif tool == "pi":
             logger.info("Task %s: launching pi in %s", task_id, primary_wt)
             success, stop_reason, last_msg = await pi_runner.run_pi_auto(
-                desc,
-                primary_wt,
-                emit=self._emit,
-                pi_path=self.cfg.pi_path,
+                desc, primary_wt, emit=emit, pi_path=self.cfg.pi_path,
             )
         else:
             logger.info(
@@ -336,49 +371,95 @@ class Worker:
                 task_id, primary_wt, self.cfg.claude_max_turns,
             )
             success, stop_reason, last_msg = await claude_runner.run_claude_auto(
-                desc,
-                primary_wt,
+                desc, primary_wt,
                 max_turns=self.cfg.claude_max_turns,
-                emit=self._emit,
+                emit=emit,
                 on_proc=_on_proc,
                 claude_path=self.cfg.claude_path,
             )
         self.current_claude = None
-        finished_at = _now_iso()
-        logger.info("Task %s: claude finished success=%s stop_reason=%s", task_id, success, stop_reason)
+        logger.info("Task %s: agent finished success=%s stop_reason=%s", task_id, success, stop_reason)
 
-        if success:
-            logger.info("Task %s: pushing branch %s", task_id, branch)
-            await github_pr.push_branch(
-                branch=branch,
-                worktree_path=primary_wt,
-                emit=self._emit,
-            )
-            logger.info("Task %s: done", task_id)
-            await self._task_update(
-                task_id, state="done", branch=branch, finishedAt=finished_at,
-            )
-            await self._send({
-                "type": "task-complete",
-                "workerId": self.cfg.worker_id,
-                "taskId": task_id,
-                "branch": branch,
-                "description": desc,
-            })
-            await self._set_state("idle")
-        else:
-            logger.warning("Task %s: failed stop_reason=%s, requesting human input", task_id, stop_reason)
-            await self._task_update(task_id, state="failed", finishedAt=finished_at)
-            await self._set_state("error")
-            await self._send({
-                "type": "needs-input",
-                "workerId": self.cfg.worker_id,
-                "taskId": task_id,
-                "description": desc,
-                "stopReason": stop_reason,
-                "lastMessage": last_msg,
-            })
+        try:
+            if success:
+                logger.info("Task %s: pushing branch %s", task_id, branch)
+                await github_pr.push_branch(branch=branch, worktree_path=primary_wt, emit=emit)
 
-        logger.info("Task %s: cleaning up %d worktree(s)", task_id, len(worktree_entries))
-        for _repo_full, repo_path, wt_path in worktree_entries:
-            await git_ops.remove_worktree(repo_path, wt_path)
+                # Notify backend the initial work is done; stay alive for follow-ups
+                await self._task_update(task_id, branch=branch, worktreePath=primary_wt, state="awaiting-review")
+                await self._send({
+                    "type": "task-complete",
+                    "workerId": self.cfg.worker_id,
+                    "taskId": task_id,
+                    "branch": branch,
+                    "description": desc,
+                })
+                await self._set_state("awaiting-review")
+
+                # Register follow-up queue; foreman can send instructions or finalize
+                followup_q: asyncio.Queue[Optional[str]] = asyncio.Queue()
+                self._followup_queues[task_id] = followup_q
+                try:
+                    while True:
+                        try:
+                            instructions = await asyncio.wait_for(followup_q.get(), timeout=300.0)
+                        except asyncio.TimeoutError:
+                            await emit("[worker] Follow-up window expired — finalizing.")
+                            break
+                        if instructions is None:
+                            await emit("[worker] Task finalized by foreman.")
+                            break
+
+                        # Execute follow-up in the same worktree on the same branch
+                        await self._set_state("working")
+                        await self._task_update(task_id, state="working")
+                        await emit(f"[worker] Follow-up: {instructions[:120]}")
+
+                        def _on_proc2(proc: claude_runner.ClaudeProcess) -> None:
+                            self.current_claude = proc
+
+                        fu_ok, fu_reason, _ = await claude_runner.run_claude_auto(
+                            instructions, primary_wt,
+                            max_turns=self.cfg.claude_max_turns,
+                            emit=emit,
+                            on_proc=_on_proc2,
+                            claude_path=self.cfg.claude_path,
+                        )
+                        self.current_claude = None
+                        logger.info("Task %s follow-up done: ok=%s reason=%s", task_id, fu_ok, fu_reason)
+
+                        if fu_ok:
+                            await github_pr.push_branch(branch=branch, worktree_path=primary_wt, emit=emit)
+
+                        await self._send({
+                            "type": "task-followup-done",
+                            "workerId": self.cfg.worker_id,
+                            "taskId": task_id,
+                            "success": fu_ok,
+                            "stopReason": fu_reason,
+                        })
+                        await self._task_update(task_id, state="awaiting-review")
+                        await self._set_state("awaiting-review")
+                finally:
+                    self._followup_queues.pop(task_id, None)
+
+                await self._task_update(task_id, state="done", finishedAt=_now_iso())
+                await self._set_state("idle")
+
+            else:
+                logger.warning("Task %s: failed stop_reason=%s", task_id, stop_reason)
+                await self._task_update(task_id, state="failed", finishedAt=_now_iso())
+                await self._set_state("error")
+                await self._send({
+                    "type": "needs-input",
+                    "workerId": self.cfg.worker_id,
+                    "taskId": task_id,
+                    "description": desc,
+                    "stopReason": stop_reason,
+                    "lastMessage": last_msg,
+                })
+
+        finally:
+            logger.info("Task %s: cleaning up %d worktree(s)", task_id, len(worktree_entries))
+            for _repo_full, repo_path, wt_path in worktree_entries:
+                await git_ops.remove_worktree(repo_path, wt_path)


### PR DESCRIPTION
Foreman now owns tasks with named entries visible in the sidebar:
- New `create_task` tool: foreman creates a named task before assigning work,
  giving every job a human-readable title and a task_id for cross-referencing
- Updated `assign_task`: accepts name, phase (plan/execute/review/followup),
  and parent_task_id to link worker tasks back to the foreman's task
- New `send_followup` tool: foreman sends follow-up instructions (update tests,
  fix lint, add docs) that execute in the same git worktree on the same branch
- New `finalize_task` tool: foreman explicitly marks a task done with no
  further follow-up needed

Worker sticky worktree support:
- After initial execution succeeds, worker pushes branch then waits up to 5
  minutes for follow-up instructions before auto-finalizing
- Follow-ups run in the same worktree/branch and push incremental commits
- `task-followup` and `task-finalize` WebSocket messages control the loop
- All terminal output tagged with taskId so backend persists lines to task_logs

Task log persistence:
- New `task_logs` table stores every terminal-output line tagged with a task
- GET /guilds/{id}/tasks — list all tasks with name, phase, state
- GET /guilds/{id}/tasks/{id}/logs — retrieve full log history
- POST /guilds/{id}/tasks/{id}/followup — send follow-up via REST
- POST /guilds/{id}/tasks/{id}/finalize — finalize via REST

task-complete now triggers foreman AI review; task-followup-done re-triggers
for another round — enabling plan → execute → review multi-step flows.

Frontend:
- New tasks.js Pinia store tracks tasks and real-time logs from WebSocket
- Sidebar tasks panel lists recent tasks with state badges; click to open
- Task tabs appear in MainView for active/recent tasks alongside agent terminals
- TaskPane.vue shows task header, live log stream, and an inline follow-up
  input that appears when the task is awaiting review

https://claude.ai/code/session_01GJu1XoFzc6E5zxBFz9y1GZ