### PR TITLE
fix: worker auth reliability — join after auth, better logging, modal send guard

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -59,6 +59,9 @@ class Worker:
         self._redirect_queues: dict[str, asyncio.Queue] = {}
         # Queue for auth codes received from the UI during claude auth login
         self._auth_code_queue: asyncio.Queue[str] | None = None
+        # Set to True once _join() has been called the first time so that
+        # _on_ws_reconnect doesn't prematurely join before auth completes.
+        self._joined = False
         # One slot per concurrent agent; each gets a stable ID for the guild.
         self.slots: list[_AgentSlot] = [
             _AgentSlot(_gen_id("a-")) for _ in range(cfg.max_agents)
@@ -299,6 +302,10 @@ class Worker:
         without this the frontend sees the worker as offline forever even though
         the worker is back online and listening.
         """
+        if not self._joined:
+            # Auth hasn't completed yet — don't expose agents to the backend.
+            logger.info("WebSocket reconnected during pre-auth phase; skipping join")
+            return
         logger.info("WebSocket reconnected — re-sending join and agent states")
         await self._join()
         # `join` resets each agent to idle in the backend. Re-send the actual
@@ -357,20 +364,19 @@ class Worker:
         logger.info("Connecting to backend WebSocket at %s", self.cfg.ws_url)
         self.ws.on_reconnect = self._on_ws_reconnect
         await self.ws.connect()
+
+        # Start listener before auth so it can relay auth codes from the UI.
+        # _join() is intentionally delayed until after auth — agents must not
+        # be visible to the foreman until Claude is ready to accept tasks.
+        listener = asyncio.create_task(self._listen())
+        await self._check_claude_auth()
+
         await self._join()
+        self._joined = True
         logger.info(
             "Joined guild %s — worker_id=%s agents=%d",
             self.cfg.guild_id, self.cfg.worker_id, len(self.slots),
         )
-        # Hold agents in busy so the foreman won't assign tasks during auth.
-        # _join() registers them as idle; override that before the listener
-        # starts so the backend sees the correct state from the start.
-        for slot in self.slots:
-            await self._set_state("busy", slot)
-
-        # Start listener before auth check so it can relay auth codes from the UI
-        listener = asyncio.create_task(self._listen())
-        await self._check_claude_auth()
         await self._emit("[worker] Online. Watching for tasks.")
         for slot in self.slots:
             await self._set_state("idle", slot)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -362,6 +362,12 @@ class Worker:
             "Joined guild %s — worker_id=%s agents=%d",
             self.cfg.guild_id, self.cfg.worker_id, len(self.slots),
         )
+        # Hold agents in busy so the foreman won't assign tasks during auth.
+        # _join() registers them as idle; override that before the listener
+        # starts so the backend sees the correct state from the start.
+        for slot in self.slots:
+            await self._set_state("busy", slot)
+
         # Start listener before auth check so it can relay auth codes from the UI
         listener = asyncio.create_task(self._listen())
         await self._check_claude_auth()

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -101,6 +101,7 @@ async def test_on_ws_reconnect_resends_join_and_register():
     cfg = _make_cfg()
     cfg.max_agents = 2
     worker = Worker(cfg)
+    worker._joined = True  # simulate post-auth state
     sent: list[dict] = []
     worker._send = AsyncMock(side_effect=lambda p: sent.append(p))
 
@@ -113,12 +114,25 @@ async def test_on_ws_reconnect_resends_join_and_register():
     assert {m["agentId"] for m in join_msgs} == {s.agent_id for s in worker.slots}
 
 
+async def test_on_ws_reconnect_skips_join_before_auth():
+    """A WS reconnect during the auth window must not register agents early."""
+    worker = Worker(_make_cfg())
+    # _joined defaults to False — auth not yet complete
+    sent: list[dict] = []
+    worker._send = AsyncMock(side_effect=lambda p: sent.append(p))
+
+    await worker._on_ws_reconnect()
+
+    assert sent == [], f"No messages should be sent before auth, got: {sent}"
+
+
 async def test_on_ws_reconnect_resends_non_idle_agent_state():
     """A reconnect during an active task must restore the slot's actual state
     so the backend doesn't leave the agent stuck at idle."""
     cfg = _make_cfg()
     cfg.max_agents = 2
     worker = Worker(cfg)
+    worker._joined = True  # simulate post-auth state
     worker.slots[0].state = "working"
     worker.slots[1].state = "idle"
     sent: list[dict] = []


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes the "worker stuck in waiting for auth code mode" report and hardens the overall auth flow.

- **Join after auth**: `_join()` is now called only after `_check_claude_auth()` completes. Agents are never visible to the foreman — never assignable — until Claude is actually authenticated and ready. A `_joined` flag prevents `_on_ws_reconnect` from registering agents early if the WebSocket bounces during the login window.

- **Auth modal send guard**: `submitAuthCode()` now checks the return value of `sendMessage()`. If the WebSocket is momentarily closed the code was silently dropped but the modal closed, leaving the worker waiting indefinitely. Now the modal stays open and an error message is shown so the user can retry.

- **Code-received feedback**: The worker now emits `[auth] Code received — submitting to Claude CLI...` immediately after dequeuing the auth code, so the terminal doesn't look frozen while `claude auth login` verifies with Anthropic's servers.

- **Detailed auth logging**: Every step of the auth handshake now logs on both sides so failures can be diagnosed from server logs without guesswork:
  - Backend: logs `claude-auth-required` receipt, pending count, `worker-auth-response` receipt with code length, and connection count before broadcast
  - Worker: logs queue open, `worker-auth-response` receipt with workerId comparison and queue state, empty-code guard, code queued with length, and `claude auth login` exit code

## Test plan

- [ ] Start a worker with no stored credentials — confirm agents don't appear in the UI until the auth modal is dismissed and auth completes
- [ ] Submit the auth code via the modal — confirm `[auth] Code received — submitting to Claude CLI...` appears in terminal
- [ ] Kill the backend WebSocket mid-auth and restore it — confirm agents still don't appear until auth completes
- [ ] Submit with a disconnected WebSocket — confirm modal stays open with error message instead of silently closing
- [ ] Check backend logs for the new auth log lines when auth runs

https://claude.ai/code/session_011K6iDfijzi9EVYHyMmGpvx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011K6iDfijzi9EVYHyMmGpvx)_