### PR TITLE
Add Claude login flow for spawned workers

### DIFF
--- a/backend/alembic/versions/b1e2f3a4c5d6_add_claude_credentials.py
+++ b/backend/alembic/versions/b1e2f3a4c5d6_add_claude_credentials.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 revision: str = 'b1e2f3a4c5d6'
-down_revision: Union[str, Sequence[str], None] = 'da1a6b1632f1'
+down_revision: Union[str, Sequence[str], None] = 'c3f8e2a91b45'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/b1e2f3a4c5d6_add_claude_credentials.py
+++ b/backend/alembic/versions/b1e2f3a4c5d6_add_claude_credentials.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 revision: str = 'b1e2f3a4c5d6'
-down_revision: Union[str, Sequence[str], None] = 'c3f8e2a91b45'
+down_revision: Union[str, Sequence[str], None] = 'f3a9c1e7b250'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/b1e2f3a4c5d6_add_claude_credentials.py
+++ b/backend/alembic/versions/b1e2f3a4c5d6_add_claude_credentials.py
@@ -1,0 +1,31 @@
+"""add_claude_credentials
+
+Revision ID: b1e2f3a4c5d6
+Revises: da1a6b1632f1
+Create Date: 2026-04-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'b1e2f3a4c5d6'
+down_revision: Union[str, Sequence[str], None] = 'da1a6b1632f1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'claude_credentials',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('guild_id', sa.Text(), sa.ForeignKey('guilds.id'), nullable=False, unique=True),
+        sa.Column('credentials_blob', sa.Text(), nullable=False),
+        sa.Column('updated_at', sa.Text(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('claude_credentials')

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,7 +24,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import AsyncSessionLocal, get_db
-from models import Agent, Guild, GithubToken, Message, Task, TaskLog, UserSession, Worker
+from models import Agent, ClaudeCredentials, Guild, GithubToken, Message, Task, TaskLog, UserSession, Worker
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
 # code reads os.environ, so ANTHROPIC_API_KEY etc. are available.
@@ -161,6 +161,10 @@ class WorkerCreate(BaseModel):
 class SpawnWorkerRequest(BaseModel):
     repos: List[str]
     name: Optional[str] = None
+
+class ClaudeCredentialsRequest(BaseModel):
+    guild_id: str
+    credentials_blob: str  # base64-encoded tar.gz of ~/.claude/
 
 
 class TaskCreate(BaseModel):
@@ -1355,6 +1359,47 @@ async def get_github_token(guild_id: str = Query(...)):
         await db.close()
 
 
+@app.get("/auth/claude/credentials")
+async def get_claude_credentials(guild_id: str = Query(...)):
+    """Return stored Claude credentials blob for a worker. Called by workers on startup."""
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(ClaudeCredentials).where(ClaudeCredentials.guild_id == guild_id)
+        )
+        row = result.scalar_one_or_none()
+        if not row:
+            raise HTTPException(status_code=404, detail="No Claude credentials stored for this guild")
+        return {"credentials_blob": row.credentials_blob}
+    finally:
+        await db.close()
+
+
+@app.post("/auth/claude/credentials")
+async def store_claude_credentials(data: ClaudeCredentialsRequest):
+    """Store Claude credentials blob (called by worker after successful login)."""
+    now = datetime.now(timezone.utc).isoformat()
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(ClaudeCredentials).where(ClaudeCredentials.guild_id == data.guild_id)
+        )
+        row = result.scalar_one_or_none()
+        if row:
+            row.credentials_blob = data.credentials_blob
+            row.updated_at = now
+        else:
+            db.add(ClaudeCredentials(
+                guild_id=data.guild_id,
+                credentials_blob=data.credentials_blob,
+                updated_at=now,
+            ))
+        await db.commit()
+    finally:
+        await db.close()
+    return {"ok": True}
+
+
 @app.get("/auth/me")
 async def get_me(github_user_id: str = Depends(require_user)):
     """Return the currently authenticated user's info."""
@@ -2195,7 +2240,6 @@ async def spawn_worker_container(guild_id: str, data: SpawnWorkerRequest):
         "PIONEER_GUILD_ID": guild_id,
         "PIONEER_REPOS": ",".join(data.repos),
         "GITHUB_TOKEN": os.environ.get("GITHUB_TOKEN", ""),
-        "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY", ""),
     }
     if data.name:
         env["PIONEER_WORKER_NAME"] = data.name

--- a/backend/models.py
+++ b/backend/models.py
@@ -100,3 +100,12 @@ class TaskLog(Base):
     worker_id = Column(Text)
     agent_id = Column(Text)
     data = Column(Text)     # JSON: full tool input/output for click-to-expand
+
+
+class ClaudeCredentials(Base):
+    __tablename__ = "claude_credentials"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    guild_id = Column(Text, ForeignKey("guilds.id"), nullable=False, unique=True)
+    credentials_blob = Column(Text, nullable=False)  # base64-encoded tar.gz of ~/.claude/
+    updated_at = Column(Text, nullable=False)

--- a/frontend/src/components/TerminalPane.vue
+++ b/frontend/src/components/TerminalPane.vue
@@ -32,7 +32,7 @@
           @click="log.detail && toggleDetail(i)"
         >
           <span class="log-time">{{ formatTime(log.timestamp) }}</span>
-          <span class="log-content" :class="lineClass(log.line)">{{ log.line }}</span>
+          <span class="log-content" :class="lineClass(log.line)" v-html="linkify(log.line)"></span>
           <span v-if="log.detail" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
         </div>
         <div v-if="log.detail && expandedIdx === i" class="log-detail">
