### PR TITLE
feat: guild rename + dynamic page title

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -134,6 +134,10 @@ class GuildCreate(BaseModel):
     name: Optional[str] = None
 
 
+class GuildUpdate(BaseModel):
+    name: str
+
+
 class RunAgentRequest(BaseModel):
     tool: str          # "claude" | "codex" | "pi"
     prompt: str
@@ -1052,6 +1056,28 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
         return [dict(r._mapping) for r in result.fetchall()]
     finally:
         await db.close()
+
+
+@app.patch("/guilds/{guild_id}")
+async def update_guild(
+    guild_id: str,
+    data: GuildUpdate,
+    github_user_id: str = Depends(require_user),
+):
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(Guild).where(Guild.id == guild_id, Guild.github_user_id == github_user_id)
+        )
+        guild = result.scalar_one_or_none()
+        if not guild:
+            raise HTTPException(status_code=404, detail="Guild not found")
+        guild.name = data.name
+        await db.commit()
+    finally:
+        await db.close()
+    await broadcast(guild_id, {"type": "guild-updated", "id": guild_id, "name": data.name})
+    return {"id": guild_id, "name": data.name}
 
 
 @app.get("/guilds/{guild_id}")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Pioneer Square</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -1,5 +1,22 @@
 <template>
   <aside class="sidebar panel-bg">
+    <div v-if="currentGuild" class="guild-name-bar">
+      <template v-if="renamingGuild">
+        <input
+          ref="renameInput"
+          v-model="renameValue"
+          class="guild-rename-input"
+          @keydown.enter="commitRename"
+          @keydown.escape="cancelRename"
+          @blur="commitRename"
+        />
+      </template>
+      <template v-else>
+        <span class="guild-name-text" @click="startRename" title="Click to rename">{{ currentGuild.name }}</span>
+        <button class="rename-btn" @click="startRename" title="Rename guild">✎</button>
+      </template>
+    </div>
+
     <div class="sidebar-header">
       <span class="sidebar-title">Tasks</span>
       <button class="pixel-btn new-btn" @click="goHome">⌂ Home</button>
@@ -104,7 +121,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGuildStore } from '../stores/guild.js'
 import { useGitHubStore } from '../stores/github.js'
@@ -125,6 +142,35 @@ const showGitHubModal = ref(false)
 const showDeployModal = ref(false)
 const currentGuild = computed(() => guildStore.currentGuild)
 const isConnected = computed(() => guildStore.isConnected)
