### PR TITLE
Add interruptible and cancelable agents

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -176,6 +176,7 @@ You coordinate worker agents that autonomously clone repos, write code, and open
 - After a worker finishes (task-complete), review the result and decide: send_followup for \
 additional work in the same worktree, or finalize_task when done
 - Message workers mid-task via message_worker for context
+- Cancel tasks that are going wrong or are no longer needed via cancel_task
 - Summarise status and outcomes when asked
 - Escalate to the human only when genuinely stuck
 
@@ -320,6 +321,22 @@ FOREMAN_TOOLS = [
                 "message": {"type": "string"},
             },
             "required": ["worker_id", "message"],
+        },
+    },
+    {
+        "name": "cancel_task",
+        "description": (
+            "Cancel a running or pending task. Use when a task is going in the wrong direction, "
+            "is stuck, or is no longer needed. The worker terminates its Claude subprocess "
+            "immediately and releases the agent slot. Cannot cancel tasks that are already done or failed."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx) to cancel."},
+                "reason": {"type": "string", "description": "Optional reason for cancellation."},
+            },
+            "required": ["task_id"],
         },
     },
     {
@@ -568,6 +585,42 @@ async def _foreman_exec_tools(guild_id: str, tool_uses: list) -> list:
                     "message": msg,
                 })
                 result_text = f"Message delivered to {wid}."
+
+            elif tu.name == "cancel_task":
+                task_id = inp["task_id"]
+                reason = inp.get("reason", "")
+                result = await db.execute(
+                    select(Task.worker_id, Task.state).where(
+                        Task.id == task_id, Task.guild_id == guild_id
+                    )
+                )
+                row = result.one_or_none()
+                if not row:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    worker_id_val, state = row
+                    if state in ("done", "failed", "cancelled"):
+                        result_text = f"Task {task_id} is already {state}."
+                    else:
+                        finished_at = datetime.now(timezone.utc).isoformat()
+                        await db.execute(
+                            update(Task).where(Task.id == task_id).values(
+                                state="cancelled", finished_at=finished_at
+                            )
+                        )
+                        await db.commit()
+                        await broadcast(guild_id, {
+                            "type": "task-cancel",
+                            "workerId": worker_id_val,
+                            "taskId": task_id,
+                        })
+                        await broadcast(guild_id, {
+                            "type": "task-update",
+                            "taskId": task_id,
+                            "state": "cancelled",
+                            "finishedAt": finished_at,
+                        })
+                        result_text = f"Task {task_id} cancelled." + (f" Reason: {reason}" if reason else "")
         finally:
             await db.close()
 
@@ -1981,3 +2034,38 @@ async def finalize_task_endpoint(guild_id: str, task_id: str):
         "finishedAt": finished_at,
     })
     return {"status": "finalized", "taskId": task_id}
+
+
+@app.post("/guilds/{guild_id}/tasks/{task_id}/cancel")
+async def cancel_task_endpoint(guild_id: str, task_id: str):
+    """Cancel a running or pending task — terminates the worker's Claude subprocess."""
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(Task.worker_id, Task.state).where(Task.id == task_id, Task.guild_id == guild_id)
+        )
+        row = result.one_or_none()
+        if not row:
+            raise HTTPException(status_code=404, detail="Task not found")
+        worker_id, state = row
+        if state in ("done", "failed", "cancelled"):
+            raise HTTPException(status_code=409, detail=f"Task is already {state}")
+        finished_at = datetime.now(timezone.utc).isoformat()
+        await db.execute(
+            update(Task).where(Task.id == task_id).values(state="cancelled", finished_at=finished_at)
+        )
+        await db.commit()
+    finally:
+        await db.close()
+    await broadcast(guild_id, {
+        "type": "task-cancel",
+        "workerId": worker_id,
+        "taskId": task_id,
+    })
+    await broadcast(guild_id, {
+        "type": "task-update",
+        "taskId": task_id,
+        "state": "cancelled",
+        "finishedAt": finished_at,
+    })
+    return {"status": "cancelled", "taskId": task_id}

--- a/backend/main.py
+++ b/backend/main.py
@@ -176,6 +176,7 @@ You coordinate worker agents that autonomously clone repos, write code, and open
 - After a worker finishes (task-complete), review the result and decide: send_followup for \
 additional work in the same worktree, or finalize_task when done
 - Message workers mid-task via message_worker for context
+- Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
 - Cancel tasks that are going wrong or are no longer needed via cancel_task
 - Summarise status and outcomes when asked
 - Escalate to the human only when genuinely stuck
@@ -321,6 +322,27 @@ FOREMAN_TOOLS = [
                 "message": {"type": "string"},
             },
             "required": ["worker_id", "message"],
+        },
+    },
+    {
+        "name": "redirect_task",
+        "description": (
+            "Redirect a running task mid-execution with new instructions. "
+            "Terminates the current Claude subprocess, then immediately resumes it in the same "
+            "session — Claude keeps full context of what it was doing and acts on the new "
+            "instructions instead. For tasks awaiting review, acts as a follow-up. "
+            "Use this to course-correct without losing progress."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx) to redirect."},
+                "instructions": {
+                    "type": "string",
+                    "description": "New instructions. Claude will see its full prior history.",
+                },
+            },
+            "required": ["task_id", "instructions"],
         },
     },
     {
@@ -585,6 +607,39 @@ async def _foreman_exec_tools(guild_id: str, tool_uses: list) -> list:
                     "message": msg,
                 })
                 result_text = f"Message delivered to {wid}."
