### PR TITLE
fix: don't close auth modal on WS send failure; add code-received feedback

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -679,6 +679,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     if pending_workers:
                         pending_worker_id = next(iter(pending_workers))
                         pending_workers.pop(pending_worker_id)
+                        logger.info("chat intercepted as auth code for %s in guild %s code_len=%d", pending_worker_id, guild_id, len(content))
                         await broadcast(guild_id, {
                             "type": "worker-auth-response",
                             "workerId": pending_worker_id,
@@ -855,11 +856,13 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
 
             elif msg_type == "claude-auth-required":
                 # Worker needs Claude authentication; broadcast URL to UI and loop foreman in.
-                await broadcast(guild_id, data, exclude=websocket)
                 worker_id = data.get("workerId", "a worker")
                 auth_url = data.get("url", "")
+                logger.info("claude-auth-required from %s in guild %s url=%s", worker_id, guild_id, auth_url[:80])
+                await broadcast(guild_id, data, exclude=websocket)
                 # Track so new frontend connections can restore the auth panel.
                 pending_claude_auth.setdefault(guild_id, {})[worker_id] = auth_url
+                logger.info("pending_claude_auth now has %d entries for guild %s", len(pending_claude_auth.get(guild_id, {})), guild_id)
                 asyncio.create_task(run_foreman_ai(
                     guild_id,
                     f"Worker {worker_id} needs Claude authentication. "
@@ -873,7 +876,11 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 # Human is submitting an auth code; clear pending state and
                 # broadcast to all connections so the waiting worker receives it.
                 worker_id = data.get("workerId", "")
+                code_len = len(data.get("code", ""))
+                logger.info("worker-auth-response for %s in guild %s code_len=%d", worker_id, guild_id, code_len)
                 pending_claude_auth.get(guild_id, {}).pop(worker_id, None)
+                peer_count = len(connections.get(guild_id, []))
+                logger.info("broadcasting worker-auth-response to %d connections in guild %s", peer_count, guild_id)
                 await broadcast(guild_id, data)
 
             elif msg_type in ("offer", "answer", "ice-candidate"):

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -294,11 +294,19 @@ function submitAuthCode() {
   const pending = claudeAuthPending.value
   const code = authCodeInput.value.trim()
   if (!pending || !code) return
-  guildStore.sendMessage({
+  const sent = guildStore.sendMessage({
     type: 'worker-auth-response',
     workerId: pending.workerId,
     code,
   })
+  if (!sent) {
+    guildStore.messages.push({
+      type: 'chat', from: 'system', to: 'user',
+      content: '⚠ Connection not ready — please wait a moment and try again.',
+      createdAt: new Date().toISOString(),
+    })
+    return
+  }
   claudeAuthPending.value = null
   authCodeInput.value = ''
 }

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -188,6 +188,7 @@ class Worker:
                     await self._emit("[auth] Waiting for auth code — paste it into the auth panel in the UI or type it into the Foreman Comms input...")
                     try:
                         code = await asyncio.wait_for(self._auth_code_queue.get(), timeout=300.0)
+                        await self._emit("[auth] Code received — submitting to Claude CLI...")
                         proc.stdin.write((code.strip() + "\n").encode())
                         await proc.stdin.drain()
                         proc.stdin.close()

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -162,6 +162,7 @@ class Worker:
         from pathlib import Path
 
         self._auth_code_queue = asyncio.Queue()
+        logger.info("Starting claude auth login — auth_code_queue is now open")
         proc = await asyncio.create_subprocess_exec(
             self.cfg.claude_path, "auth", "login",
             stdin=asyncio.subprocess.PIPE,
@@ -202,6 +203,7 @@ class Worker:
             self._auth_code_queue = None
 
         await proc.wait()
+        logger.info("claude auth login exited with rc=%s", proc.returncode)
 
         if not await self._claude_is_authenticated():
             await self._emit("[auth] Login may have failed — claude auth status returned non-zero")
@@ -418,7 +420,7 @@ class Worker:
                     # message as the auth code so the foreman can relay it.
                     if self._auth_code_queue is not None:
                         await self._auth_code_queue.put(text)
-                        logger.info("Auth code received via worker-message (login flow)")
+                        logger.info("Auth code received via worker-message (login flow) len=%d", len(text))
                         await self._emit("[worker] Auth code received and forwarded to login flow")
                     else:
                         active = next((s for s in self.slots if s.current_claude), None)
@@ -432,14 +434,23 @@ class Worker:
                             logger.debug("worker-message: no claude running; dropping")
 
             elif mtype == "worker-auth-response":
-                if msg.get("workerId") != self.cfg.worker_id:
+                msg_worker_id = msg.get("workerId")
+                logger.info("worker-auth-response received: msg_workerId=%s our_workerId=%s code_len=%d queue_open=%s",
+                            msg_worker_id, self.cfg.worker_id,
+                            len(msg.get("code", "")),
+                            self._auth_code_queue is not None)
+                if msg_worker_id != self.cfg.worker_id:
+                    logger.warning("worker-auth-response workerId mismatch — ignoring")
                     continue
                 code = msg.get("code", "")
+                if not code:
+                    logger.warning("worker-auth-response has empty code — ignoring")
+                    continue
                 if self._auth_code_queue is not None:
                     await self._auth_code_queue.put(code)
-                    logger.info("Auth code received from UI")
+                    logger.info("Auth code queued (len=%d)", len(code))
                 else:
-                    logger.warning("worker-auth-response received but no auth in progress")
+                    logger.warning("worker-auth-response received but no auth in progress (queue is None)")
 
             elif mtype == "task-followup":
                 if msg.get("workerId") != self.cfg.worker_id:


### PR DESCRIPTION
Two bugs causing "stuck in auth code mode after pasting":

1. submitAuthCode() ignored the boolean return from sendMessage(). If the
   WebSocket was momentarily closed the message was silently dropped but the
   modal closed, leaving the worker waiting indefinitely. Now we check the
   return value and show an error, keeping the modal open so the user can
   retry.

2. The worker emitted "[auth] Waiting for auth code..." but nothing after
   the code arrived, so the terminal looked frozen while claude auth login
   was verifying the code. A new "[auth] Code received — submitting to
   Claude CLI..." line confirms receipt immediately.

https://claude.ai/code/session_011K6iDfijzi9EVYHyMmGpvx