+
+const renamingGuild = ref(false)
+const renameValue = ref('')
+const renameInput = ref(null)
+
+async function startRename() {
+  if (!currentGuild.value) return
+  renameValue.value = currentGuild.value.name || ''
+  renamingGuild.value = true
+  await nextTick()
+  renameInput.value?.select()
+}
+
+async function commitRename() {
+  if (!renamingGuild.value) return
+  renamingGuild.value = false
+  const trimmed = renameValue.value.trim()
+  if (trimmed && trimmed !== currentGuild.value?.name) {
+    try {
+      await guildStore.renameGuild(currentGuild.value.id, trimmed)
+    } catch (e) {
+      console.error('Failed to rename guild', e)
+    }
+  }
+}
+
+function cancelRename() {
+  renamingGuild.value = false
+}
 
 const groupedTasks = computed(() => {
   const now = new Date()
@@ -198,6 +244,70 @@ function formatTime(isoStr) {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.guild-name-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 6px;
+  border-bottom: 1px solid var(--color-brass-dark);
+  background: var(--color-bg);
+  flex-shrink: 0;
+  min-height: 32px;
+}
+
+.guild-name-text {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  color: var(--color-brass);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  text-shadow: 0 0 6px rgba(255, 214, 68, 0.3);
+  transition: color 0.12s;
+}
+
+.guild-name-text:hover {
+  color: var(--color-brass-light);
+}
+
+.rename-btn {
+  background: none;
+  border: none;
+  color: var(--color-brass-dark);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 1px 3px;
+  border-radius: 2px;
+  line-height: 1;
+  opacity: 0.5;
+  transition: opacity 0.12s, background 0.12s;
+  flex-shrink: 0;
+}
+
+.rename-btn:hover {
+  opacity: 1;
+  background: rgba(232, 170, 0, 0.1);
+}
+
+.guild-rename-input {
+  flex: 1;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-brass);
+  color: var(--color-brass-light);
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 3px 6px;
+  outline: none;
+  border-radius: 2px;
+  min-width: 0;
 }
 
 .sidebar-header {

--- a/frontend/src/stores/guild.js
+++ b/frontend/src/stores/guild.js
@@ -27,6 +27,21 @@ export const useGuildStore = defineStore('guild', () => {
     }
   }
 
+  async function renameGuild(guildId, name) {
+    const res = await fetch(`${API_BASE}/guilds/${guildId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
+      body: JSON.stringify({ name })
+    })
+    if (!res.ok) throw new Error('Failed to rename guild')
+    if (currentGuild.value && currentGuild.value.id === guildId) {
+      currentGuild.value = { ...currentGuild.value, name }
+    }
+    const idx = guilds.value.findIndex(g => g.id === guildId)
+    if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], name }
+    return await res.json()
+  }
+
   async function createGuild(name) {
     const res = await fetch(`${API_BASE}/guilds`, {
       method: 'POST',
@@ -65,6 +80,13 @@ export const useGuildStore = defineStore('guild', () => {
       const data = JSON.parse(event.data)
       if (data.type === 'chat') {
         messages.value.push(data)
+      }
+      if (data.type === 'guild-updated') {
+        if (currentGuild.value && currentGuild.value.id === data.id) {
+          currentGuild.value = { ...currentGuild.value, name: data.name }
+        }
+        const idx = guilds.value.findIndex(g => g.id === data.id)
+        if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], name: data.name }
       }
       if (onMessage) onMessage(data)
       messageHandlers.value.forEach(h => h(data))
@@ -110,6 +132,7 @@ export const useGuildStore = defineStore('guild', () => {
     messages,
     loadGuilds,
     createGuild,
+    renameGuild,
     joinGuild,
     connectWebSocket,
     disconnectWebSocket,

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -99,6 +99,7 @@ onMounted(async () => {
 onUnmounted(() => {
   guildStore.disconnectWebSocket()
   tasksStore.clearTasks()
+  document.title = 'Pioneer Square'
 })
 
 watch(() => props.guildId, async (newId) => {
@@ -106,6 +107,14 @@ watch(() => props.guildId, async (newId) => {
     await initGuild(newId)
   }
 }, { immediate: true })
+
+watch(
+  () => guildStore.currentGuild?.name,
+  (name) => {
+    document.title = name ? `${name} — Pioneer Square` : 'Pioneer Square'
+  },
+  { immediate: true }
+)
 </script>
 
 <style>


### PR DESCRIPTION
## Summary

- **Backend**: `PATCH /guilds/{guild_id}` — accepts `{name}` (auth-gated), updates DB, broadcasts `guild-updated` to all connected WebSocket clients in the guild
- **Frontend store**: `renameGuild(guildId, name)` calls the endpoint and optimistically updates local state; incoming `guild-updated` WS events keep all connected tabs in sync
- **Sidebar UI**: Guild name displayed at the top of the sidebar with a click-to-edit inline input — confirm with Enter/blur, cancel with Escape
- **Page title**: `document.title` watches `currentGuild.name` and renders `"<Guild Name> — Pioneer Square"`; resets to `"Pioneer Square"` on navigation away; default `<title>` in `index.html` changed from `"frontend"` to `"Pioneer Square"`

## Test plan

- [ ] Open a guild — tab title should read `"<Guild Name> — Pioneer Square"`
- [ ] Click the guild name in the sidebar top bar — input appears, pre-filled with current name
- [ ] Edit and press Enter — name saves, sidebar updates, tab title updates
- [ ] Edit and press Escape — change discarded
- [ ] Open the same guild in two tabs — rename in one tab, verify the other tab updates live via WS broadcast
- [ ] Navigate home — tab title resets to `"Pioneer Square"`
- [ ] `PATCH /guilds/{id}` with a different user's token returns 404 (ownership check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)