### PR TITLE
ci: only run on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: ["**"]
 


### PR DESCRIPTION
PRs will still run via pull_request; this avoids duplicate runs when pushing to a branch with an open PR.