### PR TITLE
fix(foreman): handle NULL/missing task description

### DIFF
--- a/backend/alembic/versions/f3a9c1e7b250_backfill_null_task_descriptions.py
+++ b/backend/alembic/versions/f3a9c1e7b250_backfill_null_task_descriptions.py
@@ -1,0 +1,24 @@
+"""backfill_null_task_descriptions
+
+Revision ID: f3a9c1e7b250
+Revises: c3f8e2a91b45
+Create Date: 2026-04-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'f3a9c1e7b250'
+down_revision: Union[str, Sequence[str], None] = 'c3f8e2a91b45'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE tasks SET description = '' WHERE description IS NULL")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/main.py
+++ b/backend/main.py
@@ -644,7 +644,7 @@ async def _foreman_exec_tools(guild_id: str, tool_uses: list) -> list:
 
             elif tu.name == "assign_task":
                 wid = inp["worker_id"]
-                desc = inp["description"]
+                desc = inp.get("description", "")
                 phase = inp.get("phase", "execute")
                 tool = inp.get("tool", "claude")
                 existing_task_id = inp.get("task_id")
@@ -1061,7 +1061,10 @@ async def _run_foreman_ai(guild_id: str, human_message: str, extra_context: str 
             .order_by(Task.created_at.desc())
             .limit(10)
         )
-        task_rows = [dict(r._mapping) for r in task_result.fetchall()]
+        task_rows = [
+            {**dict(r._mapping), "description": dict(r._mapping).get("description") or ""}
+            for r in task_result.fetchall()
+        ]
     finally:
         await db.close()
 

--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -57,7 +57,7 @@ async def open_pr(
     issue_ref = f"\n\nCloses #{task['issue_number']}" if task.get("issue_number") else ""
     body = f"Automated by Pioneer Square worker agent.{issue_ref}"
     payload = json.dumps({
-        "title": task["description"][:72],
+        "title": (task.get("description") or "")[:72],
         "body": body,
         "head": branch,
         "base": "main",

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -411,7 +411,7 @@ class Worker:
     # ------------------------------------------------------------------ Execution
     async def _execute_task(self, task: dict, slot: _AgentSlot) -> None:
         task_id = task["id"]
-        desc = task["description"]
+        desc = task.get("description") or ""
         token = self.cfg.github_token
         repos = self.cfg.repos
 


### PR DESCRIPTION
## Summary
- Any task with `description = NULL` in the DB (e.g. `t-1fhafh`) caused a `KeyError`/`TypeError` crash in four separate code paths.
- All `task["description"]` hard-accesses are replaced with `.get("description") or ""` guards.
- A new Alembic migration (`f3a9c1e7b250`) backfills existing NULL rows to `''` on the next backend startup.

## Changed files
| File | Fix |
|------|-----|
| `backend/main.py` | Sanitize `task_rows` from DB before JSON-encoding into Foreman system prompt; `inp.get("description", "")` in `assign_task` handler |
| `worker/pioneer_worker/worker.py` | `task.get("description") or ""` in `_execute_task` |
| `worker/pioneer_worker/github_pr.py` | `(task.get("description") or "")[:72]` for PR title |
| `backend/alembic/versions/f3a9c1e7b250_backfill_null_task_descriptions.py` | `UPDATE tasks SET description = '' WHERE description IS NULL` |

## Test plan
- [ ] Restart backend on a DB that contains `t-1fhafh`; migration runs cleanly and sets description to `''`
- [ ] Trigger the Foreman with a guild that has the task in its recent-tasks list — no crash
- [ ] Assign a task via the Foreman without explicitly providing `description` — no `KeyError`
- [ ] Worker picks up a task with empty description — runs without TypeError

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)