### PR TITLE
Add clickable expandable output to agent and worker terminal panes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2195,7 +2195,7 @@ async def get_guild_logs(
         if not result.scalar_one_or_none():
             raise HTTPException(status_code=404, detail="Guild not found")
         stmt = select(
-            TaskLog.timestamp, TaskLog.line, TaskLog.worker_id, TaskLog.agent_id, TaskLog.task_id
+            TaskLog.timestamp, TaskLog.line, TaskLog.worker_id, TaskLog.agent_id, TaskLog.task_id, TaskLog.data
         )
         if task_id:
             stmt = stmt.where(TaskLog.task_id == task_id)
@@ -2205,7 +2205,17 @@ async def get_guild_logs(
             stmt = stmt.where(TaskLog.agent_id == agent_id)
         stmt = stmt.order_by(TaskLog.id.asc())
         result = await db.execute(stmt)
-        return [dict(r._mapping) for r in result.fetchall()]
+        rows = []
+        for r in result.fetchall():
+            row = dict(r._mapping)
+            raw = row.pop("data", None)
+            if raw:
+                try:
+                    row["detail"] = json.loads(raw)
+                except Exception:
+                    pass
+            rows.append(row)
+        return rows
     finally:
         await db.close()
 

--- a/frontend/src/components/TerminalPane.vue
+++ b/frontend/src/components/TerminalPane.vue
@@ -25,9 +25,42 @@
       <div v-if="logs.length === 0" class="terminal-empty">
         <span class="cursor-blink">_</span> Waiting for output...
       </div>
-      <div v-for="(log, i) in logs" :key="i" class="terminal-line">
-        <span class="log-time">{{ formatTime(log.timestamp) }}</span>
-        <span class="log-content" :class="lineClass(log.line)">{{ log.line }}</span>
+      <div v-for="(log, i) in logs" :key="i" class="terminal-entry">
+        <div
+          class="terminal-line"
+          :class="{ 'terminal-line--expandable': !!log.detail }"
+          @click="log.detail && toggleDetail(i)"
+        >
+          <span class="log-time">{{ formatTime(log.timestamp) }}</span>
+          <span class="log-content" :class="lineClass(log.line)">{{ log.line }}</span>
+          <span v-if="log.detail" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
+        </div>
+        <div v-if="log.detail && expandedIdx === i" class="log-detail">
+          <template v-if="log.detail.toolType === 'tool_use'">
+            <template v-if="log.detail.name === 'Edit'">
+              <div class="log-detail-label">OLD</div>
+              <pre class="log-detail-body log-detail-old">{{ log.detail.input?.old_string }}</pre>
+              <div class="log-detail-label log-detail-label--new">NEW</div>
+              <pre class="log-detail-body log-detail-new">{{ log.detail.input?.new_string }}</pre>
+            </template>
+            <template v-else-if="log.detail.name === 'Write'">
+              <div class="log-detail-label">{{ log.detail.input?.file_path }}</div>
+              <pre class="log-detail-body">{{ log.detail.input?.content }}</pre>
+            </template>
+            <template v-else-if="log.detail.name === 'Bash'">
+              <div class="log-detail-label">COMMAND</div>
+              <pre class="log-detail-body">{{ log.detail.input?.command }}</pre>
+            </template>
+            <template v-else>
+              <div class="log-detail-label">{{ log.detail.name }}</div>
+              <pre class="log-detail-body">{{ JSON.stringify(log.detail.input, null, 2) }}</pre>
+            </template>
+          </template>
+          <template v-else-if="log.detail.toolType === 'tool_result'">
+            <div class="log-detail-label">OUTPUT</div>
+            <pre class="log-detail-body">{{ log.detail.output }}</pre>
+          </template>
+        </div>
       </div>
       <div class="terminal-prompt">
         <span class="prompt-user">agent@pioneer-square</span>
@@ -101,8 +134,13 @@ const props = defineProps({
 const agentsStore = useAgentsStore()
 const guildStore = useGuildStore()
 const terminalEl = ref(null)
+const expandedIdx = ref(null)
 
 const agent = computed(() => agentsStore.agents.find(a => a.id === props.agentId))
+
+function toggleDetail(i) {
+  expandedIdx.value = expandedIdx.value === i ? null : i
+}
 
 onMounted(async () => {
   const guildId = guildStore.currentGuild?.id
@@ -268,11 +306,68 @@ watch(logs, async () => {
   gap: 4px;
 }
 
+.terminal-entry { display: flex; flex-direction: column; }
+
 .terminal-line {
   display: flex;
   gap: 12px;
   font-size: 13px;
   line-height: 1.6;
+}
+
+.terminal-line--expandable {
+  cursor: pointer;
+  border-radius: 2px;
+}
+.terminal-line--expandable:hover { background: rgba(255,255,255,0.04); }
+
+.log-expand-icon {
+  font-size: 8px;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+  margin-left: auto;
+  opacity: 0.5;
+}
+
+.log-detail {
+  margin: 3px 0 4px 56px;
+  border-left: 2px solid #2a1a05;
+  padding-left: 10px;
+}
+
+.log-detail-label {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: #5a3a10;
+  letter-spacing: 1px;
+  margin-bottom: 4px;
+  margin-top: 6px;
+}
+.log-detail-label:first-child { margin-top: 0; }
+.log-detail-label--new { color: var(--color-green); }
+
+.log-detail-body {
+  margin: 0 0 2px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-dim);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 300px;
+  overflow-y: auto;
+  background: rgba(0,0,0,0.3);
+  border: 1px solid #2a1a05;
+  padding: 6px 8px;
+}
+.log-detail-old {
+  background: rgba(180,30,30,0.08);
+  border-color: rgba(220,50,50,0.3);
+  color: #c07070;
+}
+.log-detail-new {
+  background: rgba(0,120,60,0.08);
+  border-color: rgba(0,187,100,0.3);
+  color: #70c090;
 }
 
 .log-time {

--- a/frontend/src/components/WorkerTerminalPane.vue
+++ b/frontend/src/components/WorkerTerminalPane.vue
@@ -23,9 +23,42 @@
       <div v-if="logs.length === 0" class="terminal-empty">
         <span class="cursor-blink">_</span> Waiting for output...
       </div>
-      <div v-for="(log, i) in logs" :key="i" class="terminal-line">
-        <span class="log-time">{{ formatTime(log.timestamp) }}</span>
-        <span class="log-content" :class="lineClass(log.line)">{{ log.line }}</span>
+      <div v-for="(log, i) in logs" :key="i" class="terminal-entry">
+        <div
+          class="terminal-line"
+          :class="{ 'terminal-line--expandable': !!log.detail }"
+          @click="log.detail && toggleDetail(i)"
+        >
+          <span class="log-time">{{ formatTime(log.timestamp) }}</span>
+          <span class="log-content" :class="lineClass(log.line)">{{ log.line }}</span>
+          <span v-if="log.detail" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
+        </div>
+        <div v-if="log.detail && expandedIdx === i" class="log-detail">
+          <template v-if="log.detail.toolType === 'tool_use'">
+            <template v-if="log.detail.name === 'Edit'">
+              <div class="log-detail-label">OLD</div>
+              <pre class="log-detail-body log-detail-old">{{ log.detail.input?.old_string }}</pre>
+              <div class="log-detail-label log-detail-label--new">NEW</div>
+              <pre class="log-detail-body log-detail-new">{{ log.detail.input?.new_string }}</pre>
+            </template>
+            <template v-else-if="log.detail.name === 'Write'">
+              <div class="log-detail-label">{{ log.detail.input?.file_path }}</div>
+              <pre class="log-detail-body">{{ log.detail.input?.content }}</pre>
+            </template>
+            <template v-else-if="log.detail.name === 'Bash'">
+              <div class="log-detail-label">COMMAND</div>
+              <pre class="log-detail-body">{{ log.detail.input?.command }}</pre>
+            </template>
+            <template v-else>
+              <div class="log-detail-label">{{ log.detail.name }}</div>
+              <pre class="log-detail-body">{{ JSON.stringify(log.detail.input, null, 2) }}</pre>
+            </template>
+          </template>
+          <template v-else-if="log.detail.toolType === 'tool_result'">
+            <div class="log-detail-label">OUTPUT</div>
+            <pre class="log-detail-body">{{ log.detail.output }}</pre>
+          </template>
+        </div>
       </div>
       <div class="terminal-prompt">
         <span class="prompt-user">worker@pioneer-square</span>
@@ -50,9 +83,14 @@ const props = defineProps({
 const agentsStore = useAgentsStore()
 const guildStore = useGuildStore()
 const terminalEl = ref(null)
+const expandedIdx = ref(null)
 
 const worker = computed(() => agentsStore.workers.find(w => w.id === props.workerId))
 const logs = computed(() => agentsStore.workerLogs[props.workerId] || [])
+
+function toggleDetail(i) {
+  expandedIdx.value = expandedIdx.value === i ? null : i
+}
 
 onMounted(async () => {
   const guildId = guildStore.currentGuild?.id
@@ -167,11 +205,68 @@ watch(logs, async () => {
   gap: 4px;
 }
 
+.terminal-entry { display: flex; flex-direction: column; }
+
 .terminal-line {
   display: flex;
   gap: 12px;
   font-size: 13px;
   line-height: 1.6;
+}
+
+.terminal-line--expandable {
+  cursor: pointer;
+  border-radius: 2px;
+}
+.terminal-line--expandable:hover { background: rgba(255,255,255,0.04); }
+
+.log-expand-icon {
+  font-size: 8px;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+  margin-left: auto;
+  opacity: 0.5;
+}
+
+.log-detail {
+  margin: 3px 0 4px 56px;
+  border-left: 2px solid #2a1a05;
+  padding-left: 10px;
+}
+
+.log-detail-label {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: #5a3a10;
+  letter-spacing: 1px;
+  margin-bottom: 4px;
+  margin-top: 6px;
+}
+.log-detail-label:first-child { margin-top: 0; }
+.log-detail-label--new { color: var(--color-green); }
+
+.log-detail-body {
+  margin: 0 0 2px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-dim);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 300px;
+  overflow-y: auto;
+  background: rgba(0,0,0,0.3);
+  border: 1px solid #2a1a05;
+  padding: 6px 8px;
+}
+.log-detail-old {
+  background: rgba(180,30,30,0.08);
+  border-color: rgba(220,50,50,0.3);
+  color: #c07070;
+}
+.log-detail-new {
+  background: rgba(0,120,60,0.08);
+  border-color: rgba(0,187,100,0.3);
+  color: #70c090;
 }
 
 .log-time {

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -61,20 +61,20 @@ export const useAgentsStore = defineStore('agents', () => {
     if (agent) agent.state = state
   }
 
-  function addLog(agentId, line, timestamp) {
+  function addLog(agentId, line, timestamp, detail) {
     const agent = agents.value.find(a => a.id === agentId)
     if (agent && line) {
       const ts = timestamp || new Date().toISOString()
-      agent.logs.push({ line, timestamp: ts })
+      agent.logs.push({ line, timestamp: ts, detail: detail || null })
       if (agent.logs.length > 500) agent.logs.shift()
     }
   }
 
-  function addWorkerLog(workerId, line, timestamp) {
+  function addWorkerLog(workerId, line, timestamp, detail) {
     if (!line) return
     if (!workerLogs.value[workerId]) workerLogs.value[workerId] = []
     const ts = timestamp || new Date().toISOString()
-    workerLogs.value[workerId].push({ line, timestamp: ts })
+    workerLogs.value[workerId].push({ line, timestamp: ts, detail: detail || null })
     if (workerLogs.value[workerId].length > 500) workerLogs.value[workerId].shift()
   }
 
@@ -216,8 +216,12 @@ export const useAgentsStore = defineStore('agents', () => {
     try {
       const res = await fetch(`${API_BASE}/guilds/${guildId}/logs?worker_id=${workerId}`)
       if (res.ok) {
-        const logs = await res.json()
-        workerLogs.value[workerId] = logs
+        const raw = await res.json()
+        workerLogs.value[workerId] = raw.map(r => ({
+          line: r.line,
+          timestamp: r.timestamp,
+          detail: r.detail || null,
+        }))
       }
     } catch (e) {
       console.error('Failed to fetch worker logs', e)
@@ -228,7 +232,12 @@ export const useAgentsStore = defineStore('agents', () => {
     try {
       const res = await fetch(`${API_BASE}/guilds/${guildId}/logs?agent_id=${agentId}`)
       if (res.ok) {
-        const historical = await res.json()
+        const raw = await res.json()
+        const historical = raw.map(r => ({
+          line: r.line,
+          timestamp: r.timestamp,
+          detail: r.detail || null,
+        }))
         const agent = agents.value.find(a => a.id === agentId)
         if (agent) {
           const existing = agent.logs
@@ -248,12 +257,12 @@ export const useAgentsStore = defineStore('agents', () => {
       updateAgentState(data.agentId, data.state)
     } else if (data.type === 'terminal-output') {
       // Route to per-agent log buffer (includes task logs for agent-tab view)
-      if (data.agentId) addLog(data.agentId, data.line, data.timestamp)
+      if (data.agentId) addLog(data.agentId, data.line, data.timestamp, data.detail)
       // Route to per-worker log buffer; fall back to agent's workerId if backend didn't send it
       const wid = data.workerId || (data.agentId
         ? agents.value.find(a => a.id === data.agentId)?.workerId
         : null)
-      if (wid) addWorkerLog(wid, data.line, data.timestamp)
+      if (wid) addWorkerLog(wid, data.line, data.timestamp, data.detail)
     }
   }
 


### PR DESCRIPTION
- Backend /guilds/{guild_id}/logs endpoint now returns detail field (tool use/result payloads) alongside log lines, matching the task logs endpoint
- agents.js store passes detail through in addLog/addWorkerLog and fetchWorkerLogs/fetchAgentLogs
- TerminalPane and WorkerTerminalPane now render expandable detail rows (OLD/NEW for Edit, COMMAND for Bash, OUTPUT for tool_result, etc.) identical to TaskPane; lines without detail are not clickable

https://claude.ai/code/session_01Hvxd3nFWaLanNRmsFFyPEK