### PR TITLE
feat(worker): interactive Claude auth UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -826,6 +826,19 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 )
                 asyncio.create_task(run_foreman_ai(guild_id, escalation))
 
+            elif msg_type == "claude-auth-required":
+                # Worker needs Claude authentication; broadcast URL to UI and loop foreman in.
+                await broadcast(guild_id, data, exclude=websocket)
+                worker_id = data.get("workerId", "a worker")
+                auth_url = data.get("url", "")
+                asyncio.create_task(run_foreman_ai(
+                    guild_id,
+                    f"Worker {worker_id} needs Claude authentication. "
+                    f"Auth URL: {auth_url}. "
+                    "A human must visit this URL, complete authentication, then paste the "
+                    "resulting code into the FOREMAN COMMS panel. The worker is waiting.",
+                ))
+
             elif msg_type in ("offer", "answer", "ice-candidate"):
                 # WebRTC signaling - forward to all
                 await broadcast(guild_id, data, exclude=websocket)

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -59,6 +59,29 @@
             <span class="msg-time">{{ formatTime(msg.createdAt || msg.created_at) }}</span>
           </div>
         </div>
+        <!-- Claude auth code panel — shown when a worker needs auth -->
+        <div v-if="claudeAuthPending" class="auth-panel">
+          <div class="auth-header">⚿ CLAUDE AUTH REQUIRED — {{ claudeAuthPending.workerId }}</div>
+          <div class="auth-url-row">
+            <span class="auth-label">URL:</span>
+            <a :href="claudeAuthPending.url" target="_blank" rel="noopener" class="auth-link">
+              {{ claudeAuthPending.url }}
+            </a>
+          </div>
+          <div class="auth-input-row">
+            <input
+              v-model="authCodeInput"
+              class="auth-input"
+              placeholder="Paste auth code here..."
+              @keydown.enter="submitAuthCode"
+              autofocus
+            />
+            <button class="pixel-btn auth-btn" @click="submitAuthCode" :disabled="!authCodeInput.trim()">
+              ↵ Submit
+            </button>
+          </div>
+        </div>
+
         <div class="chat-input-row">
           <input
             v-model="inputText"
@@ -185,6 +208,8 @@ const authStore = useAuthStore()
 
 const minimized = ref(false)
 const inputText = ref('')
+const authCodeInput = ref('')
+const claudeAuthPending = ref<{ workerId: string; url: string } | null>(null)
 const messagesEl = ref<HTMLElement | null>(null)
 const issuesEl = ref<HTMLElement | null>(null)
 const debugEl = ref<HTMLElement | null>(null)
@@ -256,6 +281,19 @@ async function sendMessage() {
   }
 }
 
