### PR TITLE
Add hostname to worker registration and use it in agent names

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -130,10 +130,13 @@ def generate_guild_id():
     return ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
 
 
-def _worker_name(worker_id: str) -> str:
+def _worker_name(worker_id: str, hostname: Optional[str] = None) -> str:
     raw = worker_id[2:].upper()
     split = 2 + sum(ord(c) for c in raw) % 3
-    return f"{raw[:split]}-{raw[split:]}"
+    droid = f"{raw[:split]}-{raw[split:]}"
+    if hostname:
+        return f"{hostname[:3].upper()}/{droid}"
+    return droid
 
 
 class GuildCreate(BaseModel):
@@ -155,6 +158,7 @@ class RunAgentRequest(BaseModel):
 class WorkerCreate(BaseModel):
     repos: List[str]                  # ["owner/repo", ...]
     github_token: Optional[str] = None
+    hostname: Optional[str] = None
 
 class SpawnWorkerRequest(BaseModel):
     repos: List[str]
@@ -1213,7 +1217,7 @@ async def create_worker(guild_id: str, data: WorkerCreate):
     using the returned id (see the standalone /worker package)."""
     worker_id   = "w-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
     created_at  = datetime.now(timezone.utc).isoformat()
-    worker_name = _worker_name(worker_id)
+    worker_name = _worker_name(worker_id, data.hostname)
 
     db = await get_db()
     try:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -7,6 +7,7 @@ import logging
 import os
 import random
 import re
+import socket
 import string
 from datetime import datetime, timezone
 from typing import Optional
@@ -74,7 +75,7 @@ class Worker:
         async with await self._http() as client:
             resp = await client.post(
                 f"/guilds/{self.cfg.guild_id}/workers",
-                json={"repos": self.cfg.repos, "github_token": None},
+                json={"repos": self.cfg.repos, "github_token": None, "hostname": socket.gethostname()},
             )
             resp.raise_for_status()
             wid = resp.json()["id"]
@@ -291,10 +292,13 @@ class Worker:
         })
 
     async def _join(self) -> None:
+        hostname = socket.gethostname()
+        host_prefix = hostname[:3].upper()
         for slot in self.slots:
             raw = slot.agent_id[2:].upper()
             split = 2 + sum(ord(c) for c in raw) % 3
-            name = self.cfg.worker_name or f"{raw[:split]}-{raw[split:]}"
+            droid = f"{raw[:split]}-{raw[split:]}"
+            name = self.cfg.worker_name or f"{host_prefix}/{droid}"
             await self._send({
                 "type": "join",
                 "agentId": slot.agent_id,


### PR DESCRIPTION
Worker now sends its hostname during HTTP registration; the backend uses
the first 3 letters (uppercase) as a prefix, producing names like
MYS/AB-C123 instead of AB-C123.  Agent slot names in _join() follow the
same HOS/droid pattern.  Existing registrations without a hostname fall
back to the bare droid ID.

https://claude.ai/code/session_01Q9HUiMzwE3Zk87FmYj2ZVU