### PR TITLE
fix(worker): derive branch name from task name instead of description

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -28,8 +28,8 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _slug(text: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "-", text[:40].lower()).strip("-")
+def _slug(text: str, max_len: int = 45) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text[:max_len].lower()).strip("-")
 
 
 _CANCEL_SENTINEL = object()  # placed in followup queue to signal task cancellation
@@ -419,7 +419,8 @@ class Worker:
         await self._set_state("working", slot)
         await self._task_update(task_id, state="working")
 
-        branch = f"claude/{_slug(desc)}-{task_id[:6]}"
+        name = task.get("name") or desc
+        branch = f"claude/{_slug(name)}-{task_id[:6]}"
         work_dir = os.path.join(self.cfg.work_dir, self.cfg.guild_id, self.cfg.worker_id, task_id)
         logger.info("Task %s branch=%s work_dir=%s", task_id, branch, work_dir)
         os.makedirs(work_dir, exist_ok=True)


### PR DESCRIPTION
## Summary

- Branch slugs now use the short `name` field instead of the full `description`
- Falls back to `description` if `name` is absent (backwards-compatible)
- Raised max slug length to 45 chars before the `-{task-id}` suffix
- Example: `claude/fix-mobile-chat-height-and-tap-t-1prx` instead of `claude/fix-two-mobile-bugs-in-the-jmelloy-pione-t-1prx`

Closes #64

## Test plan

- [ ] Assign a task with a meaningful `name` field and verify the branch follows `{agent}/{slug-of-name}-{short-id}`
- [ ] Assign a task without a `name` field and verify it falls back to the description slug (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)