### PR TITLE
fix: preserve multi-line log messages and render with pre-wrap

### DIFF
--- a/frontend/src/components/TaskPane.vue
+++ b/frontend/src/components/TaskPane.vue
@@ -259,7 +259,7 @@ function formatTs(iso) {
   opacity: 0.6;
 }
 
-.log-text { word-break: break-all; }
+.log-text { word-break: break-all; white-space: pre-wrap; }
 .log-success { color: var(--color-green); }
 .log-error { color: var(--color-red); }
 .log-worker { color: var(--color-brass); }

--- a/frontend/src/components/WorkerTerminalPane.vue
+++ b/frontend/src/components/WorkerTerminalPane.vue
@@ -173,7 +173,7 @@ watch(logs, async () => {
   font-size: 11px;
 }
 
-.log-content         { color: var(--color-green); word-break: break-all; }
+.log-content         { color: var(--color-green); word-break: break-all; white-space: pre-wrap; }
 .log-content.log-success { color: var(--color-teal); }
 .log-content.log-error   { color: var(--color-red); }
 .log-content.log-meta    { color: var(--color-brass-dark); }

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -63,23 +63,19 @@ export const useAgentsStore = defineStore('agents', () => {
 
   function addLog(agentId, line, timestamp) {
     const agent = agents.value.find(a => a.id === agentId)
-    if (agent) {
+    if (agent && line) {
       const ts = timestamp || new Date().toISOString()
-      for (const l of line.split('\n')) {
-        agent.logs.push({ line: l, timestamp: ts })
-        if (agent.logs.length > 500) agent.logs.shift()
-      }
+      agent.logs.push({ line, timestamp: ts })
+      if (agent.logs.length > 500) agent.logs.shift()
     }
   }
 
   function addWorkerLog(workerId, line, timestamp) {
+    if (!line) return
     if (!workerLogs.value[workerId]) workerLogs.value[workerId] = []
     const ts = timestamp || new Date().toISOString()
-    for (const l of (line || '').split('\n')) {
-      if (!l) continue
-      workerLogs.value[workerId].push({ line: l, timestamp: ts })
-      if (workerLogs.value[workerId].length > 500) workerLogs.value[workerId].shift()
-    }
+    workerLogs.value[workerId].push({ line, timestamp: ts })
+    if (workerLogs.value[workerId].length > 500) workerLogs.value[workerId].shift()
   }
 
   function selectWorker(workerId) {

--- a/frontend/src/stores/tasks.js
+++ b/frontend/src/stores/tasks.js
@@ -122,9 +122,9 @@ export const useTasksStore = defineStore('tasks', () => {
       if (task) task.state = 'awaiting-review'
     } else if (data.type === 'terminal-output' && data.taskId) {
       const { taskId, line, timestamp } = data
-      if (!taskLogs.value[taskId]) taskLogs.value[taskId] = []
-      for (const l of (line || '').split('\n')) {
-        if (l) taskLogs.value[taskId].push({ line: l, timestamp })
+      if (line) {
+        if (!taskLogs.value[taskId]) taskLogs.value[taskId] = []
+        taskLogs.value[taskId].push({ line, timestamp })
         if (taskLogs.value[taskId].length > 2000) taskLogs.value[taskId].shift()
       }
     }


### PR DESCRIPTION
## Summary

- Removed `split('\n')` loops in `agents.js` (`addLog`, `addWorkerLog`) and `tasks.js` (`handleWebSocketMessage`) that were exploding each incoming `terminal-output` message into individual single-line entries. Messages are now stored intact with embedded newlines.
- Added `white-space: pre-wrap` to `.log-text` in `TaskPane.vue` and `.log-content` in `WorkerTerminalPane.vue` so the browser renders those embedded newlines visually.

## Test plan

- [ ] Start backend + worker + frontend, assign a task, confirm multi-line Claude output (e.g. a tool result with several lines) appears as a single block in the task log pane rather than as many separate timestamped entries.
- [ ] Confirm the worker terminal pane also renders multi-line output correctly.
- [ ] Confirm single-line messages still render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)