### PR TITLE
Add New Conversation button and foreman history health check

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1394,6 +1394,78 @@ async def get_guild(guild_id: str):
         await db.close()
 
 
+@app.get("/guilds/{guild_id}/foreman/health")
+async def foreman_health(guild_id: str):
+    """Check the structural integrity of the in-memory foreman conversation history."""
+    history = foreman_conversations.get(guild_id, [])
+    issues = []
+    for i, msg in enumerate(history):
+        if msg["role"] != "assistant":
+            continue
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        tool_uses = []
+        for b in content:
+            b_type = getattr(b, "type", None) if not isinstance(b, dict) else b.get("type")
+            if b_type == "tool_use":
+                tool_uses.append(b)
+        if not tool_uses:
+            continue
+        if i + 1 >= len(history):
+            issues.append(f"tool_use block at history[{i}] has no following message")
+            continue
+        next_msg = history[i + 1]
+        if next_msg["role"] != "user":
+            issues.append(f"tool_use block at history[{i}] not followed by user tool_result message")
+            continue
+        next_content = next_msg.get("content", [])
+        if not isinstance(next_content, list):
+            issues.append(f"tool_use block at history[{i}]: following message has non-list content")
+            continue
+        use_ids = {
+            (getattr(b, "id", None) if not isinstance(b, dict) else b.get("id"))
+            for b in tool_uses
+        }
+        result_ids = set()
+        for b in next_content:
+            b_type = getattr(b, "type", None) if not isinstance(b, dict) else b.get("type")
+            if b_type == "tool_result":
+                bid = getattr(b, "tool_use_id", None) if not isinstance(b, dict) else b.get("tool_use_id")
+                if bid:
+                    result_ids.add(bid)
+        missing = use_ids - result_ids - {None}
+        if missing:
+            issues.append(f"tool_use IDs at history[{i}] with no matching tool_result: {missing}")
+    return {"healthy": len(issues) == 0, "issues": issues, "history_length": len(history)}
+
+
+@app.post("/guilds/{guild_id}/foreman/reset")
+async def reset_foreman_conversation(guild_id: str):
+    """Clear the in-memory foreman conversation history and broadcast a system notice."""
+    foreman_conversations.pop(guild_id, None)
+    now = datetime.now(timezone.utc).isoformat()
+    msg_content = "🔄 Foreman conversation history cleared. Starting fresh."
+    await broadcast(guild_id, {
+        "type": "chat", "from": "system", "to": "user",
+        "content": msg_content, "createdAt": now,
+    })
+    db = await get_db()
+    try:
+        db.add(Message(
+            guild_id=guild_id,
+            from_agent="system",
+            to_agent="user",
+            content=msg_content,
+            message_type="chat",
+            created_at=now,
+        ))
+        await db.commit()
+    finally:
+        await db.close()
+    return {"status": "ok"}
+
+
 async def broadcast(guild_id: str, message: dict, exclude: WebSocket = None):
     """Broadcast a message to all connections in a guild."""
     if guild_id not in connections:

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -7,6 +7,7 @@
           <span class="status-dot" :class="foreman.state"></span>
           {{ foreman.state }}
         </span>
+        <button class="new-convo-btn pixel-btn" @click.stop="startNewConversation" title="New Conversation">🔄 New</button>
         <span class="minimize-btn">{{ minimized ? '▲' : '▼' }}</span>
       </div>
     </div>
@@ -32,6 +33,9 @@
 
       <!-- Chat tab -->
       <template v-if="activeTab === 'chat'">
+        <div v-if="historyIssues.length > 0" class="history-warning">
+          ⚠ Conversation history has errors — consider starting a new conversation.
+        </div>
         <div class="chat-messages" ref="messagesEl">
           <div v-if="messages.length === 0" class="chat-empty">
             Awaiting foreman connection...
@@ -125,9 +129,21 @@ const inputText = ref('')
 const messagesEl = ref<HTMLElement | null>(null)
 const issuesEl = ref<HTMLElement | null>(null)
 const activeTab = ref<'chat' | 'issues'>('chat')
+const historyIssues = ref<string[]>([])
 
 const messages = computed(() => guildStore.messages)
 const foreman = computed(() => agentsStore.agents.find(a => a.type === 'foreman'))
