### PR TITLE
feat: move repo checkboxes to Add Worker form and add primary repo per guild

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_primary_repo_to_guilds.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_primary_repo_to_guilds.py
@@ -1,0 +1,26 @@
+"""add_primary_repo_to_guilds
+
+Revision ID: a1b2c3d4e5f6
+Revises: b1e2f3a4c5d6
+Create Date: 2026-04-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = 'e3f4a5b6c7d8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('guilds', sa.Column('primary_repo', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('guilds') as batch_op:
+        batch_op.drop_column('primary_repo')

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -47,11 +47,23 @@ Be concise — one short paragraph maximum unless detail is requested.\
 """
 
 
-def build_system_prompt(workers_block: str, tasks_block: str, extra_context: str = "") -> str:
+def build_system_prompt(
+    workers_block: str,
+    tasks_block: str,
+    extra_context: str = "",
+    primary_repo: str | None = None,
+) -> str:
     """Assemble the full system prompt from live worker/task context."""
-    return (
-        f"{FOREMAN_SYSTEM}\n\n"
-        f"## Current workers\n```json\n{workers_block}\n```\n\n"
-        f"## Recent tasks\n```json\n{tasks_block}\n```"
-        + (f"\n\n## Context\n{extra_context}" if extra_context else "")
-    )
+    parts = [
+        f"{FOREMAN_SYSTEM}\n\n",
+        f"## Current workers\n```json\n{workers_block}\n```\n\n",
+        f"## Recent tasks\n```json\n{tasks_block}\n```",
+    ]
+    if primary_repo:
+        parts.append(
+            f"\n\nThe primary repository for this guild is `{primary_repo}`."
+            " Check it first when searching for issues."
+        )
+    if extra_context:
+        parts.append(f"\n\n## Context\n{extra_context}")
+    return "".join(parts)

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -176,6 +176,10 @@ async def run_foreman_ai(
             {**dict(r._mapping), "description": dict(r._mapping).get("description") or ""}
             for r in task_result.fetchall()
         ]
+        guild_result = await db.execute(
+            select(Guild.primary_repo).where(Guild.id == guild_id)
+        )
+        primary_repo: str | None = guild_result.scalar_one_or_none()
     finally:
         await db.close()
 
@@ -186,7 +190,7 @@ async def run_foreman_ai(
         indent=2,
     )
     tasks_block = json.dumps(task_rows[:6], indent=2)
-    system = build_system_prompt(workers_block, tasks_block, extra_context)
+    system = build_system_prompt(workers_block, tasks_block, extra_context, primary_repo=primary_repo)
 
     # Persist and load the new human turn
     await _save_turn(guild_id, user_id, "user", human_message)

--- a/backend/main.py
+++ b/backend/main.py
@@ -130,7 +130,8 @@ class GuildCreate(BaseModel):
 
 
 class GuildUpdate(BaseModel):
-    name: str
+    name: Optional[str] = None
+    primary_repo: Optional[str] = None
 
 
 class RunAgentRequest(BaseModel):
