### PR TITLE
Add foreman debug tab, clear-context button, and fix history trimming

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -500,6 +500,30 @@ FOREMAN_TOOLS = [
 ]
 
 
+def _serialize_history_for_debug(history: list) -> list:
+    """Convert in-memory foreman history (may contain SDK objects) to JSON-safe dicts."""
+    out = []
+    for msg in history:
+        role = msg.get("role", "?") if isinstance(msg, dict) else getattr(msg, "role", "?")
+        content = msg.get("content", []) if isinstance(msg, dict) else getattr(msg, "content", [])
+        if isinstance(content, str):
+            out.append({"role": role, "content": content})
+        elif isinstance(content, list):
+            blocks = []
+            for b in content:
+                if isinstance(b, dict):
+                    blocks.append(b)
+                else:
+                    try:
+                        blocks.append(b.model_dump())
+                    except AttributeError:
+                        blocks.append({"type": str(getattr(b, "type", "unknown")), "raw": str(b)})
+            out.append({"role": role, "content": blocks})
+        else:
+            out.append({"role": role, "content": str(content)})
+    return out
+
+
 def _repair_tool_pairs(messages: list) -> list:
     """
     Ensure every tool_use block in an assistant turn has a matching tool_result
@@ -1089,9 +1113,13 @@ async def _run_foreman_ai(guild_id: str, human_message: str, extra_context: str 
             ]
             history.append({"role": "user", "content": trimmed})
 
-        # Trim history, then repair any tool_use/tool_result pairs broken by the slice
-        trimmed_history = history[-20:]
-        foreman_conversations[guild_id] = _repair_tool_pairs(trimmed_history)
+        # Trim history, repair orphaned tool pairs, then drop any leading assistant
+        # turns (which the API forbids as the first message).
+        trimmed_history = history[-10:]
+        repaired = _repair_tool_pairs(trimmed_history)
+        while repaired and repaired[0].get("role") != "user":
+            repaired = repaired[1:]
+        foreman_conversations[guild_id] = repaired
 
         response_text = "\n".join(text_parts).strip()
         if response_text:
@@ -2543,3 +2571,37 @@ async def redirect_task_endpoint(guild_id: str, task_id: str, data: RedirectCrea
         "state": "working",
     })
     return {"status": "redirected", "taskId": task_id}
+
+
+# ---------------------------------------------------------------------------
+# Foreman context endpoints
+# ---------------------------------------------------------------------------
+
+@app.get("/guilds/{guild_id}/foreman/context")
+async def get_foreman_context(guild_id: str):
+    """Return the current in-memory foreman conversation context for debugging."""
+    db = await get_db()
+    try:
+        result = await db.execute(select(Guild.id).where(Guild.id == guild_id))
+        if not result.scalar_one_or_none():
+            raise HTTPException(status_code=404, detail="Guild not found")
+    finally:
+        await db.close()
+    history = foreman_conversations.get(guild_id, [])
+    return {"messages": _serialize_history_for_debug(history), "count": len(history)}
+
+
+@app.post("/guilds/{guild_id}/foreman/clear-context")
+async def clear_foreman_context(guild_id: str):
+    """Reset the in-memory foreman conversation context. Chat history in the DB is preserved."""
+    db = await get_db()
+    try:
+        result = await db.execute(select(Guild.id).where(Guild.id == guild_id))
+        if not result.scalar_one_or_none():
+            raise HTTPException(status_code=404, detail="Guild not found")
+    finally:
+        await db.close()
+    old_len = len(foreman_conversations.get(guild_id, []))
+    foreman_conversations[guild_id] = []
+    logger.info("Foreman context cleared for guild %s (%d messages removed)", guild_id, old_len)
+    return {"status": "cleared", "removed": old_len}

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -28,6 +28,11 @@
           Issues
           <span v-if="ghStore.issues.length" class="badge">{{ ghStore.issues.length }}</span>
         </button>
+        <button
+          class="tab-btn"
+          :class="{ active: activeTab === 'debug' }"
+          @click.stop="switchToDebug"
+        >Debug</button>
       </div>
 
       <!-- Chat tab -->
@@ -105,6 +110,60 @@
           </div>
         </div>
       </template>
+
+      <!-- Debug tab -->
+      <template v-else-if="activeTab === 'debug'">
+        <div class="debug-toolbar">
+          <span class="debug-count">{{ debugContext.length }} msg{{ debugContext.length !== 1 ? 's' : '' }} in context</span>
+          <button class="pixel-btn refresh-btn" @click="refreshDebug" :disabled="debugLoading">
+            {{ debugLoading ? '...' : '↻' }}
+          </button>
+          <button class="pixel-btn clear-btn" @click="clearContext" :disabled="debugClearing">
+            {{ debugClearing ? '...' : 'CLR CTX' }}
+          </button>
+        </div>
+        <div class="debug-messages" ref="debugEl">
+          <div v-if="debugContext.length === 0 && !debugLoading" class="chat-empty">
+            No context — foreman hasn't run yet.
+          </div>
+          <div v-if="debugLoading" class="chat-empty">Loading...</div>
+          <div
+            v-for="(msg, i) in debugContext"
+            :key="i"
+            class="debug-msg"
+            :class="msg.role === 'assistant' ? 'debug-assistant' : 'debug-user'"
+          >
+            <span class="debug-role">{{ msg.role.toUpperCase() }}</span>
+            <template v-if="typeof msg.content === 'string'">
+              <span class="debug-text">{{ msg.content }}</span>
+            </template>
+            <template v-else>
+              <div
+                v-for="(block, bi) in msg.content"
+                :key="bi"
+                class="debug-block"
+                :class="`debug-block-${block.type}`"
+              >
+                <span class="debug-block-type">{{ block.type }}</span>
+                <template v-if="block.type === 'text'">
+                  <span class="debug-text">{{ block.text }}</span>
+                </template>
+                <template v-else-if="block.type === 'tool_use'">
+                  <span class="debug-tool-name">{{ block.name }}</span>
+                  <pre class="debug-pre">{{ JSON.stringify(block.input, null, 2) }}</pre>
+                </template>
+                <template v-else-if="block.type === 'tool_result'">
+                  <span class="debug-tool-id">id:{{ block.tool_use_id?.slice(-6) }}</span>
+                  <pre class="debug-pre">{{ typeof block.content === 'string' ? block.content : JSON.stringify(block.content) }}</pre>
+                </template>
+                <template v-else>
+                  <pre class="debug-pre">{{ JSON.stringify(block) }}</pre>
+                </template>
+              </div>
+            </template>
+          </div>
+        </div>
+      </template>
     </div>
   </div>
 </template>
@@ -114,17 +173,26 @@ import { ref, computed, nextTick, watch, onMounted, onUnmounted } from 'vue'
 import { useGuildStore } from '../stores/guild'
 import { useAgentsStore } from '../stores/agents'
 import { useGitHubStore } from '../stores/github'
+import { useAuthStore } from '../stores/auth'
 import type { GitHubIssue, WSMessage } from '../types'
+
+const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
 
 const guildStore = useGuildStore()
 const agentsStore = useAgentsStore()
 const ghStore = useGitHubStore()
+const authStore = useAuthStore()
 
 const minimized = ref(false)
 const inputText = ref('')
 const messagesEl = ref<HTMLElement | null>(null)
 const issuesEl = ref<HTMLElement | null>(null)
-const activeTab = ref<'chat' | 'issues'>('chat')
+const debugEl = ref<HTMLElement | null>(null)
+const activeTab = ref<'chat' | 'issues' | 'debug'>('chat')
+
+const debugContext = ref<any[]>([])
+const debugLoading = ref(false)
+const debugClearing = ref(false)
 
 const messages = computed(() => guildStore.messages)
 const foreman = computed(() => agentsStore.agents.find(a => a.type === 'foreman'))
@@ -216,6 +284,49 @@ function handleTaskEvent(data: WSMessage) {
 
 onMounted(() => guildStore.addMessageHandler(handleTaskEvent))
 onUnmounted(() => guildStore.removeMessageHandler(handleTaskEvent))
+
+async function switchToDebug() {
+  activeTab.value = 'debug'
+  await refreshDebug()
+}
+
+async function refreshDebug() {
+  const guildId = guildStore.currentGuild?.id
+  if (!guildId) return
+  debugLoading.value = true
+  try {
+    const res = await fetch(`${API_BASE}/guilds/${guildId}/foreman/context`, {
+      headers: authStore.authHeaders()
+    })
+    if (res.ok) {
+      const data = await res.json()
+      debugContext.value = data.messages || []
+    }
+  } catch (e) {
+    console.error('Failed to load foreman context', e)
+  } finally {
+    debugLoading.value = false
+    await nextTick()
+    if (debugEl.value) debugEl.value.scrollTop = debugEl.value.scrollHeight
+  }
+}
+
+async function clearContext() {
+  const guildId = guildStore.currentGuild?.id
+  if (!guildId) return
+  debugClearing.value = true
+  try {
+    await fetch(`${API_BASE}/guilds/${guildId}/foreman/clear-context`, {
+      method: 'POST',
+      headers: authStore.authHeaders()
+    })
+    debugContext.value = []
+  } catch (e) {
+    console.error('Failed to clear foreman context', e)
+  } finally {
+    debugClearing.value = false
+  }
+}
 
 async function switchToIssues() {
   activeTab.value = 'issues'
@@ -626,6 +737,137 @@ watch(messages, async () => {
   color: var(--color-text-dim);
 }
 
+/* ── Debug tab ── */
+.debug-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--color-brass-dark);
+  flex-shrink: 0;
+}
+
+.debug-count {
+  font-size: 10px;
+  color: var(--color-text-dim);
+  flex: 1;
+}
+
+.clear-btn {
+  font-size: 7px;
+  padding: 3px 6px;
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #c0392b);
+}
+
+.clear-btn:hover {
+  background: rgba(192, 57, 43, 0.15);
+}
+
+.debug-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 180px;
+  max-height: 380px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.debug-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 5px 8px;
+  border-radius: 2px;
+}
+
+.debug-assistant {
+  background: rgba(0, 187, 170, 0.06);
+  border-left: 3px solid var(--color-teal);
+}
+
+.debug-user {
+  background: rgba(232, 170, 0, 0.06);
+  border-left: 3px solid var(--color-brass-dark);
+}
+
+.debug-role {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 1px;
+  color: var(--color-text-dim);
+  margin-bottom: 2px;
+}
+
+.debug-assistant .debug-role { color: var(--color-teal); }
+.debug-user .debug-role { color: var(--color-brass); }
+
+.debug-text {
+  color: var(--color-text);
+  line-height: 1.4;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.debug-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 3px 5px;
+  border-radius: 2px;
+  margin-top: 2px;
+}
+
+.debug-block-tool_use {
+  background: rgba(255, 140, 0, 0.1);
+  border: 1px solid rgba(255, 140, 0, 0.25);
+}
+
+.debug-block-tool_result {
+  background: rgba(80, 200, 120, 0.07);
+  border: 1px solid rgba(80, 200, 120, 0.2);
+}
+
+.debug-block-text {
+  background: transparent;
+}
+
+.debug-block-type {
+  font-family: var(--font-pixel);
+  font-size: 5px;
+  letter-spacing: 1px;
+  color: var(--color-text-dim);
+  text-transform: uppercase;
+}
+
+.debug-block-tool_use .debug-block-type { color: #ff8c00; }
+.debug-block-tool_result .debug-block-type { color: #50c878; }
+
+.debug-tool-name {
+  font-weight: bold;
+  color: #ff8c00;
+  font-size: 11px;
+}
+
+.debug-tool-id {
+  font-size: 9px;
+  color: #50c878;
+}
+
+.debug-pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--color-text-dim);
+  font-size: 9px;
+  max-height: 80px;
+  overflow-y: auto;
+}
+
 @media (max-width: 1024px) {
   .chat-pane {
     max-height: 100% !important;
@@ -639,6 +881,11 @@ watch(messages, async () => {
   }
 
   .issues-list {
+    min-height: 0;
+    max-height: none;
+  }
+
+  .debug-messages {
     min-height: 0;
     max-height: none;
   }


### PR DESCRIPTION
- Add Debug tab to ChatPane showing the exact messages array sent to
  Claude, including tool_use/tool_result blocks with inputs and outputs
- Add CLR CTX button that resets the in-memory conversation without
  touching the DB chat history
- Add GET /guilds/{id}/foreman/context and POST .../clear-context endpoints
- Reduce history window from 20 to 10 messages
- Drop leading assistant turns after trim+repair (API requires first
  message to be user role — a trimmed slice could start mid-conversation
  with an assistant turn, causing API rejections)
- Add _serialize_history_for_debug to safely convert Anthropic SDK
  objects to plain dicts for JSON serialization

https://claude.ai/code/session_01LgN2118timSGfy16hvQdLf