### PR TITLE
Improve WebSocket reconnection with exponential backoff and jitter

### DIFF
--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -12,8 +12,21 @@ export const useGuildStore = defineStore('guild', () => {
   const guilds = ref<Guild[]>([])
   const isConnected = ref(false)
   const messages = ref<ChatMessage[]>([])
+  const reconnectAttempt = ref(0)
   let ws: WebSocket | null = null
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let manualClose = false
   const messageHandlers = ref<MessageHandler[]>([])
+
+  const MAX_RETRIES = 10
+  const BASE_DELAY_MS = 1000
+  const MAX_DELAY_MS = 30000
+
+  function _backoffDelay(attempt: number): number {
+    const exp = Math.min(MAX_DELAY_MS, BASE_DELAY_MS * 2 ** attempt)
+    // Full jitter: random value in [0, exp]
+    return Math.floor(Math.random() * exp)
+  }
 
   function _authHeaders(): Record<string, string> {
     const authStore = useAuthStore()
@@ -70,53 +83,113 @@ export const useGuildStore = defineStore('guild', () => {
     }
   }
 
-  function connectWebSocket(guildId: string, onMessage?: MessageHandler, retryCount = 0): WebSocket {
-    const MAX_RETRIES = 10
+  function connectWebSocket(guildId: string, onMessage?: MessageHandler): WebSocket {
+    manualClose = false
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
     if (ws) {
-      ws.close()
+      try { ws.close() } catch (e) { /* ignore */ }
     }
-    ws = new WebSocket(`ws://localhost:8000/ws/${guildId}`)
-    ws.onopen = () => {
+
+    let socket: WebSocket
+    try {
+      socket = new WebSocket(`ws://localhost:8000/ws/${guildId}`)
+    } catch (e) {
+      console.error('Failed to construct WebSocket', e)
+      _scheduleReconnect(guildId, onMessage)
+      // Return a dummy that callers won't use; the real one will be wired up on retry.
+      return ws as WebSocket
+    }
+    ws = socket
+
+    socket.onopen = () => {
       isConnected.value = true
+      reconnectAttempt.value = 0
     }
-    ws.onmessage = (event) => {
-      const data: WSMessage = JSON.parse(event.data)
-      if (data.type === 'chat') {
-        messages.value.push(data as ChatMessage)
+    socket.onmessage = (event) => {
+      let data: WSMessage
+      try {
+        data = JSON.parse(event.data)
+      } catch (e) {
+        console.warn('Dropping non-JSON WS frame', e)
+        return
       }
-      if (data.type === 'guild-updated') {
-        if (currentGuild.value && currentGuild.value.id === data.id) {
-          currentGuild.value = { ...currentGuild.value, name: data.name }
+      try {
+        if (data.type === 'chat') {
+          messages.value.push(data as ChatMessage)
         }
-        const idx = guilds.value.findIndex(g => g.id === data.id)
-        if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], name: data.name }
+        if (data.type === 'guild-updated') {
+          if (currentGuild.value && currentGuild.value.id === data.id) {
+            currentGuild.value = { ...currentGuild.value, name: data.name }
+          }
+          const idx = guilds.value.findIndex(g => g.id === data.id)
+          if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], name: data.name }
+        }
+        if (onMessage) onMessage(data)
+        messageHandlers.value.forEach(h => {
+          try { h(data) } catch (err) { console.error('WS message handler error', err) }
+        })
+      } catch (e) {
+        console.error('Error processing WS message', e)
       }
-      if (onMessage) onMessage(data)
-      messageHandlers.value.forEach(h => h(data))
     }
-    ws.onclose = (event) => {
+    socket.onclose = (event) => {
       isConnected.value = false
-      if (!event.wasClean && retryCount < MAX_RETRIES) {
-        setTimeout(() => connectWebSocket(guildId, onMessage, retryCount + 1), 2000)
+      if (manualClose) return
+      if (!event.wasClean) {
+        console.warn(`WebSocket closed (code=${event.code} reason=${event.reason || 'n/a'})`)
       }
+      _scheduleReconnect(guildId, onMessage)
     }
-    ws.onerror = () => {
+    socket.onerror = (event) => {
       isConnected.value = false
+      console.error('WebSocket error', event)
     }
-    return ws
+    return socket
+  }
+
+  function _scheduleReconnect(guildId: string, onMessage?: MessageHandler) {
+    if (manualClose) return
+    if (reconnectAttempt.value >= MAX_RETRIES) {
+      console.error(`WebSocket reconnect gave up after ${MAX_RETRIES} attempts`)
+      return
+    }
+    const delay = _backoffDelay(reconnectAttempt.value)
+    reconnectAttempt.value += 1
+    console.info(`WebSocket reconnect attempt ${reconnectAttempt.value}/${MAX_RETRIES} in ${delay}ms`)
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      connectWebSocket(guildId, onMessage)
+    }, delay)
   }
 
   function disconnectWebSocket() {
+    manualClose = true
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
     if (ws) {
-      ws.close()
+      try { ws.close() } catch (e) { /* ignore */ }
       ws = null
     }
     isConnected.value = false
+    reconnectAttempt.value = 0
   }
 
-  function sendMessage(data: WSMessage) {
-    if (ws && ws.readyState === WebSocket.OPEN) {
+  function sendMessage(data: WSMessage): boolean {
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      console.warn('sendMessage: socket not open, dropping', data.type)
+      return false
+    }
+    try {
       ws.send(JSON.stringify(data))
+      return true
+    } catch (e) {
+      console.error('sendMessage failed', e)
+      return false
     }
   }
 
@@ -132,6 +205,7 @@ export const useGuildStore = defineStore('guild', () => {
     currentGuild,
     guilds,
     isConnected,
+    reconnectAttempt,
     messages,
     loadGuilds,
     createGuild,

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import random
 from typing import AsyncIterator, Optional
 
 import websockets
@@ -25,41 +26,93 @@ def _is_open(ws) -> bool:
     return not getattr(ws, "closed", True)
 
 
+def _backoff_delay(attempt: int, base: float, cap: float) -> float:
+    """Exponential backoff with full jitter."""
+    exp = min(cap, base * (2 ** attempt))
+    return random.uniform(0, exp)
+
+
 class WSClient:
-    def __init__(self, url: str, *, max_backoff: float = 30.0) -> None:
+    def __init__(
+        self,
+        url: str,
+        *,
+        max_backoff: float = 30.0,
+        base_backoff: float = 1.0,
+        send_retries: int = 3,
+    ) -> None:
         self.url = url
         self.max_backoff = max_backoff
+        self.base_backoff = base_backoff
+        self.send_retries = max(1, send_retries)
         self._ws = None
         self._lock = asyncio.Lock()
 
     async def connect(self):
-        """Connect (or reconnect) with exponential backoff."""
+        """Connect (or reconnect) with exponential backoff and jitter.
+
+        Retries indefinitely — the worker is a long-running daemon, so a transient
+        backend outage shouldn't kill it. Backoff caps at ``max_backoff``.
+        """
         async with self._lock:
             if self._ws is not None and _is_open(self._ws):
                 return self._ws
-            backoff = 1.0
+            attempt = 0
             while True:
                 try:
-                    logger.info("Connecting to %s", self.url)
+                    logger.info("Connecting to %s (attempt %d)", self.url, attempt + 1)
                     self._ws = await websockets.connect(
                         self.url, ping_interval=20, ping_timeout=20, max_size=8 * 1024 * 1024
                     )
-                    logger.info("WebSocket connected")
+                    if attempt > 0:
+                        logger.info("WebSocket reconnected after %d attempts", attempt + 1)
+                    else:
+                        logger.info("WebSocket connected")
                     return self._ws
-                except (OSError, websockets.WebSocketException) as exc:
-                    logger.warning("WS connect failed: %s — retrying in %.1fs", exc, backoff)
-                    await asyncio.sleep(backoff)
-                    backoff = min(self.max_backoff, backoff * 2)
+                except (OSError, websockets.WebSocketException, asyncio.TimeoutError) as exc:
+                    delay = _backoff_delay(attempt, self.base_backoff, self.max_backoff)
+                    logger.warning(
+                        "WS connect failed (attempt %d): %s — retrying in %.1fs",
+                        attempt + 1, exc, delay,
+                    )
+                    await asyncio.sleep(delay)
+                    attempt += 1
 
     async def send(self, payload: dict) -> None:
-        ws = await self.connect()
+        """Send a JSON payload, reconnecting on failure.
+
+        Retries up to ``send_retries`` times with exponential backoff before
+        giving up and raising. Transport-level reconnection is handled by
+        ``connect()``; this loop guards against the socket flapping.
+        """
         try:
-            await ws.send(json.dumps(payload))
-        except (websockets.WebSocketException, ConnectionError) as exc:
-            logger.warning("WS send failed (%s); reconnecting", exc)
-            await self.close()
-            ws = await self.connect()
-            await ws.send(json.dumps(payload))
+            data = json.dumps(payload)
+        except (TypeError, ValueError) as exc:
+            logger.error("WS send: payload is not JSON-serializable: %s", exc)
+            raise
+
+        last_exc: Optional[BaseException] = None
+        for attempt in range(self.send_retries):
+            try:
+                ws = await self.connect()
+                await ws.send(data)
+                return
+            except (websockets.WebSocketException, ConnectionError, OSError) as exc:
+                last_exc = exc
+                logger.warning(
+                    "WS send failed (attempt %d/%d, type=%s): %s",
+                    attempt + 1, self.send_retries, payload.get("type"), exc,
+                )
+                await self.close()
+                if attempt + 1 < self.send_retries:
+                    delay = _backoff_delay(attempt, self.base_backoff, self.max_backoff)
+                    await asyncio.sleep(delay)
+        logger.error(
+            "WS send giving up after %d attempts (type=%s): %s",
+            self.send_retries, payload.get("type"), last_exc,
+        )
+        if last_exc is not None:
+            raise last_exc
 
     async def messages(self) -> AsyncIterator[dict]:
         """Yield JSON messages forever, reconnecting transparently."""
@@ -72,17 +125,24 @@ class WSClient:
                     except json.JSONDecodeError:
                         logger.debug("Non-JSON WS frame ignored: %r", raw[:120])
             except websockets.ConnectionClosed as exc:
-                logger.warning("WS closed (%s); reconnecting", exc)
+                logger.warning(
+                    "WS closed (code=%s reason=%s); reconnecting",
+                    getattr(exc, "code", "?"), getattr(exc, "reason", "") or "n/a",
+                )
                 await self.close()
+            except (OSError, asyncio.TimeoutError) as exc:
+                logger.warning("WS transport error: %s; reconnecting", exc)
+                await self.close()
+                await asyncio.sleep(_backoff_delay(0, self.base_backoff, self.max_backoff))
             except Exception as exc:  # pragma: no cover
                 logger.exception("WS recv error: %s", exc)
                 await self.close()
-                await asyncio.sleep(1.0)
+                await asyncio.sleep(_backoff_delay(0, self.base_backoff, self.max_backoff))
 
     async def close(self) -> None:
         if self._ws is not None:
             try:
                 await self._ws.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("WS close raised (ignored): %s", exc)
             self._ws = None


### PR DESCRIPTION
## Summary
Enhance WebSocket reliability in both frontend and backend by implementing exponential backoff with full jitter for reconnection attempts, better error handling, and improved logging.

## Key Changes

### Frontend (Vue/TypeScript)
- **Exponential backoff with jitter**: Implemented `_backoffDelay()` function that calculates delays using exponential backoff capped at 30 seconds, with full jitter to prevent thundering herd
- **Reconnection state tracking**: Added `reconnectAttempt` counter and `reconnectTimer` to properly manage reconnection lifecycle
- **Manual close flag**: Added `manualClose` flag to distinguish between intentional disconnects and unexpected failures, preventing unwanted reconnection attempts
- **Enhanced error handling**: 
  - Wrapped WebSocket construction in try-catch
  - Added JSON parsing error handling in message handler
  - Added error handling for individual message handlers
  - Improved `sendMessage()` to return boolean status and log failures
- **Better logging**: Added console warnings/errors for connection issues, reconnection attempts, and message failures
- **Graceful cleanup**: Properly clear reconnection timers and close sockets in `disconnectWebSocket()`

### Backend (Python)
- **Exponential backoff with jitter**: Implemented `_backoff_delay()` function matching frontend behavior
- **Configurable backoff parameters**: Added `base_backoff` and `send_retries` parameters to `WSClient` constructor
- **Improved `connect()` method**:
  - Tracks attempt count instead of doubling backoff each time
  - Retries indefinitely (appropriate for long-running daemon)
  - Better logging with attempt numbers
- **Robust `send()` method**:
  - Validates JSON serializability before attempting send
  - Implements retry loop with exponential backoff (up to `send_retries` times)
  - Closes socket on failure to trigger reconnection
  - Comprehensive error logging
- **Enhanced `messages()` iterator**:
  - Better exception handling for `ConnectionClosed`, `OSError`, and `TimeoutError`
  - Applies backoff delay on transport errors
  - Improved logging with connection codes and reasons
- **Better `close()` logging**: Logs exceptions during close (at debug level)

## Implementation Details
- Both implementations use the same backoff formula: `min(cap, base * 2^attempt)` with uniform random jitter in `[0, exp]`
- Frontend limits reconnection to 10 attempts; backend retries indefinitely (daemon process)
- Error handling is defensive: individual message handler failures don't break the message loop
- Logging is comprehensive to aid debugging connection issues in production

https://claude.ai/code/session_018fUj4a2iU375G1gXiJy2Jj