### PR TITLE
fix: all working agents independently walk to their task station

### DIFF
--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -195,6 +195,19 @@ let walkIdx = 0
 let walkTimer = null
 
 function tickWalk() {
+  // Each working agent independently walks to its station on every tick
+  agents.value.forEach(agent => {
+    if (isAgentAtWork(agent)) {
+      const station = stationForAgent(agent)
+      const nx = station.x + 25
+      const ny = station.y + 90
+      const cur = agentPositions[agent.id]
+      if (!cur || cur.x !== nx || cur.y !== ny) {
+        agentPositions[agent.id] = { x: nx, y: ny }
+      }
+    }
+  })
+
   const idle = agents.value.filter(a => !isAgentAtWork(a))
   if (idle.length === 0) return
   const agent = idle[walkIdx % idle.length]
@@ -211,7 +224,12 @@ onUnmounted(() => {
   if (walkTimer) clearInterval(walkTimer)
 })
 
-watch(agents, syncPositions, { deep: true })
+// Watch agent id+state+workerId as a flat string so every agent's state change
+// triggers syncPositions independently, regardless of array-reference stability.
+watch(
+  () => agents.value.map(a => `${a.id}:${a.state}:${a.workerId}`).join(','),
+  syncPositions
+)
 watch(visibleStations, syncPositions)
 
 const tickerMessages = computed(() => {


### PR DESCRIPTION
## Summary

- Replace unreliable `watch(agents, syncPositions, { deep: true })` with an explicit getter watch that serialises every agent's `id:state:workerId` into a flat string — Vue compares primitives by value, so any per-agent state change immediately fires `syncPositions` for every agent
- Add a per-agent station-sync loop at the top of `tickWalk` so every working agent is independently directed to its station on each 2-second tick, acting as a belt-and-suspenders fallback for the timing window where the reactive watch fires before the task appears in `visibleStations`

## Root cause

Two problems combined to make only the first agent animate:

1. `watch(agents, …, { deep: true })` where `agents` is a computed that always returns the **same array reference**. Vue's deep watch may not reliably re-register nested property dependencies for agents added after the watcher was set up, so a second agent's state transition to `working` didn't always trigger `syncPositions`.

2. `tickWalk` only moved **idle** agents. A working agent that slipped through the timing window (task not yet in `visibleStations` when its state changed) was never corrected — it stayed at whatever random position `tickWalk` last gave it, and neither `syncPositions` (not re-triggered) nor `tickWalk` (didn't touch "working" agents) ever moved it to the station.

## Test plan

- [ ] Start two worker processes and assign them tasks simultaneously; confirm both agents animate to their respective work stations
- [ ] Confirm idle agents still wander between random positions
- [ ] Confirm a single working agent still walks to its station (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)