### PR TITLE
fix: route Claude auth codes to waiting worker (closes #99)

### DIFF
--- a/backend/events.py
+++ b/backend/events.py
@@ -22,6 +22,9 @@ connections: Dict[str, List[WebSocket]] = {}
 # Tracks which WebSocket currently owns a given agent_id.
 agent_owners: Dict[str, WebSocket] = {}
 
+# Workers currently waiting for a Claude auth code: guild_id -> {worker_id: url}
+pending_claude_auth: Dict[str, Dict[str, str]] = {}
+
 
 async def broadcast(guild_id: str, message: dict, exclude: Optional[WebSocket] = None):
     """Broadcast a message to all connections in a guild."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     pass
 
-from events import broadcast, connections, agent_owners, emit_terminal_line
+from events import broadcast, connections, agent_owners, emit_terminal_line, pending_claude_auth
 from foreman import clear_foreman_history, get_foreman_history, maybe_post_plan_comment, run_foreman_ai
 
 
@@ -835,13 +835,24 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 await broadcast(guild_id, data, exclude=websocket)
                 worker_id = data.get("workerId", "a worker")
                 auth_url = data.get("url", "")
+                # Track so new frontend connections can restore the auth panel.
+                pending_claude_auth.setdefault(guild_id, {})[worker_id] = auth_url
                 asyncio.create_task(run_foreman_ai(
                     guild_id,
                     f"Worker {worker_id} needs Claude authentication. "
                     f"Auth URL: {auth_url}. "
                     "A human must visit this URL, complete authentication, then paste the "
-                    "resulting code into the FOREMAN COMMS panel. The worker is waiting.",
+                    "resulting code into the FOREMAN COMMS panel. The worker is waiting. "
+                    "If the human sends a message that looks like an auth code, forward it "
+                    f"immediately to the worker using message_worker(worker_id='{worker_id}', message=<code>).",
                 ))
+
+            elif msg_type == "worker-auth-response":
+                # Human is submitting an auth code; clear pending state and
+                # broadcast to all connections so the waiting worker receives it.
+                worker_id = data.get("workerId", "")
+                pending_claude_auth.get(guild_id, {}).pop(worker_id, None)
+                await broadcast(guild_id, data)
 
             elif msg_type in ("offer", "answer", "ice-candidate"):
                 # WebRTC signaling - forward to all
@@ -1262,6 +1273,17 @@ async def spawn_worker_container(guild_id: str, data: SpawnWorkerRequest):
         raise HTTPException(status_code=500, detail=f"Failed to start container: {e}")
 
     return {"container_id": container.id[:12], "image": image}
+
+
+@app.get("/guilds/{guild_id}/pending-auth")
+async def get_pending_auth(guild_id: str):
+    """Return workers currently waiting for a Claude auth code.
+
+    The frontend calls this on mount so the auth panel is restored after a
+    page refresh even if the original claude-auth-required broadcast was missed.
+    """
+    pending = pending_claude_auth.get(guild_id, {})
+    return [{"workerId": wid, "url": url} for wid, url in pending.items()]
 
 
 @app.get("/guilds/{guild_id}/workers")

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -327,7 +327,28 @@ function handleTaskEvent(data: WSMessage) {
   }
 }
 
-onMounted(() => guildStore.addMessageHandler(handleTaskEvent))
+onMounted(async () => {
+  guildStore.addMessageHandler(handleTaskEvent)
+  // Restore the auth panel if a worker was already waiting when we connected
+  // (handles page-refresh and late-join scenarios where the original
+  // claude-auth-required broadcast was missed).
+  const guildId = guildStore.currentGuild?.id
+  if (guildId && !claudeAuthPending.value) {
+    try {
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/pending-auth`, {
+        headers: authStore.authHeaders()
+      })
+      if (res.ok) {
+        const items: Array<{ workerId: string; url: string }> = await res.json()
+        if (items.length > 0) {
+          claudeAuthPending.value = { workerId: items[0].workerId, url: items[0].url }
+        }
+      }
+    } catch (e) {
+      console.warn('Could not fetch pending auth state', e)
+    }
+  }
+})
 onUnmounted(() => guildStore.removeMessageHandler(handleTaskEvent))
 
 async function switchToDebug() {

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -413,15 +413,22 @@ class Worker:
                     continue
                 text = msg.get("message", "")
                 if text:
-                    active = next((s for s in self.slots if s.current_claude), None)
-                    if active:
-                        delivered = await active.current_claude.send_message(text)
-                        if delivered:
-                            await self._emit(f"[worker] Injected: {text[:80]}")
-                        else:
-                            logger.warning("Failed to inject message (stdin closed?)")
+                    # During Claude login the auth queue is open; treat the
+                    # message as the auth code so the foreman can relay it.
+                    if self._auth_code_queue is not None:
+                        await self._auth_code_queue.put(text)
+                        logger.info("Auth code received via worker-message (login flow)")
+                        await self._emit("[worker] Auth code received and forwarded to login flow")
                     else:
-                        logger.debug("worker-message: no claude running; dropping")
+                        active = next((s for s in self.slots if s.current_claude), None)
+                        if active:
+                            delivered = await active.current_claude.send_message(text)
+                            if delivered:
+                                await self._emit(f"[worker] Injected: {text[:80]}")
+                            else:
+                                logger.warning("Failed to inject message (stdin closed?)")
+                        else:
+                            logger.debug("worker-message: no claude running; dropping")
 
             elif mtype == "worker-auth-response":
                 if msg.get("workerId") != self.cfg.worker_id:


### PR DESCRIPTION
## Summary

Fixes issue #99: auth codes entered in the Foreman Comms panel were silently dropped and never reached the waiting worker.

### Root cause

The auth flow breaks when the user types the code into the **regular chat input** rather than the dedicated red auth panel — which happens whenever the `claude-auth-required` WebSocket event is missed (page refresh, late connect, etc.).

When code goes through chat → Foreman AI → `message_worker` → `worker-message`, the worker's `_listen()` looked for an active Claude subprocess to inject into. During `_run_claude_login()` there is no subprocess, so the message was silently dropped (`logger.debug("worker-message: no claude running; dropping")`). `_auth_code_queue.get()` eventually timed out.

### Fix (3 parts)

**1. Worker** (`worker/pioneer_worker/worker.py`): When a `worker-message` arrives and `_auth_code_queue is not None` (worker is inside `_run_claude_login`), route the text to the auth queue instead of trying subprocess injection. This makes the foreman-relay path work regardless of which input the human used.

**2. Backend** (`backend/events.py`, `backend/main.py`):
- Track workers with pending Claude auth in `pending_claude_auth` (in-memory, `guild_id → {worker_id: url}`)
- Add explicit `worker-auth-response` handler to clear the pending state before broadcasting
- Add `GET /guilds/{guild_id}/pending-auth` REST endpoint for the frontend to query
- Update the foreman prompt to explicitly instruct it to forward auth-code-like chat messages via `message_worker`

**3. Frontend** (`frontend/src/components/ChatPane.vue`): On `ChatPane` mount, call `/pending-auth` and restore `claudeAuthPending` if any worker is waiting. This brings back the dedicated auth panel after a page refresh or late connection.

## Test plan

- [ ] Start a worker with no Claude credentials; verify the auth panel appears in the Foreman Comms panel
- [ ] Refresh the page while the worker is waiting; verify the auth panel reappears after refresh
- [ ] Enter the auth code in the regular chat input (not the auth panel); verify the foreman relays it and the worker completes login
- [ ] Enter the auth code in the dedicated auth panel; verify the worker completes login (original path still works)
- [ ] Verify mid-task `worker-message` injection is unaffected (no subprocess during login, so the auth-queue branch only fires when `_auth_code_queue is not None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)