### PR TITLE
Fix worker appearing offline after WebSocket reconnect

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -75,6 +75,11 @@ _http_bearer = HTTPBearer(auto_error=False)
 # In-memory WebSocket connections: guild_id -> list of WebSocket
 connections: Dict[str, List[WebSocket]] = {}
 
+# Tracks which WebSocket currently owns a given agent_id. Used so that when a
+# worker reconnects (new WS joins before the old WS's finally block runs), the
+# stale finally doesn't mark the freshly-online agent offline again.
+agent_owners: Dict[str, WebSocket] = {}
+
 # Running agent subprocesses: agent_id -> asyncio.subprocess.Process
 # Used only by /agents/{id}/run (one-off claude/codex/pi invocations).
 # Worker subprocesses live in the standalone /worker process.
@@ -1456,6 +1461,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 await db.commit()
                 if agent_id:
                     joined_agents.add(agent_id)
+                    agent_owners[agent_id] = websocket
                 broadcast_msg = {
                     "type": "agent-joined",
                     "agentId": agent_id,
@@ -1662,7 +1668,14 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
             connections[guild_id].remove(websocket)
     finally:
         try:
-            for agent_id in joined_agents:
+            # Only mark agents offline if this WS is still the current owner.
+            # If a reconnect already produced a newer WS that re-joined the
+            # agent, that newer WS owns the agent now and we must not clobber it.
+            stale_agents = [
+                aid for aid in joined_agents if agent_owners.get(aid) is websocket
+            ]
+            for agent_id in stale_agents:
+                agent_owners.pop(agent_id, None)
                 await db.execute(
                     update(Agent)
                     .where(Agent.id == agent_id, Agent.guild_id == guild_id)
@@ -1674,9 +1687,9 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     .where(Worker.id == agent_id, Worker.guild_id == guild_id)
                     .values(state="offline")
                 )
-            if joined_agents:
+            if stale_agents:
                 await db.commit()
-            for agent_id in joined_agents:
+            for agent_id in stale_agents:
                 await broadcast(guild_id, {
                     "type": "agent-state",
                     "agentId": agent_id,

--- a/backend/tests/test_disconnect.py
+++ b/backend/tests/test_disconnect.py
@@ -135,6 +135,59 @@ def test_worker_disconnect_marks_agent_and_worker_offline(client):
     assert worker_state == "offline", f"worker.state={worker_state!r}, expected 'offline'"
 
 
+def test_reconnect_does_not_get_clobbered_by_old_finally(client):
+    """If a new WebSocket joins for an existing agent before the old WS's
+    teardown finishes, the old WS's cleanup must not mark the freshly-online
+    agent offline. Otherwise the frontend shows the worker offline forever
+    after a reconnect."""
+    test_client, db_path = client
+    guild_id = "gld003"
+    worker_id = "w-rec001"
+    agent_id = "a-rec001"
+
+    _setup_guild_and_worker(db_path, guild_id, worker_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws2:
+        # First connection joins as the agent.
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws1:
+            ws1.send_json({
+                "type": "join",
+                "agentId": agent_id,
+                "agentName": "Test Worker",
+                "agentType": "worker",
+                "workerId": worker_id,
+            })
+            ws1.receive_json()
+            ws2.receive_json()  # observer drains broadcast
+
+            # Simulate a reconnect: a new WS takes over the same agent_id.
+            ws2.send_json({
+                "type": "join",
+                "agentId": agent_id,
+                "agentName": "Test Worker",
+                "agentType": "worker",
+                "workerId": worker_id,
+            })
+            ws2.receive_json()
+            ws1.receive_json()  # ws1 sees the second join broadcast
+
+            # ws1 closes when the with-block exits. Its teardown must NOT
+            # mark the agent offline because ws2 now owns it.
+
+        # After ws1 closes, but ws2 (the new owner) is still connected, the
+        # agent should still be online in the DB.
+        agent_state, worker_state = _get_states(db_path, agent_id, worker_id)
+        assert agent_state != "offline", (
+            f"Old WS's cleanup wrongly marked the reconnected agent offline: "
+            f"agent.state={agent_state!r}"
+        )
+        assert worker_state != "offline", (
+            f"Old WS's cleanup wrongly marked the reconnected worker offline: "
+            f"worker.state={worker_state!r}"
+        )
+
+
+
 def test_worker_disconnect_without_prior_join_is_harmless(client):
     """worker-disconnect with no joined agents must not crash the server.
 

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -40,6 +40,9 @@ class _AgentSlot:
         self.agent_id = agent_id
         self.current_claude: Optional[claude_runner.ClaudeProcess] = None
         self.current_task_id: Optional[str] = None
+        # Last state we told the backend about; resent on WS reconnect so the
+        # backend (and frontend) don't show the agent stuck offline.
+        self.state: str = "idle"
 
 
 class Worker:
@@ -133,6 +136,7 @@ class Worker:
         return _emit_task
 
     async def _set_state(self, state: str, slot: _AgentSlot) -> None:
+        slot.state = state
         await self._send({
             "type": "agent-state",
             "agentId": slot.agent_id,
@@ -156,6 +160,25 @@ class Worker:
             "workerId": self.cfg.worker_id,
             "repos": self.cfg.repos,
         })
+
+    async def _on_ws_reconnect(self) -> None:
+        """Re-announce ourselves after the WebSocket reconnects.
+
+        The backend marks every joined agent offline when the socket closes, so
+        without this the frontend sees the worker as offline forever even though
+        the worker is back online and listening.
+        """
+        logger.info("WebSocket reconnected — re-sending join and agent states")
+        await self._join()
+        # `join` resets each agent to idle in the backend. Re-send the actual
+        # state so a mid-task reconnect doesn't show us as idle while we work.
+        for slot in self.slots:
+            if slot.state and slot.state != "idle":
+                await self._send({
+                    "type": "agent-state",
+                    "agentId": slot.agent_id,
+                    "state": slot.state,
+                })
 
     async def _task_update(self, task_id: str, **fields: object) -> None:
         await self._send({
@@ -201,6 +224,7 @@ class Worker:
         await self._fetch_github_token_if_needed()
 
         logger.info("Connecting to backend WebSocket at %s", self.cfg.ws_url)
+        self.ws.on_reconnect = self._on_ws_reconnect
         await self.ws.connect()
         await self._join()
         logger.info(

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 import random
-from typing import AsyncIterator, Optional
+from typing import Awaitable, AsyncIterator, Callable, Optional
 
 import websockets
 from websockets.protocol import State
@@ -47,6 +47,11 @@ class WSClient:
         self.send_retries = max(1, send_retries)
         self._ws = None
         self._lock = asyncio.Lock()
+        # Fired after every successful reconnect (not the initial connect).
+        # Lets callers re-send join/register/state so the backend treats the
+        # worker as online again.
+        self.on_reconnect: Optional[Callable[[], Awaitable[None]]] = None
+        self._has_connected_once = False
 
     async def connect(self):
         """Connect (or reconnect) with exponential backoff and jitter.
@@ -54,6 +59,7 @@ class WSClient:
         Retries indefinitely — the worker is a long-running daemon, so a transient
         backend outage shouldn't kill it. Backoff caps at ``max_backoff``.
         """
+        just_reconnected = False
         async with self._lock:
             if self._ws is not None and _is_open(self._ws):
                 return self._ws
@@ -68,7 +74,11 @@ class WSClient:
                         logger.info("WebSocket reconnected after %d attempts", attempt + 1)
                     else:
                         logger.info("WebSocket connected")
-                    return self._ws
+                    if self._has_connected_once:
+                        just_reconnected = True
+                    self._has_connected_once = True
+                    ws = self._ws
+                    break
                 except (OSError, websockets.WebSocketException, asyncio.TimeoutError) as exc:
                     delay = _backoff_delay(attempt, self.base_backoff, self.max_backoff)
                     logger.warning(
@@ -77,6 +87,12 @@ class WSClient:
                     )
                     await asyncio.sleep(delay)
                     attempt += 1
+        if just_reconnected and self.on_reconnect is not None:
+            try:
+                await self.on_reconnect()
+            except Exception as exc:
+                logger.warning("on_reconnect hook raised: %s", exc)
+        return ws
 
     async def send(self, payload: dict) -> None:
         """Send a JSON payload, reconnecting on failure.

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -91,3 +91,57 @@ async def test_run_sends_disconnect_before_ws_close():
     )
     assert disconnect_msgs[0]["workerId"] == "w-test01"
     assert close_calls, "ws.close() was never called"
+
+
+async def test_on_ws_reconnect_resends_join_and_register():
+    """After a WS reconnect, the worker must re-announce itself so the backend
+    knows it's online again. Without this the frontend shows the worker offline
+    even though the WebSocket is back up."""
+    cfg = _make_cfg()
+    cfg.max_agents = 2
+    worker = Worker(cfg)
+    sent: list[dict] = []
+    worker._send = AsyncMock(side_effect=lambda p: sent.append(p))
+
+    await worker._on_ws_reconnect()
+
+    join_msgs = [m for m in sent if m.get("type") == "join"]
+    register_msgs = [m for m in sent if m.get("type") == "worker-register"]
+    assert len(join_msgs) == 2, f"Expected one join per slot, got {sent}"
+    assert len(register_msgs) == 1, f"Expected one worker-register, got {sent}"
+    assert {m["agentId"] for m in join_msgs} == {s.agent_id for s in worker.slots}
+
+
+async def test_on_ws_reconnect_resends_non_idle_agent_state():
+    """A reconnect during an active task must restore the slot's actual state
+    so the backend doesn't leave the agent stuck at idle."""
+    cfg = _make_cfg()
+    cfg.max_agents = 2
+    worker = Worker(cfg)
+    worker.slots[0].state = "working"
+    worker.slots[1].state = "idle"
+    sent: list[dict] = []
+    worker._send = AsyncMock(side_effect=lambda p: sent.append(p))
+
+    await worker._on_ws_reconnect()
+
+    state_msgs = [m for m in sent if m.get("type") == "agent-state"]
+    assert len(state_msgs) == 1, (
+        f"Only the non-idle slot should resend agent-state, got: {state_msgs}"
+    )
+    assert state_msgs[0]["agentId"] == worker.slots[0].agent_id
+    assert state_msgs[0]["state"] == "working"
+
+
+async def test_set_state_tracks_state_on_slot():
+    """_set_state must record the current state so reconnect can restore it."""
+    worker = Worker(_make_cfg())
+    worker._send = AsyncMock()
+    slot = worker.slots[0]
+    assert slot.state == "idle"
+
+    await worker._set_state("working", slot)
+    assert slot.state == "working"
+
+    await worker._set_state("awaiting-review", slot)
+    assert slot.state == "awaiting-review"


### PR DESCRIPTION
## Summary
Fixes an issue where workers would appear offline in the frontend after a WebSocket reconnection, even though the connection was restored and the worker was actively processing tasks.

## Root Cause
When a WebSocket disconnects, the backend marks all joined agents as offline. If the worker reconnects before the old connection's cleanup finishes, the stale connection's finally block would mark the freshly-online agent offline again, leaving it stuck in that state on the frontend.

Additionally, the worker wasn't re-announcing itself after reconnecting, so the backend had no record of it being online.

## Key Changes

**Worker-side changes:**
- Added `state` field to `_AgentSlot` to track the last reported state (idle, working, awaiting-review, etc.)
- Modified `_set_state()` to record the state on the slot for later restoration
- Added `_on_ws_reconnect()` method that re-sends join messages and restores non-idle agent states after reconnection
- Wired up the reconnect hook in `ws_client.py` to call `_on_ws_reconnect()` after successful reconnects
- Modified `ws_client.py` to detect reconnects (vs. initial connect) and invoke the `on_reconnect` callback

**Backend-side changes:**
- Added `agent_owners` dict to track which WebSocket currently owns each agent
- Updated join handler to record the current WebSocket as the owner of joined agents
- Modified disconnect cleanup to only mark agents offline if the disconnecting WebSocket is still the current owner
- This prevents stale connections from clobbering freshly-reconnected agents

## Implementation Details
- The reconnect detection in `ws_client.py` uses a `_has_connected_once` flag to distinguish between the initial connection and subsequent reconnects
- The `on_reconnect` callback is invoked after the lock is released to avoid blocking the connection loop
- Exceptions in the reconnect hook are logged but don't crash the worker
- Only non-idle agent states are re-sent on reconnect (idle is the default after join)

https://claude.ai/code/session_01ULyWXwhsjKFhbqCg2Ki2cu