### PR TITLE
Post task-complete callback when follow-up window times out

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1602,6 +1602,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 worker_id_msg = data.get("workerId", "")
                 desc = data.get("description", "")
                 branch = data.get("branch", "")
+                finalized_by = data.get("finalizedBy", "")
                 if task_id:
                     await db.execute(
                         update(Task)
@@ -1611,14 +1612,35 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     await db.commit()
                 await broadcast(guild_id, data, exclude=websocket)
                 if task_id:
-                    asyncio.create_task(_run_foreman_ai(
-                        guild_id,
-                        f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
-                        f"\"{desc[:80]}\" — branch: {branch}. "
-                        "Review this result. Call send_followup if additional work is needed "
-                        "(e.g. update tests, add docs, fix lint errors). "
-                        "Otherwise call finalize_task to mark it complete.",
-                    ))
+                    if finalized_by == "timeout":
+                        finished_at = datetime.now(timezone.utc).isoformat()
+                        await db.execute(
+                            update(Task)
+                            .where(Task.id == task_id)
+                            .values(state="done", finished_at=finished_at)
+                        )
+                        await db.commit()
+                        await broadcast(guild_id, {
+                            "type": "task-update",
+                            "taskId": task_id,
+                            "state": "done",
+                            "finishedAt": finished_at,
+                        })
+                        asyncio.create_task(_run_foreman_ai(
+                            guild_id,
+                            f"[timeout] Follow-up window expired for task {task_id} "
+                            f"(worker {worker_id_msg}). The task has been auto-finalized "
+                            "as done — no foreman action required.",
+                        ))
+                    else:
+                        asyncio.create_task(_run_foreman_ai(
+                            guild_id,
+                            f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
+                            f"\"{desc[:80]}\" — branch: {branch}. "
+                            "Review this result. Call send_followup if additional work is needed "
+                            "(e.g. update tests, add docs, fix lint errors). "
+                            "Otherwise call finalize_task to mark it complete.",
+                        ))
 
             elif msg_type == "task-followup-done":
                 task_id = data.get("taskId")

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -601,6 +601,16 @@ class Worker:
                         )
                     except asyncio.TimeoutError:
                         await emit("[worker] Follow-up window expired — finalizing.")
+                        await self._send({
+                            "type": "task-complete",
+                            "workerId": self.cfg.worker_id,
+                            "taskId": task_id,
+                            "branch": branch,
+                            "description": desc,
+                            "prUrl": pr_url or "",
+                            "sessionId": resume_session_id or "",
+                            "finalizedBy": "timeout",
+                        })
                         break
                     if instructions is _CANCEL_SENTINEL:
                         await emit("[worker] Task cancelled.")


### PR DESCRIPTION
## Summary

- When the 300-second follow-up window expires without a foreman response, the worker now sends a `task-complete` message with `"finalizedBy": "timeout"` before breaking out of the loop
- The backend detects this flag, immediately auto-finalizes the task as `done` (no second foreman round-trip), broadcasts a `task-update` with the final state, and sends the foreman an informational `[timeout]` notification to keep its in-memory conversation consistent
- Normal task-complete flow (no `finalizedBy` field) is unchanged

## Test plan

- [ ] Start a task and let the foreman deliberately not respond — confirm the task transitions to `done` after 300 s and the foreman's conversation log shows the `[timeout]` message
- [ ] Verify normal task completion (foreman calls `finalize_task` before the window) still works as before
- [ ] Check `task-update` broadcast reaches the frontend and updates task state in the UI

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)