@@ -167,6 +167,18 @@ function formatTime(isoStr?: string) {
   if (!isoStr) return '00:00:00'
   const d = new Date(isoStr)
   return d.toLocaleTimeString('en-US', { hour12: false })
+}
+
+function linkify(text: string): string {
+  const escaped = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+  return escaped.replace(
+    /(https?:\/\/[^\s<>"]+)/g,
+    '<a href="$1" target="_blank" rel="noopener noreferrer" class="terminal-link">$1</a>'
+  )
 }
 
 function lineClass(line: string) {
@@ -379,6 +391,7 @@ watch(logs, async () => {
 .log-content.log-tool    { color: var(--color-amber); }
 .log-content.log-result  { color: var(--color-text-dim); }
 .log-content.log-meta    { color: var(--color-brass-dark); }
+.terminal-link { color: var(--color-teal); text-decoration: underline; cursor: pointer; }
 
 .terminal-prompt {
   margin-top: 8px;

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -95,6 +95,86 @@ class Worker:
         except Exception as exc:
             logger.warning("Could not fetch GitHub token: %s", exc)
 
+    async def _check_claude_auth(self) -> None:
+        """Ensure Claude is authenticated. Restores stored credentials or runs login flow."""
+        import base64
+        import io
+        import tarfile
+        from pathlib import Path
+
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            logger.info("ANTHROPIC_API_KEY set — skipping Claude login flow")
+            return
+
+        creds_file = Path.home() / ".claude" / ".credentials.json"
+        if creds_file.exists():
+            logger.info("Claude credentials already present")
+            return
+
+        # Try restoring credentials stored in the backend
+        try:
+            async with await self._http() as client:
+                resp = await client.get(
+                    "/auth/claude/credentials",
+                    params={"guild_id": self.cfg.guild_id},
+                )
+            if resp.status_code == 200:
+                blob = resp.json().get("credentials_blob", "")
+                if blob:
+                    claude_dir = Path.home() / ".claude"
+                    claude_dir.mkdir(parents=True, exist_ok=True)
+                    tar_bytes = base64.b64decode(blob)
+                    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as tar:
+                        tar.extractall(path=Path.home())
+                    logger.info("Restored Claude credentials from backend")
+                    return
+        except Exception as exc:
+            logger.warning("Could not fetch Claude credentials from backend: %s", exc)
+
+        await self._emit("[auth] No Claude credentials found — starting login...")
+        await self._run_claude_login()
+
+    async def _run_claude_login(self) -> None:
+        """Run `claude login`, stream output to the frontend, then persist credentials."""
+        import base64
+        import io
+        import tarfile
+        from pathlib import Path
+
+        proc = await asyncio.create_subprocess_exec(
+            self.cfg.claude_path, "login",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        assert proc.stdout is not None
+        async for raw_line in proc.stdout:
+            line = raw_line.decode(errors="replace").rstrip()
+            logger.info("[claude login] %s", line)
+            await self._emit(f"[auth] {line}")
+        await proc.wait()
+
+        claude_dir = Path.home() / ".claude"
+        if not claude_dir.exists():
+            await self._emit("[auth] Login may have failed — ~/.claude not found")
+            return
+
+        try:
+            buf = io.BytesIO()
+            with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+                tar.add(str(claude_dir), arcname=".claude")
+            blob = base64.b64encode(buf.getvalue()).decode()
+            async with await self._http() as client:
+                await client.post(
+                    "/auth/claude/credentials",
+                    json={"guild_id": self.cfg.guild_id, "credentials_blob": blob},
+                )
+            await self._emit("[auth] Credentials saved — future workers will skip login")
+            logger.info("Posted Claude credentials to backend")
+        except Exception as exc:
+            logger.warning("Could not store Claude credentials: %s", exc)
+            await self._emit(f"[auth] Warning: could not store credentials: {exc}")
+
     async def _fetch_pending_tasks(self) -> list[dict]:
         async with await self._http() as client:
             resp = await client.get(
@@ -231,6 +311,7 @@ class Worker:
             "Joined guild %s — worker_id=%s agents=%d",
             self.cfg.guild_id, self.cfg.worker_id, len(self.slots),
         )
+        await self._check_claude_auth()
         await self._emit("[worker] Online. Watching for tasks.")
         for slot in self.slots:
             await self._set_state("idle", slot)

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -71,6 +71,7 @@ async def test_run_sends_disconnect_before_ws_close():
     worker._send = capture_send
     worker._register = AsyncMock()
     worker._fetch_github_token_if_needed = AsyncMock()
+    worker._check_claude_auth = AsyncMock()
     worker._fetch_pending_tasks = AsyncMock(return_value=[])
     worker.ws.connect = AsyncMock()
     worker.ws.close = capture_close


### PR DESCRIPTION
Workers no longer receive ANTHROPIC_API_KEY from the backend on spawn. Instead, on startup each worker checks for stored Claude credentials via GET /auth/claude/credentials; if none exist it runs `claude login`, streams the output (including the auth URL) to the frontend terminal, then POSTs the resulting ~/.claude/ tarball to POST /auth/claude/credentials so future workers can skip the login step.

Frontend terminal now linkifies https:// URLs so the Claude auth URL is clickable directly from the terminal pane.

https://claude.ai/code/session_01GYu3NDAFWodUB6KUv8MPnw