### PR TITLE
feat(worker): post plan output as GitHub issue comment

### DIFF
--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -85,3 +85,37 @@ async def open_pr(
     except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
         await emit(f"[worker] PR failed: {exc}")
         return None
+
+
+async def post_issue_comment(
+    *,
+    repo_full: str,
+    issue_number: int,
+    body: str,
+    token: str,
+    emit: EmitFn,
+) -> bool:
+    """Post a comment on a GitHub issue. Returns True on success."""
+    payload = json.dumps({"body": body}).encode()
+
+    def _post() -> None:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo_full}/issues/{issue_number}/comments",
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.v3+json",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            resp.read()
+
+    try:
+        await asyncio.to_thread(_post)
+        await emit(f"[worker] ✓ Posted plan to issue #{issue_number}")
+        return True
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+        await emit(f"[worker] Failed to post issue comment: {exc}")
+        return False

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -274,6 +274,7 @@ class Worker:
                     "guild_id": self.cfg.guild_id,
                     "description": msg.get("description", ""),
                     "tool": msg.get("tool", "claude"),
+                    "phase": msg.get("phase", "execute"),
                     "issue_number": msg.get("issueNumber"),
                     "issue_repo": msg.get("issueRepo"),
                 })
@@ -548,6 +549,15 @@ class Worker:
             pr_url: Optional[str] = None
 
             if success:
+                if task.get("phase") == "plan" and task.get("issue_number") and task.get("issue_repo") and token:
+                    comment = f"## 🗂 Implementation Plan\n\n{last_msg}"
+                    await github_pr.post_issue_comment(
+                        repo_full=task["issue_repo"],
+                        issue_number=task["issue_number"],
+                        body=comment,
+                        token=token,
+                        emit=emit,
+                    )
                 if push_ok:
                     pr_url = await github_pr.open_pr(
                         task=task, branch=branch, worktree_path=primary_wt,


### PR DESCRIPTION
## Summary

- Extracts `phase` from the `task-assigned` WebSocket message and stores it in the worker's task dict (alongside the existing `issue_number` and `issue_repo` fields).
- Adds `post_issue_comment()` to `github_pr.py` — a thin wrapper around the GitHub REST API using the same `urllib.request` + Bearer token pattern as `open_pr()`.
- After a successful plan-phase run, if the task has `issue_number` + `issue_repo` + a GitHub token, the worker posts the plan output as a `## 🗂 Implementation Plan` comment on the issue **before** sending `task-complete`. Falls back to current behaviour (branch only) if any of those conditions aren't met.

Closes #71

## Test plan

- [ ] Assign a `phase=plan` task with `issue_number` and `issue_repo` set; confirm a formatted comment appears on the GitHub issue.
- [ ] Assign a `phase=execute` task; confirm no issue comment is posted.
- [ ] Assign a `phase=plan` task with no `issue_number`; confirm it falls back gracefully (no error, branch still pushed).
- [ ] Revoke the GitHub token and assign a `phase=plan` task; confirm the worker logs a warning and continues to `task-complete` normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)