### PR TITLE
fix(landing): make landing page responsive on mobile viewports

### DIFF
--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -740,4 +740,99 @@ function sparkleStyle(n: number) {
   background: rgba(255, 255, 255, 0.05);
   box-shadow: none;
 }
+
+/* ── Responsive: tablet (≤ 900px) — stack columns ── */
+@media (max-width: 900px) {
+  .landing {
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .landing-content {
+    flex-direction: column;
+    padding: 24px 20px;
+    gap: 24px;
+    max-width: 100%;
+  }
+
+  .workshop-panel {
+    flex: none;
+    width: 100%;
+    position: static;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .workshop-frame {
+    flex: 0 0 180px;
+    max-width: 180px;
+  }
+
+  .workshop-lore {
+    flex: 1;
+    align-self: center;
+  }
+}
+
+/* ── Responsive: mobile (≤ 600px) ── */
+@media (max-width: 600px) {
+  .landing-content {
+    padding: 16px 12px;
+    gap: 16px;
+  }
+
+  .workshop-frame {
+    flex: 0 0 110px;
+    max-width: 110px;
+  }
+
+  .workshop-lore {
+    font-size: 9px;
+  }
+
+  .landing-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding-bottom: 14px;
+  }
+
+  .logo-title {
+    font-size: 13px;
+    letter-spacing: 2px;
+  }
+
+  .logo-subtitle {
+    font-size: 11px;
+    letter-spacing: 1px;
+  }
+
+  .header-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    width: 100%;
+  }
+
+  .sessions-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .login-gate {
+    padding: 20px 0;
+  }
+
+  .login-card {
+    padding: 28px 16px;
+  }
+
+  .modal {
+    width: calc(100vw - 32px);
+  }
+
+  .modal-footer {
+    flex-wrap: wrap;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary

- Stacks the workshop panel and main panel vertically below 900px (tablet/mobile) instead of the fixed side-by-side layout
- Workshop panel reflows to a compact horizontal strip (thumbnail + lore text) on tablet; further shrinks on mobile
- Adds `overflow-y: auto` to `.landing` on small screens so stacked content is scrollable (no horizontal overflow)
- Logo title scales down from 22px → 13px pixel font on phones, letter-spacing reduced
- Header actions (user pill + New Guild + Sign Out buttons) use `flex-wrap` to stack gracefully
- Sessions grid collapses to a single column below 600px (was `minmax(260px, 1fr)` — wider than most phones)
- Modal uses `calc(100vw - 32px)` instead of fixed `width: 380px` on mobile

## Test plan

- [ ] Resize browser to 375px wide (iPhone SE) — columns should stack, no horizontal scrollbar
- [ ] Resize to 768px (tablet) — workshop panel appears as horizontal strip above main content
- [ ] Logged-in header (user pill + buttons) wraps cleanly at narrow widths
- [ ] Guild cards grid shows 1 column on mobile, auto-fill on wider screens
- [ ] New Guild modal fits within phone screen width
- [ ] No content clipped or cut off at any common mobile breakpoint

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)