### PR TITLE
Fix sidebar worker ID display and add worker tab navigation

### DIFF
--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -57,9 +57,9 @@
       </div>
       <template v-for="worker in agentsStore.workers" :key="worker.id">
         <!-- Worker row -->
-        <div class="worker-row" :class="worker.state">
+        <div class="worker-row" :class="worker.state" @click="agentsStore.selectWorker(worker.id)">
           <span class="worker-dot" :class="'wdot-' + worker.state"></span>
-          <span class="worker-row-name">{{ worker.name }}</span>
+          <span class="worker-row-name">{{ worker.id }}</span>
           <span class="worker-row-state">{{ worker.state }}</span>
         </div>
         <!-- Agent rows under this worker -->
@@ -479,6 +479,12 @@ function formatTime(isoStr) {
   padding: 5px 12px;
   background: var(--color-bg-secondary);
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.worker-row:hover {
+  background: rgba(0, 187, 170, 0.08);
 }
 
 .worker-row-name {

--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -21,6 +21,18 @@
         <span class="tab-label">{{ agent.name }}</span>
         <span class="tab-close">×</span>
       </button>
+      <!-- Worker tabs — opened from sidebar worker click -->
+      <button
+        v-for="worker in visibleWorkerTabs"
+        :key="'worker-' + worker.id"
+        class="tab worker-tab"
+        :class="{ active: activeTab === 'worker-' + worker.id }"
+        @click="onWorkerTabClick($event, worker.id)"
+      >
+        <span class="state-dot" :class="worker.state"></span>
+        <span class="tab-label">{{ worker.id }}</span>
+        <span class="tab-close">×</span>
+      </button>
       <!-- Task tabs — only shown when explicitly opened -->
       <button
         v-for="task in visibleTaskTabs"
@@ -37,6 +49,7 @@
     <div class="tab-content">
       <FactoryFloor v-if="activeTab === 'factory'" />
       <TerminalPane v-else-if="activeTab.startsWith('agent-')" :agentId="activeTab.slice(6)" />
+      <WorkerTerminalPane v-else-if="activeTab.startsWith('worker-')" :workerId="activeTab.slice(7)" />
       <TaskPane v-else-if="activeTab.startsWith('task-')" :taskId="activeTab.slice(5)" />
     </div>
   </div>
@@ -48,6 +61,7 @@ import { useAgentsStore } from '../stores/agents.js'
 import { useTasksStore } from '../stores/tasks.js'
 import FactoryFloor from './FactoryFloor.vue'
 import TerminalPane from './TerminalPane.vue'
+import WorkerTerminalPane from './WorkerTerminalPane.vue'
 import TaskPane from './TaskPane.vue'
 
 const agentsStore = useAgentsStore()
@@ -57,6 +71,12 @@ const activeTab = ref('factory')
 const visibleAgentTabs = computed(() =>
   agentsStore.openedAgentIds
     .map(id => agentsStore.agents.find(a => a.id === id))
+    .filter(Boolean)
+)
+
+const visibleWorkerTabs = computed(() =>
+  agentsStore.openedWorkerIds
+    .map(id => agentsStore.workers.find(w => w.id === id))
     .filter(Boolean)
 )
 
@@ -70,9 +90,22 @@ watch(() => agentsStore.selectedAgentId, (id) => {
   if (id) activeTab.value = 'agent-' + id
 })
 
+watch(() => agentsStore.selectedWorkerId, (id) => {
+  if (id) activeTab.value = 'worker-' + id
+})
+
 watch(() => tasksStore.selectedTaskId, (id) => {
   if (id) activeTab.value = 'task-' + id
 })
+
+function onWorkerTabClick(event, workerId) {
+  if (event.target.closest('.tab-close')) {
+    agentsStore.closeWorker(workerId)
+    if (activeTab.value === 'worker-' + workerId) activeTab.value = 'factory'
+  } else {
+    activeTab.value = 'worker-' + workerId
+  }
+}
 
 function onAgentTabClick(event, agentId) {
   if (event.target.closest('.tab-close')) {


### PR DESCRIPTION
## Summary

- **Bug 1 – Worker ID displayed incorrectly**: The sidebar was showing `worker.name`, which is derived from the connecting agent's name (itself derived from the agent ID). Changed to `worker.id` so the actual worker ID (e.g. `w-u2gmlf`) is shown instead.
- **Bug 2 – Clicking a worker should open the worker tab**: The worker row in the sidebar had no click handler. Added `@click="agentsStore.selectWorker(worker.id)"` on the row, then wired `selectedWorkerId` → `activeTab` in `MainView.vue` with a matching tab button and `<WorkerTerminalPane>` panel — following the same pattern used by agent and task tabs.
- Also adds `cursor: pointer` + hover highlight on worker rows for affordance.

Closes #34

## Test plan
- [ ] Start backend + worker; open the sidebar — the worker entry should show the `w-xxxxx` ID, not an agent-derived name
- [ ] Click a worker row in the sidebar — a new tab labelled with the worker ID should appear and open the worker terminal pane
- [ ] Clicking the × on the worker tab should close it and return to Factory Floor
- [ ] Existing agent tabs and task tabs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)