### PR TITLE
Downgrade tool_use and tool_result logging to DEBUG

### DIFF
--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -168,7 +168,7 @@ def _log_event_full(event: dict, pid: int, n: int) -> None:
                     pid, n, i, blk.get("text", ""),
                 )
             elif btype == "tool_use":
-                logger.info(
+                logger.debug(
                     "claude[%d] event#%d tool_use[%d] name=%s id=%s input=%s",
                     pid, n, i, blk.get("name", ""), blk.get("id", ""),
                     json.dumps(blk.get("input", {}), ensure_ascii=False),
@@ -190,7 +190,7 @@ def _log_event_full(event: dict, pid: int, n: int) -> None:
                 content = blk.get("content")
                 if not isinstance(content, str):
                     content = json.dumps(content, ensure_ascii=False)
-                logger.info(
+                logger.debug(
                     "claude[%d] event#%d tool_result[%d] tool_use_id=%s is_error=%s:\n%s",
                     pid, n, i, blk.get("tool_use_id", ""),
                     blk.get("is_error", False), content,


### PR DESCRIPTION
## Summary

- `tool_use` and `tool_result` log entries in `claude_runner.py` were emitted at `INFO` level, flooding the console with full JSON payloads (file contents, command output, etc.) on every tool call
- Demoted both to `logger.debug(...)` so they only appear when `--log-level DEBUG` is passed
- No other log levels changed (errors, warnings, task state changes all untouched)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)