### PR TITLE
Redirect GitHub OAuth callback to frontend instead of backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -64,7 +64,7 @@ app.add_middleware(
 # GitHub OAuth config (set via environment variables)
 GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID", "")
 GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "")
-GITHUB_REDIRECT_URI = os.environ.get("GITHUB_REDIRECT_URI", "http://localhost:8000/auth/github/callback")
+GITHUB_REDIRECT_URI = os.environ.get("GITHUB_REDIRECT_URI", "http://localhost:5173/")
 FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
 
 # In-memory: short-lived state tokens for OAuth CSRF protection
@@ -1160,9 +1160,8 @@ async def github_login():
     return {"url": f"https://github.com/login/oauth/authorize?{params}"}
 
 
-@app.get("/auth/github/callback")
-async def github_callback(code: str = Query(...), state: str = Query(...)):
-    """Handle the GitHub OAuth callback: store token, issue a login_token, redirect to frontend."""
+async def _gh_create_session(code: str, state: str) -> dict:
+    """Exchange an OAuth code+state for a login session. Returns the session payload dict."""
     if state not in oauth_states:
         raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
     oauth_states.discard(state)
@@ -1213,15 +1212,32 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
     finally:
         await db.close()
 
-    # Redirect to the frontend landing page with the login_token and GitHub info
-    qs = urllib.parse.urlencode({
+    return {
         "login_token": login_token,
         "gh_token": access_token,
         "gh_user_id": github_user_id,
         "gh_login": github_username,
         "gh_name": user_data.get("name") or "",
         "gh_avatar": user_data.get("avatar_url") or "",
-    })
+    }
+
+
+class CodeExchangeRequest(BaseModel):
+    code: str
+    state: str
+
+
+@app.post("/auth/github/exchange")
+async def github_exchange(body: CodeExchangeRequest):
+    """Exchange a GitHub OAuth code+state for a login session. Called by the frontend."""
+    return await _gh_create_session(body.code, body.state)
+
+
+@app.get("/auth/github/callback")
+async def github_callback(code: str = Query(...), state: str = Query(...)):
+    """Legacy backend OAuth callback — redirects to the frontend with session params in the query string."""
+    payload = await _gh_create_session(code, state)
+    qs = urllib.parse.urlencode(payload)
     return RedirectResponse(url=f"{FRONTEND_URL}/?{qs}")
 
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -43,6 +43,23 @@ export const useAuthStore = defineStore('auth', () => {
     return true
   }
 
+  // Exchange an OAuth code+state with the backend and persist the resulting session.
+  async function exchangeCode(code: string, state: string): Promise<{ gh_token: string } | null> {
+    const res = await fetch(`${API_BASE}/auth/github/exchange`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code, state }),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new Error(body.detail || `Auth exchange failed: ${res.status}`)
+    }
+    const data = await res.json()
+    const params = new URLSearchParams(data)
+    restoreFromCallback(params)
+    return data
+  }
+
   async function logout() {
     if (loginToken.value) {
       await fetch(`${API_BASE}/auth/logout`, {
@@ -63,6 +80,7 @@ export const useAuthStore = defineStore('auth', () => {
     authHeaders,
     loginWithGitHub,
     restoreFromCallback,
+    exchangeCode,
     logout,
   }
 })

--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -149,7 +149,17 @@ const loginError = ref('')
 
 onMounted(async () => {
   const params = new URLSearchParams(window.location.search)
-  if (params.has('login_token')) {
+  if (params.has('code') && params.has('state')) {
+    // GitHub redirected directly to the frontend with an OAuth code — exchange it.
+    window.history.replaceState({}, '', '/')
+    try {
+      const data = await authStore.exchangeCode(params.get('code')!, params.get('state')!)
+      if (data) ghStore.restoreGitHubToken(new URLSearchParams(data as any))
+    } catch (e: any) {
+      loginError.value = e.message
+    }
+  } else if (params.has('login_token')) {
+    // Legacy: backend callback redirected here with session params in the query string.
     authStore.restoreFromCallback(params)
     ghStore.restoreGitHubToken(params)
     window.history.replaceState({}, '', '/')


### PR DESCRIPTION
- Change GITHUB_REDIRECT_URI default to http://localhost:5173/ so GitHub sends the code directly to the frontend
- Add POST /auth/github/exchange endpoint that accepts {code, state} JSON and returns session data
- Refactor callback DB logic into _gh_create_session helper shared by both endpoints
- Keep GET /auth/github/callback as a legacy redirect-based fallback
- Add exchangeCode() to the auth store for the frontend to call after receiving the OAuth code
- Update LandingView to detect code+state params and call exchangeCode instead of restoreFromCallback

https://claude.ai/code/session_0131KU8VRom77NwKDczaBdwH