### PR TITLE
refactor(foreman): extract foreman AI into dedicated foreman/ package

### DIFF
--- a/backend/events.py
+++ b/backend/events.py
@@ -1,0 +1,60 @@
+"""WebSocket connection state and broadcast utilities.
+
+Extracted here so both main.py and the foreman package can import
+broadcast/emit_terminal_line without circular dependencies.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from fastapi import WebSocket
+from sqlalchemy import select
+
+from database import get_db
+from models import Agent, TaskLog
+
+logger = logging.getLogger(__name__)
+
+# In-memory WebSocket connections: guild_id -> list of WebSocket
+connections: Dict[str, List[WebSocket]] = {}
+
+# Tracks which WebSocket currently owns a given agent_id.
+agent_owners: Dict[str, WebSocket] = {}
+
+
+async def broadcast(guild_id: str, message: dict, exclude: Optional[WebSocket] = None):
+    """Broadcast a message to all connections in a guild."""
+    if guild_id not in connections:
+        return
+    dead = []
+    for ws in connections[guild_id]:
+        if ws is exclude:
+            continue
+        try:
+            await ws.send_json(message)
+        except Exception:
+            dead.append(ws)
+    for ws in dead:
+        connections[guild_id].remove(ws)
+
+
+async def emit_terminal_line(guild_id: str, agent_id: str, line: str):
+    """Broadcast and persist a terminal output line."""
+    now = datetime.now(timezone.utc).isoformat()
+    await broadcast(guild_id, {
+        "type": "terminal-output",
+        "agentId": agent_id,
+        "line": line,
+        "timestamp": now,
+    })
+    if line:
+        db = await get_db()
+        try:
+            result = await db.execute(select(Agent.worker_id).where(Agent.id == agent_id))
+            worker_id_for_log = result.scalar_one_or_none()
+            db.add(TaskLog(task_id=None, timestamp=now, line=line,
+                           worker_id=worker_id_for_log, agent_id=agent_id))
+            await db.commit()
+        finally:
+            await db.close()

--- a/backend/foreman/__init__.py
+++ b/backend/foreman/__init__.py
@@ -1,0 +1,6 @@
+"""Foreman AI package — re-exports for convenient importing from main.py."""
+
+from foreman.runner import run_foreman_ai, serialize_history_for_debug
+from foreman.state import foreman_conversations
+
+__all__ = ["run_foreman_ai", "serialize_history_for_debug", "foreman_conversations"]

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -1,0 +1,57 @@
+"""Foreman system prompt and system-prompt builder."""
+
+FOREMAN_SYSTEM = """\
+You are the Foreman AI in Pioneer Square, a multi-agent coding workshop.
+You coordinate worker agents that autonomously clone repos, write code, and open PRs.
+
+## Your responsibilities
+- Understand what the human wants and break it into named, tracked tasks
+- Always call create_task first to name the work and get a task_id; then pass that task_id to assign_task so the same record is assigned to a worker (no duplicate rows)
+- After a worker finishes (task-complete), review the result and decide: send_followup for \
+additional work in the same worktree, or finalize_task when done
+- Message workers mid-task via message_worker for context
+- Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
+- Cancel tasks that are going wrong or are no longer needed via cancel_task
+- Summarise status and outcomes when asked
+- Escalate to the human only when genuinely stuck
+
+## Multi-step flows
+For complex work use phases:
+1. **plan** — create_task(phase='plan'), assign a worker to produce an outline/spec
+2. **execute** — assign workers to implement
+3. **review** — assign a worker to verify correctness, run tests, check the PR
+
+## Task ownership
+- create_task before assign_task so every job has a human-readable name in the sidebar
+- Pass the task_id from create_task into assign_task — this assigns the same task to a worker instead of creating a second row
+- After task-complete: call send_followup for further work (update tests, fix lint, add docs),
+  or call finalize_task to mark it complete — don't leave tasks in limbo
+
+## GitHub access
+You have direct GitHub access via list_github_issues, get_github_issue, list_github_prs,
+search_github_issues, create_github_issue, and claim_github_issue.
+
+## Issue-first workflow
+Before assigning work that is more than a trivial fix (new features, refactors, multi-file
+changes), use search_github_issues to check whether an issue already exists. If not, create
+one with create_github_issue to track it. Pass issue_number and issue_repo to assign_task so
+the worker's PR references the issue automatically.
+
+## Checking task progress
+Use get_task_status to verify a task is making progress — it returns the current state,
+the active agent and its state, and the last log lines. If a task looks stalled, use
+redirect_task to course-correct or cancel_task if it's going in the wrong direction.
+
+Workers are configured with repos. Prefer workers whose repos cover the task.
+Be concise — one short paragraph maximum unless detail is requested.\
+"""
+
+
+def build_system_prompt(workers_block: str, tasks_block: str, extra_context: str = "") -> str:
+    """Assemble the full system prompt from live worker/task context."""
+    return (
+        f"{FOREMAN_SYSTEM}\n\n"
+        f"## Current workers\n```json\n{workers_block}\n```\n\n"
+        f"## Recent tasks\n```json\n{tasks_block}\n```"
+        + (f"\n\n## Context\n{extra_context}" if extra_context else "")
+    )

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -1,0 +1,250 @@
+"""Foreman AI runner: conversation management and main loop."""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import select, text
+
+from database import get_db
+from events import broadcast
+from foreman.prompt import build_system_prompt
+from foreman.state import foreman_conversations
+from foreman.tools import FOREMAN_TOOLS, exec_tools
+from models import Message, Task
+
+try:
+    import anthropic as _anthropic
+    HAS_ANTHROPIC = True
+except ImportError:
+    HAS_ANTHROPIC = False
+
+logger = logging.getLogger(__name__)
+
+
+def serialize_history_for_debug(history: list) -> list:
+    """Convert in-memory foreman history (may contain SDK objects) to JSON-safe dicts."""
+    out = []
+    for msg in history:
+        role = msg.get("role", "?") if isinstance(msg, dict) else getattr(msg, "role", "?")
+        content = msg.get("content", []) if isinstance(msg, dict) else getattr(msg, "content", [])
+        if isinstance(content, str):
+            out.append({"role": role, "content": content})
+        elif isinstance(content, list):
+            blocks = []
+            for b in content:
+                if isinstance(b, dict):
+                    blocks.append(b)
+                else:
+                    try:
+                        blocks.append(b.model_dump())
+                    except AttributeError:
+                        blocks.append({"type": str(getattr(b, "type", "unknown")), "raw": str(b)})
+            out.append({"role": role, "content": blocks})
+        else:
+            out.append({"role": role, "content": str(content)})
+    return out
+
+
+def _repair_tool_pairs(messages: list) -> list:
+    """
+    Ensure every tool_use block in an assistant turn has a matching tool_result
+    in the immediately following user turn.
+
+    When the conversation history is trimmed or otherwise truncated, assistant
+    messages that contain tool_use blocks can lose their paired tool_result
+    responses.  The Anthropic API rejects such histories.  This function does a
+    single forward pass and inserts a synthetic error tool_result for every
+    orphaned tool_use ID, keeping the history self-consistent.
+    """
+    result: list = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+
+        if msg.get("role") != "assistant":
+            result.append(msg)
+            i += 1
+            continue
+
+        content = msg.get("content", [])
+        tool_use_ids: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "tool_use":
+                    tool_use_ids.append(block["id"])
+            elif getattr(block, "type", None) == "tool_use":
+                tool_use_ids.append(block.id)
+
+        result.append(msg)
+        i += 1
+
+        if not tool_use_ids:
+            continue
+
+        next_msg = messages[i] if i < len(messages) else None
+
+        if next_msg is not None and next_msg.get("role") == "user":
+            next_content = next_msg.get("content", [])
+            if isinstance(next_content, list):
+                covered = {
+                    b.get("tool_use_id")
+                    for b in next_content
+                    if isinstance(b, dict) and b.get("type") == "tool_result"
+                }
+            else:
+                covered = set()
+            orphans = [tid for tid in tool_use_ids if tid not in covered]
+        else:
+            orphans = list(tool_use_ids)
+
+        if not orphans:
+            continue
+
+        logger.warning(
+            "Repairing foreman history: inserting synthetic tool_result for "
+            "orphaned tool_use ids %s",
+            orphans,
+        )
+        synthetic = [
+            {
+                "type": "tool_result",
+                "tool_use_id": tid,
+                "content": '{"error": "tool result missing"}',
+            }
+            for tid in orphans
+        ]
+        if next_msg is not None and next_msg.get("role") == "user":
+            existing = next_msg.get("content", [])
+            existing_list = existing if isinstance(existing, list) else [{"type": "text", "text": str(existing)}]
+            result.append({"role": "user", "content": synthetic + existing_list})
+            i += 1  # skip the original next_msg; we just replaced it
+        else:
+            result.append({"role": "user", "content": synthetic})
+
+    return result
+
+
+async def run_foreman_ai(guild_id: str, human_message: str, extra_context: str = ""):
+    """Process a human message (or escalation) through the Claude foreman AI."""
+    if not HAS_ANTHROPIC:
+        now = datetime.now(timezone.utc).isoformat()
+        await broadcast(guild_id, {
+            "type": "chat", "from": "foreman", "to": "user",
+            "content": "Foreman AI offline (install `anthropic` package to enable).",
+            "createdAt": now,
+        })
+        return
+
+    # Build live context for the system prompt
+    db = await get_db()
+    try:
+        result = await db.execute(
+            text(
+                "SELECT w.id, w.repos, w.state as worker_state,"
+                " COUNT(a.id) as agent_count,"
+                " GROUP_CONCAT(a.id || ':' || a.state) as agents"
+                " FROM workers w"
+                " LEFT JOIN agents a ON a.worker_id = w.id AND a.state != 'offline'"
+                " WHERE w.guild_id = :guild_id"
+                " GROUP BY w.id"
+                " UNION ALL"
+                " SELECT a.id, '[]', a.state, 1, a.id || ':' || a.state"
+                " FROM agents a"
+                " WHERE a.guild_id = :guild_id AND a.type = 'worker'"
+                " AND a.worker_id IS NULL AND a.state != 'offline'"
+            ),
+            {"guild_id": guild_id},
+        )
+        worker_rows = [dict(r._mapping) for r in result.fetchall()]
+        task_result = await db.execute(
+            select(Task.id, Task.worker_id, Task.description, Task.state, Task.branch, Task.pr_url)
+            .where(Task.guild_id == guild_id)
+            .order_by(Task.created_at.desc())
+            .limit(10)
+        )
+        task_rows = [
+            {**dict(r._mapping), "description": dict(r._mapping).get("description") or ""}
+            for r in task_result.fetchall()
+        ]
+    finally:
+        await db.close()
+
+    workers_block = json.dumps(
+        [{"id": r["id"], "state": r["worker_state"] or "idle",
+          "repos": json.loads(r["repos"] or "[]"),
+          "agent_count": r["agent_count"] or 0} for r in worker_rows],
+        indent=2,
+    )
+    tasks_block = json.dumps(task_rows[:6], indent=2)
+    system = build_system_prompt(workers_block, tasks_block, extra_context)
+
+    history = foreman_conversations.setdefault(guild_id, [])
+    history.append({"role": "user", "content": human_message})
+
+    client = _anthropic.AsyncAnthropic()
+
+    _RESULT_MAX = 400  # chars kept per tool result in history
+
+    try:
+        text_parts = []
+        for _ in range(6):  # safety cap on tool-call rounds
+            history = _repair_tool_pairs(history)
+            resp = await client.messages.create(
+                model="claude-sonnet-4-6",
+                max_tokens=1024,
+                system=system,
+                messages=history,
+                tools=FOREMAN_TOOLS,
+            )
+            history.append({"role": "assistant", "content": resp.content})
+            text_parts += [b.text for b in resp.content if b.type == "text" and b.text.strip()]
+
+            tool_uses = [b for b in resp.content if b.type == "tool_use"]
+            if not tool_uses:
+                break  # end_turn — foreman is done
+
+            tool_results = await exec_tools(guild_id, tool_uses)
+            # Truncate verbose results (e.g. GitHub JSON) before storing in history
+            trimmed = [
+                {**r, "content": r["content"][:_RESULT_MAX] + " …[truncated]"}
+                if len(r.get("content", "")) > _RESULT_MAX else r
+                for r in tool_results
+            ]
+            history.append({"role": "user", "content": trimmed})
+
+        # Trim history, repair orphaned tool pairs, then drop any leading assistant
+        # turns (which the API forbids as the first message).
+        trimmed_history = history[-10:]
+        repaired = _repair_tool_pairs(trimmed_history)
+        while repaired and repaired[0].get("role") != "user":
+            repaired = repaired[1:]
+        foreman_conversations[guild_id] = repaired
+
+        response_text = "\n".join(text_parts).strip()
+        if response_text:
+            now = datetime.now(timezone.utc).isoformat()
+            await broadcast(guild_id, {
+                "type": "chat", "from": "foreman", "to": "user",
+                "content": response_text, "createdAt": now,
+            })
+            db = await get_db()
+            try:
+                db.add(Message(
+                    guild_id=guild_id,
+                    from_agent="foreman",
+                    to_agent="user",
+                    content=response_text,
+                    message_type="chat",
+                    created_at=now,
+                ))
+                await db.commit()
+            finally:
+                await db.close()
+
+    except Exception as exc:
+        now = datetime.now(timezone.utc).isoformat()
+        await broadcast(guild_id, {
+            "type": "chat", "from": "foreman", "to": "user",
+            "content": f"Foreman error: {exc}", "createdAt": now,
+        })

--- a/backend/foreman/state.py
+++ b/backend/foreman/state.py
@@ -1,0 +1,10 @@
+"""Shared in-memory state for the foreman AI.
+
+Kept in its own module so both runner.py and tools.py can import it
+without creating a circular dependency.
+"""
+
+from typing import Dict, List
+
+# Per-guild foreman conversation history (trimmed to ~40 messages).
+foreman_conversations: Dict[str, List[dict]] = {}

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1,0 +1,760 @@
+"""Foreman tool definitions, GitHub API helpers, and tool-call executor."""
+
+import asyncio
+import json
+import random
+import string
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select, update
+
+from database import get_db
+from events import broadcast, emit_terminal_line
+from models import Agent, GithubToken, Guild, Task, TaskLog, Worker
+from foreman.state import foreman_conversations
+
+FOREMAN_TOOLS = [
+    {
+        "name": "create_task",
+        "description": (
+            "Create a named foreman task. Call this before assigning worker tasks — it gives the "
+            "work a human-readable name visible in the sidebar and returns a task_id to reference "
+            "in assign_task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Short human-readable name (≤60 chars), e.g. 'Implement OAuth login'.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Full description of the work to be done.",
+                },
+                "phase": {
+                    "type": "string",
+                    "enum": ["plan", "execute", "review"],
+                    "description": "Starting phase. Default: execute.",
+                },
+            },
+            "required": ["name", "description"],
+        },
+    },
+    {
+        "name": "assign_task",
+        "description": (
+            "Queue a coding task for a worker agent. The worker creates a git worktree, "
+            "runs the chosen coding agent on the description, then pushes the branch. "
+            "Pass task_id (from create_task) to assign that existing task to a worker instead "
+            "of creating a duplicate — this is the preferred flow."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "worker_id": {
+                    "type": "string",
+                    "description": "Worker agent ID (e.g. w-abc123). Must be idle.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Detailed, self-contained task description the coding agent receives.",
+                },
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID returned by create_task. When provided, assigns that "
+                                   "existing task to the worker instead of creating a new row.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Short task name shown in the sidebar (≤60 chars).",
+                },
+                "tool": {
+                    "type": "string",
+                    "enum": ["claude", "codex", "pi"],
+                    "description": "Coding agent to use. Default: claude.",
+                },
+                "parent_task_id": {
+                    "type": "string",
+                    "description": "Foreman task ID this worker task belongs to (optional, ignored if task_id provided).",
+                },
+                "phase": {
+                    "type": "string",
+                    "enum": ["plan", "execute", "review", "followup"],
+                    "description": "Phase of work.",
+                },
+                "issue_number": {"type": "integer", "description": "GitHub issue to close (optional)."},
+                "issue_repo": {"type": "string", "description": "owner/repo for the issue (optional)."},
+            },
+            "required": ["worker_id", "description"],
+        },
+    },
+    {
+        "name": "send_followup",
+        "description": (
+            "Send follow-up instructions to a worker for a task that just completed. "
+            "The worker executes these in the same git worktree on the same branch — "
+            "ideal for 'update tests', 'fix type errors', 'add docs', etc. "
+            "Call after receiving a task-complete notification."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx)."},
+                "instructions": {
+                    "type": "string",
+                    "description": "Follow-up instructions to execute in the existing worktree.",
+                },
+            },
+            "required": ["task_id", "instructions"],
+        },
+    },
+    {
+        "name": "finalize_task",
+        "description": (
+            "Mark a task complete with no further follow-up needed. "
+            "Call after reviewing a completed task when no additional work is required."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID to finalize."},
+            },
+            "required": ["task_id"],
+        },
+    },
+    {
+        "name": "message_worker",
+        "description": "Send a message to a worker's terminal — for mid-task context injection.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "worker_id": {"type": "string"},
+                "message": {"type": "string"},
+            },
+            "required": ["worker_id", "message"],
+        },
+    },
+    {
+        "name": "redirect_task",
+        "description": (
+            "Redirect a running task mid-execution with new instructions. "
+            "Terminates the current Claude subprocess, then immediately resumes it in the same "
+            "session — Claude keeps full context of what it was doing and acts on the new "
+            "instructions instead. For tasks awaiting review, acts as a follow-up. "
+            "Use this to course-correct without losing progress."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx) to redirect."},
+                "instructions": {
+                    "type": "string",
+                    "description": "New instructions. Claude will see its full prior history.",
+                },
+            },
+            "required": ["task_id", "instructions"],
+        },
+    },
+    {
+        "name": "cancel_task",
+        "description": (
+            "Cancel a running or pending task. Use when a task is going in the wrong direction, "
+            "is stuck, or is no longer needed. The worker terminates its Claude subprocess "
+            "immediately and releases the agent slot. Cannot cancel tasks that are already done or failed."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx) to cancel."},
+                "reason": {"type": "string", "description": "Optional reason for cancellation."},
+            },
+            "required": ["task_id"],
+        },
+    },
+    {
+        "name": "list_github_issues",
+        "description": (
+            "List GitHub issues for a repo. Use this to discover work that needs to be done."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo, e.g. 'acme/backend'"},
+                "state": {"type": "string", "enum": ["open", "closed", "all"], "description": "Default: open"},
+                "limit": {"type": "integer", "description": "Max issues to return (default 20, max 50)"},
+            },
+            "required": ["repo"],
+        },
+    },
+    {
+        "name": "get_github_issue",
+        "description": "Get full details of a single GitHub issue including its body and comments.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "issue_number": {"type": "integer"},
+            },
+            "required": ["repo", "issue_number"],
+        },
+    },
+    {
+        "name": "list_github_prs",
+        "description": "List pull requests for a repo — useful for reviewing completed worker branches.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "state": {"type": "string", "enum": ["open", "closed", "all"], "description": "Default: open"},
+            },
+            "required": ["repo"],
+        },
+    },
+    {
+        "name": "claim_github_issue",
+        "description": (
+            "Assign a GitHub issue to the authenticated user (claim it for this guild's operator). "
+            "Call this when picking up an issue to work on, before assigning a worker task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "issue_number": {"type": "integer"},
+            },
+            "required": ["repo", "issue_number"],
+        },
+    },
+    {
+        "name": "get_task_status",
+        "description": (
+            "Get the current status of a task: state, phase, assigned worker and active agent state, "
+            "and the last log lines. Use this to verify a task is progressing and to diagnose stalls."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx)."},
+                "log_lines": {
+                    "type": "integer",
+                    "description": "Number of recent log lines to return (default 10, max 50).",
+                },
+            },
+            "required": ["task_id"],
+        },
+    },
+    {
+        "name": "create_github_issue",
+        "description": (
+            "Create a new GitHub issue to track work before assigning it to a worker. "
+            "Search first with search_github_issues to avoid duplicates."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "title": {"type": "string", "description": "Issue title."},
+                "body": {"type": "string", "description": "Issue body in markdown."},
+                "labels": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Label names to apply (labels must already exist in the repo).",
+                },
+            },
+            "required": ["repo", "title", "body"],
+        },
+    },
+    {
+        "name": "search_github_issues",
+        "description": (
+            "Search GitHub issues and PRs by keyword within a repo. "
+            "Call this before create_github_issue to check whether an issue already exists."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo to restrict search to."},
+                "query": {"type": "string", "description": "Search keywords."},
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "all"],
+                    "description": "Filter by state. Default: open.",
+                },
+            },
+            "required": ["repo", "query"],
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+def _gh_api(path: str, token: str) -> object:
+    """GET a GitHub API path and return parsed JSON."""
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3+json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+def _gh_api_post(path: str, token: str, payload: dict, method: str = "POST") -> object:
+    """POST/PATCH a GitHub API path with a JSON body and return parsed JSON."""
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3+json",
+            "Content-Type": "application/json",
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+async def _guild_github_token(guild_id: str) -> Optional[tuple[str, str]]:
+    """Return (access_token, github_username) for this guild, or None."""
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(GithubToken.access_token, GithubToken.github_username)
+            .join(Guild, Guild.github_user_id == GithubToken.github_user_id)
+            .where(Guild.id == guild_id)
+        )
+        row = result.first()
+        return (row.access_token, row.github_username) if row else None
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tool executor
+# ---------------------------------------------------------------------------
+
+async def exec_tools(guild_id: str, tool_uses: list) -> list:
+    """Execute tool calls from the foreman AI and return tool-result blocks."""
+    results = []
+    for tu in tool_uses:
+        inp = tu.input
+        result_text = ""
+        db = await get_db()
+        try:
+            if tu.name == "create_task":
+                name = (inp.get("name") or "")[:80]
+                desc = inp.get("description", name)
+                phase = inp.get("phase", "execute")
+                task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+                created_at = datetime.now(timezone.utc).isoformat()
+                db.add(Task(
+                    id=task_id,
+                    worker_id="foreman",
+                    guild_id=guild_id,
+                    name=name,
+                    description=desc,
+                    tool="claude",
+                    state="pending",
+                    phase=phase,
+                    created_at=created_at,
+                ))
+                await db.commit()
+                await broadcast(guild_id, {
+                    "type": "task-created",
+                    "taskId": task_id,
+                    "name": name,
+                    "description": desc,
+                    "phase": phase,
+                    "state": "pending",
+                    "createdAt": created_at,
+                })
+                result_text = f"Task {task_id} created: '{name}'. Reference this task_id in assign_task."
+
+            elif tu.name == "assign_task":
+                wid = inp["worker_id"]
+                desc = inp.get("description", "")
+                phase = inp.get("phase", "execute")
+                tool = inp.get("tool", "claude")
+                existing_task_id = inp.get("task_id")
+                worker_result = await db.execute(
+                    select(Worker.id).where(Worker.id == wid, Worker.guild_id == guild_id)
+                )
+                worker_row = worker_result.scalar_one_or_none()
+                if not worker_row:
+                    result_text = f"Worker {wid} not found — task NOT queued."
+                elif existing_task_id:
+                    name_override = inp.get("name")
+                    update_values: dict = {
+                        "worker_id": wid,
+                        "description": desc,
+                        "tool": tool,
+                        "phase": phase,
+                        "state": "pending",
+                    }
+                    if name_override:
+                        update_values["name"] = name_override
+                    if inp.get("issue_number") is not None:
+                        update_values["issue_number"] = inp["issue_number"]
+                    if inp.get("issue_repo"):
+                        update_values["issue_repo"] = inp["issue_repo"]
+                    await db.execute(
+                        update(Task)
+                        .where(Task.id == existing_task_id, Task.guild_id == guild_id)
+                        .values(**update_values)
+                    )
+                    await db.commit()
+                    name_result = await db.execute(
+                        select(Task.name).where(Task.id == existing_task_id)
+                    )
+                    task_name = name_result.scalar_one_or_none() or desc[:60]
+                    task_id = existing_task_id
+                    await broadcast(guild_id, {
+                        "type": "task-assigned",
+                        "workerId": wid,
+                        "taskId": task_id,
+                        "name": task_name,
+                        "description": desc,
+                        "tool": tool,
+                        "phase": phase,
+                        "issueNumber": inp.get("issue_number"),
+                        "issueRepo": inp.get("issue_repo"),
+                    })
+                    result_text = f"Task {task_id} assigned to {wid}."
+                else:
+                    name = (inp.get("name") or desc[:60])
+                    parent_task_id = inp.get("parent_task_id")
+                    task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+                    created_at = datetime.now(timezone.utc).isoformat()
+                    db.add(Task(
+                        id=task_id,
+                        worker_id=wid,
+                        guild_id=guild_id,
+                        name=name,
+                        description=desc,
+                        tool=tool,
+                        issue_number=inp.get("issue_number"),
+                        issue_repo=inp.get("issue_repo"),
+                        state="pending",
+                        phase=phase,
+                        parent_task_id=parent_task_id,
+                        created_at=created_at,
+                    ))
+                    await db.commit()
+                    await broadcast(guild_id, {
+                        "type": "task-assigned",
+                        "workerId": wid,
+                        "taskId": task_id,
+                        "name": name,
+                        "description": desc,
+                        "tool": tool,
+                        "phase": phase,
+                        "parentTaskId": parent_task_id,
+                        "issueNumber": inp.get("issue_number"),
+                        "issueRepo": inp.get("issue_repo"),
+                    })
+                    result_text = f"Task {task_id} queued for {wid}."
+
+            elif tu.name == "send_followup":
+                task_id = inp["task_id"]
+                instructions = inp["instructions"]
+                result = await db.execute(
+                    select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
+                )
+                worker_id_val = result.scalar_one_or_none()
+                if not worker_id_val:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    await db.execute(
+                        update(Task).where(Task.id == task_id).values(state="working", phase="followup")
+                    )
+                    await db.commit()
+                    await broadcast(guild_id, {
+                        "type": "task-followup",
+                        "workerId": worker_id_val,
+                        "taskId": task_id,
+                        "instructions": instructions,
+                    })
+                    result_text = f"Follow-up sent to {worker_id_val} for task {task_id}."
+
+            elif tu.name == "finalize_task":
+                task_id = inp["task_id"]
+                result = await db.execute(
+                    select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
+                )
+                worker_id_val = result.scalar_one_or_none()
+                if not worker_id_val:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    finished_at = datetime.now(timezone.utc).isoformat()
+                    await db.execute(
+                        update(Task).where(Task.id == task_id).values(state="done", finished_at=finished_at)
+                    )
+                    await db.commit()
+                    await broadcast(guild_id, {
+                        "type": "task-finalize",
+                        "workerId": worker_id_val,
+                        "taskId": task_id,
+                    })
+                    await broadcast(guild_id, {
+                        "type": "task-update",
+                        "taskId": task_id,
+                        "state": "done",
+                        "finishedAt": finished_at,
+                    })
+                    result_text = f"Task {task_id} finalized."
+                    # Compact all prior tool-result blocks mentioning this task
+                    for msg in foreman_conversations.get(guild_id, []):
+                        if msg["role"] == "user" and isinstance(msg["content"], list):
+                            for block in msg["content"]:
+                                if (block.get("type") == "tool_result"
+                                        and task_id in block.get("content", "")):
+                                    block["content"] = f"[{task_id}: done]"
+
+            elif tu.name == "message_worker":
+                wid = inp["worker_id"]
+                msg = inp["message"]
+                await emit_terminal_line(guild_id, wid, f"[foreman] {msg}")
+                await broadcast(guild_id, {
+                    "type": "worker-message",
+                    "workerId": wid,
+                    "message": msg,
+                })
+                result_text = f"Message delivered to {wid}."
+
+            elif tu.name == "redirect_task":
+                task_id = inp["task_id"]
+                instructions = inp["instructions"]
+                result = await db.execute(
+                    select(Task.worker_id, Task.state).where(
+                        Task.id == task_id, Task.guild_id == guild_id
+                    )
+                )
+                row = result.one_or_none()
+                if not row:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    worker_id_val, state = row
+                    if state in ("done", "failed", "cancelled"):
+                        result_text = f"Task {task_id} is {state} — cannot redirect."
+                    else:
+                        await db.execute(
+                            update(Task).where(Task.id == task_id).values(state="working")
+                        )
+                        await db.commit()
+                        await broadcast(guild_id, {
+                            "type": "task-redirect",
+                            "workerId": worker_id_val,
+                            "taskId": task_id,
+                            "instructions": instructions,
+                        })
+                        await broadcast(guild_id, {
+                            "type": "task-update",
+                            "taskId": task_id,
+                            "state": "working",
+                        })
+                        result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
+
+            elif tu.name == "cancel_task":
+                task_id = inp["task_id"]
+                reason = inp.get("reason", "")
+                result = await db.execute(
+                    select(Task.worker_id, Task.state).where(
+                        Task.id == task_id, Task.guild_id == guild_id
+                    )
+                )
+                row = result.one_or_none()
+                if not row:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    worker_id_val, state = row
+                    if state in ("done", "failed", "cancelled"):
+                        result_text = f"Task {task_id} is already {state}."
+                    else:
+                        finished_at = datetime.now(timezone.utc).isoformat()
+                        await db.execute(
+                            update(Task).where(Task.id == task_id).values(
+                                state="cancelled", finished_at=finished_at
+                            )
+                        )
+                        await db.commit()
+                        await broadcast(guild_id, {
+                            "type": "task-cancel",
+                            "workerId": worker_id_val,
+                            "taskId": task_id,
+                        })
+                        await broadcast(guild_id, {
+                            "type": "task-update",
+                            "taskId": task_id,
+                            "state": "cancelled",
+                            "finishedAt": finished_at,
+                        })
+                        result_text = f"Task {task_id} cancelled." + (f" Reason: {reason}" if reason else "")
+
+            elif tu.name == "get_task_status":
+                task_id = inp["task_id"]
+                limit = min(int(inp.get("log_lines", 10)), 50)
+                task_result = await db.execute(
+                    select(Task).where(Task.id == task_id, Task.guild_id == guild_id)
+                )
+                task = task_result.scalar_one_or_none()
+                if not task:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    agent_info = None
+                    if task.worker_id and task.worker_id != "foreman":
+                        agent_result = await db.execute(
+                            select(Agent.id, Agent.state)
+                            .where(Agent.worker_id == task.worker_id, Agent.state != "offline")
+                            .limit(1)
+                        )
+                        agent_row = agent_result.one_or_none()
+                        if agent_row:
+                            agent_info = {"agent_id": agent_row[0], "agent_state": agent_row[1]}
+                    logs_result = await db.execute(
+                        select(TaskLog.timestamp, TaskLog.line)
+                        .where(TaskLog.task_id == task_id)
+                        .order_by(TaskLog.id.desc())
+                        .limit(limit)
+                    )
+                    log_rows = list(reversed(logs_result.fetchall()))
+                    result_text = json.dumps({
+                        "id": task.id,
+                        "name": task.name,
+                        "state": task.state,
+                        "phase": task.phase,
+                        "worker_id": task.worker_id,
+                        "agent": agent_info,
+                        "branch": task.branch,
+                        "pr_url": task.pr_url,
+                        "created_at": task.created_at,
+                        "finished_at": task.finished_at,
+                        "recent_logs": [{"time": r[0], "line": r[1]} for r in log_rows],
+                    })
+        finally:
+            await db.close()
+
+        # GitHub tools — use guild's OAuth token
+        if tu.name in (
+            "list_github_issues", "get_github_issue", "list_github_prs",
+            "claim_github_issue", "create_github_issue", "search_github_issues",
+        ):
+            creds = await _guild_github_token(guild_id)
+            if not creds:
+                result_text = "No GitHub token found for this guild — user must connect GitHub first."
+            else:
+                token, username = creds
+                try:
+                    if tu.name == "list_github_issues":
+                        repo = inp["repo"]
+                        state = inp.get("state", "open")
+                        limit = min(int(inp.get("limit", 20)), 50)
+                        issues = await asyncio.to_thread(
+                            _gh_api, f"/repos/{repo}/issues?state={state}&per_page={limit}", token
+                        )
+                        trimmed = [
+                            {"number": i["number"], "title": i["title"],
+                             "state": i["state"], "labels": [l["name"] for l in i.get("labels", [])],
+                             "assignees": [a["login"] for a in i.get("assignees", [])],
+                             "created_at": i["created_at"]}
+                            for i in issues if "pull_request" not in i
+                        ]
+                        result_text = json.dumps(trimmed)
+
+                    elif tu.name == "get_github_issue":
+                        repo = inp["repo"]
+                        num = int(inp["issue_number"])
+                        issue = await asyncio.to_thread(_gh_api, f"/repos/{repo}/issues/{num}", token)
+                        comments_raw = await asyncio.to_thread(
+                            _gh_api, f"/repos/{repo}/issues/{num}/comments?per_page=20", token
+                        )
+                        result_text = json.dumps({
+                            "number": issue["number"],
+                            "title": issue["title"],
+                            "state": issue["state"],
+                            "body": (issue.get("body") or "")[:2000],
+                            "labels": [l["name"] for l in issue.get("labels", [])],
+                            "comments": [
+                                {"author": c["user"]["login"], "body": (c.get("body") or "")[:500]}
+                                for c in comments_raw
+                            ],
+                        })
+
+                    elif tu.name == "list_github_prs":
+                        repo = inp["repo"]
+                        state = inp.get("state", "open")
+                        prs = await asyncio.to_thread(
+                            _gh_api, f"/repos/{repo}/pulls?state={state}&per_page=20", token
+                        )
+                        result_text = json.dumps([
+                            {"number": p["number"], "title": p["title"],
+                             "state": p["state"], "head": p["head"]["ref"],
+                             "draft": p.get("draft", False)}
+                            for p in prs
+                        ])
+
+                    elif tu.name == "claim_github_issue":
+                        repo = inp["repo"]
+                        num = int(inp["issue_number"])
+                        await asyncio.to_thread(
+                            _gh_api_post,
+                            f"/repos/{repo}/issues/{num}/assignees",
+                            token,
+                            {"assignees": [username]},
+                        )
+                        result_text = f"Issue #{num} in {repo} assigned to {username}."
+
+                    elif tu.name == "create_github_issue":
+                        repo = inp["repo"]
+                        payload: dict = {"title": inp["title"], "body": inp.get("body", "")}
+                        if inp.get("labels"):
+                            payload["labels"] = inp["labels"]
+                        issue = await asyncio.to_thread(
+                            _gh_api_post, f"/repos/{repo}/issues", token, payload
+                        )
+                        result_text = json.dumps({
+                            "number": issue["number"],
+                            "url": issue["html_url"],
+                            "title": issue["title"],
+                        })
+
+                    elif tu.name == "search_github_issues":
+                        repo = inp["repo"]
+                        query = inp["query"]
+                        state = inp.get("state", "open")
+                        state_q = "" if state == "all" else f"+state:{state}"
+                        search_url = (
+                            f"/search/issues?q={urllib.parse.quote(query)}"
+                            f"+repo:{repo}{state_q}&per_page=10&sort=created&order=desc"
+                        )
+                        data = await asyncio.to_thread(_gh_api, search_url, token)
+                        items = data.get("items", []) if isinstance(data, dict) else data
+                        result_text = json.dumps([
+                            {
+                                "number": i["number"],
+                                "title": i["title"],
+                                "state": i["state"],
+                                "url": i["html_url"],
+                                "labels": [l["name"] for l in i.get("labels", [])],
+                            }
+                            for i in items
+                        ])
+
+                except urllib.error.HTTPError as exc:
+                    result_text = f"GitHub API error: {exc.code} {exc.reason}"
+                except Exception as exc:
+                    result_text = f"GitHub error: {exc}"
+
+        results.append({"type": "tool_result", "tool_use_id": tu.id, "content": result_text})
+    return results

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,11 +35,8 @@ try:
 except ImportError:
     pass
 
-try:
-    import anthropic as _anthropic
-    HAS_ANTHROPIC = True
-except ImportError:
-    HAS_ANTHROPIC = False
+from events import broadcast, connections, agent_owners, emit_terminal_line
+from foreman import foreman_conversations, run_foreman_ai, serialize_history_for_debug
 
 
 logger = logging.getLogger(__name__)
@@ -76,21 +73,10 @@ oauth_states: set[str] = set()
 
 _http_bearer = HTTPBearer(auto_error=False)
 
-# In-memory WebSocket connections: guild_id -> list of WebSocket
-connections: Dict[str, List[WebSocket]] = {}
-
-# Tracks which WebSocket currently owns a given agent_id. Used so that when a
-# worker reconnects (new WS joins before the old WS's finally block runs), the
-# stale finally doesn't mark the freshly-online agent offline again.
-agent_owners: Dict[str, WebSocket] = {}
-
 # Running agent subprocesses: agent_id -> asyncio.subprocess.Process
 # Used only by /agents/{id}/run (one-off claude/codex/pi invocations).
 # Worker subprocesses live in the standalone /worker process.
 running_processes: Dict[str, asyncio.subprocess.Process] = {}
-
-# Foreman AI conversation history per guild
-foreman_conversations: Dict[str, List[dict]] = {}    # guild_id -> messages list
 
 
 async def init_db():
@@ -179,982 +165,8 @@ class TaskCreate(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-FOREMAN_SYSTEM = """\
-You are the Foreman AI in Pioneer Square, a multi-agent coding workshop.
-You coordinate worker agents that autonomously clone repos, write code, and open PRs.
-
-## Your responsibilities
-- Understand what the human wants and break it into named, tracked tasks
-- Always call create_task first to name the work and get a task_id; then pass that task_id to assign_task so the same record is assigned to a worker (no duplicate rows)
-- After a worker finishes (task-complete), review the result and decide: send_followup for \
-additional work in the same worktree, or finalize_task when done
-- Message workers mid-task via message_worker for context
-- Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
-- Cancel tasks that are going wrong or are no longer needed via cancel_task
-- Summarise status and outcomes when asked
-- Escalate to the human only when genuinely stuck
-
-## Multi-step flows
-For complex work use phases:
-1. **plan** — create_task(phase='plan'), assign a worker to produce an outline/spec
-2. **execute** — assign workers to implement
-3. **review** — assign a worker to verify correctness, run tests, check the PR
-
-## Task ownership
-- create_task before assign_task so every job has a human-readable name in the sidebar
-- Pass the task_id from create_task into assign_task — this assigns the same task to a worker instead of creating a second row
-- After task-complete: call send_followup for further work (update tests, fix lint, add docs),
-  or call finalize_task to mark it complete — don't leave tasks in limbo
-
-## GitHub access
-You have direct GitHub access via list_github_issues, get_github_issue, list_github_prs,
-search_github_issues, create_github_issue, and claim_github_issue.
-
-## Issue-first workflow
-Before assigning work that is more than a trivial fix (new features, refactors, multi-file
-changes), use search_github_issues to check whether an issue already exists. If not, create
-one with create_github_issue to track it. Pass issue_number and issue_repo to assign_task so
-the worker's PR references the issue automatically.
-
-## Checking task progress
-Use get_task_status to verify a task is making progress — it returns the current state,
-the active agent and its state, and the last log lines. If a task looks stalled, use
-redirect_task to course-correct or cancel_task if it's going in the wrong direction.
-
-Workers are configured with repos. Prefer workers whose repos cover the task.
-Be concise — one short paragraph maximum unless detail is requested.\
-"""
-
-FOREMAN_TOOLS = [
-    {
-        "name": "create_task",
-        "description": (
-            "Create a named foreman task. Call this before assigning worker tasks — it gives the "
-            "work a human-readable name visible in the sidebar and returns a task_id to reference "
-            "in assign_task."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Short human-readable name (≤60 chars), e.g. 'Implement OAuth login'.",
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Full description of the work to be done.",
-                },
-                "phase": {
-                    "type": "string",
-                    "enum": ["plan", "execute", "review"],
-                    "description": "Starting phase. Default: execute.",
-                },
-            },
-            "required": ["name", "description"],
-        },
-    },
-    {
-        "name": "assign_task",
-        "description": (
-            "Queue a coding task for a worker agent. The worker creates a git worktree, "
-            "runs the chosen coding agent on the description, then pushes the branch. "
-            "Pass task_id (from create_task) to assign that existing task to a worker instead "
-            "of creating a duplicate — this is the preferred flow."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "worker_id": {
-                    "type": "string",
-                    "description": "Worker agent ID (e.g. w-abc123). Must be idle.",
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Detailed, self-contained task description the coding agent receives.",
-                },
-                "task_id": {
-                    "type": "string",
-                    "description": "Task ID returned by create_task. When provided, assigns that "
-                                   "existing task to the worker instead of creating a new row.",
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Short task name shown in the sidebar (≤60 chars).",
-                },
-                "tool": {
-                    "type": "string",
-                    "enum": ["claude", "codex", "pi"],
-                    "description": "Coding agent to use. Default: claude.",
-                },
-                "parent_task_id": {
-                    "type": "string",
-                    "description": "Foreman task ID this worker task belongs to (optional, ignored if task_id provided).",
-                },
-                "phase": {
-                    "type": "string",
-                    "enum": ["plan", "execute", "review", "followup"],
-                    "description": "Phase of work.",
-                },
-                "issue_number": {"type": "integer", "description": "GitHub issue to close (optional)."},
-                "issue_repo": {"type": "string", "description": "owner/repo for the issue (optional)."},
-            },
-            "required": ["worker_id", "description"],
-        },
-    },
-    {
-        "name": "send_followup",
-        "description": (
-            "Send follow-up instructions to a worker for a task that just completed. "
-            "The worker executes these in the same git worktree on the same branch — "
-            "ideal for 'update tests', 'fix type errors', 'add docs', etc. "
-            "Call after receiving a task-complete notification."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx)."},
-                "instructions": {
-                    "type": "string",
-                    "description": "Follow-up instructions to execute in the existing worktree.",
-                },
-            },
-            "required": ["task_id", "instructions"],
-        },
-    },
-    {
-        "name": "finalize_task",
-        "description": (
-            "Mark a task complete with no further follow-up needed. "
-            "Call after reviewing a completed task when no additional work is required."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "task_id": {"type": "string", "description": "Task ID to finalize."},
-            },
-            "required": ["task_id"],
-        },
-    },
-    {
-        "name": "message_worker",
-        "description": "Send a message to a worker's terminal — for mid-task context injection.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "worker_id": {"type": "string"},
-                "message": {"type": "string"},
-            },
-            "required": ["worker_id", "message"],
-        },
-    },
-    {
-        "name": "redirect_task",
-        "description": (
-            "Redirect a running task mid-execution with new instructions. "
-            "Terminates the current Claude subprocess, then immediately resumes it in the same "
-            "session — Claude keeps full context of what it was doing and acts on the new "
-            "instructions instead. For tasks awaiting review, acts as a follow-up. "
-            "Use this to course-correct without losing progress."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx) to redirect."},
-                "instructions": {
-                    "type": "string",
-                    "description": "New instructions. Claude will see its full prior history.",
-                },
-            },
-            "required": ["task_id", "instructions"],
-        },
-    },
-    {
-        "name": "cancel_task",
-        "description": (
-            "Cancel a running or pending task. Use when a task is going in the wrong direction, "
-            "is stuck, or is no longer needed. The worker terminates its Claude subprocess "
-            "immediately and releases the agent slot. Cannot cancel tasks that are already done or failed."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx) to cancel."},
-                "reason": {"type": "string", "description": "Optional reason for cancellation."},
-            },
-            "required": ["task_id"],
-        },
-    },
-    {
-        "name": "list_github_issues",
-        "description": (
-            "List GitHub issues for a repo. Use this to discover work that needs to be done."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "repo": {"type": "string", "description": "owner/repo, e.g. 'acme/backend'"},
-                "state": {"type": "string", "enum": ["open", "closed", "all"], "description": "Default: open"},
-                "limit": {"type": "integer", "description": "Max issues to return (default 20, max 50)"},
-            },
-            "required": ["repo"],
-        },
-    },
-    {
-        "name": "get_github_issue",
-        "description": "Get full details of a single GitHub issue including its body and comments.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "repo": {"type": "string", "description": "owner/repo"},
-                "issue_number": {"type": "integer"},
-            },
-            "required": ["repo", "issue_number"],
-        },
-    },
-    {
-        "name": "list_github_prs",
-        "description": "List pull requests for a repo — useful for reviewing completed worker branches.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "repo": {"type": "string", "description": "owner/repo"},
-                "state": {"type": "string", "enum": ["open", "closed", "all"], "description": "Default: open"},
-            },
-            "required": ["repo"],
-        },
-    },
-    {
-        "name": "claim_github_issue",
-        "description": (
-            "Assign a GitHub issue to the authenticated user (claim it for this guild's operator). "
-            "Call this when picking up an issue to work on, before assigning a worker task."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "repo": {"type": "string", "description": "owner/repo"},
-                "issue_number": {"type": "integer"},
-            },
-            "required": ["repo", "issue_number"],
-        },
-    },
-    {
-        "name": "get_task_status",
-        "description": (
-            "Get the current status of a task: state, phase, assigned worker and active agent state, "
-            "and the last log lines. Use this to verify a task is progressing and to diagnose stalls."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx)."},
-                "log_lines": {
-                    "type": "integer",
-                    "description": "Number of recent log lines to return (default 10, max 50).",
-                },
-            },
-            "required": ["task_id"],
-        },
-    },
-    {
-        "name": "create_github_issue",
-        "description": (
-            "Create a new GitHub issue to track work before assigning it to a worker. "
-            "Search first with search_github_issues to avoid duplicates."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "repo": {"type": "string", "description": "owner/repo"},
-                "title": {"type": "string", "description": "Issue title."},
-                "body": {"type": "string", "description": "Issue body in markdown."},
-                "labels": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Label names to apply (labels must already exist in the repo).",
-                },
-            },
-            "required": ["repo", "title", "body"],
-        },
-    },
-    {
-        "name": "search_github_issues",
-        "description": (
-            "Search GitHub issues and PRs by keyword within a repo. "
-            "Call this before create_github_issue to check whether an issue already exists."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "repo": {"type": "string", "description": "owner/repo to restrict search to."},
-                "query": {"type": "string", "description": "Search keywords."},
-                "state": {
-                    "type": "string",
-                    "enum": ["open", "closed", "all"],
-                    "description": "Filter by state. Default: open.",
-                },
-            },
-            "required": ["repo", "query"],
-        },
-    },
-]
-
-
-def _serialize_history_for_debug(history: list) -> list:
-    """Convert in-memory foreman history (may contain SDK objects) to JSON-safe dicts."""
-    out = []
-    for msg in history:
-        role = msg.get("role", "?") if isinstance(msg, dict) else getattr(msg, "role", "?")
-        content = msg.get("content", []) if isinstance(msg, dict) else getattr(msg, "content", [])
-        if isinstance(content, str):
-            out.append({"role": role, "content": content})
-        elif isinstance(content, list):
-            blocks = []
-            for b in content:
-                if isinstance(b, dict):
-                    blocks.append(b)
-                else:
-                    try:
-                        blocks.append(b.model_dump())
-                    except AttributeError:
-                        blocks.append({"type": str(getattr(b, "type", "unknown")), "raw": str(b)})
-            out.append({"role": role, "content": blocks})
-        else:
-            out.append({"role": role, "content": str(content)})
-    return out
-
-
-def _repair_tool_pairs(messages: list) -> list:
-    """
-    Ensure every tool_use block in an assistant turn has a matching tool_result
-    in the immediately following user turn.
-
-    When the conversation history is trimmed or otherwise truncated, assistant
-    messages that contain tool_use blocks can lose their paired tool_result
-    responses.  The Anthropic API rejects such histories.  This function does a
-    single forward pass and inserts a synthetic error tool_result for every
-    orphaned tool_use ID, keeping the history self-consistent.
-    """
-    result: list = []
-    i = 0
-    while i < len(messages):
-        msg = messages[i]
-
-        if msg.get("role") != "assistant":
-            result.append(msg)
-            i += 1
-            continue
-
-        content = msg.get("content", [])
-        tool_use_ids: list[str] = []
-        for block in content:
-            if isinstance(block, dict):
-                if block.get("type") == "tool_use":
-                    tool_use_ids.append(block["id"])
-            elif getattr(block, "type", None) == "tool_use":
-                tool_use_ids.append(block.id)
-
-        result.append(msg)
-        i += 1
-
-        if not tool_use_ids:
-            continue
-
-        next_msg = messages[i] if i < len(messages) else None
-
-        if next_msg is not None and next_msg.get("role") == "user":
-            next_content = next_msg.get("content", [])
-            if isinstance(next_content, list):
-                covered = {
-                    b.get("tool_use_id")
-                    for b in next_content
-                    if isinstance(b, dict) and b.get("type") == "tool_result"
-                }
-            else:
-                covered = set()
-            orphans = [tid for tid in tool_use_ids if tid not in covered]
-        else:
-            orphans = list(tool_use_ids)
-
-        if not orphans:
-            continue
-
-        logger.warning(
-            "Repairing foreman history: inserting synthetic tool_result for "
-            "orphaned tool_use ids %s",
-            orphans,
-        )
-        synthetic = [
-            {
-                "type": "tool_result",
-                "tool_use_id": tid,
-                "content": '{"error": "tool result missing"}',
-            }
-            for tid in orphans
-        ]
-        if next_msg is not None and next_msg.get("role") == "user":
-            # Merge synthetic results into the existing next user message so
-            # there are no consecutive user turns.
-            existing = next_msg.get("content", [])
-            existing_list = existing if isinstance(existing, list) else [{"type": "text", "text": str(existing)}]
-            result.append({"role": "user", "content": synthetic + existing_list})
-            i += 1  # skip the original next_msg; we just replaced it
-        else:
-            result.append({"role": "user", "content": synthetic})
-
-    return result
-
-
-async def _foreman_exec_tools(guild_id: str, tool_uses: list) -> list:
-    """Execute tool calls from the foreman AI and return tool-result blocks."""
-    results = []
-    for tu in tool_uses:
-        inp = tu.input
-        result_text = ""
-        db = await get_db()
-        try:
-            if tu.name == "create_task":
-                name = (inp.get("name") or "")[:80]
-                desc = inp.get("description", name)
-                phase = inp.get("phase", "execute")
-                task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
-                created_at = datetime.now(timezone.utc).isoformat()
-                db.add(Task(
-                    id=task_id,
-                    worker_id="foreman",
-                    guild_id=guild_id,
-                    name=name,
-                    description=desc,
-                    tool="claude",
-                    state="pending",
-                    phase=phase,
-                    created_at=created_at,
-                ))
-                await db.commit()
-                await broadcast(guild_id, {
-                    "type": "task-created",
-                    "taskId": task_id,
-                    "name": name,
-                    "description": desc,
-                    "phase": phase,
-                    "state": "pending",
-                    "createdAt": created_at,
-                })
-                result_text = f"Task {task_id} created: '{name}'. Reference this task_id in assign_task."
-
-            elif tu.name == "assign_task":
-                wid = inp["worker_id"]
-                desc = inp.get("description", "")
-                phase = inp.get("phase", "execute")
-                tool = inp.get("tool", "claude")
-                existing_task_id = inp.get("task_id")
-                result = await db.execute(
-                    select(Worker.id).where(Worker.id == wid, Worker.guild_id == guild_id)
-                )
-                worker_row = result.scalar_one_or_none()
-                if not worker_row:
-                    result_text = f"Worker {wid} not found — task NOT queued."
-                elif existing_task_id:
-                    # Update the existing foreman task in place — no duplicate row
-                    name_override = inp.get("name")
-                    update_values: dict = {
-                        "worker_id": wid,
-                        "description": desc,
-                        "tool": tool,
-                        "phase": phase,
-                        "state": "pending",
-                    }
-                    if name_override:
-                        update_values["name"] = name_override
-                    if inp.get("issue_number") is not None:
-                        update_values["issue_number"] = inp["issue_number"]
-                    if inp.get("issue_repo"):
-                        update_values["issue_repo"] = inp["issue_repo"]
-                    await db.execute(
-                        update(Task)
-                        .where(Task.id == existing_task_id, Task.guild_id == guild_id)
-                        .values(**update_values)
-                    )
-                    await db.commit()
-                    name_result = await db.execute(
-                        select(Task.name).where(Task.id == existing_task_id)
-                    )
-                    task_name = name_result.scalar_one_or_none() or desc[:60]
-                    task_id = existing_task_id
-                    await broadcast(guild_id, {
-                        "type": "task-assigned",
-                        "workerId": wid,
-                        "taskId": task_id,
-                        "name": task_name,
-                        "description": desc,
-                        "tool": tool,
-                        "phase": phase,
-                        "issueNumber": inp.get("issue_number"),
-                        "issueRepo": inp.get("issue_repo"),
-                    })
-                    result_text = f"Task {task_id} assigned to {wid}."
-                else:
-                    # No existing task_id — create a new row
-                    name = (inp.get("name") or desc[:60])
-                    parent_task_id = inp.get("parent_task_id")
-                    task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
-                    created_at = datetime.now(timezone.utc).isoformat()
-                    db.add(Task(
-                        id=task_id,
-                        worker_id=wid,
-                        guild_id=guild_id,
-                        name=name,
-                        description=desc,
-                        tool=tool,
-                        issue_number=inp.get("issue_number"),
-                        issue_repo=inp.get("issue_repo"),
-                        state="pending",
-                        phase=phase,
-                        parent_task_id=parent_task_id,
-                        created_at=created_at,
-                    ))
-                    await db.commit()
-                    await broadcast(guild_id, {
-                        "type": "task-assigned",
-                        "workerId": wid,
-                        "taskId": task_id,
-                        "name": name,
-                        "description": desc,
-                        "tool": tool,
-                        "phase": phase,
-                        "parentTaskId": parent_task_id,
-                        "issueNumber": inp.get("issue_number"),
-                        "issueRepo": inp.get("issue_repo"),
-                    })
-                    result_text = f"Task {task_id} queued for {wid}."
-
-            elif tu.name == "send_followup":
-                task_id = inp["task_id"]
-                instructions = inp["instructions"]
-                result = await db.execute(
-                    select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
-                )
-                worker_id_val = result.scalar_one_or_none()
-                if not worker_id_val:
-                    result_text = f"Task {task_id} not found."
-                else:
-                    await db.execute(
-                        update(Task).where(Task.id == task_id).values(state="working", phase="followup")
-                    )
-                    await db.commit()
-                    await broadcast(guild_id, {
-                        "type": "task-followup",
-                        "workerId": worker_id_val,
-                        "taskId": task_id,
-                        "instructions": instructions,
-                    })
-                    result_text = f"Follow-up sent to {worker_id_val} for task {task_id}."
-
-            elif tu.name == "finalize_task":
-                task_id = inp["task_id"]
-                result = await db.execute(
-                    select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
-                )
-                worker_id_val = result.scalar_one_or_none()
-                if not worker_id_val:
-                    result_text = f"Task {task_id} not found."
-                else:
-                    finished_at = datetime.now(timezone.utc).isoformat()
-                    await db.execute(
-                        update(Task).where(Task.id == task_id).values(state="done", finished_at=finished_at)
-                    )
-                    await db.commit()
-                    await broadcast(guild_id, {
-                        "type": "task-finalize",
-                        "workerId": worker_id_val,
-                        "taskId": task_id,
-                    })
-                    await broadcast(guild_id, {
-                        "type": "task-update",
-                        "taskId": task_id,
-                        "state": "done",
-                        "finishedAt": finished_at,
-                    })
-                    result_text = f"Task {task_id} finalized."
-                    # Compact all prior tool-result blocks mentioning this task
-                    for msg in foreman_conversations.get(guild_id, []):
-                        if msg["role"] == "user" and isinstance(msg["content"], list):
-                            for block in msg["content"]:
-                                if (block.get("type") == "tool_result"
-                                        and task_id in block.get("content", "")):
-                                    block["content"] = f"[{task_id}: done]"
-
-            elif tu.name == "message_worker":
-                wid = inp["worker_id"]
-                msg = inp["message"]
-                await _emit_terminal_line(guild_id, wid, f"[foreman] {msg}")
-                await broadcast(guild_id, {
-                    "type": "worker-message",
-                    "workerId": wid,
-                    "message": msg,
-                })
-                result_text = f"Message delivered to {wid}."
-
-            elif tu.name == "redirect_task":
-                task_id = inp["task_id"]
-                instructions = inp["instructions"]
-                result = await db.execute(
-                    select(Task.worker_id, Task.state).where(
-                        Task.id == task_id, Task.guild_id == guild_id
-                    )
-                )
-                row = result.one_or_none()
-                if not row:
-                    result_text = f"Task {task_id} not found."
-                else:
-                    worker_id_val, state = row
-                    if state in ("done", "failed", "cancelled"):
-                        result_text = f"Task {task_id} is {state} — cannot redirect."
-                    else:
-                        await db.execute(
-                            update(Task).where(Task.id == task_id).values(state="working")
-                        )
-                        await db.commit()
-                        await broadcast(guild_id, {
-                            "type": "task-redirect",
-                            "workerId": worker_id_val,
-                            "taskId": task_id,
-                            "instructions": instructions,
-                        })
-                        await broadcast(guild_id, {
-                            "type": "task-update",
-                            "taskId": task_id,
-                            "state": "working",
-                        })
-                        result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
-
-            elif tu.name == "cancel_task":
-                task_id = inp["task_id"]
-                reason = inp.get("reason", "")
-                result = await db.execute(
-                    select(Task.worker_id, Task.state).where(
-                        Task.id == task_id, Task.guild_id == guild_id
-                    )
-                )
-                row = result.one_or_none()
-                if not row:
-                    result_text = f"Task {task_id} not found."
-                else:
-                    worker_id_val, state = row
-                    if state in ("done", "failed", "cancelled"):
-                        result_text = f"Task {task_id} is already {state}."
-                    else:
-                        finished_at = datetime.now(timezone.utc).isoformat()
-                        await db.execute(
-                            update(Task).where(Task.id == task_id).values(
-                                state="cancelled", finished_at=finished_at
-                            )
-                        )
-                        await db.commit()
-                        await broadcast(guild_id, {
-                            "type": "task-cancel",
-                            "workerId": worker_id_val,
-                            "taskId": task_id,
-                        })
-                        await broadcast(guild_id, {
-                            "type": "task-update",
-                            "taskId": task_id,
-                            "state": "cancelled",
-                            "finishedAt": finished_at,
-                        })
-                        result_text = f"Task {task_id} cancelled." + (f" Reason: {reason}" if reason else "")
-
-            elif tu.name == "get_task_status":
-                task_id = inp["task_id"]
-                limit = min(int(inp.get("log_lines", 10)), 50)
-                task_result = await db.execute(
-                    select(Task).where(Task.id == task_id, Task.guild_id == guild_id)
-                )
-                task = task_result.scalar_one_or_none()
-                if not task:
-                    result_text = f"Task {task_id} not found."
-                else:
-                    agent_info = None
-                    if task.worker_id and task.worker_id != "foreman":
-                        agent_result = await db.execute(
-                            select(Agent.id, Agent.state)
-                            .where(Agent.worker_id == task.worker_id, Agent.state != "offline")
-                            .limit(1)
-                        )
-                        agent_row = agent_result.one_or_none()
-                        if agent_row:
-                            agent_info = {"agent_id": agent_row[0], "agent_state": agent_row[1]}
-                    logs_result = await db.execute(
-                        select(TaskLog.timestamp, TaskLog.line)
-                        .where(TaskLog.task_id == task_id)
-                        .order_by(TaskLog.id.desc())
-                        .limit(limit)
-                    )
-                    log_rows = list(reversed(logs_result.fetchall()))
-                    result_text = json.dumps({
-                        "id": task.id,
-                        "name": task.name,
-                        "state": task.state,
-                        "phase": task.phase,
-                        "worker_id": task.worker_id,
-                        "agent": agent_info,
-                        "branch": task.branch,
-                        "pr_url": task.pr_url,
-                        "created_at": task.created_at,
-                        "finished_at": task.finished_at,
-                        "recent_logs": [{"time": r[0], "line": r[1]} for r in log_rows],
-                    })
-        finally:
-            await db.close()
-
-        # GitHub tools — use guild's OAuth token
-        if tu.name in (
-            "list_github_issues", "get_github_issue", "list_github_prs",
-            "claim_github_issue", "create_github_issue", "search_github_issues",
-        ):
-            creds = await _guild_github_token(guild_id)
-            if not creds:
-                result_text = "No GitHub token found for this guild — user must connect GitHub first."
-            else:
-                token, username = creds
-                try:
-                    if tu.name == "list_github_issues":
-                        repo = inp["repo"]
-                        state = inp.get("state", "open")
-                        limit = min(int(inp.get("limit", 20)), 50)
-                        issues = await asyncio.to_thread(
-                            _gh_api, f"/repos/{repo}/issues?state={state}&per_page={limit}", token
-                        )
-                        trimmed = [
-                            {"number": i["number"], "title": i["title"],
-                             "state": i["state"], "labels": [l["name"] for l in i.get("labels", [])],
-                             "assignees": [a["login"] for a in i.get("assignees", [])],
-                             "created_at": i["created_at"]}
-                            for i in issues if "pull_request" not in i
-                        ]
-                        result_text = json.dumps(trimmed)
-
-                    elif tu.name == "get_github_issue":
-                        repo = inp["repo"]
-                        num = int(inp["issue_number"])
-                        issue = await asyncio.to_thread(_gh_api, f"/repos/{repo}/issues/{num}", token)
-                        comments_raw = await asyncio.to_thread(
-                            _gh_api, f"/repos/{repo}/issues/{num}/comments?per_page=20", token
-                        )
-                        result_text = json.dumps({
-                            "number": issue["number"],
-                            "title": issue["title"],
-                            "state": issue["state"],
-                            "body": (issue.get("body") or "")[:2000],
-                            "labels": [l["name"] for l in issue.get("labels", [])],
-                            "comments": [
-                                {"author": c["user"]["login"], "body": (c.get("body") or "")[:500]}
-                                for c in comments_raw
-                            ],
-                        })
-
-                    elif tu.name == "list_github_prs":
-                        repo = inp["repo"]
-                        state = inp.get("state", "open")
-                        prs = await asyncio.to_thread(
-                            _gh_api, f"/repos/{repo}/pulls?state={state}&per_page=20", token
-                        )
-                        result_text = json.dumps([
-                            {"number": p["number"], "title": p["title"],
-                             "state": p["state"], "head": p["head"]["ref"],
-                             "draft": p.get("draft", False)}
-                            for p in prs
-                        ])
-
-                    elif tu.name == "claim_github_issue":
-                        repo = inp["repo"]
-                        num = int(inp["issue_number"])
-                        await asyncio.to_thread(
-                            _gh_api_post,
-                            f"/repos/{repo}/issues/{num}/assignees",
-                            token,
-                            {"assignees": [username]},
-                        )
-                        result_text = f"Issue #{num} in {repo} assigned to {username}."
-
-                    elif tu.name == "create_github_issue":
-                        repo = inp["repo"]
-                        payload: dict = {"title": inp["title"], "body": inp.get("body", "")}
-                        if inp.get("labels"):
-                            payload["labels"] = inp["labels"]
-                        issue = await asyncio.to_thread(
-                            _gh_api_post, f"/repos/{repo}/issues", token, payload
-                        )
-                        result_text = json.dumps({
-                            "number": issue["number"],
-                            "url": issue["html_url"],
-                            "title": issue["title"],
-                        })
-
-                    elif tu.name == "search_github_issues":
-                        repo = inp["repo"]
-                        query = inp["query"]
-                        state = inp.get("state", "open")
-                        state_q = "" if state == "all" else f"+state:{state}"
-                        search_url = (
-                            f"/search/issues?q={urllib.parse.quote(query)}"
-                            f"+repo:{repo}{state_q}&per_page=10&sort=created&order=desc"
-                        )
-                        data = await asyncio.to_thread(_gh_api, search_url, token)
-                        items = data.get("items", []) if isinstance(data, dict) else data
-                        result_text = json.dumps([
-                            {
-                                "number": i["number"],
-                                "title": i["title"],
-                                "state": i["state"],
-                                "url": i["html_url"],
-                                "labels": [l["name"] for l in i.get("labels", [])],
-                            }
-                            for i in items
-                        ])
-
-                except urllib.error.HTTPError as exc:
-                    result_text = f"GitHub API error: {exc.code} {exc.reason}"
-                except Exception as exc:
-                    result_text = f"GitHub error: {exc}"
-
-        results.append({"type": "tool_result", "tool_use_id": tu.id, "content": result_text})
-    return results
-
-
-async def _run_foreman_ai(guild_id: str, human_message: str, extra_context: str = ""):
-    """Process a human message (or escalation) through the Claude foreman AI."""
-    if not HAS_ANTHROPIC:
-        now = datetime.now(timezone.utc).isoformat()
-        await broadcast(guild_id, {
-            "type": "chat", "from": "foreman", "to": "user",
-            "content": "Foreman AI offline (install `anthropic` package to enable).",
-            "createdAt": now,
-        })
-        return
-
-    # Build live context for the system prompt
-    db = await get_db()
-    try:
-        # Complex UNION query: registered workers (with connected agents) + ephemeral agents
-        result = await db.execute(
-            text(
-                "SELECT w.id, w.repos, w.state as worker_state,"
-                " COUNT(a.id) as agent_count,"
-                " GROUP_CONCAT(a.id || ':' || a.state) as agents"
-                " FROM workers w"
-                " LEFT JOIN agents a ON a.worker_id = w.id AND a.state != 'offline'"
-                " WHERE w.guild_id = :guild_id"
-                " GROUP BY w.id"
-                " UNION ALL"
-                " SELECT a.id, '[]', a.state, 1, a.id || ':' || a.state"
-                " FROM agents a"
-                " WHERE a.guild_id = :guild_id AND a.type = 'worker'"
-                " AND a.worker_id IS NULL AND a.state != 'offline'"
-            ),
-            {"guild_id": guild_id},
-        )
-        worker_rows = [dict(r._mapping) for r in result.fetchall()]
-        task_result = await db.execute(
-            select(Task.id, Task.worker_id, Task.description, Task.state, Task.branch, Task.pr_url)
-            .where(Task.guild_id == guild_id)
-            .order_by(Task.created_at.desc())
-            .limit(10)
-        )
-        task_rows = [
-            {**dict(r._mapping), "description": dict(r._mapping).get("description") or ""}
-            for r in task_result.fetchall()
-        ]
-    finally:
-        await db.close()
-
-    workers_block = json.dumps(
-        [{"id": r["id"], "state": r["worker_state"] or "idle",
-          "repos": json.loads(r["repos"] or "[]"),
-          "agent_count": r["agent_count"] or 0} for r in worker_rows],
-        indent=2,
-    )
-    tasks_block = json.dumps(task_rows[:6], indent=2)
-    system = (
-        f"{FOREMAN_SYSTEM}\n\n"
-        f"## Current workers\n```json\n{workers_block}\n```\n\n"
-        f"## Recent tasks\n```json\n{tasks_block}\n```"
-        + (f"\n\n## Context\n{extra_context}" if extra_context else "")
-    )
-
-    history = foreman_conversations.setdefault(guild_id, [])
-    history.append({"role": "user", "content": human_message})
-
-    client = _anthropic.AsyncAnthropic()
-
-    _RESULT_MAX = 400  # chars kept per tool result in history
-
-    try:
-        text_parts = []
-        for _ in range(6):  # safety cap on tool-call rounds
-            history = _repair_tool_pairs(history)
-            resp = await client.messages.create(
-                model="claude-sonnet-4-6",
-                max_tokens=1024,
-                system=system,
-                messages=history,
-                tools=FOREMAN_TOOLS,
-            )
-            history.append({"role": "assistant", "content": resp.content})
-            text_parts += [b.text for b in resp.content if b.type == "text" and b.text.strip()]
-
-            tool_uses = [b for b in resp.content if b.type == "tool_use"]
-            if not tool_uses:
-                break  # end_turn — foreman is done
-
-            tool_results = await _foreman_exec_tools(guild_id, tool_uses)
-            # Truncate verbose results (e.g. GitHub JSON) before storing in history
-            trimmed = [
-                {**r, "content": r["content"][:_RESULT_MAX] + " …[truncated]"}
-                if len(r.get("content", "")) > _RESULT_MAX else r
-                for r in tool_results
-            ]
-            history.append({"role": "user", "content": trimmed})
-
-        # Trim history, repair orphaned tool pairs, then drop any leading assistant
-        # turns (which the API forbids as the first message).
-        trimmed_history = history[-10:]
-        repaired = _repair_tool_pairs(trimmed_history)
-        while repaired and repaired[0].get("role") != "user":
-            repaired = repaired[1:]
-        foreman_conversations[guild_id] = repaired
-
-        response_text = "\n".join(text_parts).strip()
-        if response_text:
-            now = datetime.now(timezone.utc).isoformat()
-            await broadcast(guild_id, {
-                "type": "chat", "from": "foreman", "to": "user",
-                "content": response_text, "createdAt": now,
-            })
-            db = await get_db()
-            try:
-                db.add(Message(
-                    guild_id=guild_id,
-                    from_agent="foreman",
-                    to_agent="user",
-                    content=response_text,
-                    message_type="chat",
-                    created_at=now,
-                ))
-                await db.commit()
-            finally:
-                await db.close()
-
-    except Exception as exc:
-        now = datetime.now(timezone.utc).isoformat()
-        await broadcast(guild_id, {
-            "type": "chat", "from": "foreman", "to": "user",
-            "content": f"Foreman error: {exc}", "createdAt": now,
-        })
-
-
 # ---------------------------------------------------------------------------
-# GitHub OAuth helpers
+# GitHub OAuth helpers (OAuth flow only — foreman GitHub tools are in foreman/tools.py)
 # ---------------------------------------------------------------------------
 
 def _gh_exchange_code(code: str) -> dict:
@@ -1184,51 +196,6 @@ def _gh_get_user(token: str) -> dict:
     )
     with urllib.request.urlopen(req, timeout=15) as resp:
         return json.loads(resp.read())
-
-
-def _gh_api(path: str, token: str) -> object:
-    """GET a GitHub API path and return parsed JSON."""
-    req = urllib.request.Request(
-        f"https://api.github.com{path}",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github.v3+json",
-        },
-    )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
-
-
-def _gh_api_post(path: str, token: str, payload: dict, method: str = "POST") -> object:
-    """POST/PATCH a GitHub API path with a JSON body and return parsed JSON."""
-    data = json.dumps(payload).encode()
-    req = urllib.request.Request(
-        f"https://api.github.com{path}",
-        data=data,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github.v3+json",
-            "Content-Type": "application/json",
-        },
-        method=method,
-    )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
-
-
-async def _guild_github_token(guild_id: str) -> Optional[tuple[str, str]]:
-    """Return (access_token, github_username) for this guild, or None."""
-    db = await get_db()
-    try:
-        result = await db.execute(
-            select(GithubToken.access_token, GithubToken.github_username)
-            .join(Guild, Guild.github_user_id == GithubToken.github_user_id)
-            .where(Guild.id == guild_id)
-        )
-        row = result.first()
-        return (row.access_token, row.github_username) if row else None
-    finally:
-        await db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -1525,22 +492,6 @@ async def get_guild(guild_id: str):
         await db.close()
 
 
-async def broadcast(guild_id: str, message: dict, exclude: WebSocket = None):
-    """Broadcast a message to all connections in a guild."""
-    if guild_id not in connections:
-        return
-    dead = []
-    for ws in connections[guild_id]:
-        if ws is exclude:
-            continue
-        try:
-            await ws.send_json(message)
-        except Exception:
-            dead.append(ws)
-    for ws in dead:
-        connections[guild_id].remove(ws)
-
-
 @app.websocket("/ws/{guild_id}")
 async def websocket_endpoint(websocket: WebSocket, guild_id: str):
     await websocket.accept()
@@ -1642,7 +593,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 })
                 # Route human messages addressed to foreman through the AI
                 if from_agent == "user" and to_agent == "foreman" and content:
-                    asyncio.create_task(_run_foreman_ai(guild_id, content))
+                    asyncio.create_task(run_foreman_ai(guild_id, content))
 
             elif msg_type == "terminal-output":
                 msg_agent_id = data.get("agentId")
@@ -1757,14 +708,14 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                             "state": "done",
                             "finishedAt": finished_at,
                         })
-                        asyncio.create_task(_run_foreman_ai(
+                        asyncio.create_task(run_foreman_ai(
                             guild_id,
                             f"[timeout] Follow-up window expired for task {task_id} "
                             f"(worker {worker_id_msg}). The task has been auto-finalized "
                             "as done — no foreman action required.",
                         ))
                     else:
-                        asyncio.create_task(_run_foreman_ai(
+                        asyncio.create_task(run_foreman_ai(
                             guild_id,
                             f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
                             f"\"{desc[:80]}\" — branch: {branch}. "
@@ -1783,7 +734,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     await db.commit()
                 await broadcast(guild_id, data, exclude=websocket)
                 if task_id:
-                    asyncio.create_task(_run_foreman_ai(
+                    asyncio.create_task(run_foreman_ai(
                         guild_id,
                         f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
                         "Decide: call send_followup for more work, or call finalize_task to mark it done.",
@@ -1803,7 +754,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     f"Stop reason: {stop_reason}"
                     + (f"\nLast message: {last_msg}" if last_msg else "")
                 )
-                asyncio.create_task(_run_foreman_ai(guild_id, escalation))
+                asyncio.create_task(run_foreman_ai(guild_id, escalation))
 
             elif msg_type in ("offer", "answer", "ice-candidate"):
                 # WebRTC signaling - forward to all
@@ -1855,27 +806,6 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
 # ---------------------------------------------------------------------------
 # Agent process management
 # ---------------------------------------------------------------------------
-
-async def _emit_terminal_line(guild_id: str, agent_id: str, line: str):
-    """Broadcast and persist a terminal output line."""
-    now = datetime.now(timezone.utc).isoformat()
-    await broadcast(guild_id, {
-        "type": "terminal-output",
-        "agentId": agent_id,
-        "line": line,
-        "timestamp": now,
-    })
-    if line:
-        db = await get_db()
-        try:
-            result = await db.execute(select(Agent.worker_id).where(Agent.id == agent_id))
-            worker_id_for_log = result.scalar_one_or_none()
-            db.add(TaskLog(task_id=None, timestamp=now, line=line,
-                           worker_id=worker_id_for_log, agent_id=agent_id))
-            await db.commit()
-        finally:
-            await db.close()
-
 
 async def _set_agent_state(guild_id: str, agent_id: str, state: str):
     """Broadcast and persist an agent state change."""
@@ -1932,7 +862,7 @@ async def _stream_agent(guild_id: str, agent_id: str, req: RunAgentRequest):
     try:
         cmd, needs_stdin = _build_command(req)
     except ValueError as exc:
-        await _emit_terminal_line(guild_id, agent_id, f"✗ {exc}")
+        await emit_terminal_line(guild_id, agent_id, f"✗ {exc}")
         return
 
     stdin_pipe = asyncio.subprocess.PIPE if needs_stdin else asyncio.subprocess.DEVNULL
@@ -1944,11 +874,11 @@ async def _stream_agent(guild_id: str, agent_id: str, req: RunAgentRequest):
             stderr=asyncio.subprocess.PIPE,
         )
     except FileNotFoundError:
-        await _emit_terminal_line(guild_id, agent_id, f"✗ command not found: {cmd[0]}")
+        await emit_terminal_line(guild_id, agent_id, f"✗ command not found: {cmd[0]}")
         await _set_agent_state(guild_id, agent_id, "error")
         return
     except Exception as exc:
-        await _emit_terminal_line(guild_id, agent_id, f"✗ failed to start process: {exc}")
+        await emit_terminal_line(guild_id, agent_id, f"✗ failed to start process: {exc}")
         await _set_agent_state(guild_id, agent_id, "error")
         return
 
@@ -1968,7 +898,7 @@ async def _stream_agent(guild_id: str, agent_id: str, req: RunAgentRequest):
         async for raw in proc.stderr:  # type: ignore[union-attr]
             line = raw.decode(errors="replace").strip()
             if line:
-                await _emit_terminal_line(guild_id, agent_id, f"[stderr] {line}")
+                await emit_terminal_line(guild_id, agent_id, f"[stderr] {line}")
 
     stderr_task = asyncio.create_task(_drain_stderr())
 
@@ -1981,7 +911,7 @@ async def _stream_agent(guild_id: str, agent_id: str, req: RunAgentRequest):
             try:
                 event = json.loads(line_str)
             except json.JSONDecodeError:
-                await _emit_terminal_line(guild_id, agent_id, line_str)
+                await emit_terminal_line(guild_id, agent_id, line_str)
                 continue
 
             text_out = _parse_event(tool, event, pi_last_text)
@@ -1997,7 +927,7 @@ async def _stream_agent(guild_id: str, agent_id: str, req: RunAgentRequest):
                 pi_last_text = ""
 
             if text_out:
-                await _emit_terminal_line(guild_id, agent_id, text_out)
+                await emit_terminal_line(guild_id, agent_id, text_out)
 
     finally:
         if needs_stdin and proc.stdin and not proc.stdin.is_closing():
@@ -2333,7 +1263,7 @@ async def message_worker(guild_id: str, worker_id: str, data: WorkerMessage):
     if not text_msg:
         raise HTTPException(status_code=400, detail="Empty message")
 
-    await _emit_terminal_line(guild_id, worker_id, f"[foreman → worker] {text_msg}")
+    await emit_terminal_line(guild_id, worker_id, f"[foreman → worker] {text_msg}")
     await broadcast(guild_id, {
         "type": "worker-message",
         "workerId": worker_id,
@@ -2591,7 +1521,7 @@ async def get_foreman_context(guild_id: str):
     finally:
         await db.close()
     history = foreman_conversations.get(guild_id, [])
-    return {"messages": _serialize_history_for_debug(history), "count": len(history)}
+    return {"messages": serialize_history_for_debug(history), "count": len(history)}
 
 
 @app.post("/guilds/{guild_id}/foreman/clear-context")


### PR DESCRIPTION
## Summary

- Moves all foreman-related code out of the 2611-line `main.py` into a structured `backend/foreman/` package
- Extracts WebSocket broadcast utilities into `backend/events.py` to break the circular-import dependency
- `main.py` shrinks from 2611 → 1540 lines (−41%)

### New files

| File | Contents |
|------|----------|
| `backend/foreman/prompt.py` | `FOREMAN_SYSTEM` constant + `build_system_prompt()` |
| `backend/foreman/tools.py` | `FOREMAN_TOOLS` list, GitHub API helpers (`_gh_api`, `_gh_api_post`, `_guild_github_token`), `exec_tools()` |
| `backend/foreman/runner.py` | `run_foreman_ai()`, `_repair_tool_pairs()`, `serialize_history_for_debug()` |
| `backend/foreman/state.py` | Shared `foreman_conversations` dict (isolated to avoid circular imports between tools ↔ runner) |
| `backend/foreman/__init__.py` | Public re-exports: `run_foreman_ai`, `foreman_conversations`, `serialize_history_for_debug` |
| `backend/events.py` | `broadcast()`, `emit_terminal_line()`, `connections`, `agent_owners` |

### What stays in `main.py`

- FastAPI app, routes, WebSocket handler
- OAuth helpers (`_gh_exchange_code`, `_gh_get_user`) — OAuth-only, not foreman
- Agent subprocess management (`_stream_agent`, `_parse_event`)
- Foreman context endpoints (`/foreman/context`, `/foreman/clear-context`) — thin wrappers over imports

## Test plan

- [x] All 21 existing tests pass (`pytest tests/ -x -q`)
- [x] All foreman submodule imports verified (`from foreman import ...` in fresh Python session)
- [x] `main.py` imports cleanly with no circular dependency errors

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)