### PR TITLE
fix: route Claude auth codes from Foreman Comms panel to waiting worker

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -169,6 +169,10 @@ class TaskCreate(BaseModel):
 # persists worker/task state and dispatches assignments over WebSocket.
 # ---------------------------------------------------------------------------
 
+# Tracks which worker is waiting for a Claude auth code in each guild.
+# Set when a worker sends claude-auth-required; cleared when the code is delivered.
+pending_claude_auths: Dict[str, str] = {}  # guild_id -> worker_id
+
 
 # ---------------------------------------------------------------------------
 # GitHub OAuth helpers (OAuth flow only — foreman GitHub tools are in foreman/tools.py)
@@ -661,8 +665,18 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 })
                 # Route human messages addressed to foreman through the AI.
                 # Each authenticated user gets their own foreman conversation thread.
+                # Exception: if a worker is waiting for a Claude auth code, treat
+                # the next user message as that code and forward it directly.
                 if from_agent == "user" and to_agent == "foreman" and content:
-                    asyncio.create_task(run_foreman_ai(guild_id, content, user_id=ws_user_id))
+                    pending_worker = pending_claude_auths.pop(guild_id, None)
+                    if pending_worker:
+                        await broadcast(guild_id, {
+                            "type": "worker-auth-response",
+                            "workerId": pending_worker,
+                            "code": content,
+                        })
+                    else:
+                        asyncio.create_task(run_foreman_ai(guild_id, content, user_id=ws_user_id))
 
             elif msg_type == "terminal-output":
                 msg_agent_id = data.get("agentId")
@@ -831,17 +845,25 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 asyncio.create_task(run_foreman_ai(guild_id, escalation))
 
             elif msg_type == "claude-auth-required":
-                # Worker needs Claude authentication; broadcast URL to UI and loop foreman in.
+                # Worker needs Claude authentication; broadcast URL to UI and track pending state.
                 await broadcast(guild_id, data, exclude=websocket)
                 worker_id = data.get("workerId", "a worker")
                 auth_url = data.get("url", "")
+                pending_claude_auths[guild_id] = worker_id
                 asyncio.create_task(run_foreman_ai(
                     guild_id,
                     f"Worker {worker_id} needs Claude authentication. "
                     f"Auth URL: {auth_url}. "
                     "A human must visit this URL, complete authentication, then paste the "
-                    "resulting code into the FOREMAN COMMS panel. The worker is waiting.",
+                    "resulting code into the auth panel that has appeared in the chat UI "
+                    "(or type it into the Foreman Comms input). The worker is waiting.",
                 ))
+
+            elif msg_type == "worker-auth-response":
+                # Auth code submitted via the dedicated auth panel; clear pending state and
+                # forward to all connections so the waiting worker receives it.
+                pending_claude_auths.pop(guild_id, None)
+                await broadcast(guild_id, data)
 
             elif msg_type in ("offer", "answer", "ice-candidate"):
                 # WebRTC signaling - forward to all

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -185,7 +185,7 @@ class Worker:
                         "workerId": self.cfg.worker_id,
                         "url": url,
                     })
-                    await self._emit("[auth] Waiting for auth code — enter it in the FOREMAN COMMS panel...")
+                    await self._emit("[auth] Waiting for auth code — paste it into the auth panel in the UI or type it into the Foreman Comms input...")
                     try:
                         code = await asyncio.wait_for(self._auth_code_queue.get(), timeout=300.0)
                         proc.stdin.write((code.strip() + "\n").encode())


### PR DESCRIPTION
## Summary

Fixes #99.

### Root cause

When a worker needs Claude authentication, it sends `claude-auth-required` and logs:
> `[auth] Waiting for auth code — enter it in the FOREMAN COMMS panel...`

The backend also tells the foreman AI to instruct the user to paste into "the FOREMAN COMMS panel." When the user does exactly that, the chat message goes to the foreman AI as a regular `chat` event. The foreman's closest tool, `message_worker`, sends a `worker-message` — but the worker only accepts auth codes via `worker-auth-response`. Since Claude isn't running during the auth wait, `worker-message` hits the "no claude running; dropping" branch and the code is silently lost. The worker times out.

The frontend *does* have a dedicated auth panel (`claudeAuthPending`) with a "Paste auth code here" input that sends `worker-auth-response` correctly — but users followed the log instructions and used the Foreman Comms panel instead.

### Fix (backend/main.py)

- Added `pending_claude_auths: Dict[str, str]` (guild_id → worker_id) to track which worker is waiting for an auth code.
- `claude-auth-required` handler now sets `pending_claude_auths[guild_id]`.
- `chat` handler: when a user message arrives while auth is pending, the backend intercepts it and broadcasts `worker-auth-response` directly — bypassing the foreman AI. After delivery, the pending state is cleared.
- Added an explicit `worker-auth-response` handler (instead of relying on the generic fallthrough) that also clears pending state.

### Fix (worker/pioneer_worker/worker.py)

- Updated the misleading log message to mention both input methods.

## Test plan

- [ ] Start a worker with no Claude credentials — it should send `claude-auth-required` and show an auth panel in the UI
- [ ] Visit the OAuth URL, complete login, paste the code into the **Foreman Comms** panel — worker should receive the code and continue
- [ ] Repeat, but paste via the **auth panel** input instead — should also work unchanged
- [ ] Confirm that after the code is delivered, normal user chat messages route to the foreman AI again (pending state is cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)