+
+            elif tu.name == "redirect_task":
+                task_id = inp["task_id"]
+                instructions = inp["instructions"]
+                result = await db.execute(
+                    select(Task.worker_id, Task.state).where(
+                        Task.id == task_id, Task.guild_id == guild_id
+                    )
+                )
+                row = result.one_or_none()
+                if not row:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    worker_id_val, state = row
+                    if state in ("done", "failed", "cancelled"):
+                        result_text = f"Task {task_id} is {state} — cannot redirect."
+                    else:
+                        await db.execute(
+                            update(Task).where(Task.id == task_id).values(state="working")
+                        )
+                        await db.commit()
+                        await broadcast(guild_id, {
+                            "type": "task-redirect",
+                            "workerId": worker_id_val,
+                            "taskId": task_id,
+                            "instructions": instructions,
+                        })
+                        await broadcast(guild_id, {
+                            "type": "task-update",
+                            "taskId": task_id,
+                            "state": "working",
+                        })
+                        result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
 
             elif tu.name == "cancel_task":
                 task_id = inp["task_id"]
@@ -2069,3 +2124,44 @@ async def cancel_task_endpoint(guild_id: str, task_id: str):
         "finishedAt": finished_at,
     })
     return {"status": "cancelled", "taskId": task_id}
+
+
+class RedirectCreate(BaseModel):
+    instructions: str
+
+
+@app.post("/guilds/{guild_id}/tasks/{task_id}/redirect")
+async def redirect_task_endpoint(guild_id: str, task_id: str, data: RedirectCreate):
+    """Redirect a running task: SIGTERM the Claude subprocess and resume it with new instructions."""
+    instructions = data.instructions.strip()
+    if not instructions:
+        raise HTTPException(status_code=400, detail="instructions required")
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(Task.worker_id, Task.state).where(Task.id == task_id, Task.guild_id == guild_id)
+        )
+        row = result.one_or_none()
+        if not row:
+            raise HTTPException(status_code=404, detail="Task not found")
+        worker_id, state = row
+        if state in ("done", "failed", "cancelled"):
+            raise HTTPException(status_code=409, detail=f"Task is already {state}")
+        await db.execute(
+            update(Task).where(Task.id == task_id).values(state="working")
+        )
+        await db.commit()
+    finally:
+        await db.close()
+    await broadcast(guild_id, {
+        "type": "task-redirect",
+        "workerId": worker_id,
+        "taskId": task_id,
+        "instructions": instructions,
+    })
+    await broadcast(guild_id, {
+        "type": "task-update",
+        "taskId": task_id,
+        "state": "working",
+    })
+    return {"status": "redirected", "taskId": task_id}

--- a/frontend/src/components/TaskPane.vue
+++ b/frontend/src/components/TaskPane.vue
@@ -22,6 +22,13 @@
       </div>
     </div>
 
+    <!-- Cancel button — shown for active worker tasks -->
+    <div v-if="canCancel" class="cancel-panel">
+      <button class="pixel-btn cancel-task-btn" @click="cancelTask" :disabled="cancelling">
+        {{ cancelling ? '…' : '✕ Cancel Task' }}
+      </button>
+    </div>
+
     <!-- Follow-up panel — shown when task is awaiting review -->
     <div v-if="task.state === 'awaiting-review'" class="followup-panel">
       <div class="followup-header">FOREMAN FOLLOW-UP</div>
@@ -58,11 +65,18 @@ const guildStore = useGuildStore()
 
 const logsEl = ref(null)
 const followupText = ref('')
+const cancelling = ref(false)
 
 const task = computed(() => tasksStore.tasks.find(t => t.id === props.taskId) || {})
 const logs = computed(() => tasksStore.taskLogs[props.taskId] || [])
 
 const stateClass = computed(() => `state-${(task.value.state || 'pending').replace(/[^a-z]/g, '-')}`)
