### PR TITLE
fix(mobile): chat full height and task tap navigation

### DIFF
--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -625,4 +625,22 @@ watch(messages, async () => {
   font-size: 9px;
   color: var(--color-text-dim);
 }
+
+@media (max-width: 1024px) {
+  .chat-pane {
+    max-height: 100% !important;
+    border-radius: 0;
+  }
+
+  .chat-messages {
+    min-height: 0;
+    max-height: none;
+    flex: 1;
+  }
+
+  .issues-list {
+    min-height: 0;
+    max-height: none;
+  }
+}
 </style>

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -135,7 +135,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, inject } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGuildStore } from '../stores/guild'
 import { useGitHubStore } from '../stores/github'
@@ -153,6 +153,8 @@ const ghStore = useGitHubStore()
 const authStore = useAuthStore()
 const tasksStore = useTasksStore()
 const agentsStore = useAgentsStore()
+
+const switchMobileTab = inject<(tab: string) => void>('switchMobileTab', () => {})
 
 const showGitHubModal = ref(false)
 const currentGuild = computed(() => guildStore.currentGuild)
@@ -258,6 +260,7 @@ function goHome() {
 
 function openTask(taskId: string) {
   tasksStore.selectTask(taskId)
+  switchMobileTab('work')
 }
 
 function agentsForWorker(workerId: string) {

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, watch, ref } from 'vue'
+import { onMounted, onUnmounted, watch, ref, provide } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGuildStore } from '../stores/guild'
 import { useAgentsStore } from '../stores/agents'
@@ -35,6 +35,7 @@ import ChatPane from '../components/ChatPane.vue'
 const props = defineProps<{ guildId?: string }>()
 
 const activeTab = ref<'tasks' | 'work' | 'chat'>('chat')
+provide('switchMobileTab', (tab: 'tasks' | 'work' | 'chat') => { activeTab.value = tab })
 
 const router = useRouter()
 const guildStore = useGuildStore()
@@ -208,7 +209,8 @@ watch(
     width: 100vw !important;
     min-width: 0 !important;
     max-width: 100vw !important;
-    height: calc(100vh - 52px) !important;
+    height: calc(100dvh - 52px) !important;
+    max-height: calc(100dvh - 52px) !important;
     display: none !important;
   }
 


### PR DESCRIPTION
## Summary

- **Fixes #59** — Chat/manager panel now fills the full viewport on mobile. Overrides ChatPane's fixed `max-height: 500px` and inner `.chat-messages` `max-height: 340px` with a `@media (max-width: 1024px)` rule that removes those caps and lets the flex layout fill `100dvh - 52px`. Also switched AppView from `100vh` to `100dvh` so the panel respects the mobile browser's dynamic viewport (address bar show/hide).
- **Fixes #60** — Tapping a task in the sidebar on mobile now navigates to the Work tab. `AppView` provides a `switchMobileTab` callback via `provide/inject`; `GuildSidebar.openTask()` injects it and calls `switchMobileTab('work')` after selecting the task, so the user lands on the task detail immediately instead of staying on the Tasks tab.

## Test plan

- [ ] Open on a mobile-width viewport (≤1024px) and tap the Chat tab — panel should fill the screen from top to the tab bar with messages scrolling internally and the input pinned at the bottom
- [ ] Tap the Tasks tab, tap any task — app should switch to the Work tab and show the task detail
- [ ] Verify desktop layout is unaffected (sidebar + main view + floating chat pane in corner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)