+function submitAuthCode() {
+  const pending = claudeAuthPending.value
+  const code = authCodeInput.value.trim()
+  if (!pending || !code) return
+  guildStore.sendMessage({
+    type: 'worker-auth-response',
+    workerId: pending.workerId,
+    code,
+  })
+  claudeAuthPending.value = null
+  authCodeInput.value = ''
+}
+
 // Listen for task lifecycle + escalation broadcasts
 function handleTaskEvent(data: WSMessage) {
   if (data.type === 'task-complete') {
@@ -271,6 +309,13 @@ function handleTaskEvent(data: WSMessage) {
     guildStore.messages.push({
       type: 'chat', from: 'system', to: 'user',
       content: `⚠ ${data.workerId} needs attention on: "${data.description}"`,
+      createdAt: new Date().toISOString(),
+    })
+  } else if (data.type === 'claude-auth-required') {
+    claudeAuthPending.value = { workerId: data.workerId, url: data.url }
+    guildStore.messages.push({
+      type: 'chat', from: 'system', to: 'user',
+      content: `⚿ ${data.workerId} needs Claude auth — visit the URL and paste the code below`,
       createdAt: new Date().toISOString(),
     })
   } else if (data.type === 'task-assigned') {
@@ -866,6 +911,91 @@ watch(messages, async () => {
   font-size: 9px;
   max-height: 80px;
   overflow-y: auto;
+}
+
+/* ── Claude auth panel ── */
+.auth-panel {
+  border-top: 2px solid var(--color-red, #c0392b);
+  background: rgba(192, 57, 43, 0.08);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.auth-header {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 1px;
+  color: var(--color-red, #e74c3c);
+  text-shadow: 0 0 6px rgba(231, 76, 60, 0.5);
+}
+
+.auth-url-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 10px;
+}
+
+.auth-label {
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.auth-link {
+  color: var(--color-teal);
+  text-decoration: none;
+  word-break: break-all;
+  line-height: 1.3;
+}
+
+.auth-link:hover {
+  text-decoration: underline;
+}
+
+.auth-input-row {
+  display: flex;
+  gap: 6px;
+}
+
+.auth-input {
+  flex: 1;
+  background: var(--color-bg);
+  border: 2px solid var(--color-red, #c0392b);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 5px 8px;
+  outline: none;
+}
+
+.auth-input:focus {
+  border-color: var(--color-red, #e74c3c);
+  box-shadow: 0 0 8px rgba(231, 76, 60, 0.35);
+}
+
+.auth-input::placeholder {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+
+.auth-btn {
+  padding: 5px 10px;
+  font-size: 10px;
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #e74c3c);
+}
+
+.auth-btn:hover:not(:disabled) {
+  background: rgba(192, 57, 43, 0.2);
+}
+
+.auth-btn:disabled {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 @media (max-width: 1024px) {

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -57,6 +57,8 @@ class Worker:
         self._cancelled_tasks: set[str] = set()
         # Per-task queues for mid-run redirect instructions (SIGTERM + --resume)
         self._redirect_queues: dict[str, asyncio.Queue] = {}
+        # Queue for auth codes received from the UI during claude auth login
+        self._auth_code_queue: asyncio.Queue[str] | None = None
         # One slot per concurrent agent; each gets a stable ID for the guild.
         self.slots: list[_AgentSlot] = [
             _AgentSlot(_gen_id("a-")) for _ in range(cfg.max_agents)
@@ -153,23 +155,51 @@ class Worker:
         await self._run_claude_login()
 
     async def _run_claude_login(self) -> None:
-        """Run `claude auth login`, stream output to the frontend, then persist credentials."""
+        """Run `claude auth login`, surface the URL to the UI, wait for the code, then persist credentials."""
         import base64
         import io
         import tarfile
         from pathlib import Path
 
+        self._auth_code_queue = asyncio.Queue()
         proc = await asyncio.create_subprocess_exec(
             self.cfg.claude_path, "auth", "login",
-            stdin=asyncio.subprocess.DEVNULL,
+            stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
         assert proc.stdout is not None
-        async for raw_line in proc.stdout:
-            line = raw_line.decode(errors="replace").rstrip()
-            logger.info("[claude login] %s", line)
-            await self._emit(f"[auth] {line}")
+        assert proc.stdin is not None
+
+        code_sent = False
+        try:
+            async for raw_line in proc.stdout:
+                line = raw_line.decode(errors="replace").rstrip()
+                logger.info("[claude login] %s", line)
+                await self._emit(f"[auth] {line}")
+
+                if not code_sent and "https://" in line:
+                    url = next((w for w in line.split() if w.startswith("https://")), line.strip())
+                    await self._send({
+                        "type": "claude-auth-required",
+                        "workerId": self.cfg.worker_id,
+                        "url": url,
+                    })
+                    await self._emit("[auth] Waiting for auth code — enter it in the FOREMAN COMMS panel...")
+                    try:
+                        code = await asyncio.wait_for(self._auth_code_queue.get(), timeout=300.0)
+                        proc.stdin.write((code.strip() + "\n").encode())
+                        await proc.stdin.drain()
+                        proc.stdin.close()
+                        code_sent = True
+                    except asyncio.TimeoutError:
+                        await self._emit("[auth] Timed out waiting for auth code — restart the worker to retry")
+                        proc.kill()
+                        await proc.wait()
+                        return
+        finally:
+            self._auth_code_queue = None
+
         await proc.wait()
 
         if not await self._claude_is_authenticated():
@@ -329,6 +359,8 @@ class Worker:
             "Joined guild %s — worker_id=%s agents=%d",
             self.cfg.guild_id, self.cfg.worker_id, len(self.slots),
         )
+        # Start listener before auth check so it can relay auth codes from the UI
+        listener = asyncio.create_task(self._listen())
         await self._check_claude_auth()
         await self._emit("[worker] Online. Watching for tasks.")
         for slot in self.slots:
@@ -341,7 +373,6 @@ class Worker:
             self._known_task_ids.add(task["id"])
             await self.task_queue.put(task)
 
-        listener = asyncio.create_task(self._listen())
         runners  = [asyncio.create_task(self._agent_loop(slot)) for slot in self.slots]
         puller   = asyncio.create_task(self._idle_puller())
         try:
@@ -391,6 +422,16 @@ class Worker:
                             logger.warning("Failed to inject message (stdin closed?)")
                     else:
                         logger.debug("worker-message: no claude running; dropping")
+
+            elif mtype == "worker-auth-response":
+                if msg.get("workerId") != self.cfg.worker_id:
+                    continue
+                code = msg.get("code", "")
+                if self._auth_code_queue is not None:
+                    await self._auth_code_queue.put(code)
+                    logger.info("Auth code received from UI")
+                else:
+                    logger.warning("worker-auth-response received but no auth in progress")
 
             elif mtype == "task-followup":
                 if msg.get("workerId") != self.cfg.worker_id:


### PR DESCRIPTION
## Summary

- Worker now emits `claude-auth-required` over WebSocket (with the auth URL) when `claude auth login` is needed at startup, instead of silently streaming output with no way to respond
- Frontend shows a red auth panel in the FOREMAN COMMS pane with a clickable URL link and a code input field; submitting sends `worker-auth-response` back to the worker
- Worker pipes the received code into the login process stdin, then continues the normal credential-persist flow
- Listener task is now started before the auth check so it can relay UI responses during startup
- Backend broadcasts the `claude-auth-required` event and notifies the foreman AI so it's aware and can guide the user

## Test plan

- [ ] Start a worker without existing Claude credentials — confirm the FOREMAN COMMS panel shows the auth URL and code input
- [ ] Click the URL link, complete auth in browser, paste the code — confirm the worker receives it and authenticates successfully
- [ ] Confirm credentials are stored and the worker goes online normally after auth
- [ ] Confirm workers with existing credentials skip the flow entirely (no UI shown)
- [ ] Confirm the 5-minute timeout emits a helpful message and kills the process cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)