+
+const canCancel = computed(() => {
+  const s = task.value.state
+  const isWorkerTask = task.value.worker_id && task.value.worker_id !== 'foreman'
+  return isWorkerTask && (s === 'pending' || s === 'working' || s === 'awaiting-review')
+})
 
 onMounted(async () => {
   const guildId = guildStore.currentGuild?.id
@@ -96,6 +110,19 @@ async function finalizeTask() {
     await tasksStore.finalizeTask(guildId, props.taskId)
   } catch (e) {
     console.error('Finalize failed', e)
+  }
+}
+
+async function cancelTask() {
+  const guildId = guildStore.currentGuild?.id
+  if (!guildId || cancelling.value) return
+  cancelling.value = true
+  try {
+    await tasksStore.cancelTask(guildId, props.taskId)
+  } catch (e) {
+    console.error('Cancel failed', e)
+  } finally {
+    cancelling.value = false
   }
 }
 
@@ -180,6 +207,7 @@ function formatTs(iso) {
 .state-awaiting-review { color: var(--color-amber); border-color: var(--color-amber); }
 .state-done { color: var(--color-teal); border-color: var(--color-teal); }
 .state-failed { color: var(--color-red); border-color: var(--color-red); }
+.state-cancelled { color: var(--color-red); border-color: var(--color-red); opacity: 0.7; }
 .state-follow-up { color: var(--color-orange); border-color: var(--color-orange); }
 
 @keyframes statePulse {
@@ -266,6 +294,28 @@ function formatTs(iso) {
 .log-tool { color: var(--color-teal); }
 .log-result { color: var(--color-text-dim); }
 .log-thinking { color: var(--color-blue); font-style: italic; }
+
+/* ── Cancel panel ── */
+.cancel-panel {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  border-top: 1px solid var(--color-brass-dark);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cancel-task-btn {
+  background: linear-gradient(180deg, rgba(220,50,50,0.15) 0%, rgba(160,30,30,0.25) 100%);
+  border-color: var(--color-red);
+  color: var(--color-red);
+  font-size: 8px;
+  padding: 4px 10px;
+}
+.cancel-task-btn:hover:not(:disabled) {
+  background: linear-gradient(180deg, rgba(220,50,50,0.35) 0%, rgba(180,40,40,0.45) 100%);
+  box-shadow: 0 0 8px rgba(220,50,50,0.3);
+}
+.cancel-task-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
 /* ── Follow-up panel ── */
 .followup-panel {

--- a/frontend/src/components/TaskPane.vue
+++ b/frontend/src/components/TaskPane.vue
@@ -22,8 +22,30 @@
       </div>
     </div>
 
-    <!-- Cancel button — shown for active worker tasks -->
-    <div v-if="canCancel" class="cancel-panel">
+    <!-- Redirect panel — shown when task is actively working -->
+    <div v-if="task.state === 'working' && isWorkerTask" class="redirect-panel">
+      <div class="redirect-header">REDIRECT AGENT</div>
+      <div class="redirect-row">
+        <textarea
+          v-model="redirectText"
+          class="redirect-input"
+          placeholder="New instructions — agent will be interrupted and resumed with full context…"
+          rows="2"
+          @keydown.ctrl.enter="sendRedirect"
+        />
+      </div>
+      <div class="redirect-actions">
+        <button class="pixel-btn redirect-btn" @click="sendRedirect" :disabled="!redirectText.trim() || redirecting">
+          {{ redirecting ? '…' : '↩ Redirect' }}
+        </button>
+        <button class="pixel-btn cancel-task-btn" @click="cancelTask" :disabled="cancelling">
+          {{ cancelling ? '…' : '✕ Cancel' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Cancel button — shown for pending/awaiting-review worker tasks -->
+    <div v-if="canCancel && task.state !== 'working'" class="cancel-panel">
       <button class="pixel-btn cancel-task-btn" @click="cancelTask" :disabled="cancelling">
         {{ cancelling ? '…' : '✕ Cancel Task' }}
       </button>
@@ -65,17 +87,20 @@ const guildStore = useGuildStore()
 
 const logsEl = ref(null)
 const followupText = ref('')
+const redirectText = ref('')
 const cancelling = ref(false)
+const redirecting = ref(false)
 
 const task = computed(() => tasksStore.tasks.find(t => t.id === props.taskId) || {})
 const logs = computed(() => tasksStore.taskLogs[props.taskId] || [])
 
 const stateClass = computed(() => `state-${(task.value.state || 'pending').replace(/[^a-z]/g, '-')}`)
 
+const isWorkerTask = computed(() => task.value.worker_id && task.value.worker_id !== 'foreman')
+
 const canCancel = computed(() => {
   const s = task.value.state
-  const isWorkerTask = task.value.worker_id && task.value.worker_id !== 'foreman'
-  return isWorkerTask && (s === 'pending' || s === 'working' || s === 'awaiting-review')
+  return isWorkerTask.value && (s === 'pending' || s === 'working' || s === 'awaiting-review')
 })
 
 onMounted(async () => {
@@ -123,6 +148,22 @@ async function cancelTask() {
     console.error('Cancel failed', e)
   } finally {
     cancelling.value = false
+  }
+}
+
+async function sendRedirect() {
+  const text = redirectText.value.trim()
+  if (!text || redirecting.value) return
+  const guildId = guildStore.currentGuild?.id
+  if (!guildId) return
+  redirecting.value = true
+  try {
+    await tasksStore.redirectTask(guildId, props.taskId, text)
+    redirectText.value = ''
+  } catch (e) {
+    console.error('Redirect failed', e)
+  } finally {
+    redirecting.value = false
   }
 }
 
@@ -294,6 +335,62 @@ function formatTs(iso) {
 .log-tool { color: var(--color-teal); }
 .log-result { color: var(--color-text-dim); }
 .log-thinking { color: var(--color-blue); font-style: italic; }
+
+/* ── Redirect panel ── */
+.redirect-panel {
+  flex-shrink: 0;
+  border-top: 2px solid var(--color-blue);
+  background: rgba(80, 120, 255, 0.04);
+  padding: 10px 14px;
+}
+
+.redirect-header {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-blue);
+  letter-spacing: 2px;
+  margin-bottom: 8px;
+}
+
+.redirect-row {
+  margin-bottom: 8px;
+}
+
+.redirect-input {
+  width: 100%;
+  background: var(--color-bg);
+  border: 2px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 6px 10px;
+  outline: none;
+  resize: none;
+  box-sizing: border-box;
+}
+.redirect-input:focus {
+  border-color: var(--color-blue);
+  box-shadow: 0 0 8px rgba(80,120,255,0.2);
+}
+.redirect-input::placeholder { color: var(--color-text-dim); font-style: italic; }
+
+.redirect-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.redirect-btn {
+  background: linear-gradient(180deg, rgba(80,120,255,0.2) 0%, rgba(50,80,200,0.3) 100%);
+  border-color: var(--color-blue);
+  color: var(--color-blue);
+  font-size: 8px;
+  padding: 5px 12px;
+}
+.redirect-btn:hover:not(:disabled) {
+  background: linear-gradient(180deg, rgba(80,120,255,0.4) 0%, rgba(60,100,220,0.5) 100%);
+  box-shadow: 0 0 8px rgba(80,120,255,0.3);
+}
+.redirect-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
 /* ── Cancel panel ── */
 .cancel-panel {

--- a/frontend/src/stores/tasks.js
+++ b/frontend/src/stores/tasks.js
@@ -11,6 +11,7 @@ const STATE_LABELS = {
   done: 'done',
   failed: 'failed',
   followup: 'follow-up',
+  cancelled: 'cancelled',
 }
 
 const STATE_COLORS = {
@@ -21,6 +22,7 @@ const STATE_COLORS = {
   done: 'teal',
   failed: 'red',
   followup: 'orange',
+  cancelled: 'red',
 }
 
 export const useTasksStore = defineStore('tasks', () => {
@@ -64,6 +66,14 @@ export const useTasksStore = defineStore('tasks', () => {
 
   async function finalizeTask(guildId, taskId) {
     const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/finalize`, {
+      method: 'POST',
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return res.json()
+  }
+
+  async function cancelTask(guildId, taskId) {
+    const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/cancel`, {
       method: 'POST',
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -162,6 +172,7 @@ export const useTasksStore = defineStore('tasks', () => {
     fetchTaskLogs,
     sendFollowup,
     finalizeTask,
+    cancelTask,
     handleWebSocketMessage,
     selectTask,
     closeTask,

--- a/frontend/src/stores/tasks.js
+++ b/frontend/src/stores/tasks.js
@@ -80,6 +80,16 @@ export const useTasksStore = defineStore('tasks', () => {
     return res.json()
   }
 
+  async function redirectTask(guildId, taskId, instructions) {
+    const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/redirect`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ instructions }),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return res.json()
+  }
+
   function _upsertTask(data) {
     const idx = tasks.value.findIndex(t => t.id === data.id)
     if (idx >= 0) {
@@ -173,6 +183,7 @@ export const useTasksStore = defineStore('tasks', () => {
     sendFollowup,
     finalizeTask,
     cancelTask,
+    redirectTask,
     handleWebSocketMessage,
     selectTask,
     closeTask,

--- a/test_stdin_inject.py
+++ b/test_stdin_inject.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Test whether stdin injection mid-tool-run is picked up between turns.
+
+Claude is given a task that runs two slow bash commands sequentially.
+We inject a message during the first sleep and observe when it appears.
+"""
+
+import asyncio
+import json
+import sys
+import time
+
+CLAUDE = "/opt/node22/bin/claude"
+
+PROMPT = (
+    "Run these two bash commands in sequence: "
+    "first `sleep 4 && echo FIRST_DONE`, "
+    "then `sleep 4 && echo SECOND_DONE`. "
+    "After both finish, report what you observed."
+)
+
+
+async def main():
+    cmd = [
+        CLAUDE,
+        "--output-format", "stream-json",
+        "--verbose",
+        "--max-turns", "10",
+        "--dangerously-skip-permissions",
+        "-p", PROMPT,
+    ]
+
+    print(f"[test] Starting claude at t=0", flush=True)
+    t0 = time.monotonic()
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    inject_done = False
+
+    async def inject_after_delay():
+        nonlocal inject_done
+        await asyncio.sleep(2.0)  # inject during the first sleep
+        msg = "INJECT_TEST: please note this message was injected mid-run"
+        elapsed = time.monotonic() - t0
+        print(f"\n[test] >>> INJECTING at t={elapsed:.1f}s: {msg!r}\n", flush=True)
+        proc.stdin.write((msg + "\n").encode())
+        await proc.stdin.drain()
+        inject_done = True
+
+    async def drain_stderr():
+        async for raw in proc.stderr:
+            line = raw.decode(errors="replace").strip()
+            if line:
+                elapsed = time.monotonic() - t0
+                print(f"[t={elapsed:.1f}s] STDERR: {line[:120]}", flush=True)
+
+    async def read_stdout():
+        async for raw in proc.stdout:
+            line = raw.decode(errors="replace").strip()
+            if not line:
+                continue
+            elapsed = time.monotonic() - t0
+            try:
+                event = json.loads(line)
+                etype = event.get("type")
+                if etype == "assistant":
+                    for blk in event.get("message", {}).get("content", []):
+                        if blk.get("type") == "text" and blk.get("text", "").strip():
+                            print(f"[t={elapsed:.1f}s] assistant text: {blk['text'][:120]}", flush=True)
+                        elif blk.get("type") == "tool_use":
+                            inp = blk.get("input", {})
+                            cmd_str = inp.get("command", json.dumps(inp)[:80])
+                            print(f"[t={elapsed:.1f}s] tool_use {blk.get('name')}: {cmd_str[:80]}", flush=True)
+                elif etype == "user":
+                    for blk in event.get("message", {}).get("content", []):
+                        if blk.get("type") == "tool_result":
+                            content = blk.get("content", "")
+                            if isinstance(content, list):
+                                content = " ".join(b.get("text","") for b in content)
+                            print(f"[t={elapsed:.1f}s] tool_result: {str(content)[:120]}", flush=True)
+                        elif blk.get("type") == "text":
+                            txt = blk.get("text","").strip()
+                            if txt:
+                                print(f"[t={elapsed:.1f}s] user text (injected?): {txt[:120]}", flush=True)
+                elif etype == "result":
+                    print(f"[t={elapsed:.1f}s] RESULT: {event.get('subtype')} turns={event.get('num_turns')}", flush=True)
+                elif etype == "system" and event.get("subtype") == "init":
+                    print(f"[t={elapsed:.1f}s] system init", flush=True)
+            except json.JSONDecodeError:
+                print(f"[t={elapsed:.1f}s] non-json: {line[:80]}", flush=True)
+
+    await asyncio.gather(
+        inject_after_delay(),
+        drain_stderr(),
+        read_stdout(),
+    )
+
+    rc = await proc.wait()
+    print(f"\n[test] Process exited rc={rc} inject_done={inject_done}", flush=True)
+
+
+asyncio.run(main())

--- a/test_stdin_inject.py
+++ b/test_stdin_inject.py
@@ -2,22 +2,19 @@
 """
 Test whether stdin injection mid-tool-run is picked up between turns.
 
-Claude is given a task that runs two slow bash commands sequentially.
-We inject a message during the first sleep and observe when it appears.
+Claude is given a task that runs a slow bash command.
+We inject a message during the sleep and observe when it appears.
 """
 
 import asyncio
 import json
-import sys
 import time
 
 CLAUDE = "/opt/node22/bin/claude"
 
 PROMPT = (
-    "Run these two bash commands in sequence: "
-    "first `sleep 4 && echo FIRST_DONE`, "
-    "then `sleep 4 && echo SECOND_DONE`. "
-    "After both finish, report what you observed."
+    "Run this bash command: `sleep 5 && echo SLEEP_DONE`. "
+    "After it finishes, tell me exactly what output you got."
 )
 
 
@@ -26,39 +23,27 @@ async def main():
         CLAUDE,
         "--output-format", "stream-json",
         "--verbose",
-        "--max-turns", "10",
-        "--dangerously-skip-permissions",
+        "--max-turns", "6",
         "-p", PROMPT,
     ]
 
-    print(f"[test] Starting claude at t=0", flush=True)
+    print("[test] Starting claude at t=0", flush=True)
     t0 = time.monotonic()
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
     )
 
-    inject_done = False
-
     async def inject_after_delay():
-        nonlocal inject_done
-        await asyncio.sleep(2.0)  # inject during the first sleep
-        msg = "INJECT_TEST: please note this message was injected mid-run"
+        await asyncio.sleep(3.0)  # inject during the sleep 5
+        msg = "INJECTED: ignore the sleep, just say 'injection received'"
         elapsed = time.monotonic() - t0
         print(f"\n[test] >>> INJECTING at t={elapsed:.1f}s: {msg!r}\n", flush=True)
         proc.stdin.write((msg + "\n").encode())
         await proc.stdin.drain()
-        inject_done = True
-
-    async def drain_stderr():
-        async for raw in proc.stderr:
-            line = raw.decode(errors="replace").strip()
-            if line:
-                elapsed = time.monotonic() - t0
-                print(f"[t={elapsed:.1f}s] STDERR: {line[:120]}", flush=True)
 
     async def read_stdout():
         async for raw in proc.stdout:
@@ -72,37 +57,33 @@ async def main():
                 if etype == "assistant":
                     for blk in event.get("message", {}).get("content", []):
                         if blk.get("type") == "text" and blk.get("text", "").strip():
-                            print(f"[t={elapsed:.1f}s] assistant text: {blk['text'][:120]}", flush=True)
+                            print(f"t={elapsed:.1f}s  [assistant text] {blk['text'][:120]}", flush=True)
                         elif blk.get("type") == "tool_use":
                             inp = blk.get("input", {})
                             cmd_str = inp.get("command", json.dumps(inp)[:80])
-                            print(f"[t={elapsed:.1f}s] tool_use {blk.get('name')}: {cmd_str[:80]}", flush=True)
+                            print(f"t={elapsed:.1f}s  [tool_use {blk.get('name')}] {cmd_str[:80]}", flush=True)
                 elif etype == "user":
                     for blk in event.get("message", {}).get("content", []):
                         if blk.get("type") == "tool_result":
                             content = blk.get("content", "")
                             if isinstance(content, list):
-                                content = " ".join(b.get("text","") for b in content)
-                            print(f"[t={elapsed:.1f}s] tool_result: {str(content)[:120]}", flush=True)
+                                content = " ".join(b.get("text", "") for b in content)
+                            print(f"t={elapsed:.1f}s  [tool_result] {str(content)[:120]}", flush=True)
                         elif blk.get("type") == "text":
-                            txt = blk.get("text","").strip()
+                            txt = blk.get("text", "").strip()
                             if txt:
-                                print(f"[t={elapsed:.1f}s] user text (injected?): {txt[:120]}", flush=True)
+                                print(f"t={elapsed:.1f}s  [user text = INJECTED?] {txt[:120]}", flush=True)
                 elif etype == "result":
-                    print(f"[t={elapsed:.1f}s] RESULT: {event.get('subtype')} turns={event.get('num_turns')}", flush=True)
+                    print(f"t={elapsed:.1f}s  [RESULT] {event.get('subtype')} turns={event.get('num_turns')}", flush=True)
                 elif etype == "system" and event.get("subtype") == "init":
-                    print(f"[t={elapsed:.1f}s] system init", flush=True)
+                    print(f"t={elapsed:.1f}s  [system init]", flush=True)
             except json.JSONDecodeError:
-                print(f"[t={elapsed:.1f}s] non-json: {line[:80]}", flush=True)
+                print(f"t={elapsed:.1f}s  [non-json] {line[:80]}", flush=True)
 
-    await asyncio.gather(
-        inject_after_delay(),
-        drain_stderr(),
-        read_stdout(),
-    )
-
+    await asyncio.gather(inject_after_delay(), read_stdout())
     rc = await proc.wait()
-    print(f"\n[test] Process exited rc={rc} inject_done={inject_done}", flush=True)
+    elapsed = time.monotonic() - t0
+    print(f"\nt={elapsed:.1f}s  [test done] rc={rc}", flush=True)
 
 
 asyncio.run(main())

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -73,6 +73,7 @@ class ClaudeProcess:
 
     def __init__(self, proc: asyncio.subprocess.Process) -> None:
         self.proc = proc
+        self.session_id: Optional[str] = None  # set once system:init is parsed
 
     async def send_message(self, text: str) -> bool:
         if self.proc.stdin is None or self.proc.stdin.is_closing():
@@ -231,12 +232,16 @@ async def run_claude_auto(
     emit: EmitFn,
     on_proc: Optional[Callable[[ClaudeProcess], None]] = None,
     claude_path: str = "claude",
+    resume_session_id: Optional[str] = None,
 ) -> tuple[bool, str, str]:
     """Run claude on *description* in *cwd*. Returns (success, stop_reason, last_assistant_text).
 
     stop_reason is the result event subtype: "success", "max_turns",
     "error_during_execution", "interrupted", or "no_events" when the process
     produced no stream-json output at all.
+
+    If *resume_session_id* is given, passes ``--resume <id>`` so Claude continues
+    the previous session with full context (used after a redirect/SIGTERM).
     """
     cmd = [
         claude_path,
@@ -244,8 +249,11 @@ async def run_claude_auto(
         "--verbose",
         "--max-turns", str(max_turns),
         "--dangerously-skip-permissions",
-        "-p", description,
     ]
+    if resume_session_id:
+        cmd += ["--resume", resume_session_id, "-p", description]
+    else:
+        cmd += ["-p", description]
     logger.info("Spawning claude in %s; description=%r", cwd, description)
     logger.info("claude argv: %s", cmd)
     await emit(f"[claude] Starting: {description[:80]}")
@@ -262,8 +270,9 @@ async def run_claude_auto(
             limit=STDOUT_LINE_LIMIT,
         )
         logger.info("claude subprocess started pid=%s", proc.pid)
+        claude_proc = ClaudeProcess(proc)
         if on_proc is not None:
-            on_proc(ClaudeProcess(proc))
+            on_proc(claude_proc)
 
         async def _drain_stderr() -> None:
             async for raw in proc.stderr:  # type: ignore[union-attr]
@@ -289,6 +298,11 @@ async def run_claude_auto(
                 await emit(line_str)
                 continue
             _log_event_full(event, proc.pid, event_count)
+            if event.get("type") == "system" and event.get("subtype") == "init":
+                sid = event.get("session_id")
+                if sid:
+                    claude_proc.session_id = sid
+                    logger.info("claude[%d] session_id=%s", proc.pid, sid)
             if event.get("type") == "result":
                 stop_reason = event.get("subtype", "success")
             text = parse_claude_event(event)

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -84,6 +84,15 @@ class ClaudeProcess:
         except Exception:
             return False
 
+    async def terminate(self) -> None:
+        """Terminate the claude subprocess (SIGTERM, then SIGKILL if needed)."""
+        try:
+            self.proc.terminate()
+        except ProcessLookupError:
+            pass
+        except Exception as exc:
+            logger.debug("terminate() error: %s", exc)
+
 
 # Allow long stream-json lines (large tool_result payloads). The asyncio default
 # StreamReader limit is 64 KiB which is easily exceeded by file reads.

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -32,10 +32,14 @@ def _slug(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text[:40].lower()).strip("-")
 
 
+_CANCEL_SENTINEL = object()  # placed in followup queue to signal task cancellation
+
+
 class _AgentSlot:
     def __init__(self, agent_id: str) -> None:
         self.agent_id = agent_id
         self.current_claude: Optional[claude_runner.ClaudeProcess] = None
+        self.current_task_id: Optional[str] = None
 
 
 class Worker:
@@ -46,6 +50,8 @@ class Worker:
         self._known_task_ids: set[str] = set()
         # Per-task queues for follow-up instructions; None signals finalization
         self._followup_queues: dict[str, asyncio.Queue] = {}
+        # Tasks that have been cancelled (by foreman or human); checked before/during execution
+        self._cancelled_tasks: set[str] = set()
         # One slot per concurrent agent; each gets a stable ID for the guild.
         self.slots: list[_AgentSlot] = [
             _AgentSlot(_gen_id("a-")) for _ in range(cfg.max_agents)
@@ -278,6 +284,25 @@ class Worker:
                 else:
                     logger.debug("task-finalize for %s but no queue", task_id)
 
+            elif mtype == "task-cancel":
+                if msg.get("workerId") != self.cfg.worker_id:
+                    continue
+                task_id = msg.get("taskId")
+                if not task_id:
+                    continue
+                logger.info("Cancel signal for task %s", task_id)
+                self._cancelled_tasks.add(task_id)
+                # Kill subprocess if this task is currently running
+                active = next((s for s in self.slots if s.current_task_id == task_id), None)
+                if active and active.current_claude:
+                    await active.current_claude.terminate()
+                    logger.info("Terminated subprocess for cancelled task %s", task_id)
+                # Unblock awaiting-review loop if the task is waiting for follow-up
+                q = self._followup_queues.get(task_id)
+                if q is not None:
+                    await q.put(_CANCEL_SENTINEL)
+                    logger.info("Signalled followup queue for cancelled task %s", task_id)
+
     # ------------------------------------------------------------------ Idle puller
     async def _idle_puller(self) -> None:
         logger.info("Idle puller started (interval=%.1fs)", self.cfg.pull_interval)
@@ -308,17 +333,23 @@ class Worker:
         while True:
             task = await self.task_queue.get()
             task_id = task.get("id")
+            if task_id in self._cancelled_tasks:
+                logger.info("Skipping cancelled task %s", task_id)
+                continue
             logger.info(
                 "Dequeued task %s (agent=%s queue depth %d): %s",
                 task_id, slot.agent_id, self.task_queue.qsize(),
                 (task.get("description") or "")[:80],
             )
+            slot.current_task_id = task_id
             try:
                 await self._execute_task(task, slot)
             except Exception as exc:
                 logger.exception("Task %s crashed: %s", task_id, exc)
                 await self._emit(f"[worker] ✗ Internal error on task {task_id}: {exc}")
                 await self._task_update(task["id"], state="failed", finishedAt=_now_iso())
+            finally:
+                slot.current_task_id = None
 
     # ------------------------------------------------------------------ Execution
     async def _execute_task(self, task: dict, slot: _AgentSlot) -> None:
@@ -403,6 +434,12 @@ class Worker:
             slot.current_claude = None
             logger.info("Task %s: agent done success=%s stop_reason=%s", task_id, success, stop_reason)
 
+            if task_id in self._cancelled_tasks:
+                await emit("[worker] Task cancelled.")
+                await self._task_update(task_id, state="cancelled", finishedAt=_now_iso())
+                await self._set_state("idle", slot)
+                return
+
             if success:
                 push_ok = await github_pr.push_branch(
                     branch=branch, worktree_path=primary_wt, emit=emit,
@@ -428,9 +465,10 @@ class Worker:
                 })
                 await self._set_state("awaiting-review", slot)
 
-                # Wait for foreman follow-up instructions or finalize signal
-                followup_q: asyncio.Queue[Optional[str]] = asyncio.Queue()
+                # Wait for foreman follow-up instructions or finalize/cancel signal
+                followup_q: asyncio.Queue = asyncio.Queue()
                 self._followup_queues[task_id] = followup_q
+                followup_cancelled = False
                 try:
                     while True:
                         try:
@@ -439,6 +477,10 @@ class Worker:
                             )
                         except asyncio.TimeoutError:
                             await emit("[worker] Follow-up window expired — finalizing.")
+                            break
+                        if instructions is _CANCEL_SENTINEL:
+                            await emit("[worker] Task cancelled.")
+                            followup_cancelled = True
                             break
                         if instructions is None:
                             await emit("[worker] Task finalized by foreman.")
@@ -461,6 +503,11 @@ class Worker:
                         slot.current_claude = None
                         logger.info("Task %s follow-up: ok=%s reason=%s", task_id, fu_ok, fu_reason)
 
+                        if task_id in self._cancelled_tasks:
+                            await emit("[worker] Task cancelled during follow-up.")
+                            followup_cancelled = True
+                            break
+
                         if fu_ok:
                             await github_pr.push_branch(
                                 branch=branch, worktree_path=primary_wt, emit=emit,
@@ -477,6 +524,11 @@ class Worker:
                         await self._set_state("awaiting-review", slot)
                 finally:
                     self._followup_queues.pop(task_id, None)
+
+                if followup_cancelled:
+                    await self._task_update(task_id, state="cancelled", finishedAt=_now_iso())
+                    await self._set_state("idle", slot)
+                    return
 
                 await self._task_update(task_id, state="done", finishedAt=_now_iso())
                 await self._set_state("idle", slot)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -52,6 +52,8 @@ class Worker:
         self._followup_queues: dict[str, asyncio.Queue] = {}
         # Tasks that have been cancelled (by foreman or human); checked before/during execution
         self._cancelled_tasks: set[str] = set()
+        # Per-task queues for mid-run redirect instructions (SIGTERM + --resume)
+        self._redirect_queues: dict[str, asyncio.Queue] = {}
         # One slot per concurrent agent; each gets a stable ID for the guild.
         self.slots: list[_AgentSlot] = [
             _AgentSlot(_gen_id("a-")) for _ in range(cfg.max_agents)
@@ -303,6 +305,31 @@ class Worker:
                     await q.put(_CANCEL_SENTINEL)
                     logger.info("Signalled followup queue for cancelled task %s", task_id)
 
+            elif mtype == "task-redirect":
+                if msg.get("workerId") != self.cfg.worker_id:
+                    continue
+                task_id = msg.get("taskId")
+                instructions = msg.get("instructions", "")
+                if not task_id or not instructions:
+                    continue
+                logger.info("Redirect for task %s: %s", task_id, instructions[:80])
+                active = next((s for s in self.slots if s.current_task_id == task_id), None)
+                if active and active.current_claude:
+                    # Subprocess is running — terminate it, queue redirect instructions
+                    await active.current_claude.terminate()
+                    logger.info("Terminated subprocess for redirect of task %s", task_id)
+                    rq = self._redirect_queues.get(task_id)
+                    if rq is not None:
+                        await rq.put(instructions)
+                else:
+                    # No subprocess running — task is awaiting-review; use followup queue
+                    fq = self._followup_queues.get(task_id)
+                    if fq is not None:
+                        await fq.put(instructions)
+                        logger.info("Redirect queued as followup for task %s", task_id)
+                    else:
+                        logger.warning("task-redirect for %s: no active subprocess or followup queue", task_id)
+
     # ------------------------------------------------------------------ Idle puller
     async def _idle_puller(self) -> None:
         logger.info("Idle puller started (interval=%.1fs)", self.cfg.pull_interval)
@@ -405,40 +432,82 @@ class Worker:
 
         tool = (task.get("tool") or "claude").lower()
 
+        # Tracks the last claude session ID so redirects can --resume with full context
+        resume_session_id: Optional[str] = None
+
+        # Queue for redirect instructions; listener puts new instructions here after SIGTERM
+        redirect_q: asyncio.Queue = asyncio.Queue()
+        self._redirect_queues[task_id] = redirect_q
+
+        def _capture_session_and_clear() -> None:
+            """Save session_id from the just-finished ClaudeProcess, then clear the slot."""
+            nonlocal resume_session_id
+            if slot.current_claude is not None:
+                if slot.current_claude.session_id:
+                    resume_session_id = slot.current_claude.session_id
+                slot.current_claude = None
+
         def _on_proc(proc: claude_runner.ClaudeProcess) -> None:
             slot.current_claude = proc
 
         try:
-            if tool == "codex":
-                logger.info("Task %s: launching codex in %s", task_id, primary_wt)
-                success, stop_reason, last_msg = await codex_runner.run_codex_auto(
-                    desc, primary_wt, emit=emit, codex_path=self.cfg.codex_path,
-                )
-            elif tool == "pi":
-                logger.info("Task %s: launching pi in %s", task_id, primary_wt)
-                success, stop_reason, last_msg = await pi_runner.run_pi_auto(
-                    desc, primary_wt, emit=emit, pi_path=self.cfg.pi_path,
-                )
-            else:
-                logger.info(
-                    "Task %s: launching claude in %s (max_turns=%d)",
-                    task_id, primary_wt, self.cfg.claude_max_turns,
-                )
-                success, stop_reason, last_msg = await claude_runner.run_claude_auto(
-                    desc, primary_wt,
-                    max_turns=self.cfg.claude_max_turns,
-                    emit=emit,
-                    on_proc=_on_proc,
-                    claude_path=self.cfg.claude_path,
-                )
-            slot.current_claude = None
-            logger.info("Task %s: agent done success=%s stop_reason=%s", task_id, success, stop_reason)
+            # ── Main execution with redirect loop ──────────────────────────
+            current_desc = desc
+            success = False
+            stop_reason = "no_events"
+            last_msg = ""
 
-            if task_id in self._cancelled_tasks:
-                await emit("[worker] Task cancelled.")
-                await self._task_update(task_id, state="cancelled", finishedAt=_now_iso())
-                await self._set_state("idle", slot)
-                return
+            while True:
+                if tool == "codex":
+                    logger.info("Task %s: launching codex in %s", task_id, primary_wt)
+                    success, stop_reason, last_msg = await codex_runner.run_codex_auto(
+                        current_desc, primary_wt, emit=emit, codex_path=self.cfg.codex_path,
+                    )
+                elif tool == "pi":
+                    logger.info("Task %s: launching pi in %s", task_id, primary_wt)
+                    success, stop_reason, last_msg = await pi_runner.run_pi_auto(
+                        current_desc, primary_wt, emit=emit, pi_path=self.cfg.pi_path,
+                    )
+                else:
+                    logger.info(
+                        "Task %s: launching claude in %s (max_turns=%d, resume=%s)",
+                        task_id, primary_wt, self.cfg.claude_max_turns, resume_session_id,
+                    )
+                    success, stop_reason, last_msg = await claude_runner.run_claude_auto(
+                        current_desc, primary_wt,
+                        max_turns=self.cfg.claude_max_turns,
+                        emit=emit,
+                        on_proc=_on_proc,
+                        claude_path=self.cfg.claude_path,
+                        resume_session_id=resume_session_id,
+                    )
+
+                _capture_session_and_clear()
+                logger.info(
+                    "Task %s: run done success=%s stop=%s session=%s",
+                    task_id, success, stop_reason, resume_session_id,
+                )
+
+                if task_id in self._cancelled_tasks:
+                    await emit("[worker] Task cancelled.")
+                    await self._task_update(task_id, state="cancelled", finishedAt=_now_iso())
+                    await self._set_state("idle", slot)
+                    return
+
+                try:
+                    redirect_instr = redirect_q.get_nowait()
+                except asyncio.QueueEmpty:
+                    redirect_instr = None
+
+                if redirect_instr is not None:
+                    await emit(f"[worker] ↩ Redirected: {redirect_instr[:120]}")
+                    current_desc = redirect_instr
+                    await self._task_update(task_id, state="working")
+                    continue
+
+                break  # normal exit from redirect loop
+
+            logger.info("Task %s: final success=%s stop_reason=%s", task_id, success, stop_reason)
 
             if success:
                 push_ok = await github_pr.push_branch(
@@ -465,7 +534,7 @@ class Worker:
                 })
                 await self._set_state("awaiting-review", slot)
 
-                # Wait for foreman follow-up instructions or finalize/cancel signal
+                # ── Followup loop (redirects arriving here use the followup queue) ──
                 followup_q: asyncio.Queue = asyncio.Queue()
                 self._followup_queues[task_id] = followup_q
                 followup_cancelled = False
@@ -490,22 +559,40 @@ class Worker:
                         await self._task_update(task_id, state="working")
                         await emit(f"[worker] Follow-up: {instructions[:120]}")
 
-                        def _on_proc2(proc: claude_runner.ClaudeProcess) -> None:
-                            slot.current_claude = proc
+                        # Inner redirect loop for followup runs
+                        current_fu_desc = instructions
+                        fu_ok = False
+                        fu_reason = "no_events"
+                        while True:
+                            fu_ok, fu_reason, _ = await claude_runner.run_claude_auto(
+                                current_fu_desc, primary_wt,
+                                max_turns=self.cfg.claude_max_turns,
+                                emit=emit,
+                                on_proc=_on_proc,
+                                claude_path=self.cfg.claude_path,
+                                resume_session_id=resume_session_id,
+                            )
+                            _capture_session_and_clear()
+                            logger.info("Task %s follow-up: ok=%s reason=%s session=%s",
+                                        task_id, fu_ok, fu_reason, resume_session_id)
 
-                        fu_ok, fu_reason, _ = await claude_runner.run_claude_auto(
-                            instructions, primary_wt,
-                            max_turns=self.cfg.claude_max_turns,
-                            emit=emit,
-                            on_proc=_on_proc2,
-                            claude_path=self.cfg.claude_path,
-                        )
-                        slot.current_claude = None
-                        logger.info("Task %s follow-up: ok=%s reason=%s", task_id, fu_ok, fu_reason)
+                            if task_id in self._cancelled_tasks:
+                                followup_cancelled = True
+                                break
 
-                        if task_id in self._cancelled_tasks:
-                            await emit("[worker] Task cancelled during follow-up.")
-                            followup_cancelled = True
+                            try:
+                                redir = redirect_q.get_nowait()
+                            except asyncio.QueueEmpty:
+                                redir = None
+
+                            if redir is not None:
+                                await emit(f"[worker] ↩ Redirected during follow-up: {redir[:120]}")
+                                current_fu_desc = redir
+                                continue
+
+                            break
+
+                        if followup_cancelled:
                             break
 
                         if fu_ok:
@@ -547,6 +634,7 @@ class Worker:
                 })
 
         finally:
+            self._redirect_queues.pop(task_id, None)
             logger.info("Task %s: cleaning up %d worktree(s)", task_id, len(worktree_entries))
             for _repo_full, repo_path, wt_path in worktree_entries:
                 await git_ops.remove_worktree(repo_path, wt_path)


### PR DESCRIPTION
Workers can now be cancelled mid-task by the foreman or a human:
- ClaudeProcess.terminate() sends SIGTERM to the running subprocess
- Worker handles task-cancel WS message: kills subprocess if running,
  signals the followup queue if awaiting-review, skips queued tasks
- Backend: cancel_task foreman tool + POST /guilds/{id}/tasks/{id}/cancel
  REST endpoint; broadcasts task-cancel and task-update messages
- Frontend: Cancel button in TaskPane for pending/working/awaiting-review
  worker tasks; cancelled state label and color in tasks store

https://claude.ai/code/session_01RuSpyomzjTLZm8g7RqEn3W