+
+async function checkHistoryHealth() {
+  const result = await guildStore.fetchForemanHealth()
+  historyIssues.value = result?.issues ?? []
+}
+
+async function startNewConversation() {
+  if (!confirm('Start a new conversation? This will clear the current chat history.')) return
+  await guildStore.resetForemanConversation()
+  historyIssues.value = []
+}
 
 // Issue assignment pattern: "Work on issue #N in owner/repo: title"
 const ISSUE_PATTERN = /Work on issue #(\d+) in ([^:]+): "(.+)"/
@@ -214,7 +230,10 @@ function handleTaskEvent(data: WSMessage) {
   }
 }
 
-onMounted(() => guildStore.addMessageHandler(handleTaskEvent))
+onMounted(() => {
+  guildStore.addMessageHandler(handleTaskEvent)
+  checkHistoryHealth()
+})
 onUnmounted(() => guildStore.removeMessageHandler(handleTaskEvent))
 
 async function switchToIssues() {
@@ -624,5 +643,22 @@ watch(messages, async () => {
   margin-left: auto;
   font-size: 9px;
   color: var(--color-text-dim);
+}
+
+.new-convo-btn {
+  font-size: 7px;
+  padding: 3px 7px;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.history-warning {
+  background: rgba(255, 204, 0, 0.12);
+  border-bottom: 1px solid rgba(255, 204, 0, 0.4);
+  color: #ffcc00;
+  font-size: 10px;
+  padding: 6px 12px;
+  flex-shrink: 0;
+  line-height: 1.4;
 }
 </style>

--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -201,6 +201,28 @@ export const useGuildStore = defineStore('guild', () => {
     messageHandlers.value = messageHandlers.value.filter(h => h !== handler)
   }
 
+  async function resetForemanConversation(): Promise<void> {
+    if (!currentGuild.value) return
+    messages.value = []
+    await fetch(`${API_BASE}/guilds/${currentGuild.value.id}/foreman/reset`, {
+      method: 'POST',
+      headers: _authHeaders(),
+    })
+  }
+
+  async function fetchForemanHealth(): Promise<{ healthy: boolean; issues: string[]; history_length: number } | null> {
+    if (!currentGuild.value) return null
+    try {
+      const res = await fetch(`${API_BASE}/guilds/${currentGuild.value.id}/foreman/health`, {
+        headers: _authHeaders(),
+      })
+      if (!res.ok) return null
+      return await res.json()
+    } catch {
+      return null
+    }
+  }
+
   return {
     currentGuild,
     guilds,
@@ -215,6 +237,8 @@ export const useGuildStore = defineStore('guild', () => {
     disconnectWebSocket,
     sendMessage,
     addMessageHandler,
-    removeMessageHandler
+    removeMessageHandler,
+    resetForemanConversation,
+    fetchForemanHealth,
   }
 })


### PR DESCRIPTION
## Summary

- **New Conversation button**: A `🔄 New` button is always visible in the Foreman chat header. Clicking it shows a confirmation prompt; on confirm it clears the client-side message list and calls the new reset endpoint to wipe the server-side foreman conversation history.
- **History health check**: On component mount, the UI calls `GET /guilds/{id}/foreman/health` which scans the in-memory foreman conversation for `tool_use` blocks that have no matching `tool_result` immediately after (the structural error that breaks Claude API calls). If issues are found, a yellow warning banner appears above the chat input.
- **Backend endpoints added**:
  - `GET /guilds/{guild_id}/foreman/health` — returns `{healthy, issues[], history_length}`
  - `POST /guilds/{guild_id}/foreman/reset` — clears `foreman_conversations[guild_id]`, broadcasts and persists a system chat message

## Test plan

- [ ] Start the backend and frontend; open the Foreman chat panel
- [ ] Verify the `🔄 New` button is visible in the header at all times
- [ ] Click `🔄 New`, cancel the prompt — verify nothing changes
- [ ] Click `🔄 New`, confirm — verify the chat clears and a "🔄 Foreman conversation history cleared" system message appears
- [ ] Verify `GET /guilds/{id}/foreman/health` returns `{"healthy": true, "issues": [], "history_length": 0}` after reset
- [ ] (Optional) Manually corrupt the foreman history in memory and verify the warning banner appears

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)