### PR TITLE
fix(worker): auto-commit uncommitted changes before git push

### DIFF
--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -21,6 +21,20 @@ async def push_branch(
     emit: EmitFn,
 ) -> bool:
     """Push *branch* to origin. Returns True on success."""
+    # Stage and commit any uncommitted work so it isn't silently lost on push
+    # (can happen on max-turns, plan-phase completion, or normal task end).
+    rc_status, status_out, _ = await git_ops.run_git(["status", "--porcelain"], cwd=worktree_path)
+    if rc_status == 0 and status_out.strip():
+        await emit("[worker] Uncommitted changes detected — auto-committing before push")
+        await git_ops.run_git(["add", "-A"], cwd=worktree_path)
+        rc_commit, _, commit_err = await git_ops.run_git(
+            ["commit", "-m", "chore: save uncommitted work before push [auto-commit]"],
+            cwd=worktree_path,
+        )
+        if rc_commit != 0:
+            await emit(f"[worker] ✗ Auto-commit failed: {commit_err.strip()[:120]}")
+            return False
+
     await emit(f"[worker] Pushing {branch}...")
     rc, _, err = await git_ops.run_git(["push", "-u", "origin", branch], cwd=worktree_path)
     if rc != 0:


### PR DESCRIPTION
## Summary

- Before every `git push`, check `git status --porcelain` to detect a dirty working tree
- If dirty: `git add -A` then commit with `chore: save uncommitted work before push [auto-commit]`
- Auto-commit failure (e.g. detached HEAD, merge conflict) causes the push to abort with an error message rather than silently dropping changes
- Clean trees skip the auto-commit entirely — no behavior change for the happy path

Closes #77

## Test plan

- [ ] Task that ends at max-turns with unsaved files: verify they appear in the pushed branch
- [ ] Normal task completion with clean tree: verify no spurious auto-commit is created
- [ ] Confirm terminal output shows `[worker] Uncommitted changes detected — auto-committing before push` when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)