@@ -497,12 +498,15 @@ async def update_guild(
         guild = result.scalar_one_or_none()
         if not guild:
             raise HTTPException(status_code=404, detail="Guild not found")
-        guild.name = data.name
+        if data.name is not None:
+            guild.name = data.name
+        if "primary_repo" in data.model_fields_set:
+            guild.primary_repo = data.primary_repo
         await db.commit()
     finally:
         await db.close()
-    await broadcast(guild_id, {"type": "guild-updated", "id": guild_id, "name": data.name})
-    return {"id": guild_id, "name": data.name}
+    await broadcast(guild_id, {"type": "guild-updated", "id": guild_id, "name": guild.name, "primary_repo": guild.primary_repo})
+    return {"id": guild_id, "name": guild.name, "primary_repo": guild.primary_repo}
 
 
 @app.get("/guilds/{guild_id}")

--- a/backend/models.py
+++ b/backend/models.py
@@ -13,6 +13,7 @@ class Guild(Base):
     created_at = Column(Text, nullable=False)
     name = Column(Text)
     github_user_id = Column(Text)
+    primary_repo = Column(Text, nullable=True)
 
 
 class Agent(Base):

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -109,3 +109,67 @@ def test_update_guild_not_found(client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 404
+
+
+def test_update_guild_primary_repo(client):
+    test_client, db_path = client
+    token = make_auth_token(db_path)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    create_resp = test_client.post("/guilds", json={"name": "Repo Guild"}, headers=headers)
+    guild_id = create_resp.json()["id"]
+
+    patch_resp = test_client.patch(
+        f"/guilds/{guild_id}",
+        json={"primary_repo": "owner/myrepo"},
+        headers=headers,
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["primary_repo"] == "owner/myrepo"
+
+    get_resp = test_client.get(f"/guilds/{guild_id}")
+    assert get_resp.json()["primary_repo"] == "owner/myrepo"
+
+
+def test_update_guild_clear_primary_repo(client):
+    test_client, db_path = client
+    token = make_auth_token(db_path)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    create_resp = test_client.post("/guilds", json={"name": "Clear Repo Guild"}, headers=headers)
+    guild_id = create_resp.json()["id"]
+
+    test_client.patch(f"/guilds/{guild_id}", json={"primary_repo": "owner/repo"}, headers=headers)
+
+    # Clear by sending null
+    patch_resp = test_client.patch(
+        f"/guilds/{guild_id}",
+        json={"primary_repo": None},
+        headers=headers,
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["primary_repo"] is None
+
+
+def test_primary_repo_in_foreman_prompt():
+    import sys, os
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    from foreman.prompt import build_system_prompt
+
+    # Primary repo is included when set
+    prompt = build_system_prompt("[]", "[]", primary_repo="jmelloy/pioneer-square")
+    assert "jmelloy/pioneer-square" in prompt
+    assert "primary repository" in prompt.lower()
+
+    # Primary repo line is absent when not set
+    prompt_no_repo = build_system_prompt("[]", "[]")
+    assert "primary repository" not in prompt_no_repo.lower()
+
+    # Primary repo line is absent when explicitly None
+    prompt_none = build_system_prompt("[]", "[]", primary_repo=None)
+    assert "primary repository" not in prompt_none.lower()
+
+    # extra_context still works alongside primary_repo
+    prompt_both = build_system_prompt("[]", "[]", extra_context="some context", primary_repo="o/r")
+    assert "o/r" in prompt_both
+    assert "some context" in prompt_both

--- a/frontend/src/components/GitHubConfigModal.vue
+++ b/frontend/src/components/GitHubConfigModal.vue
@@ -14,91 +14,20 @@
             <div class="user-label">{{ authStore.user?.name || 'GitHub User' }}</div>
           </div>
         </div>
-
-        <div class="divider"></div>
-
-        <div class="repos-section">
-          <div class="section-label">WATCHED REPOSITORIES</div>
-          <div class="repo-hint">Select repos for agents to work on and issue tracking.</div>
-
-          <div v-if="loadingRepos" class="loading-row">Loading repos...</div>
-
-          <div v-else-if="ghStore.repos.length === 0" class="loading-row">
-            No repositories found.
-          </div>
-
-          <div v-else class="repo-list">
-            <label
-              v-for="repo in ghStore.repos"
-              :key="repo.full_name"
-              class="repo-row"
-              :class="{ selected: isSelected(repo.full_name) }"
-            >
-              <input
-                type="checkbox"
-                :checked="isSelected(repo.full_name)"
-                @change="toggleRepo(repo.full_name)"
-                class="repo-check"
-              />
-              <span class="repo-name">{{ repo.full_name }}</span>
-              <span class="repo-lang" v-if="repo.language">{{ repo.language }}</span>
-            </label>
-          </div>
-        </div>
       </div>
 
       <div class="modal-footer">
-        <div class="selected-count">
-          {{ selectedCount }} repo{{ selectedCount !== 1 ? 's' : '' }} selected
-        </div>
-        <button class="pixel-btn" @click="save">SAVE</button>
+        <button class="pixel-btn" @click="$emit('close')">CLOSE</button>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
-import { useGitHubStore } from '../stores/github'
 import { useAuthStore } from '../stores/auth'
 
-const emit = defineEmits(['close'])
-const ghStore = useGitHubStore()
+defineEmits(['close'])
 const authStore = useAuthStore()
-
-const loadingRepos = ref(false)
-const localSelected = ref([...ghStore.selectedRepos])
-
-const selectedCount = computed(() => localSelected.value.length)
-
-onMounted(async () => {
-  if (ghStore.repos.length === 0 && ghStore.token) {
-    loadingRepos.value = true
-    await ghStore.fetchRepos()
-    loadingRepos.value = false
-  }
-})
-
-function isSelected(fullName: string) {
-  return localSelected.value.includes(fullName)
-}
-
-function toggleRepo(fullName: string) {
-  const idx = localSelected.value.indexOf(fullName)
-  if (idx >= 0) {
-    localSelected.value.splice(idx, 1)
-  } else {
-    localSelected.value.push(fullName)
-  }
-}
-
-async function save() {
-  ghStore.setSelectedRepos(localSelected.value)
-  if (localSelected.value.length > 0) {
-    await ghStore.fetchIssues()
-  }
-  emit('close')
-}
 </script>
 
 <style scoped>
@@ -195,85 +124,6 @@ async function save() {
   color: var(--color-text-dim);
 }
 
-.divider {
-  height: 1px;
-  background: var(--color-brass-dark);
-  opacity: 0.5;
-}
-
-.section-label {
-  font-family: var(--font-pixel);
-  font-size: 6px;
-  color: var(--color-brass);
-  letter-spacing: 2px;
-  margin-bottom: 6px;
-}
-
-.repos-section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.repo-hint {
-  font-size: 11px;
-  color: var(--color-text-dim);
-}
-
-.loading-row {
-  font-size: 11px;
-  color: var(--color-text-dim);
-  padding: 8px 0;
-}
-
-.repo-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  max-height: 280px;
-  overflow-y: auto;
-}
-
-.repo-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 7px 10px;
-  cursor: pointer;
-  transition: background 0.1s;
-  border: 1px solid transparent;
-}
-
-.repo-row:hover {
-  background: var(--color-bg-tertiary);
-}
-
-.repo-row.selected {
-  background: rgba(232, 170, 0, 0.08);
-  border-color: var(--color-brass-dark);
-}
-
-.repo-check {
-  accent-color: var(--color-brass);
-  width: 14px;
-  height: 14px;
-  cursor: pointer;
-}
-
-.repo-name {
-  flex: 1;
-  font-size: 12px;
-  color: var(--color-text);
-}
-
-.repo-lang {
-  font-size: 10px;
-  color: var(--color-text-dim);
-  background: var(--color-bg-tertiary);
-  padding: 2px 6px;
-  border: 1px solid var(--color-brass-dark);
-}
-
 .modal-footer {
   display: flex;
   align-items: center;
@@ -283,11 +133,5 @@ async function save() {
   border-top: 2px solid var(--color-brass-dark);
   background: var(--color-bg-tertiary);
   flex-shrink: 0;
-}
-
-.selected-count {
-  flex: 1;
-  font-size: 11px;
-  color: var(--color-text-dim);
 }
 </style>

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -61,17 +61,31 @@
 
       <!-- Spawn form -->
       <div v-if="showSpawnForm" class="spawn-form">
-        <label class="spawn-label">Repos <span class="spawn-hint">(one per line)</span></label>
-        <textarea
-          v-model="spawnRepos"
-          class="spawn-textarea"
-          placeholder="owner/repo"
-          rows="3"
-        />
+        <label class="spawn-label">Repos</label>
+        <div v-if="loadingRepos" class="spawn-hint-text">Loading repos…</div>
+        <div v-else-if="ghStore.repos.length === 0" class="spawn-hint-text">
+          No repos found — configure GitHub first.
+        </div>
+        <div v-else class="spawn-repo-list">
+          <label
+            v-for="repo in ghStore.repos"
+            :key="repo.full_name"
+            class="spawn-repo-row"
+            :class="{ selected: spawnSelectedRepos.includes(repo.full_name) }"
+          >
+            <input
+              type="checkbox"
+              :checked="spawnSelectedRepos.includes(repo.full_name)"
+              @change="toggleSpawnRepo(repo.full_name)"
+              class="spawn-repo-check"
+            />
+            <span class="spawn-repo-name">{{ repo.full_name }}</span>
+          </label>
+        </div>
         <label class="spawn-label">Name <span class="spawn-hint">(optional)</span></label>
         <input v-model="spawnName" class="spawn-input" type="text" placeholder="auto-generated" />
         <div class="spawn-actions">
-          <button class="pixel-btn spawn-launch-btn" :disabled="spawning || !spawnRepos.trim()" @click="launchWorker">
+          <button class="pixel-btn spawn-launch-btn" :disabled="spawning || spawnSelectedRepos.length === 0" @click="launchWorker">
             {{ spawning ? 'Launching…' : 'Launch' }}
           </button>
         </div>
@@ -124,6 +138,20 @@
         </div>
       </div>
 
+      <div v-if="currentGuild" class="primary-repo-row">
+        <span class="primary-repo-label">PRIMARY REPO</span>
+        <select
+          v-model="primaryRepoValue"
+          class="primary-repo-select"
+          @change="savePrimaryRepo"
+        >
+          <option value="">— none —</option>
+          <option v-for="repo in ghStore.repos" :key="repo.full_name" :value="repo.full_name">
+            {{ repo.full_name }}
+          </option>
+        </select>
+      </div>
+
       <div class="connection-status" :class="{ connected: isConnected }">
         <span class="status-dot"></span>
         {{ isConnected ? 'Connected' : 'Disconnected' }}
@@ -135,7 +163,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, inject } from 'vue'
+import { ref, computed, watch, nextTick, inject } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGuildStore } from '../stores/guild'
 import { useGitHubStore } from '../stores/github'
@@ -161,30 +189,44 @@ const currentGuild = computed(() => guildStore.currentGuild)
 const isConnected = computed(() => guildStore.isConnected)
 
 const showSpawnForm = ref(false)
-const spawnRepos = ref('')
+const spawnSelectedRepos = ref<string[]>([])
 const spawnName = ref('')
 const spawning = ref(false)
 const spawnError = ref('')
+const loadingRepos = ref(false)
 
-function toggleSpawnForm() {
+async function toggleSpawnForm() {
   showSpawnForm.value = !showSpawnForm.value
   if (showSpawnForm.value) {
-    spawnRepos.value = ghStore.selectedRepos.join('\n')
+    spawnSelectedRepos.value = [...ghStore.selectedRepos]
     spawnName.value = ''
     spawnError.value = ''
+    if (ghStore.repos.length === 0 && ghStore.token) {
+      loadingRepos.value = true
+      await ghStore.fetchRepos()
+      loadingRepos.value = false
+    }
+  }
+}
+
+function toggleSpawnRepo(fullName: string) {
+  const idx = spawnSelectedRepos.value.indexOf(fullName)
+  if (idx >= 0) {
+    spawnSelectedRepos.value.splice(idx, 1)
+  } else {
+    spawnSelectedRepos.value.push(fullName)
   }
 }
 
 async function launchWorker() {
-  if (!currentGuild.value || !spawnRepos.value.trim()) return
+  if (!currentGuild.value || spawnSelectedRepos.value.length === 0) return
   spawning.value = true
   spawnError.value = ''
-  const repos = spawnRepos.value.split('\n').map(r => r.trim()).filter(Boolean)
   try {
     const res = await fetch(`${API_BASE}/guilds/${currentGuild.value.id}/spawn-worker`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...authStore.authHeaders() },
-      body: JSON.stringify({ repos, name: spawnName.value.trim() || undefined }),
+      body: JSON.stringify({ repos: spawnSelectedRepos.value, name: spawnName.value.trim() || undefined }),
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({ detail: res.statusText }))
@@ -195,6 +237,23 @@ async function launchWorker() {
     spawnError.value = e.message
   } finally {
     spawning.value = false
+  }
+}
+
+const primaryRepoValue = ref('')
+
+watch(currentGuild, (guild) => {
+  primaryRepoValue.value = guild?.primary_repo ?? ''
+}, { immediate: true })
+
+async function savePrimaryRepo() {
+  if (!currentGuild.value) return
+  try {
+    await guildStore.updateGuild(currentGuild.value.id, {
+      primary_repo: primaryRepoValue.value || null,
+    })
+  } catch (e) {
+    console.error('Failed to save primary repo', e)
   }
 }
 
@@ -629,6 +688,90 @@ function formatTime(isoStr?: string) {
   font-size: 10px;
   color: var(--color-red);
   word-break: break-word;
+}
+
+.spawn-hint-text {
+  font-size: 10px;
+  color: var(--color-text-dim);
+  padding: 4px 0;
+  font-style: italic;
+}
+
+.spawn-repo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 160px;
+  overflow-y: auto;
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+  background: var(--color-bg);
+}
+
+.spawn-repo-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 7px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.1s;
+}
+
+.spawn-repo-row:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.spawn-repo-row.selected {
+  background: rgba(232, 170, 0, 0.08);
+  border-color: var(--color-brass-dark);
+}
+
+.spawn-repo-check {
+  accent-color: var(--color-brass);
+  width: 12px;
+  height: 12px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.spawn-repo-name {
+  font-size: 10px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.primary-repo-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.primary-repo-label {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass-dark);
+  letter-spacing: 1px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.primary-repo-select {
+  flex: 1;
+  background: var(--color-bg);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-size: 10px;
+  padding: 3px 5px;
+  outline: none;
+  border-radius: 2px;
+  min-width: 0;
+}
+
+.primary-repo-select:focus {
+  border-color: var(--color-brass);
 }
 
 /* Worker top-level row */

--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -44,17 +44,21 @@ export const useGuildStore = defineStore('guild', () => {
   }
 
   async function renameGuild(guildId: string, name: string) {
+    return updateGuild(guildId, { name })
+  }
+
+  async function updateGuild(guildId: string, updates: { name?: string; primary_repo?: string | null }) {
     const res = await fetch(`${API_BASE}/guilds/${guildId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', ..._authHeaders() },
-      body: JSON.stringify({ name })
+      body: JSON.stringify(updates)
     })
-    if (!res.ok) throw new Error('Failed to rename guild')
+    if (!res.ok) throw new Error('Failed to update guild')
     if (currentGuild.value && currentGuild.value.id === guildId) {
-      currentGuild.value = { ...currentGuild.value, name }
+      currentGuild.value = { ...currentGuild.value, ...updates }
     }
     const idx = guilds.value.findIndex(g => g.id === guildId)
-    if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], name }
+    if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], ...updates }
     return await res.json()
   }
 
@@ -213,6 +217,7 @@ export const useGuildStore = defineStore('guild', () => {
     loadGuilds,
     createGuild,
     renameGuild,
+    updateGuild,
     joinGuild,
     connectWebSocket,
     disconnectWebSocket,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -67,6 +67,7 @@ export interface Task {
 export interface Guild {
   id: string
   name?: string
+  primary_repo?: string | null
   agents?: Array<{
     id: string
     name: string


### PR DESCRIPTION
Closes #86

## Summary

- **Move repo checkboxes to Add Worker tab**: The spawn-worker form now shows a checkbox list of all GitHub repos (`ghStore.repos`) instead of a free-text textarea. Repos are pre-selected from the user's existing selection. The repo multi-select is removed from `GitHubConfigModal` (which is now just a GitHub account info panel).

- **Primary repo per guild** — full stack implementation:
  - **DB migration** (`a1b2c3d4e5f6`): adds `primary_repo TEXT NULL` to the `guilds` table, chained after `e3f4a5b6c7d8`
  - **Backend**: `GuildUpdate` accepts optional `primary_repo`; `PATCH /guilds/{id}` persists it; `GET /guilds/{id}` returns it via `_row(guild)`
  - **Foreman prompt**: `build_system_prompt` takes an optional `primary_repo` param; `runner.py` fetches it from the DB and injects the line *"The primary repository for this guild is `{repo}`. Check it first when searching for issues."* — omitted when null
  - **Frontend**: `Guild` type gains `primary_repo?`; guild store gains `updateGuild()`; sidebar footer shows a **Primary Repo** dropdown populated from `ghStore.repos`, saving on change via `PATCH`

## Test plan

- [ ] All 24 existing backend tests pass (`pytest tests/ -q`)
- [ ] 3 new guild API tests: `test_update_guild_primary_repo`, `test_update_guild_clear_primary_repo`, `test_primary_repo_in_foreman_prompt`
- [ ] Frontend builds cleanly (`npm run build`)
- [ ] Spawn form shows repo checkboxes (not textarea) when GitHub is configured
- [ ] Primary Repo dropdown in sidebar footer reads/saves correctly
- [ ] GitHub config modal no longer shows repo checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)