### PR TITLE
fix(worker): auto-commit dirty worktree before git push

### DIFF
--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -19,8 +19,18 @@ async def push_branch(
     branch: str,
     worktree_path: str,
     emit: EmitFn,
+    task_id: Optional[str] = None,
 ) -> bool:
     """Push *branch* to origin. Returns True on success."""
+    _, status_out, _ = await git_ops.run_git(["status", "--porcelain"], cwd=worktree_path)
+    if status_out.strip():
+        await emit("[worker] Auto-committing uncommitted changes before push...")
+        await git_ops.run_git(["add", "-A"], cwd=worktree_path)
+        msg = f"chore: auto-commit uncommitted changes before push [task {task_id}]" if task_id else "chore: auto-commit uncommitted changes before push"
+        rc_commit, _, commit_err = await git_ops.run_git(["commit", "-m", msg], cwd=worktree_path)
+        if rc_commit != 0:
+            await emit(f"[worker] ✗ Auto-commit failed: {commit_err.strip()[:120]}")
+
     await emit(f"[worker] Pushing {branch}...")
     rc, _, err = await git_ops.run_git(["push", "-u", "origin", branch], cwd=worktree_path)
     if rc != 0:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -624,7 +624,7 @@ class Worker:
             # Push the branch regardless of outcome so partial work is visible
             # and a follow-up run can build on it.
             push_ok = await github_pr.push_branch(
-                branch=branch, worktree_path=primary_wt, emit=emit,
+                branch=branch, worktree_path=primary_wt, emit=emit, task_id=task_id,
             )
             pr_url: Optional[str] = None
 
@@ -747,7 +747,7 @@ class Worker:
 
                     if fu_ok:
                         await github_pr.push_branch(
-                            branch=branch, worktree_path=primary_wt, emit=emit,
+                            branch=branch, worktree_path=primary_wt, emit=emit, task_id=task_id,
                         )
                         # Originally-failed tasks never opened a PR; do it now
                         # that we have something worth reviewing.


### PR DESCRIPTION
## Summary

- Before every `git push`, run `git status --porcelain` to detect uncommitted working tree changes
- If dirty, automatically run `git add -A` and commit with `chore: auto-commit uncommitted changes before push [task <id>]`
- Clean trees are unaffected — no extra commits
- Covers both the initial push (after main task run) and all follow-up pushes, so all exit paths are handled

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)