### PR TITLE
feat: log line tagging, contextual filtering, and hierarchical agents panel

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -211,6 +211,14 @@ async def init_db():
             FOREIGN KEY (task_id) REFERENCES tasks(id)
         )
     """)
+    for col_sql in [
+        "ALTER TABLE task_logs ADD COLUMN worker_id TEXT",
+        "ALTER TABLE task_logs ADD COLUMN agent_id TEXT",
+    ]:
+        try:
+            await db.execute(col_sql)
+        except aiosqlite.OperationalError:
+            pass
     # On every startup, no worker processes are connected yet.
     await db.execute("UPDATE workers SET state = 'offline'")
     await db.execute("UPDATE agents SET state = 'offline' WHERE type = 'worker'")
@@ -1252,15 +1260,26 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 line = data.get("line", "")
                 task_id = data.get("taskId")
                 created_at = datetime.now(timezone.utc).isoformat()
+                # Look up worker_id for this agent to tag logs for cross-filter queries.
+                worker_id = None
+                if agent_id:
+                    async with db.execute(
+                        "SELECT worker_id FROM agents WHERE id=?", (agent_id,)
+                    ) as cur:
+                        row = await cur.fetchone()
+                        if row:
+                            worker_id = row["worker_id"]
                 if task_id and line:
                     await db.execute(
-                        "INSERT INTO task_logs (task_id, timestamp, line) VALUES (?, ?, ?)",
-                        (task_id, created_at, line),
+                        "INSERT INTO task_logs (task_id, timestamp, line, worker_id, agent_id)"
+                        " VALUES (?, ?, ?, ?, ?)",
+                        (task_id, created_at, line, worker_id, agent_id),
                     )
                     await db.commit()
                 await broadcast(guild_id, {
                     "type": "terminal-output",
                     "agentId": agent_id,
+                    "workerId": worker_id,
                     "taskId": task_id,
                     "line": line,
                     "timestamp": created_at
@@ -1827,8 +1846,41 @@ async def get_task_logs(guild_id: str, task_id: str):
             if not await cur.fetchone():
                 raise HTTPException(status_code=404, detail="Task not found")
         async with db.execute(
-            "SELECT timestamp, line FROM task_logs WHERE task_id=? ORDER BY id ASC",
+            "SELECT timestamp, line, worker_id, agent_id FROM task_logs"
+            " WHERE task_id=? ORDER BY id ASC",
             (task_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        await db.close()
+
+
+@app.get("/guilds/{guild_id}/logs")
+async def get_guild_logs(
+    guild_id: str,
+    worker_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+):
+    """Get task_logs filtered by worker_id, agent_id, or task_id."""
+    if not (worker_id or agent_id or task_id):
+        raise HTTPException(status_code=400, detail="Specify worker_id, agent_id, or task_id")
+    db = await get_db()
+    try:
+        async with db.execute("SELECT 1 FROM guilds WHERE id=?", (guild_id,)) as cur:
+            if not await cur.fetchone():
+                raise HTTPException(status_code=404, detail="Guild not found")
+        if task_id:
+            col, val = "task_id", task_id
+        elif worker_id:
+            col, val = "worker_id", worker_id
+        else:
+            col, val = "agent_id", agent_id
+        async with db.execute(
+            f"SELECT timestamp, line, worker_id, agent_id, task_id"
+            f" FROM task_logs WHERE {col}=? ORDER BY id ASC",
+            (val,),
         ) as cur:
             rows = await cur.fetchall()
         return [dict(r) for r in rows]

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -32,23 +32,42 @@
       </template>
     </div>
 
-    <!-- Agents section -->
-    <div v-if="agentsStore.agents.length > 0" class="workers-section">
+    <!-- Workers/Agents hierarchical section -->
+    <div v-if="agentsStore.workers.length > 0" class="workers-section">
       <div class="section-header">
-        <span class="section-label">Agents</span>
-        <span class="section-count">{{ agentsStore.agents.length }}</span>
+        <span class="section-label">Workers</span>
+        <span class="section-count">{{ agentsStore.workers.length }}</span>
       </div>
-      <div
-        v-for="agent in agentsStore.agents"
-        :key="agent.id"
-        class="worker-item"
-        :class="{ selected: agentsStore.selectedAgentId === agent.id }"
-        @click="agentsStore.selectAgent(agent.id)"
-      >
-        <span class="worker-dot" :class="'wdot-' + agent.state"></span>
-        <span class="worker-name">{{ agent.name }}</span>
-        <span class="worker-state">{{ agent.state }}</span>
-      </div>
+      <template v-for="worker in agentsStore.workers" :key="worker.id">
+        <!-- Worker row -->
+        <div class="worker-row" :class="worker.state">
+          <span class="worker-dot" :class="'wdot-' + worker.state"></span>
+          <span class="worker-row-name">{{ worker.name }}</span>
+          <span class="worker-row-state">{{ worker.state }}</span>
+        </div>
+        <!-- Agent rows under this worker -->
+        <div
+          v-for="agent in agentsForWorker(worker.id)"
+          :key="agent.id"
+          class="agent-row"
+        >
+          <span class="agent-dot" :class="'wdot-' + agent.state"></span>
+          <span class="agent-row-name">{{ agent.name }}</span>
+          <div class="agent-actions">
+            <button
+              class="agent-icon-btn"
+              title="Open agent terminal"
+              @click.stop="agentsStore.selectAgent(agent.id)"
+            >🤖</button>
+            <button
+              class="agent-icon-btn"
+              :disabled="!currentTaskForWorker(worker.id)"
+              :title="currentTaskForWorker(worker.id) ? 'Open current task' : 'No active task'"
+              @click.stop="openAgentTask(worker.id)"
+            >📋</button>
+          </div>
+        </div>
+      </template>
     </div>
 
     <div class="sidebar-footer">
@@ -140,6 +159,23 @@ function goHome() {
 
 function openTask(taskId) {
   tasksStore.selectTask(taskId)
+}
+
+function agentsForWorker(workerId) {
+  return agentsStore.agents.filter(a => a.workerId === workerId)
+}
+
+function currentTaskForWorker(workerId) {
+  const active = tasksStore.tasks.filter(
+    t => t.worker_id === workerId && !['done', 'failed'].includes(t.state)
+  )
+  if (active.length) return active[0]
+  return tasksStore.tasks.find(t => t.worker_id === workerId) || null
+}
+
+function openAgentTask(workerId) {
+  const task = currentTaskForWorker(workerId)
+  if (task) tasksStore.selectTask(task.id)
 }
 
 function formatTime(isoStr) {
@@ -304,7 +340,7 @@ function formatTime(isoStr) {
 .workers-section {
   border-top: 2px solid var(--color-brass-dark);
   flex-shrink: 0;
-  max-height: 160px;
+  max-height: 240px;
   overflow-y: auto;
 }
 
@@ -335,24 +371,91 @@ function formatTime(isoStr) {
   border-radius: 2px;
 }
 
-.worker-item {
+/* Worker top-level row */
+.worker-row {
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 7px 12px;
-  cursor: pointer;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  padding: 5px 12px;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.worker-row-name {
+  font-size: 10px;
+  color: var(--color-teal);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-pixel);
+  letter-spacing: 0.5px;
+}
+
+.worker-row-state {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Agent row (indented under worker) */
+.agent-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px 5px 22px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.02);
   transition: background 0.12s;
 }
 
-.worker-item:hover {
+.agent-row:hover {
   background: rgba(0, 187, 170, 0.06);
 }
 
-.worker-item.selected {
-  background: rgba(0, 187, 170, 0.12);
-  border-left: 3px solid var(--color-teal);
-  padding-left: 9px;
+.agent-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.agent-row-name {
+  font-size: 10px;
+  color: var(--color-text);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agent-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.agent-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 1px 3px;
+  border-radius: 2px;
+  opacity: 0.6;
+  transition: opacity 0.12s, background 0.12s;
+  line-height: 1;
+}
+
+.agent-icon-btn:hover:not(:disabled) {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.agent-icon-btn:disabled {
+  opacity: 0.2;
+  cursor: not-allowed;
 }
 
 .worker-dot {
@@ -367,23 +470,6 @@ function formatTime(isoStr) {
 .wdot-busy    { background: var(--color-orange); animation: pulse 0.8s infinite; }
 .wdot-error   { background: var(--color-red); }
 .wdot-offline { background: #333; }
-
-.worker-name {
-  font-size: 11px;
-  color: var(--color-teal);
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.worker-state {
-  font-family: var(--font-pixel);
-  font-size: 6px;
-  color: var(--color-text-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
 
 /* ── Footer ── */
 .sidebar-footer {

--- a/frontend/src/components/TerminalPane.vue
+++ b/frontend/src/components/TerminalPane.vue
@@ -87,8 +87,9 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick, onMounted } from 'vue'
 import { useAgentsStore } from '../stores/agents.js'
+import { useGuildStore } from '../stores/guild.js'
 
 const props = defineProps({
   agentId: {
@@ -98,9 +99,15 @@ const props = defineProps({
 })
 
 const agentsStore = useAgentsStore()
+const guildStore = useGuildStore()
 const terminalEl = ref(null)
 
 const agent = computed(() => agentsStore.agents.find(a => a.id === props.agentId))
+
+onMounted(async () => {
+  const guildId = guildStore.currentGuild?.id
+  if (guildId) await agentsStore.fetchAgentLogs(guildId, props.agentId)
+})
 const logs = computed(() => agent.value?.logs || [])
 const isRunning = computed(() => agent.value?.state === 'working' || agent.value?.state === 'thinking' || agent.value?.state === 'busy')
 

--- a/frontend/src/components/WorkerTerminalPane.vue
+++ b/frontend/src/components/WorkerTerminalPane.vue
@@ -39,18 +39,25 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick, onMounted } from 'vue'
 import { useAgentsStore } from '../stores/agents.js'
+import { useGuildStore } from '../stores/guild.js'
 
 const props = defineProps({
   workerId: { type: String, required: true }
 })
 
 const agentsStore = useAgentsStore()
+const guildStore = useGuildStore()
 const terminalEl = ref(null)
 
 const worker = computed(() => agentsStore.workers.find(w => w.id === props.workerId))
 const logs = computed(() => agentsStore.workerLogs[props.workerId] || [])
+
+onMounted(async () => {
+  const guildId = guildStore.currentGuild?.id
+  if (guildId) await agentsStore.fetchWorkerLogs(guildId, props.workerId)
+})
 
 function padName(name) {
   if (!name) return ''.padEnd(20)

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -233,13 +233,48 @@ export const useAgentsStore = defineStore('agents', () => {
     openedAgentIds.value = []
   }
 
+  async function fetchWorkerLogs(guildId, workerId) {
+    try {
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/logs?worker_id=${workerId}`)
+      if (res.ok) {
+        const logs = await res.json()
+        workerLogs.value[workerId] = logs
+      }
+    } catch (e) {
+      console.error('Failed to fetch worker logs', e)
+    }
+  }
+
+  async function fetchAgentLogs(guildId, agentId) {
+    try {
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/logs?agent_id=${agentId}`)
+      if (res.ok) {
+        const historical = await res.json()
+        const agent = agents.value.find(a => a.id === agentId)
+        if (agent) {
+          const existing = agent.logs
+          agent.logs = [...historical, ...existing]
+          if (agent.logs.length > 2000) agent.logs = agent.logs.slice(-2000)
+        }
+      }
+    } catch (e) {
+      console.error('Failed to fetch agent logs', e)
+    }
+  }
+
   function handleWebSocketMessage(data) {
     if (data.type === 'agent-joined') {
       registerAgent(data)
     } else if (data.type === 'agent-state') {
       updateAgentState(data.agentId, data.state)
-    } else if (data.type === 'terminal-output' && !data.taskId) {
-      addLog(data.agentId, data.line, data.timestamp)
+    } else if (data.type === 'terminal-output') {
+      // Route to per-agent log buffer (includes task logs for agent-tab view)
+      if (data.agentId) addLog(data.agentId, data.line, data.timestamp)
+      // Route to per-worker log buffer; fall back to agent's workerId if backend didn't send it
+      const wid = data.workerId || (data.agentId
+        ? agents.value.find(a => a.id === data.agentId)?.workerId
+        : null)
+      if (wid) addWorkerLog(wid, data.line, data.timestamp)
     }
   }
 
@@ -255,6 +290,8 @@ export const useAgentsStore = defineStore('agents', () => {
     updateAgentState,
     addLog,
     addWorkerLog,
+    fetchWorkerLogs,
+    fetchAgentLogs,
     selectWorker,
     closeWorker,
     selectAgent,


### PR DESCRIPTION
## Summary

- **Log tagging**: Every `task_log` row now carries `worker_id` and `agent_id`. The `terminal-output` WebSocket handler looks up the agent's `worker_id` in the DB and stores/broadcasts all three IDs alongside the log line. DB migration is idempotent `ALTER TABLE` wrapped in try/except.
- **Filtered log endpoint**: New `GET /guilds/{id}/logs?worker_id=|agent_id=|task_id=` endpoint returns matching log rows. Existing `/tasks/{id}/logs` now also returns `worker_id` and `agent_id` fields.
- **Contextual log display**: `agents.js` now routes all `terminal-output` messages (task and non-task) to both `agent.logs` (for agent-tab view) and `workerLogs[workerId]` (for worker-tab view). `TerminalPane` and `WorkerTerminalPane` each call the new endpoint on mount to hydrate historical logs.
- **Hierarchical agents panel**: `GuildSidebar` workers section is redesigned as a two-level tree — worker rows (name + state dot) with indented agent rows beneath each. Agent rows show a state dot, name, and two icon buttons: 🤖 opens the agent terminal tab, 📋 opens the task pane for that worker's current/most-recent task.

## Test plan
- [ ] Start backend + worker; verify `task_logs` table gains `worker_id`/`agent_id` columns after restart
- [ ] Run a task; confirm `GET /guilds/{id}/logs?worker_id=w-xxx` returns the task's log lines
- [ ] Open worker tab in sidebar → `WorkerTerminalPane` shows historical task logs (not just idle-poll lines)
- [ ] Open agent tab (🤖 icon) → `TerminalPane` shows historical logs for that agent including task output
- [ ] Click 📋 icon → `TaskPane` opens for the worker's current/last task
- [ ] Sidebar workers section shows correct tree: worker name at top, agent rows indented below

🤖 Generated with [Claude Code](https://claude.com/claude-code)