### PR TITLE
style(frontend): apply prettier --write across src and enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Lint
         run: npm run lint:check
 
+      - name: Format check
+        run: npm run format:check
+
       - name: Type-check
         run: npm run type-check
 

--- a/frontend/src/components/AgentAvatar.vue
+++ b/frontend/src/components/AgentAvatar.vue
@@ -9,8 +9,8 @@
 
     <div class="avatar-label">{{ agent.name.slice(0, 8) }}</div>
     <div v-if="agent.state === 'thinking'" class="think-bubble">💭</div>
-    <div v-if="agent.state === 'working'"  class="work-burst">⭐</div>
-    <div v-if="agent.state === 'error'"    class="error-burst">!</div>
+    <div v-if="agent.state === 'working'" class="work-burst">⭐</div>
+    <div v-if="agent.state === 'error'" class="error-burst">!</div>
   </div>
 </template>
 
@@ -19,12 +19,15 @@ import { computed } from 'vue'
 import RobotWorker from './sprites/RobotWorker.vue'
 import type { Agent } from '../types'
 
-const props = withDefaults(defineProps<{
-  agent: Agent
-  walking?: boolean
-}>(), {
-  walking: false,
-})
+const props = withDefaults(
+  defineProps<{
+    agent: Agent
+    walking?: boolean
+  }>(),
+  {
+    walking: false,
+  },
+)
 
 /* Warm SNES/CT palette — gold, teal, orange, sky, red, lime, copper, amber */
 const palette = [
@@ -69,10 +72,18 @@ const agentColorDim = computed(() => {
 }
 
 /* State glows applied to the whole wrapper (sprite + label + bubbles) */
-.avatar-wrapper.thinking { filter: drop-shadow(0 0 6px var(--color-blue,   #44aaee)); }
-.avatar-wrapper.working  { filter: drop-shadow(0 0 6px var(--color-green,  #88dd22)); }
-.avatar-wrapper.busy     { filter: drop-shadow(0 0 6px var(--color-orange, #ff7700)); }
-.avatar-wrapper.error    { filter: drop-shadow(0 0 8px var(--color-red,    #ee3322)); }
+.avatar-wrapper.thinking {
+  filter: drop-shadow(0 0 6px var(--color-blue, #44aaee));
+}
+.avatar-wrapper.working {
+  filter: drop-shadow(0 0 6px var(--color-green, #88dd22));
+}
+.avatar-wrapper.busy {
+  filter: drop-shadow(0 0 6px var(--color-orange, #ff7700));
+}
+.avatar-wrapper.error {
+  filter: drop-shadow(0 0 8px var(--color-red, #ee3322));
+}
 
 .avatar-label {
   font-family: var(--font-pixel);
@@ -116,19 +127,39 @@ const agentColorDim = computed(() => {
 }
 
 @keyframes bubblePop {
-  0%, 100% { opacity: 1;   transform: scale(1)    rotate(-5deg); }
-  50%       { opacity: 0.7; transform: scale(0.85) rotate(5deg); }
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(-5deg);
+  }
+  50% {
+    opacity: 0.7;
+    transform: scale(0.85) rotate(5deg);
+  }
 }
 
 @keyframes burstSpin {
-  from { transform: rotate(0deg)   scale(1); }
-  50%  { transform: rotate(180deg) scale(1.2); }
-  to   { transform: rotate(360deg) scale(1); }
+  from {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.2);
+  }
+  to {
+    transform: rotate(360deg) scale(1);
+  }
 }
 
 @keyframes shake {
-  0%, 100% { transform: translateX(0); }
-  25%       { transform: translateX(-3px); }
-  75%       { transform: translateX(3px); }
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-3px);
+  }
+  75% {
+    transform: translateX(3px);
+  }
 }
 </style>

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -18,7 +18,9 @@
           class="tab-btn"
           :class="{ active: activeTab === 'chat' }"
           @click.stop="activeTab = 'chat'"
-        >Chat</button>
+        >
+          Chat
+        </button>
         <button
           v-if="ghStore.isConfigured"
           class="tab-btn"
@@ -32,15 +34,15 @@
           class="tab-btn"
           :class="{ active: activeTab === 'debug' }"
           @click.stop="switchToDebug"
-        >Debug</button>
+        >
+          Debug
+        </button>
       </div>
 
       <!-- Chat tab -->
       <template v-if="activeTab === 'chat'">
         <div class="chat-messages" ref="messagesEl">
-          <div v-if="messages.length === 0" class="chat-empty">
-            Awaiting foreman connection...
-          </div>
+          <div v-if="messages.length === 0" class="chat-empty">Awaiting foreman connection...</div>
           <div
             v-for="(msg, i) in messages"
             :key="i"
@@ -48,10 +50,12 @@
             :class="{
               'from-user': msg.from === 'user',
               'from-system': msg.from === 'system',
-              'from-agent': msg.from !== 'user' && msg.from !== 'system'
+              'from-agent': msg.from !== 'user' && msg.from !== 'system',
             }"
           >
-            <span class="msg-from">{{ msg.from === 'user' ? 'YOU' : msg.from === 'system' ? 'SYS' : msg.from }}</span>
+            <span class="msg-from">{{
+              msg.from === 'user' ? 'YOU' : msg.from === 'system' ? 'SYS' : msg.from
+            }}</span>
             <span class="msg-content">{{ msg.content }}</span>
             <a v-if="msg.prUrl" :href="msg.prUrl" target="_blank" rel="noopener" class="pr-link">
               Open PR →
@@ -77,7 +81,11 @@
             {{ ghStore.loading ? '...' : '↻' }}
           </button>
           <span class="issues-count">{{ ghStore.issues.length }} open</span>
-          <span class="issues-repos">{{ ghStore.selectedRepos.length }} repo{{ ghStore.selectedRepos.length !== 1 ? 's' : '' }}</span>
+          <span class="issues-repos"
+            >{{ ghStore.selectedRepos.length }} repo{{
+              ghStore.selectedRepos.length !== 1 ? 's' : ''
+            }}</span
+          >
         </div>
 
         <div class="issues-list" ref="issuesEl">
@@ -104,7 +112,8 @@
                 :key="label.id"
                 class="issue-label"
                 :style="{ borderColor: '#' + label.color, color: '#' + label.color }"
-              >{{ label.name }}</span>
+                >{{ label.name }}</span
+              >
               <span class="issue-age">{{ formatAge(issue.created_at) }}</span>
             </div>
           </div>
@@ -114,7 +123,10 @@
       <!-- Debug tab -->
       <template v-else-if="activeTab === 'debug'">
         <div class="debug-toolbar">
-          <span class="debug-count">{{ debugContext.length }} msg{{ debugContext.length !== 1 ? 's' : '' }} in context</span>
+          <span class="debug-count"
+            >{{ debugContext.length }} msg{{ debugContext.length !== 1 ? 's' : '' }} in
+            context</span
+          >
           <button class="pixel-btn refresh-btn" @click="refreshDebug" :disabled="debugLoading">
             {{ debugLoading ? '...' : '↻' }}
           </button>
@@ -131,9 +143,17 @@
             v-for="(msg, i) in debugContext"
             :key="i"
             class="debug-msg"
-            :class="msg.role === 'assistant' ? 'debug-assistant' : isToolResponseMsg(msg) ? 'debug-tool-response' : 'debug-user'"
+            :class="
+              msg.role === 'assistant'
+                ? 'debug-assistant'
+                : isToolResponseMsg(msg)
+                  ? 'debug-tool-response'
+                  : 'debug-user'
+            "
           >
-            <span class="debug-role">{{ isToolResponseMsg(msg) ? 'TOOL RESPONSE' : msg.role.toUpperCase() }}</span>
+            <span class="debug-role">{{
+              isToolResponseMsg(msg) ? 'TOOL RESPONSE' : msg.role.toUpperCase()
+            }}</span>
             <template v-if="typeof msg.content === 'string'">
               <span class="debug-text">{{ msg.content }}</span>
             </template>
@@ -154,7 +174,11 @@
                 </template>
                 <template v-else-if="block.type === 'tool_result'">
                   <span class="debug-tool-id">id:{{ block.tool_use_id?.slice(-6) }}</span>
-                  <pre class="debug-pre">{{ typeof block.content === 'string' ? block.content : JSON.stringify(block.content) }}</pre>
+                  <pre class="debug-pre">{{
+                    typeof block.content === 'string'
+                      ? block.content
+                      : JSON.stringify(block.content)
+                  }}</pre>
                 </template>
                 <template v-else>
                   <pre class="debug-pre">{{ JSON.stringify(block) }}</pre>
@@ -190,7 +214,11 @@
               @keydown.enter="submitAuthCode"
               autofocus
             />
-            <button class="pixel-btn auth-submit-btn" @click="submitAuthCode" :disabled="!authCodeInput.trim()">
+            <button
+              class="pixel-btn auth-submit-btn"
+              @click="submitAuthCode"
+              :disabled="!authCodeInput.trim()"
+            >
               ↵ Submit
             </button>
           </div>
@@ -229,7 +257,7 @@ const debugLoading = ref(false)
 const debugClearing = ref(false)
 
 const messages = computed(() => guildStore.messages)
-const foreman = computed(() => agentsStore.agents.find(a => a.type === 'foreman'))
+const foreman = computed(() => agentsStore.agents.find((a) => a.type === 'foreman'))
 
 // Issue assignment pattern: "Work on issue #N in owner/repo: title"
 const ISSUE_PATTERN = /Work on issue #(\d+) in ([^:]+): "(.+)"/
@@ -301,7 +329,9 @@ function submitAuthCode() {
   })
   if (!sent) {
     guildStore.messages.push({
-      type: 'chat', from: 'system', to: 'user',
+      type: 'chat',
+      from: 'system',
+      to: 'user',
       content: '⚠ Connection not ready — please wait a moment and try again.',
       createdAt: new Date().toISOString(),
     })
@@ -315,7 +345,9 @@ function submitAuthCode() {
 function handleTaskEvent(data: WSMessage) {
   if (data.type === 'task-complete') {
     guildStore.messages.push({
-      type: 'chat', from: 'system', to: 'user',
+      type: 'chat',
+      from: 'system',
+      to: 'user',
       content: data.prUrl
         ? `✓ ${data.workerId} done — PR: ${data.prUrl}`
         : `✓ ${data.workerId} finished (no PR)`,
@@ -324,20 +356,26 @@ function handleTaskEvent(data: WSMessage) {
     })
   } else if (data.type === 'needs-input') {
     guildStore.messages.push({
-      type: 'chat', from: 'system', to: 'user',
+      type: 'chat',
+      from: 'system',
+      to: 'user',
       content: `⚠ ${data.workerId} needs attention on: "${data.description}"`,
       createdAt: new Date().toISOString(),
     })
   } else if (data.type === 'claude-auth-required') {
     claudeAuthPending.value = { workerId: data.workerId, url: data.url }
     guildStore.messages.push({
-      type: 'chat', from: 'system', to: 'user',
+      type: 'chat',
+      from: 'system',
+      to: 'user',
       content: `⚿ ${data.workerId} needs Claude auth — visit the URL and paste the code below`,
       createdAt: new Date().toISOString(),
     })
   } else if (data.type === 'task-assigned') {
     guildStore.messages.push({
-      type: 'chat', from: 'system', to: 'user',
+      type: 'chat',
+      from: 'system',
+      to: 'user',
       content: `→ ${data.workerId} assigned: ${data.description}`,
       createdAt: new Date().toISOString(),
     })
@@ -353,7 +391,7 @@ onMounted(async () => {
   if (guildId && !claudeAuthPending.value) {
     try {
       const res = await fetch(`${API_BASE}/guilds/${guildId}/pending-auth`, {
-        headers: authStore.authHeaders()
+        headers: authStore.authHeaders(),
       })
       if (res.ok) {
         const items: Array<{ workerId: string; url: string }> = await res.json()
@@ -369,7 +407,11 @@ onMounted(async () => {
 onUnmounted(() => guildStore.removeMessageHandler(handleTaskEvent))
 
 function isToolResponseMsg(msg: { role: string; content: unknown }) {
-  return msg.role === 'user' && Array.isArray(msg.content) && (msg.content as { type: string }[]).every(b => b.type === 'tool_result')
+  return (
+    msg.role === 'user' &&
+    Array.isArray(msg.content) &&
+    (msg.content as { type: string }[]).every((b) => b.type === 'tool_result')
+  )
 }
 
 async function switchToDebug() {
@@ -383,7 +425,7 @@ async function refreshDebug() {
   debugLoading.value = true
   try {
     const res = await fetch(`${API_BASE}/guilds/${guildId}/foreman/context`, {
-      headers: authStore.authHeaders()
+      headers: authStore.authHeaders(),
     })
     if (res.ok) {
       const data = await res.json()
@@ -405,7 +447,7 @@ async function clearContext() {
   try {
     await fetch(`${API_BASE}/guilds/${guildId}/foreman/clear-context`, {
       method: 'POST',
-      headers: authStore.authHeaders()
+      headers: authStore.authHeaders(),
     })
     debugContext.value = []
   } catch (e) {
@@ -431,7 +473,7 @@ function assignIssue(issue: GitHubIssue) {
   inputText.value = msg
   activeTab.value = 'chat'
   nextTick(() => {
-    (document.querySelector('.chat-input') as HTMLInputElement | null)?.focus()
+    ;(document.querySelector('.chat-input') as HTMLInputElement | null)?.focus()
   })
 }
 
@@ -449,12 +491,16 @@ function formatAge(isoStr?: string) {
   return `${Math.floor(diffHours / 24)}d`
 }
 
-watch(messages, async () => {
-  await nextTick()
-  if (messagesEl.value) {
-    messagesEl.value.scrollTop = messagesEl.value.scrollHeight
-  }
-}, { deep: true })
+watch(
+  messages,
+  async () => {
+    await nextTick()
+    if (messagesEl.value) {
+      messagesEl.value.scrollTop = messagesEl.value.scrollHeight
+    }
+  },
+  { deep: true },
+)
 </script>
 
 <style scoped>
@@ -517,11 +563,21 @@ watch(messages, async () => {
   display: inline-block;
 }
 
-.status-dot.idle { background: var(--color-text-dim); }
-.status-dot.thinking { background: var(--color-blue); }
-.status-dot.working { background: var(--color-green); }
-.status-dot.busy { background: var(--color-orange); }
-.status-dot.error { background: var(--color-red); }
+.status-dot.idle {
+  background: var(--color-text-dim);
+}
+.status-dot.thinking {
+  background: var(--color-blue);
+}
+.status-dot.working {
+  background: var(--color-green);
+}
+.status-dot.busy {
+  background: var(--color-orange);
+}
+.status-dot.error {
+  background: var(--color-red);
+}
 
 .minimize-btn {
   font-size: 10px;
@@ -895,9 +951,15 @@ watch(messages, async () => {
   margin-bottom: 2px;
 }
 
-.debug-assistant .debug-role { color: var(--color-teal); }
-.debug-user .debug-role { color: var(--color-brass); }
-.debug-tool-response .debug-role { color: #50c878; }
+.debug-assistant .debug-role {
+  color: var(--color-teal);
+}
+.debug-user .debug-role {
+  color: var(--color-brass);
+}
+.debug-tool-response .debug-role {
+  color: #50c878;
+}
 
 .debug-text {
   color: var(--color-text);
@@ -937,8 +999,12 @@ watch(messages, async () => {
   text-transform: uppercase;
 }
 
-.debug-block-tool_use .debug-block-type { color: #ff8c00; }
-.debug-block-tool_result .debug-block-type { color: #50c878; }
+.debug-block-tool_use .debug-block-type {
+  color: #ff8c00;
+}
+.debug-block-tool_result .debug-block-type {
+  color: #50c878;
+}
 
 .debug-tool-name {
   font-weight: bold;
@@ -975,7 +1041,9 @@ watch(messages, async () => {
 .auth-modal {
   background: var(--color-bg-secondary, #1a1a2e);
   border: 3px solid var(--color-red, #c0392b);
-  box-shadow: 0 0 40px rgba(192, 57, 43, 0.4), 0 0 80px rgba(192, 57, 43, 0.15);
+  box-shadow:
+    0 0 40px rgba(192, 57, 43, 0.4),
+    0 0 80px rgba(192, 57, 43, 0.15);
   width: 520px;
   max-width: calc(100vw - 32px);
   display: flex;

--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -10,7 +10,9 @@
         v-for="n in 14"
         :key="`sp${n}`"
         :style="`left: ${(n * 73 + 11) % 93}%; top: ${(n * 59 + 17) % 80}%; font-size: ${8 + (n % 3) * 3}px; animation-delay: ${((n * 0.37) % 2.8).toFixed(1)}s; animation-duration: ${2.5 + (n % 3) * 0.8}s;`"
-      >{{ ['✦','★','✧','⋆','✩'][n % 5] }}</div>
+      >
+        {{ ['✦', '★', '✧', '⋆', '✩'][n % 5] }}
+      </div>
     </div>
 
     <!-- Ceiling pipes -->
@@ -60,7 +62,14 @@
     <!-- Conveyor belt -->
     <div class="conveyor-belt">
       <div class="belt-track">
-        <div class="belt-item" v-for="(item, n) in beltItems" :key="n" :style="`--offset: ${n * 60}px`">{{ item }}</div>
+        <div
+          class="belt-item"
+          v-for="(item, n) in beltItems"
+          :key="n"
+          :style="`--offset: ${n * 60}px`"
+        >
+          {{ item }}
+        </div>
       </div>
       <div class="belt-roller left"></div>
       <div class="belt-roller right"></div>
@@ -85,7 +94,9 @@
         </div>
         <div class="station-table"></div>
       </div>
-      <div class="station-label">{{ station.task ? truncate(station.task.name, 10) : `WS-${i + 1}` }}</div>
+      <div class="station-label">
+        {{ station.task ? truncate(station.task.name, 10) : `WS-${i + 1}` }}
+      </div>
       <div v-if="station.task" class="task-badge" :class="`state-${station.task.state}`">
         {{ stateLabel(station.task.state) }}
       </div>
@@ -101,7 +112,7 @@
 
     <div class="poi bulletin-board">
       <div class="bb-frame">
-        <div class="bb-pin" v-for="n in 3" :key="n" :style="`left:${8+n*18}px;top:6px`"></div>
+        <div class="bb-pin" v-for="n in 3" :key="n" :style="`left:${8 + n * 18}px;top:6px`"></div>
         <div class="bb-note n1"></div>
         <div class="bb-note n2"></div>
         <div class="bb-note n3"></div>
@@ -114,7 +125,7 @@
       <div class="wc-base">
         <div class="wc-tap"></div>
       </div>
-      <div class="wc-drop" v-for="n in 2" :key="n" :style="`--delay:${n*0.6}s`"></div>
+      <div class="wc-drop" v-for="n in 2" :key="n" :style="`--delay:${n * 0.6}s`"></div>
       <div class="poi-label">H₂O</div>
     </div>
 
@@ -124,14 +135,17 @@
         <div class="cm-spout"></div>
         <div class="cm-cup">☕</div>
       </div>
-      <div class="steam-particle" v-for="n in 2" :key="n" :style="`--delay:${n*0.45}s`"></div>
+      <div class="steam-particle" v-for="n in 2" :key="n" :style="`--delay:${n * 0.45}s`"></div>
       <div class="poi-label">COFFEE</div>
     </div>
 
     <!-- Activity points of interest — agents walk here based on what Claude is doing -->
 
     <!-- Scrying Orb — web search -->
-    <div class="poi activity-poi scrying-orb" :style="`left: ${ACTIVITY_POIS['searching'].x - 18}px; top: ${ACTIVITY_POIS['searching'].y - 40}px`">
+    <div
+      class="poi activity-poi scrying-orb"
+      :style="`left: ${ACTIVITY_POIS['searching'].x - 18}px; top: ${ACTIVITY_POIS['searching'].y - 40}px`"
+    >
       <div class="orb-glow"></div>
       <div class="orb-sphere">🔮</div>
       <div class="orb-base"></div>
@@ -139,7 +153,10 @@
     </div>
 
     <!-- Archive — reading files -->
-    <div class="poi activity-poi archive" :style="`left: ${ACTIVITY_POIS['reading'].x - 24}px; top: ${ACTIVITY_POIS['reading'].y - 36}px`">
+    <div
+      class="poi activity-poi archive"
+      :style="`left: ${ACTIVITY_POIS['reading'].x - 24}px; top: ${ACTIVITY_POIS['reading'].y - 36}px`"
+    >
       <div class="archive-shelf">
         <div class="book b1"></div>
         <div class="book b2"></div>
@@ -150,7 +167,10 @@
     </div>
 
     <!-- Telegraph — web fetch -->
-    <div class="poi activity-poi telegraph" :style="`left: ${ACTIVITY_POIS['fetching'].x - 18}px; top: ${ACTIVITY_POIS['fetching'].y - 38}px`">
+    <div
+      class="poi activity-poi telegraph"
+      :style="`left: ${ACTIVITY_POIS['fetching'].x - 18}px; top: ${ACTIVITY_POIS['fetching'].y - 38}px`"
+    >
       <div class="tg-body">
         <div class="tg-key"></div>
         <div class="tg-spark" v-for="n in 2" :key="n" :style="`--delay: ${n * 0.5}s`"></div>
@@ -160,22 +180,36 @@
     </div>
 
     <!-- Think Tank — extended thinking -->
-    <div class="poi activity-poi think-tank" :style="`left: ${ACTIVITY_POIS['thinking'].x - 22}px; top: ${ACTIVITY_POIS['thinking'].y - 44}px`">
+    <div
+      class="poi activity-poi think-tank"
+      :style="`left: ${ACTIVITY_POIS['thinking'].x - 22}px; top: ${ACTIVITY_POIS['thinking'].y - 44}px`"
+    >
       <div class="tank-vessel">
-        <div class="tank-bubble" v-for="n in 3" :key="n" :style="`--delay: ${n * 0.35}s; --xoff: ${(n - 2) * 5}px`"></div>
+        <div
+          class="tank-bubble"
+          v-for="n in 3"
+          :key="n"
+          :style="`--delay: ${n * 0.35}s; --xoff: ${(n - 2) * 5}px`"
+        ></div>
       </div>
       <div class="tank-gauge"></div>
       <div class="poi-label">THINK TANK</div>
     </div>
 
     <!-- Engine Room marker — running bash -->
-    <div class="poi activity-poi engine-room" :style="`left: ${ACTIVITY_POIS['running'].x - 18}px; top: ${ACTIVITY_POIS['running'].y - 20}px`">
+    <div
+      class="poi activity-poi engine-room"
+      :style="`left: ${ACTIVITY_POIS['running'].x - 18}px; top: ${ACTIVITY_POIS['running'].y - 20}px`"
+    >
       <div class="engine-icon">⚙</div>
       <div class="poi-label">ENGINE</div>
     </div>
 
     <!-- The Forge marker — editing/writing code (near furnace) -->
-    <div class="poi activity-poi the-forge" :style="`left: ${ACTIVITY_POIS['editing'].x - 16}px; top: ${ACTIVITY_POIS['editing'].y - 20}px`">
+    <div
+      class="poi activity-poi the-forge"
+      :style="`left: ${ACTIVITY_POIS['editing'].x - 16}px; top: ${ACTIVITY_POIS['editing'].y - 20}px`"
+    >
       <div class="forge-icon">🔥</div>
       <div class="poi-label">THE FORGE</div>
     </div>
@@ -201,9 +235,7 @@
     <!-- Ticker tape -->
     <div class="ticker-tape">
       <div class="ticker-content">
-        <span v-for="(msg, i) in tickerMessages" :key="i" class="ticker-msg">
-          ⚙ {{ msg }}
-        </span>
+        <span v-for="(msg, i) in tickerMessages" :key="i" class="ticker-msg"> ⚙ {{ msg }} </span>
       </div>
     </div>
   </div>
@@ -216,25 +248,34 @@ import { useTasksStore } from '../stores/tasks'
 import type { Agent, Task } from '../types'
 import AgentAvatar from './AgentAvatar.vue'
 
-interface ActivityPoi { x: number; y: number; label: string }
+interface ActivityPoi {
+  x: number
+  y: number
+  label: string
+}
 
-interface Position { x: number; y: number }
-interface Station extends Position { task: Task | null }
+interface Position {
+  x: number
+  y: number
+}
+interface Station extends Position {
+  task: Task | null
+}
 
 const agentsStore = useAgentsStore()
 const tasksStore = useTasksStore()
-const agents = computed(() => agentsStore.agents.filter(a => a.state !== 'offline'))
+const agents = computed(() => agentsStore.agents.filter((a) => a.state !== 'offline'))
 
 const beltItems = ['🔩', '⚙️', '🔧', '🪙', '⭐', '🔨']
 
 // ── Canvas dimensions ──────────────────────────────────────
 const floorEl = ref<HTMLElement | null>(null)
-const floorW  = ref(800)
-const floorH  = ref(600)
+const floorW = ref(800)
+const floorH = ref(600)
 
 function updateFloorSize() {
   if (floorEl.value) {
-    floorW.value = floorEl.value.clientWidth  || 800
+    floorW.value = floorEl.value.clientWidth || 800
     floorH.value = floorEl.value.clientHeight || 600
   }
 }
@@ -244,24 +285,30 @@ function updateFloorSize() {
 // Usable width excludes the foreman chat pane (fixed 360px on the right)
 // so desks stay clear of its boundary.
 // Fixed per-desk jitter (seeded values) gives an organic, stable look.
-const CHAT_PANE_W   = 360
-const STATION_W     = 100
-const COL_FRACS     = [0.08, 0.42, 0.78]
-const ROW_FRACS     = [0.22, 0.60]
-const JITTER        = [[8,-5],[-6,12],[14,-8],[-10,7],[5,10],[-12,-6]]
-const GAP_X_FRACS   = [0.01, 0.25, 0.55, 0.87]
+const CHAT_PANE_W = 360
+const STATION_W = 100
+const COL_FRACS = [0.08, 0.42, 0.78]
+const ROW_FRACS = [0.22, 0.6]
+const JITTER = [
+  [8, -5],
+  [-6, 12],
+  [14, -8],
+  [-10, 7],
+  [5, 10],
+  [-12, -6],
+]
+const GAP_X_FRACS = [0.01, 0.25, 0.55, 0.87]
 
-const usableW = computed(() =>
-  Math.max(floorW.value - CHAT_PANE_W - STATION_W, 300)
-)
+const usableW = computed(() => Math.max(floorW.value - CHAT_PANE_W - STATION_W, 300))
 
 const stationPositions = computed(() => {
-  const W = usableW.value, H = floorH.value
+  const W = usableW.value,
+    H = floorH.value
   return ROW_FRACS.flatMap((yf, ri) =>
     COL_FRACS.map((xf, ci) => ({
       x: Math.round(xf * W) + JITTER[ri * 3 + ci][0],
       y: Math.round(yf * H) + JITTER[ri * 3 + ci][1],
-    }))
+    })),
   )
 })
 
@@ -284,9 +331,7 @@ const ROW2 = computed(() => ({
 }))
 
 // Clear vertical lanes between desk columns
-const GAP_XS = computed(() =>
-  GAP_X_FRACS.map(f => Math.round(f * usableW.value))
-)
+const GAP_XS = computed(() => GAP_X_FRACS.map((f) => Math.round(f * usableW.value)))
 
 // Coffee maker sits beside the rightmost top-row desk (index 2)
 const coffeePotPos = computed(() => {
@@ -296,10 +341,10 @@ const coffeePotPos = computed(() => {
 
 // Points of interest — idle robots walk here occasionally
 const POIS = computed(() => [
-  { id: 'toolbox', x: 26,  y: 88 },
-  { id: 'board',   x: 318, y: 88 },
-  { id: 'cooler',  x: 26,  y: Math.round(floorH.value * 0.42) },
-  { id: 'coffee',  x: coffeePotPos.value.x + 5, y: coffeePotPos.value.y + 30 },
+  { id: 'toolbox', x: 26, y: 88 },
+  { id: 'board', x: 318, y: 88 },
+  { id: 'cooler', x: 26, y: Math.round(floorH.value * 0.42) },
+  { id: 'coffee', x: coffeePotPos.value.x + 5, y: coffeePotPos.value.y + 30 },
 ])
 
 // Activity POIs — agents walk here based on what Claude is doing
@@ -307,19 +352,21 @@ const ACTIVITY_POIS = computed<Record<string, ActivityPoi>>(() => {
   const W = usableW.value + STATION_W
   const H = floorH.value
   return {
-    reading:  { x: Math.round(W * 0.30), y: Math.round(H * 0.10), label: 'ARCHIVE' },
-    editing:  { x: Math.round(W * 0.88), y: Math.round(H * 0.12), label: 'THE FORGE' },
-    running:  { x: Math.round(W * 0.80), y: Math.round(H * 0.44), label: 'ENGINE' },
-    searching:{ x: Math.round(W * 0.05), y: Math.round(H * 0.44), label: 'SCRYING ORB' },
+    reading: { x: Math.round(W * 0.3), y: Math.round(H * 0.1), label: 'ARCHIVE' },
+    editing: { x: Math.round(W * 0.88), y: Math.round(H * 0.12), label: 'THE FORGE' },
+    running: { x: Math.round(W * 0.8), y: Math.round(H * 0.44), label: 'ENGINE' },
+    searching: { x: Math.round(W * 0.05), y: Math.round(H * 0.44), label: 'SCRYING ORB' },
     fetching: { x: Math.round(W * 0.56), y: Math.round(H * 0.09), label: 'TELEGRAPH' },
-    thinking: { x: Math.round(W * 0.50), y: Math.round(H * 0.50), label: 'THINK TANK' },
-    planning: { x: Math.round(W * 0.30), y: Math.round(H * 0.10), label: 'ARCHIVE' },
+    thinking: { x: Math.round(W * 0.5), y: Math.round(H * 0.5), label: 'THINK TANK' },
+    planning: { x: Math.round(W * 0.3), y: Math.round(H * 0.1), label: 'ARCHIVE' },
   }
 })
 
 const visibleStations = computed<Station[]>(() => {
   const active = tasksStore.tasks
-    .filter(t => !['done', 'failed'].includes(t.state) && t.worker_id && t.worker_id !== 'foreman')
+    .filter(
+      (t) => !['done', 'failed'].includes(t.state) && t.worker_id && t.worker_id !== 'foreman',
+    )
     .slice(0, 6)
   return stationPositions.value.map((pos, i) => ({
     ...pos,
@@ -329,9 +376,9 @@ const visibleStations = computed<Station[]>(() => {
 
 // Reactive per-agent state (bound to template)
 const agentPositions = reactive<Record<string, Position>>({})
-const agentWalking   = reactive<Record<string, boolean>>({})
-const agentDuration  = reactive<Record<string, number>>({}) // CSS transition seconds
-const agentChatting  = reactive<Record<string, boolean>>({})
+const agentWalking = reactive<Record<string, boolean>>({})
+const agentDuration = reactive<Record<string, number>>({}) // CSS transition seconds
+const agentChatting = reactive<Record<string, boolean>>({})
 
 // Non-reactive walk queues and timers
 const agentWaypoints: Record<string, Position[]> = {}
@@ -348,7 +395,8 @@ function agentPos(id: string): Position {
 // ── Pathfinding helpers ────────────────────────────────────
 
 function getYZone(y: number) {
-  const r1 = ROW1.value, r2 = ROW2.value
+  const r1 = ROW1.value,
+    r2 = ROW2.value
   if (y < r1.yMin) return 'top'
   if (y < r1.yMax) return 'row1'
   if (y < r2.yMin) return 'mid'
@@ -357,7 +405,7 @@ function getYZone(y: number) {
 }
 
 function closestGapX(x: number) {
-  return GAP_XS.value.reduce((best, gx) => Math.abs(gx - x) < Math.abs(best - x) ? gx : best)
+  return GAP_XS.value.reduce((best, gx) => (Math.abs(gx - x) < Math.abs(best - x) ? gx : best))
 }
 
 // Returns a list of {x,y} waypoints from (x1,y1) to (x2,y2) that avoid station rows.
@@ -384,10 +432,10 @@ function randomInClearZone(): Position {
   const { yMin: r1Min, yMax: r1Max } = ROW1.value
   const { yMin: r2Min, yMax: r2Max } = ROW2.value
   const zones = [
-    { yMin: walkYMin,  yMax: r1Min - 2 },
+    { yMin: walkYMin, yMax: r1Min - 2 },
     { yMin: r1Max + 2, yMax: r2Min - 2 },
-    { yMin: r2Max + 2, yMax: walkYMax  },
-  ].filter(z => z.yMax > z.yMin + 10)
+    { yMin: r2Max + 2, yMax: walkYMax },
+  ].filter((z) => z.yMax > z.yMin + 10)
   if (zones.length === 0) return { x: (xMin + xMax) / 2, y: (walkYMin + walkYMax) / 2 }
   const z = zones[Math.floor(Math.random() * zones.length)]
   return {
@@ -415,12 +463,13 @@ function walkDuration(x1: number, y1: number, x2: number, y2: number) {
 function tryStartChat(id: string): boolean {
   const myPoi = agentDestPoi[id]
   if (!myPoi || !SOCIAL_POIS.has(myPoi)) return false
-  const partner = agents.value.find(a =>
-    a.id !== id &&
-    agentDestPoi[a.id] === myPoi &&
-    !agentWalking[a.id] &&
-    !agentChatting[a.id] &&
-    !isAgentAtWork(a)
+  const partner = agents.value.find(
+    (a) =>
+      a.id !== id &&
+      agentDestPoi[a.id] === myPoi &&
+      !agentWalking[a.id] &&
+      !agentChatting[a.id] &&
+      !isAgentAtWork(a),
   )
   if (!partner) return false
   const dur = 10000 + Math.random() * 5000 // 10–15s
@@ -447,7 +496,10 @@ function stepAgent(id: string) {
     agentTimers[id] = setTimeout(() => scheduleWalk(id), rest)
     return
   }
-  const cur = agentPositions[id] || { x: Math.round(floorW.value / 2), y: Math.round(floorH.value / 2) }
+  const cur = agentPositions[id] || {
+    x: Math.round(floorW.value / 2),
+    y: Math.round(floorH.value / 2),
+  }
   const next = queue.shift()!
   const dur = walkDuration(cur.x, cur.y, next.x, next.y)
   agentDuration[id] = dur
@@ -457,7 +509,7 @@ function stepAgent(id: string) {
 }
 
 function scheduleWalk(id: string) {
-  const agent = agents.value.find(a => a.id === id)
+  const agent = agents.value.find((a) => a.id === id)
   if (!agent || isAgentAtWork(agent)) return
   agentChatting[id] = false
   const cur = agentPositions[id] || randomInClearZone()
@@ -471,7 +523,7 @@ function scheduleWalk(id: string) {
 
 function stationForAgent(agent: Agent) {
   if (!agent.workerId) return null
-  return visibleStations.value.find(s => s.task && s.task.worker_id === agent.workerId) || null
+  return visibleStations.value.find((s) => s.task && s.task.worker_id === agent.workerId) || null
 }
 
 function isAgentAtWork(agent: Agent) {
@@ -518,7 +570,7 @@ function initAgent(agent: Agent) {
 }
 
 function syncPositions() {
-  agents.value.forEach(agent => {
+  agents.value.forEach((agent) => {
     const key = activityKey(agent)
     const prevKey = prevActivityKey[agent.id]
 
@@ -556,21 +608,21 @@ onUnmounted(() => {
 // Watch id+state+workerId+activity so any change to what an agent is doing
 // triggers syncPositions and moves them to the right POI.
 watch(
-  () => agents.value.map(a => `${a.id}:${a.state}:${a.workerId}:${a.activity ?? ''}`).join(','),
-  syncPositions
+  () => agents.value.map((a) => `${a.id}:${a.state}:${a.workerId}:${a.activity ?? ''}`).join(','),
+  syncPositions,
 )
 watch(visibleStations, syncPositions)
 
 const tickerMessages = computed(() => {
   const msgs = []
-  agents.value.forEach(a => {
+  agents.value.forEach((a) => {
     const label = a.activity ? `${a.state.toUpperCase()} [${a.activity}]` : a.state.toUpperCase()
     msgs.push(`${a.name}: ${label}`)
   })
   tasksStore.tasks
-    .filter(t => !['done', 'failed'].includes(t.state))
+    .filter((t) => !['done', 'failed'].includes(t.state))
     .slice(0, 4)
-    .forEach(t => msgs.push(`TASK: ${t.name}`))
+    .forEach((t) => msgs.push(`TASK: ${t.name}`))
   if (msgs.length === 0) msgs.push('AWAITING WORKERS', 'SYSTEMS NOMINAL', 'BOILER PRESSURE: 87 PSI')
   return msgs
 })
@@ -618,15 +670,33 @@ function stateLabel(state: string) {
   animation: sparkleFade 2.5s infinite ease-in-out;
 }
 
-.sparkle:nth-child(5n+1) { color: var(--color-gold); }
-.sparkle:nth-child(5n+2) { color: var(--color-teal); }
-.sparkle:nth-child(5n+3) { color: var(--color-amber); }
-.sparkle:nth-child(5n+4) { color: var(--color-cream); }
-.sparkle:nth-child(5n)   { color: var(--color-orange); }
+.sparkle:nth-child(5n + 1) {
+  color: var(--color-gold);
+}
+.sparkle:nth-child(5n + 2) {
+  color: var(--color-teal);
+}
+.sparkle:nth-child(5n + 3) {
+  color: var(--color-amber);
+}
+.sparkle:nth-child(5n + 4) {
+  color: var(--color-cream);
+}
+.sparkle:nth-child(5n) {
+  color: var(--color-orange);
+}
 
 @keyframes sparkleFade {
-  0%, 100% { opacity: 0; transform: scale(0.3) rotate(0deg); }
-  40%, 60%  { opacity: 0.85; transform: scale(1.1) rotate(180deg); }
+  0%,
+  100% {
+    opacity: 0;
+    transform: scale(0.3) rotate(0deg);
+  }
+  40%,
+  60% {
+    opacity: 0.85;
+    transform: scale(1.1) rotate(180deg);
+  }
 }
 
 /* Pipes — rich warm copper */
@@ -637,27 +707,58 @@ function stateLabel(state: string) {
   box-shadow: 0 0 6px rgba(204, 85, 0, 0.4);
 }
 
-.pipe-h { height: 12px; }
-.pipe-v { width: 12px; }
+.pipe-h {
+  height: 12px;
+}
+.pipe-v {
+  width: 12px;
+}
 
-.pipe1 { top: 20px; left: 0; right: 0; }
-.pipe2 { top: 50px; left: 100px; width: 200px; }
-.pipe3 { top: 0; left: 150px; height: 80px; }
-.pipe4 { top: 0; left: 400px; height: 60px; }
+.pipe1 {
+  top: 20px;
+  left: 0;
+  right: 0;
+}
+.pipe2 {
+  top: 50px;
+  left: 100px;
+  width: 200px;
+}
+.pipe3 {
+  top: 0;
+  left: 150px;
+  height: 80px;
+}
+.pipe4 {
+  top: 0;
+  left: 400px;
+  height: 60px;
+}
 
 /* Pipe joints (bolted flanges) */
 .pipe-joint {
   position: absolute;
   width: 18px;
   height: 18px;
-  background: radial-gradient(circle, var(--color-brass-light) 20%, var(--color-brass) 60%, var(--color-brass-dark) 100%);
+  background: radial-gradient(
+    circle,
+    var(--color-brass-light) 20%,
+    var(--color-brass) 60%,
+    var(--color-brass-dark) 100%
+  );
   border: 2px solid var(--color-brass-dark);
   border-radius: 50%;
   box-shadow: 0 0 5px rgba(232, 170, 0, 0.5);
 }
 
-.j1 { top: 14px; left: 147px; }
-.j2 { top: 14px; left: 397px; }
+.j1 {
+  top: 14px;
+  left: 147px;
+}
+.j2 {
+  top: 14px;
+  left: 397px;
+}
 
 /* Steam vents */
 .steam-vent {
@@ -665,9 +766,18 @@ function stateLabel(state: string) {
   width: 14px;
 }
 
-.vent1 { top: 32px; left: 155px; }
-.vent2 { top: 32px; left: 405px; }
-.vent3 { top: 62px; left: 230px; }
+.vent1 {
+  top: 32px;
+  left: 155px;
+}
+.vent2 {
+  top: 32px;
+  left: 405px;
+}
+.vent3 {
+  top: 62px;
+  left: 230px;
+}
 
 .steam-particle {
   position: absolute;
@@ -679,9 +789,18 @@ function stateLabel(state: string) {
 }
 
 @keyframes steamRise {
-  0%   { transform: translateY(0) scale(0.5); opacity: 0.8; }
-  50%  { transform: translateY(-30px) scale(1.5) translateX(5px); opacity: 0.4; }
-  100% { transform: translateY(-60px) scale(2) translateX(-5px); opacity: 0; }
+  0% {
+    transform: translateY(0) scale(0.5);
+    opacity: 0.8;
+  }
+  50% {
+    transform: translateY(-30px) scale(1.5) translateX(5px);
+    opacity: 0.4;
+  }
+  100% {
+    transform: translateY(-60px) scale(2) translateX(-5px);
+    opacity: 0;
+  }
 }
 
 /* Gears — warm SNES palette, each a distinct color */
@@ -691,19 +810,67 @@ function stateLabel(state: string) {
   line-height: 1;
 }
 
-.gear-large  { font-size: 56px; animation: gearSpin 8s linear infinite; }
-.gear-medium { font-size: 36px; animation: gearSpin 5s linear infinite reverse; }
-.gear-small  { font-size: 22px; animation: gearSpin 3s linear infinite; }
+.gear-large {
+  font-size: 56px;
+  animation: gearSpin 8s linear infinite;
+}
+.gear-medium {
+  font-size: 36px;
+  animation: gearSpin 5s linear infinite reverse;
+}
+.gear-small {
+  font-size: 22px;
+  animation: gearSpin 3s linear infinite;
+}
 
-.g1 { right: 30px;  top: 60px;  color: var(--color-gold);    text-shadow: 0 0 10px var(--color-gold),   0 0 20px rgba(255,214,68,0.4); }
-.g2 { right: 75px;  top: 80px;  color: var(--color-teal);    text-shadow: 0 0 10px var(--color-teal),   0 0 20px rgba(0,187,170,0.4); }
-.g3 { right: 55px;  top: 100px; color: var(--color-orange);  text-shadow: 0 0 10px var(--color-orange), 0 0 20px rgba(255,119,0,0.4); }
-.g4 { left: 620px;  top: 40px;  color: var(--color-sky);     text-shadow: 0 0 10px var(--color-sky),    0 0 20px rgba(68,170,238,0.4); }
-.g5 { left: 650px;  top: 65px;  color: var(--color-amber);   text-shadow: 0 0 10px var(--color-amber),  0 0 20px rgba(255,204,0,0.4); }
+.g1 {
+  right: 30px;
+  top: 60px;
+  color: var(--color-gold);
+  text-shadow:
+    0 0 10px var(--color-gold),
+    0 0 20px rgba(255, 214, 68, 0.4);
+}
+.g2 {
+  right: 75px;
+  top: 80px;
+  color: var(--color-teal);
+  text-shadow:
+    0 0 10px var(--color-teal),
+    0 0 20px rgba(0, 187, 170, 0.4);
+}
+.g3 {
+  right: 55px;
+  top: 100px;
+  color: var(--color-orange);
+  text-shadow:
+    0 0 10px var(--color-orange),
+    0 0 20px rgba(255, 119, 0, 0.4);
+}
+.g4 {
+  left: 620px;
+  top: 40px;
+  color: var(--color-sky);
+  text-shadow:
+    0 0 10px var(--color-sky),
+    0 0 20px rgba(68, 170, 238, 0.4);
+}
+.g5 {
+  left: 650px;
+  top: 65px;
+  color: var(--color-amber);
+  text-shadow:
+    0 0 10px var(--color-amber),
+    0 0 20px rgba(255, 204, 0, 0.4);
+}
 
 @keyframes gearSpin {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Furnace */
@@ -724,7 +891,9 @@ function stateLabel(state: string) {
   align-items: center;
   justify-content: space-around;
   padding: 6px;
-  box-shadow: 0 0 14px rgba(204, 85, 0, 0.4), inset 0 0 8px rgba(255, 119, 0, 0.1);
+  box-shadow:
+    0 0 14px rgba(204, 85, 0, 0.4),
+    inset 0 0 8px rgba(255, 119, 0, 0.1);
 }
 
 .furnace-door {
@@ -742,8 +911,14 @@ function stateLabel(state: string) {
 }
 
 @keyframes flicker {
-  from { opacity: 0.85; box-shadow: inset 0 0 8px rgba(255, 80, 0, 0.4); }
-  to   { opacity: 1;    box-shadow: inset 0 0 14px rgba(255, 120, 0, 0.7); }
+  from {
+    opacity: 0.85;
+    box-shadow: inset 0 0 8px rgba(255, 80, 0, 0.4);
+  }
+  to {
+    opacity: 1;
+    box-shadow: inset 0 0 14px rgba(255, 120, 0, 0.7);
+  }
 }
 
 .furnace-gauge {
@@ -770,8 +945,12 @@ function stateLabel(state: string) {
 }
 
 @keyframes needleSpin {
-  from { transform: rotate(-60deg); }
-  to   { transform: rotate(60deg); }
+  from {
+    transform: rotate(-60deg);
+  }
+  to {
+    transform: rotate(60deg);
+  }
 }
 
 .furnace-chimney {
@@ -798,8 +977,14 @@ function stateLabel(state: string) {
 }
 
 @keyframes smokeRise {
-  0%   { transform: translate(-50%, 0) scale(0.5); opacity: 0.8; }
-  100% { transform: translate(calc(-50% + 20px), -50px) scale(3); opacity: 0; }
+  0% {
+    transform: translate(-50%, 0) scale(0.5);
+    opacity: 0.8;
+  }
+  100% {
+    transform: translate(calc(-50% + 20px), -50px) scale(3);
+    opacity: 0;
+  }
 }
 
 .furnace-label {
@@ -846,16 +1031,32 @@ function stateLabel(state: string) {
   animation-delay: calc(var(--offset, 0) * -1ms / 10);
 }
 
-.belt-item:nth-child(6n+1) { filter: drop-shadow(0 0 3px var(--color-gold)); }
-.belt-item:nth-child(6n+2) { filter: drop-shadow(0 0 3px var(--color-teal)); }
-.belt-item:nth-child(6n+3) { filter: drop-shadow(0 0 3px var(--color-amber)); }
-.belt-item:nth-child(6n+4) { filter: drop-shadow(0 0 3px var(--color-sky)); }
-.belt-item:nth-child(6n+5) { filter: drop-shadow(0 0 3px var(--color-orange)); }
-.belt-item:nth-child(6n)   { filter: drop-shadow(0 0 3px var(--color-gold)); }
+.belt-item:nth-child(6n + 1) {
+  filter: drop-shadow(0 0 3px var(--color-gold));
+}
+.belt-item:nth-child(6n + 2) {
+  filter: drop-shadow(0 0 3px var(--color-teal));
+}
+.belt-item:nth-child(6n + 3) {
+  filter: drop-shadow(0 0 3px var(--color-amber));
+}
+.belt-item:nth-child(6n + 4) {
+  filter: drop-shadow(0 0 3px var(--color-sky));
+}
+.belt-item:nth-child(6n + 5) {
+  filter: drop-shadow(0 0 3px var(--color-orange));
+}
+.belt-item:nth-child(6n) {
+  filter: drop-shadow(0 0 3px var(--color-gold));
+}
 
 @keyframes beltMove {
-  from { transform: translateX(120%); }
-  to   { transform: translateX(-100px); }
+  from {
+    transform: translateX(120%);
+  }
+  to {
+    transform: translateX(-100px);
+  }
 }
 
 .belt-roller {
@@ -863,14 +1064,23 @@ function stateLabel(state: string) {
   bottom: 0;
   width: 28px;
   height: 28px;
-  background: radial-gradient(circle, var(--color-copper-light) 20%, var(--color-copper) 55%, var(--color-brass-dark) 100%);
+  background: radial-gradient(
+    circle,
+    var(--color-copper-light) 20%,
+    var(--color-copper) 55%,
+    var(--color-brass-dark) 100%
+  );
   border-radius: 50%;
   border: 3px solid var(--color-brass-dark);
   box-shadow: 0 0 6px rgba(204, 85, 0, 0.5);
 }
 
-.belt-roller.left  { left: -14px; }
-.belt-roller.right { right: -14px; }
+.belt-roller.left {
+  left: -14px;
+}
+.belt-roller.right {
+  right: -14px;
+}
 
 /* Work Stations */
 .work-station {
@@ -923,14 +1133,31 @@ function stateLabel(state: string) {
   border-radius: 1px;
 }
 
-.screen-line:nth-child(1) { background: var(--color-teal); }
-.screen-line:nth-child(2) { background: var(--color-sky); animation-delay: -0.7s; opacity: 0.5; }
-.screen-line:nth-child(3) { background: var(--color-green); animation-delay: -1.4s; opacity: 0.3; width: 60%; }
+.screen-line:nth-child(1) {
+  background: var(--color-teal);
+}
+.screen-line:nth-child(2) {
+  background: var(--color-sky);
+  animation-delay: -0.7s;
+  opacity: 0.5;
+}
+.screen-line:nth-child(3) {
+  background: var(--color-green);
+  animation-delay: -1.4s;
+  opacity: 0.3;
+  width: 60%;
+}
 
 @keyframes screenScroll {
-  0%   { opacity: 0.85; }
-  50%  { opacity: 0.3; }
-  100% { opacity: 0.85; }
+  0% {
+    opacity: 0.85;
+  }
+  50% {
+    opacity: 0.3;
+  }
+  100% {
+    opacity: 0.85;
+  }
 }
 
 .screen-idle {
@@ -947,10 +1174,10 @@ function stateLabel(state: string) {
   border-top: 3px solid var(--color-brass);
 }
 
-.station-agent, .station-empty {
+.station-agent,
+.station-empty {
   margin-top: 2px;
 }
-
 
 .empty-slot {
   width: 30px;
@@ -983,13 +1210,33 @@ function stateLabel(state: string) {
   text-transform: uppercase;
 }
 
-.state-working       { color: var(--color-green);  text-shadow: 0 0 4px var(--color-green); }
-.state-pending       { color: var(--color-text-dim); }
-.state-planning      { color: var(--color-sky);    text-shadow: 0 0 4px var(--color-sky); }
-.state-awaiting-review { color: var(--color-amber); text-shadow: 0 0 4px var(--color-amber); }
-.state-followup      { color: var(--color-orange); text-shadow: 0 0 4px var(--color-orange); }
-.state-failed        { color: var(--color-red);    text-shadow: 0 0 4px var(--color-red); }
-.state-done          { color: var(--color-teal);   text-shadow: 0 0 4px var(--color-teal); }
+.state-working {
+  color: var(--color-green);
+  text-shadow: 0 0 4px var(--color-green);
+}
+.state-pending {
+  color: var(--color-text-dim);
+}
+.state-planning {
+  color: var(--color-sky);
+  text-shadow: 0 0 4px var(--color-sky);
+}
+.state-awaiting-review {
+  color: var(--color-amber);
+  text-shadow: 0 0 4px var(--color-amber);
+}
+.state-followup {
+  color: var(--color-orange);
+  text-shadow: 0 0 4px var(--color-orange);
+}
+.state-failed {
+  color: var(--color-red);
+  text-shadow: 0 0 4px var(--color-red);
+}
+.state-done {
+  color: var(--color-teal);
+  text-shadow: 0 0 4px var(--color-teal);
+}
 
 .work-station.occupied .station-table {
   border-top-color: var(--color-brass-light);
@@ -1000,7 +1247,9 @@ function stateLabel(state: string) {
 .floating-agent {
   position: absolute;
   z-index: 5;
-  transition: left var(--walk-dur, 1.5s) ease-in-out, top var(--walk-dur, 1.5s) ease-in-out;
+  transition:
+    left var(--walk-dur, 1.5s) ease-in-out,
+    top var(--walk-dur, 1.5s) ease-in-out;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1025,8 +1274,15 @@ function stateLabel(state: string) {
 }
 
 @keyframes chatBob {
-  0%, 100% { transform: translateY(0); opacity: 0.9; }
-  50%       { transform: translateY(-2px); opacity: 1; }
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.9;
+  }
+  50% {
+    transform: translateY(-2px);
+    opacity: 1;
+  }
 }
 
 /* ── Points of interest ──────────────────────────────── */
@@ -1043,7 +1299,7 @@ function stateLabel(state: string) {
   color: var(--color-brass-dark);
   letter-spacing: 1px;
   white-space: nowrap;
-  text-shadow: 0 0 4px rgba(232,170,0,0.4);
+  text-shadow: 0 0 4px rgba(232, 170, 0, 0.4);
 }
 
 /* Tool cabinet — top-left */
@@ -1060,7 +1316,7 @@ function stateLabel(state: string) {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  box-shadow: 0 0 6px rgba(204,85,0,0.25);
+  box-shadow: 0 0 6px rgba(204, 85, 0, 0.25);
 }
 .tc-drawer {
   height: 7px;
@@ -1094,7 +1350,7 @@ function stateLabel(state: string) {
   border-radius: 2px;
   position: relative;
   overflow: hidden;
-  box-shadow: 0 0 8px rgba(232,170,0,0.2);
+  box-shadow: 0 0 8px rgba(232, 170, 0, 0.2);
 }
 .bb-pin {
   position: absolute;
@@ -1108,9 +1364,30 @@ function stateLabel(state: string) {
   position: absolute;
   border-radius: 1px;
 }
-.bb-note.n1 { width: 24px; height: 16px; background: #ffe8a0; left: 6px;  top: 14px; transform: rotate(-2deg); }
-.bb-note.n2 { width: 20px; height: 14px; background: #a0f0d0; left: 34px; top: 12px; transform: rotate(3deg); }
-.bb-note.n3 { width: 18px; height: 12px; background: #f0c0a0; left: 20px; top: 28px; transform: rotate(-1deg); }
+.bb-note.n1 {
+  width: 24px;
+  height: 16px;
+  background: #ffe8a0;
+  left: 6px;
+  top: 14px;
+  transform: rotate(-2deg);
+}
+.bb-note.n2 {
+  width: 20px;
+  height: 14px;
+  background: #a0f0d0;
+  left: 34px;
+  top: 12px;
+  transform: rotate(3deg);
+}
+.bb-note.n3 {
+  width: 18px;
+  height: 12px;
+  background: #f0c0a0;
+  left: 20px;
+  top: 28px;
+  transform: rotate(-1deg);
+}
 
 /* Water cooler — mid-left */
 .water-cooler {
@@ -1120,10 +1397,10 @@ function stateLabel(state: string) {
 .wc-bottle {
   width: 22px;
   height: 36px;
-  background: linear-gradient(180deg, rgba(68,170,238,0.4) 0%, rgba(68,170,238,0.15) 100%);
+  background: linear-gradient(180deg, rgba(68, 170, 238, 0.4) 0%, rgba(68, 170, 238, 0.15) 100%);
   border: 2px solid var(--color-sky);
   border-radius: 4px 4px 2px 2px;
-  box-shadow: 0 0 6px rgba(68,170,238,0.3);
+  box-shadow: 0 0 6px rgba(68, 170, 238, 0.3);
 }
 .wc-base {
   width: 30px;
@@ -1156,9 +1433,17 @@ function stateLabel(state: string) {
   opacity: 0.7;
 }
 @keyframes drip {
-  0%   { transform: translateY(-8px); opacity: 0.8; }
-  60%  { opacity: 0.6; }
-  100% { transform: translateY(12px); opacity: 0; }
+  0% {
+    transform: translateY(-8px);
+    opacity: 0.8;
+  }
+  60% {
+    opacity: 0.6;
+  }
+  100% {
+    transform: translateY(12px);
+    opacity: 0;
+  }
 }
 
 /* Coffee maker — position set dynamically beside the top-right desk */
@@ -1174,7 +1459,7 @@ function stateLabel(state: string) {
   justify-content: flex-end;
   padding-bottom: 4px;
   position: relative;
-  box-shadow: 0 0 8px rgba(204,85,0,0.3);
+  box-shadow: 0 0 8px rgba(204, 85, 0, 0.3);
 }
 .cm-tank {
   position: absolute;
@@ -1182,7 +1467,7 @@ function stateLabel(state: string) {
   left: 6px;
   right: 6px;
   height: 20px;
-  background: linear-gradient(180deg, rgba(68,170,238,0.25), rgba(68,170,238,0.08));
+  background: linear-gradient(180deg, rgba(68, 170, 238, 0.25), rgba(68, 170, 238, 0.08));
   border: 1px solid var(--color-sky);
   border-radius: 2px;
 }
@@ -1215,7 +1500,7 @@ function stateLabel(state: string) {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(136,68,255,0.4) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(136, 68, 255, 0.4) 0%, transparent 70%);
   animation: orbPulse 2.2s ease-in-out infinite;
   top: 4px;
   left: 4px;
@@ -1223,7 +1508,7 @@ function stateLabel(state: string) {
 .orb-sphere {
   font-size: 20px;
   line-height: 1;
-  filter: drop-shadow(0 0 6px rgba(136,68,255,0.8));
+  filter: drop-shadow(0 0 6px rgba(136, 68, 255, 0.8));
   animation: orbFloat 3s ease-in-out infinite;
   position: relative;
   z-index: 1;
@@ -1237,12 +1522,24 @@ function stateLabel(state: string) {
   border: 1px solid var(--color-copper);
 }
 @keyframes orbPulse {
-  0%, 100% { opacity: 0.4; transform: scale(0.9); }
-  50%       { opacity: 0.8; transform: scale(1.2); }
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: scale(0.9);
+  }
+  50% {
+    opacity: 0.8;
+    transform: scale(1.2);
+  }
 }
 @keyframes orbFloat {
-  0%, 100% { transform: translateY(0px); }
-  50%       { transform: translateY(-3px); }
+  0%,
+  100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
 }
 
 /* Archive */
@@ -1259,17 +1556,33 @@ function stateLabel(state: string) {
   align-items: flex-end;
   gap: 2px;
   padding: 2px 3px;
-  box-shadow: 0 0 6px rgba(232,170,0,0.15);
+  box-shadow: 0 0 6px rgba(232, 170, 0, 0.15);
 }
 .book {
   border-radius: 1px 1px 0 0;
-  border: 1px solid rgba(0,0,0,0.3);
+  border: 1px solid rgba(0, 0, 0, 0.3);
   flex: 1;
 }
-.book.b1 { height: 22px; background: var(--color-teal);   box-shadow: 0 0 3px var(--color-teal); }
-.book.b2 { height: 18px; background: var(--color-amber);  box-shadow: 0 0 3px var(--color-amber); }
-.book.b3 { height: 26px; background: var(--color-sky);    box-shadow: 0 0 3px var(--color-sky); }
-.book.b4 { height: 20px; background: var(--color-orange); box-shadow: 0 0 3px var(--color-orange); }
+.book.b1 {
+  height: 22px;
+  background: var(--color-teal);
+  box-shadow: 0 0 3px var(--color-teal);
+}
+.book.b2 {
+  height: 18px;
+  background: var(--color-amber);
+  box-shadow: 0 0 3px var(--color-amber);
+}
+.book.b3 {
+  height: 26px;
+  background: var(--color-sky);
+  box-shadow: 0 0 3px var(--color-sky);
+}
+.book.b4 {
+  height: 20px;
+  background: var(--color-orange);
+  box-shadow: 0 0 3px var(--color-orange);
+}
 
 /* Telegraph */
 .telegraph {
@@ -1286,7 +1599,7 @@ function stateLabel(state: string) {
   justify-content: center;
   padding-bottom: 3px;
   position: relative;
-  box-shadow: 0 0 6px rgba(68,170,238,0.2);
+  box-shadow: 0 0 6px rgba(68, 170, 238, 0.2);
 }
 .tg-key {
   width: 14px;
@@ -1297,8 +1610,14 @@ function stateLabel(state: string) {
   animation: keyTap 1.8s ease-in-out infinite;
 }
 @keyframes keyTap {
-  0%, 85%, 100% { transform: translateY(0); }
-  90%            { transform: translateY(2px); }
+  0%,
+  85%,
+  100% {
+    transform: translateY(0);
+  }
+  90% {
+    transform: translateY(2px);
+  }
 }
 .tg-spark {
   position: absolute;
@@ -1311,9 +1630,18 @@ function stateLabel(state: string) {
   animation: spark 1.8s var(--delay, 0s) ease-out infinite;
 }
 @keyframes spark {
-  0%   { opacity: 0; transform: translate(0, 0) scale(1); }
-  30%  { opacity: 1; transform: translate(3px, -4px) scale(1.4); }
-  100% { opacity: 0; transform: translate(6px, -10px) scale(0.2); }
+  0% {
+    opacity: 0;
+    transform: translate(0, 0) scale(1);
+  }
+  30% {
+    opacity: 1;
+    transform: translate(3px, -4px) scale(1.4);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(6px, -10px) scale(0.2);
+  }
 }
 .tg-wire {
   width: 2px;
@@ -1329,12 +1657,14 @@ function stateLabel(state: string) {
 .tank-vessel {
   width: 44px;
   height: 36px;
-  background: linear-gradient(180deg, rgba(68,153,255,0.12) 0%, rgba(0,0,0,0) 100%);
-  border: 2px solid rgba(68,153,255,0.4);
+  background: linear-gradient(180deg, rgba(68, 153, 255, 0.12) 0%, rgba(0, 0, 0, 0) 100%);
+  border: 2px solid rgba(68, 153, 255, 0.4);
   border-radius: 4px 4px 2px 2px;
   position: relative;
   overflow: hidden;
-  box-shadow: 0 0 10px rgba(68,153,255,0.25), inset 0 0 8px rgba(68,153,255,0.1);
+  box-shadow:
+    0 0 10px rgba(68, 153, 255, 0.25),
+    inset 0 0 8px rgba(68, 153, 255, 0.1);
 }
 .tank-bubble {
   position: absolute;
@@ -1342,19 +1672,25 @@ function stateLabel(state: string) {
   left: calc(50% + var(--xoff, 0px));
   width: 6px;
   height: 6px;
-  background: radial-gradient(circle, rgba(68,153,255,0.7) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(68, 153, 255, 0.7) 0%, transparent 70%);
   border-radius: 50%;
   animation: bubbleRise 2.4s var(--delay, 0s) ease-out infinite;
 }
 @keyframes bubbleRise {
-  0%   { transform: translateY(0) scale(0.6); opacity: 0.8; }
-  100% { transform: translateY(-34px) scale(1.8); opacity: 0; }
+  0% {
+    transform: translateY(0) scale(0.6);
+    opacity: 0.8;
+  }
+  100% {
+    transform: translateY(-34px) scale(1.8);
+    opacity: 0;
+  }
 }
 .tank-gauge {
   width: 16px;
   height: 8px;
-  background: rgba(68,153,255,0.2);
-  border: 1px solid rgba(68,153,255,0.4);
+  background: rgba(68, 153, 255, 0.2);
+  border: 1px solid rgba(68, 153, 255, 0.4);
   border-radius: 1px;
   margin: 1px auto 0;
 }
@@ -1381,7 +1717,7 @@ function stateLabel(state: string) {
   font-size: 20px;
   line-height: 1;
   animation: flicker 0.4s infinite alternate;
-  filter: drop-shadow(0 0 6px rgba(255,100,0,0.8));
+  filter: drop-shadow(0 0 6px rgba(255, 100, 0, 0.8));
 }
 
 /* Factory info overlay */
@@ -1397,13 +1733,16 @@ function stateLabel(state: string) {
   border: 1px solid var(--color-brass);
   padding: 4px 14px;
   z-index: 10;
-  box-shadow: 0 0 12px rgba(232, 170, 0, 0.3), inset 0 0 6px rgba(232, 170, 0, 0.06);
+  box-shadow:
+    0 0 12px rgba(232, 170, 0, 0.3),
+    inset 0 0 6px rgba(232, 170, 0, 0.06);
 }
 
 .factory-title {
   font-size: 7px;
   letter-spacing: 2px;
-  background: linear-gradient(90deg,
+  background: linear-gradient(
+    90deg,
     var(--color-amber),
     var(--color-gold),
     var(--color-cream),
@@ -1420,8 +1759,12 @@ function stateLabel(state: string) {
 }
 
 @keyframes goldShimmer {
-  from { background-position: 0% center; }
-  to   { background-position: 250% center; }
+  from {
+    background-position: 0% center;
+  }
+  to {
+    background-position: 250% center;
+  }
 }
 
 .agent-count {
@@ -1458,12 +1801,24 @@ function stateLabel(state: string) {
   text-shadow: 0 0 4px rgba(255, 204, 0, 0.5);
 }
 
-.ticker-msg:nth-child(3n+1) { color: var(--color-amber); }
-.ticker-msg:nth-child(3n+2) { color: var(--color-teal); text-shadow: 0 0 4px rgba(0,187,170,0.5); }
-.ticker-msg:nth-child(3n)   { color: var(--color-gold); text-shadow: 0 0 4px rgba(255,214,68,0.5); }
+.ticker-msg:nth-child(3n + 1) {
+  color: var(--color-amber);
+}
+.ticker-msg:nth-child(3n + 2) {
+  color: var(--color-teal);
+  text-shadow: 0 0 4px rgba(0, 187, 170, 0.5);
+}
+.ticker-msg:nth-child(3n) {
+  color: var(--color-gold);
+  text-shadow: 0 0 4px rgba(255, 214, 68, 0.5);
+}
 
 @keyframes tickerScroll {
-  from { transform: translateX(100vw); }
-  to   { transform: translateX(-100%); }
+  from {
+    transform: translateX(100vw);
+  }
+  to {
+    transform: translateX(-100%);
+  }
 }
 </style>

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -12,18 +12,16 @@
         />
       </template>
       <template v-else>
-        <span class="guild-name-text" @click="startRename" title="Click to rename">{{ currentGuild.name }}</span>
+        <span class="guild-name-text" @click="startRename" title="Click to rename">{{
+          currentGuild.name
+        }}</span>
         <button class="rename-btn" @click="startRename" title="Rename guild">✎</button>
       </template>
     </div>
 
     <div v-if="currentGuild" class="primary-repo-bar">
       <span class="primary-repo-bar-label">Primary repo:</span>
-      <select
-        v-model="primaryRepoValue"
-        class="primary-repo-bar-select"
-        @change="savePrimaryRepo"
-      >
+      <select v-model="primaryRepoValue" class="primary-repo-bar-select" @change="savePrimaryRepo">
         <option value="">— select primary repo —</option>
         <option v-for="repo in ghStore.repos" :key="repo.full_name" :value="repo.full_name">
           {{ repo.full_name }}
@@ -55,7 +53,10 @@
           @click="openTask(task.id)"
         >
           <div class="task-top">
-            <span class="task-dot" :class="'dot-' + (task.state || 'pending').replace(/[^a-z]/g, '-')"></span>
+            <span
+              class="task-dot"
+              :class="'dot-' + (task.state || 'pending').replace(/[^a-z]/g, '-')"
+            ></span>
             <span class="task-name">{{ task.name || task.id }}</span>
           </div>
           <div class="task-meta">
@@ -67,11 +68,20 @@
     </div>
 
     <!-- Workers/Agents hierarchical section -->
-    <div class="workers-section" :class="{ 'workers-section--empty': onlineWorkers.length === 0 && !showSpawnForm }">
+    <div
+      class="workers-section"
+      :class="{ 'workers-section--empty': onlineWorkers.length === 0 && !showSpawnForm }"
+    >
       <div class="section-header">
         <span class="section-label">Workers</span>
-        <span class="section-count" v-if="onlineWorkers.length > 0">{{ onlineWorkers.length }}</span>
-        <button class="spawn-btn" @click="toggleSpawnForm" :title="showSpawnForm ? 'Cancel' : 'Launch a new worker container'">
+        <span class="section-count" v-if="onlineWorkers.length > 0">{{
+          onlineWorkers.length
+        }}</span>
+        <button
+          class="spawn-btn"
+          @click="toggleSpawnForm"
+          :title="showSpawnForm ? 'Cancel' : 'Launch a new worker container'"
+        >
           {{ showSpawnForm ? '✕' : '+' }}
         </button>
       </div>
@@ -102,7 +112,11 @@
         <label class="spawn-label">Name <span class="spawn-hint">(optional)</span></label>
         <input v-model="spawnName" class="spawn-input" type="text" placeholder="auto-generated" />
         <div class="spawn-actions">
-          <button class="pixel-btn spawn-launch-btn" :disabled="spawning || spawnSelectedRepos.length === 0" @click="launchWorker">
+          <button
+            class="pixel-btn spawn-launch-btn"
+            :disabled="spawning || spawnSelectedRepos.length === 0"
+            @click="launchWorker"
+          >
             {{ spawning ? 'Launching…' : 'Launch' }}
           </button>
         </div>
@@ -116,11 +130,7 @@
           <span class="worker-row-state">{{ worker.state }}</span>
         </div>
         <!-- Agent rows under this worker -->
-        <div
-          v-for="agent in agentsForWorker(worker.id)"
-          :key="agent.id"
-          class="agent-row"
-        >
+        <div v-for="agent in agentsForWorker(worker.id)" :key="agent.id" class="agent-row">
           <span class="agent-dot" :class="'wdot-' + agent.state"></span>
           <span class="agent-row-name">{{ agent.name }}</span>
           <div class="agent-actions">
@@ -128,28 +138,43 @@
               class="agent-icon-btn"
               title="Open agent terminal"
               @click.stop="agentsStore.selectAgent(agent.id)"
-            >🤖</button>
+            >
+              🤖
+            </button>
             <button
               class="agent-icon-btn"
               :disabled="!currentTaskForWorker(worker.id)"
               :title="currentTaskForWorker(worker.id) ? 'Open current task' : 'No active task'"
               @click.stop="openAgentTask(worker.id)"
-            >📋</button>
+            >
+              📋
+            </button>
           </div>
         </div>
       </template>
     </div>
 
     <div class="sidebar-footer">
-      <div class="gh-block" @click="showGitHubModal = true" :title="authStore.user ? 'GitHub: ' + authStore.user.login : 'Configure GitHub'">
+      <div
+        class="gh-block"
+        @click="showGitHubModal = true"
+        :title="authStore.user ? 'GitHub: ' + authStore.user.login : 'Configure GitHub'"
+      >
         <div class="gh-inner" :class="{ configured: authStore.isLoggedIn }">
-          <img v-if="authStore.isLoggedIn" :src="authStore.user?.avatar_url" class="gh-avatar" alt="gh" />
+          <img
+            v-if="authStore.isLoggedIn"
+            :src="authStore.user?.avatar_url"
+            class="gh-avatar"
+            alt="gh"
+          />
           <span v-else class="gh-icon">⚙</span>
           <div class="gh-text">
             <span v-if="authStore.isLoggedIn" class="gh-login">{{ authStore.user?.login }}</span>
             <span v-else class="gh-setup">Connect GitHub</span>
             <span class="gh-repos" v-if="authStore.isLoggedIn && ghStore.selectedRepos.length > 0">
-              {{ ghStore.selectedRepos.length }} repo{{ ghStore.selectedRepos.length !== 1 ? 's' : '' }}
+              {{ ghStore.selectedRepos.length }} repo{{
+                ghStore.selectedRepos.length !== 1 ? 's' : ''
+              }}
             </span>
           </div>
         </div>
@@ -190,7 +215,7 @@ const switchMobileTab = inject<(tab: string) => void>('switchMobileTab', () => {
 const showGitHubModal = ref(false)
 const currentGuild = computed(() => guildStore.currentGuild)
 const isConnected = computed(() => guildStore.isConnected)
-const onlineWorkers = computed(() => agentsStore.workers.filter(w => w.state !== 'offline'))
+const onlineWorkers = computed(() => agentsStore.workers.filter((w) => w.state !== 'offline'))
 
 const showSpawnForm = ref(false)
 const spawnSelectedRepos = ref<string[]>([])
@@ -230,7 +255,10 @@ async function launchWorker() {
     const res = await fetch(`${API_BASE}/guilds/${currentGuild.value.id}/spawn-worker`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...authStore.authHeaders() },
-      body: JSON.stringify({ repos: spawnSelectedRepos.value, name: spawnName.value.trim() || undefined }),
+      body: JSON.stringify({
+        repos: spawnSelectedRepos.value,
+        name: spawnName.value.trim() || undefined,
+      }),
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({ detail: res.statusText }))
@@ -248,9 +276,13 @@ const primaryRepoValue = ref('')
 const saveStatus = ref('')
 let saveStatusTimer: ReturnType<typeof setTimeout> | null = null
 
-watch(currentGuild, (guild) => {
-  primaryRepoValue.value = guild?.primary_repo ?? ''
-}, { immediate: true })
+watch(
+  currentGuild,
+  (guild) => {
+    primaryRepoValue.value = guild?.primary_repo ?? ''
+  },
+  { immediate: true },
+)
 
 async function savePrimaryRepo() {
   if (!currentGuild.value) return
@@ -264,7 +296,9 @@ async function savePrimaryRepo() {
     saveStatus.value = 'error'
   } finally {
     if (saveStatusTimer) clearTimeout(saveStatusTimer)
-    saveStatusTimer = setTimeout(() => { saveStatus.value = '' }, 2000)
+    saveStatusTimer = setTimeout(() => {
+      saveStatus.value = ''
+    }, 2000)
   }
 }
 
@@ -340,15 +374,15 @@ function openTask(taskId: string) {
 }
 
 function agentsForWorker(workerId: string) {
-  return agentsStore.agents.filter(a => a.workerId === workerId)
+  return agentsStore.agents.filter((a) => a.workerId === workerId)
 }
 
 function currentTaskForWorker(workerId: string) {
   const active = tasksStore.tasks.filter(
-    t => t.worker_id === workerId && !['done', 'failed'].includes(t.state)
+    (t) => t.worker_id === workerId && !['done', 'failed'].includes(t.state),
   )
   if (active.length) return active[0]
-  return tasksStore.tasks.find(t => t.worker_id === workerId) || null
+  return tasksStore.tasks.find((t) => t.worker_id === workerId) || null
 }
 
 function openAgentTask(workerId: string) {
@@ -418,7 +452,9 @@ function formatTime(isoStr?: string) {
   border-radius: 2px;
   line-height: 1;
   opacity: 0.5;
-  transition: opacity 0.12s, background 0.12s;
+  transition:
+    opacity 0.12s,
+    background 0.12s;
   flex-shrink: 0;
 }
 
@@ -539,14 +575,34 @@ function formatTime(isoStr?: string) {
   border-radius: 2px;
   flex-shrink: 0;
 }
-.dot-pending { background: var(--color-text-dim); }
-.dot-planning { background: var(--color-blue); }
-.dot-working { background: var(--color-green); animation: pulse 0.5s infinite; }
-.dot-awaiting-review { background: var(--color-amber); animation: pulse 1.5s infinite; }
-.dot-done { background: var(--color-teal); }
-.dot-failed { background: var(--color-red); }
-.dot-follow-up { background: var(--color-orange); animation: pulse 0.8s infinite; }
-.dot-followup { background: var(--color-orange); animation: pulse 0.8s infinite; }
+.dot-pending {
+  background: var(--color-text-dim);
+}
+.dot-planning {
+  background: var(--color-blue);
+}
+.dot-working {
+  background: var(--color-green);
+  animation: pulse 0.5s infinite;
+}
+.dot-awaiting-review {
+  background: var(--color-amber);
+  animation: pulse 1.5s infinite;
+}
+.dot-done {
+  background: var(--color-teal);
+}
+.dot-failed {
+  background: var(--color-red);
+}
+.dot-follow-up {
+  background: var(--color-orange);
+  animation: pulse 0.8s infinite;
+}
+.dot-followup {
+  background: var(--color-orange);
+  animation: pulse 0.8s infinite;
+}
 
 .task-name {
   font-size: 11px;
@@ -632,7 +688,9 @@ function formatTime(isoStr?: string) {
   justify-content: center;
   padding: 0;
   opacity: 0.7;
-  transition: opacity 0.12s, background 0.12s;
+  transition:
+    opacity 0.12s,
+    background 0.12s;
 }
 
 .spawn-btn:hover {
@@ -804,8 +862,12 @@ function formatTime(isoStr?: string) {
   flex-shrink: 0;
 }
 
-.save-status-saved { color: var(--color-green); }
-.save-status-error { color: var(--color-red); }
+.save-status-saved {
+  color: var(--color-green);
+}
+.save-status-error {
+  color: var(--color-red);
+}
 
 /* Worker top-level row */
 .worker-row {
@@ -886,7 +948,9 @@ function formatTime(isoStr?: string) {
   padding: 1px 3px;
   border-radius: 2px;
   opacity: 0.6;
-  transition: opacity 0.12s, background 0.12s;
+  transition:
+    opacity 0.12s,
+    background 0.12s;
   line-height: 1;
 }
 
@@ -906,12 +970,27 @@ function formatTime(isoStr?: string) {
   border-radius: 50%;
   flex-shrink: 0;
 }
-.wdot-idle    { background: var(--color-text-dim); }
-.wdot-working { background: var(--color-green); animation: pulse 0.5s infinite; }
-.wdot-thinking { background: var(--color-blue); animation: pulse 1s infinite; }
-.wdot-busy    { background: var(--color-orange); animation: pulse 0.8s infinite; }
-.wdot-error   { background: var(--color-red); }
-.wdot-offline { background: #333; }
+.wdot-idle {
+  background: var(--color-text-dim);
+}
+.wdot-working {
+  background: var(--color-green);
+  animation: pulse 0.5s infinite;
+}
+.wdot-thinking {
+  background: var(--color-blue);
+  animation: pulse 1s infinite;
+}
+.wdot-busy {
+  background: var(--color-orange);
+  animation: pulse 0.8s infinite;
+}
+.wdot-error {
+  background: var(--color-red);
+}
+.wdot-offline {
+  background: #333;
+}
 
 /* ── Footer ── */
 .sidebar-footer {
@@ -1014,7 +1093,12 @@ function formatTime(isoStr?: string) {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 </style>

--- a/frontend/src/components/HelloWorld.vue
+++ b/frontend/src/components/HelloWorld.vue
@@ -18,9 +18,7 @@ const count = ref(0)
       <h1>Get started</h1>
       <p>Edit <code>src/App.vue</code> and save to test <code>HMR</code></p>
     </div>
-    <button type="button" class="counter" @click="count++">
-      Count is {{ count }}
-    </button>
+    <button type="button" class="counter" @click="count++">Count is {{ count }}</button>
   </section>
 
   <div class="ticks"></div>

--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -49,7 +49,10 @@
     <div class="tab-content">
       <FactoryFloor v-if="activeTab === 'factory'" />
       <TerminalPane v-else-if="activeTab.startsWith('agent-')" :agent-id="activeTab.slice(6)" />
-      <WorkerTerminalPane v-else-if="activeTab.startsWith('worker-')" :worker-id="activeTab.slice(7)" />
+      <WorkerTerminalPane
+        v-else-if="activeTab.startsWith('worker-')"
+        :worker-id="activeTab.slice(7)"
+      />
       <TaskPane v-else-if="activeTab.startsWith('task-')" :task-id="activeTab.slice(5)" />
     </div>
   </div>
@@ -70,33 +73,40 @@ const activeTab = ref('factory')
 
 const visibleAgentTabs = computed(() =>
   agentsStore.openedAgentIds
-    .map(id => agentsStore.agents.find(a => a.id === id))
-    .filter(Boolean)
+    .map((id) => agentsStore.agents.find((a) => a.id === id))
+    .filter(Boolean),
 )
 
 const visibleWorkerTabs = computed(() =>
   agentsStore.openedWorkerIds
-    .map(id => agentsStore.workers.find(w => w.id === id))
-    .filter(Boolean)
+    .map((id) => agentsStore.workers.find((w) => w.id === id))
+    .filter(Boolean),
 )
 
 const visibleTaskTabs = computed(() =>
-  tasksStore.openedTaskIds
-    .map(id => tasksStore.tasks.find(t => t.id === id))
-    .filter(Boolean)
+  tasksStore.openedTaskIds.map((id) => tasksStore.tasks.find((t) => t.id === id)).filter(Boolean),
 )
 
-watch(() => agentsStore.selectedAgentId, (id) => {
-  if (id) activeTab.value = 'agent-' + id
-})
+watch(
+  () => agentsStore.selectedAgentId,
+  (id) => {
+    if (id) activeTab.value = 'agent-' + id
+  },
+)
 
-watch(() => agentsStore.selectedWorkerId, (id) => {
-  if (id) activeTab.value = 'worker-' + id
-})
+watch(
+  () => agentsStore.selectedWorkerId,
+  (id) => {
+    if (id) activeTab.value = 'worker-' + id
+  },
+)
 
-watch(() => tasksStore.selectedTaskId, (id) => {
-  if (id) activeTab.value = 'task-' + id
-})
+watch(
+  () => tasksStore.selectedTaskId,
+  (id) => {
+    if (id) activeTab.value = 'task-' + id
+  },
+)
 
 function onWorkerTabClick(event: MouseEvent, workerId: string) {
   if ((event.target as HTMLElement).closest('.tab-close')) {
@@ -172,8 +182,12 @@ function onTabClick(event: MouseEvent, taskId: string) {
   box-shadow: inset 0 -2px 6px rgba(232, 170, 0, 0.1);
 }
 
-.tab-icon { font-size: 14px; }
-.tab-label { font-size: 11px; }
+.tab-icon {
+  font-size: 14px;
+}
+.tab-label {
+  font-size: 11px;
+}
 
 .state-dot {
   width: 8px;
@@ -182,16 +196,36 @@ function onTabClick(event: MouseEvent, taskId: string) {
   display: inline-block;
   flex-shrink: 0;
 }
-.state-dot.idle    { background: var(--color-text-dim); }
-.state-dot.thinking { background: var(--color-blue); animation: dotPulse 1s infinite; }
-.state-dot.working  { background: var(--color-green); animation: dotPulse 0.5s infinite; }
-.state-dot.busy     { background: var(--color-orange); animation: dotPulse 0.8s infinite; }
-.state-dot.error    { background: var(--color-red); }
+.state-dot.idle {
+  background: var(--color-text-dim);
+}
+.state-dot.thinking {
+  background: var(--color-blue);
+  animation: dotPulse 1s infinite;
+}
+.state-dot.working {
+  background: var(--color-green);
+  animation: dotPulse 0.5s infinite;
+}
+.state-dot.busy {
+  background: var(--color-orange);
+  animation: dotPulse 0.8s infinite;
+}
+.state-dot.error {
+  background: var(--color-red);
+}
 
-.worker-tab { border-left: 1px solid rgba(0,187,170,0.2); }
-.worker-tab.active { border-bottom-color: var(--color-teal); color: var(--color-teal); }
+.worker-tab {
+  border-left: 1px solid rgba(0, 187, 170, 0.2);
+}
+.worker-tab.active {
+  border-bottom-color: var(--color-teal);
+  color: var(--color-teal);
+}
 
-.task-tab { border-left: 1px solid rgba(255,204,0,0.2); }
+.task-tab {
+  border-left: 1px solid rgba(255, 204, 0, 0.2);
+}
 
 .tab-close {
   font-size: 13px;
@@ -201,7 +235,9 @@ function onTabClick(event: MouseEvent, taskId: string) {
   padding: 0 2px;
   border-radius: 2px;
   opacity: 0;
-  transition: opacity 0.1s, color 0.1s;
+  transition:
+    opacity 0.1s,
+    color 0.1s;
 }
 
 .worker-tab:hover .tab-close,
@@ -223,16 +259,38 @@ function onTabClick(event: MouseEvent, taskId: string) {
   display: inline-block;
   flex-shrink: 0;
 }
-.task-dot-pending         { background: var(--color-text-dim); }
-.task-dot-working         { background: var(--color-green); animation: dotPulse 0.5s infinite; }
-.task-dot-awaiting-review { background: var(--color-amber); animation: dotPulse 1.5s infinite; }
-.task-dot-done            { background: var(--color-teal); }
-.task-dot-failed          { background: var(--color-red); }
-.task-dot-follow-up       { background: var(--color-orange); animation: dotPulse 0.8s infinite; }
+.task-dot-pending {
+  background: var(--color-text-dim);
+}
+.task-dot-working {
+  background: var(--color-green);
+  animation: dotPulse 0.5s infinite;
+}
+.task-dot-awaiting-review {
+  background: var(--color-amber);
+  animation: dotPulse 1.5s infinite;
+}
+.task-dot-done {
+  background: var(--color-teal);
+}
+.task-dot-failed {
+  background: var(--color-red);
+}
+.task-dot-follow-up {
+  background: var(--color-orange);
+  animation: dotPulse 0.8s infinite;
+}
 
 @keyframes dotPulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50%       { opacity: 0.5; transform: scale(0.7); }
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(0.7);
+  }
 }
 
 .tab-content {

--- a/frontend/src/components/PanelFrame.vue
+++ b/frontend/src/components/PanelFrame.vue
@@ -5,13 +5,16 @@
 </template>
 
 <script setup lang="ts">
-withDefaults(defineProps<{
-  direction?: 'row' | 'column'
-  borderWidth?: number
-}>(), {
-  direction: 'column',
-  borderWidth: 36,
-})
+withDefaults(
+  defineProps<{
+    direction?: 'row' | 'column'
+    borderWidth?: number
+  }>(),
+  {
+    direction: 'column',
+    borderWidth: 36,
+  },
+)
 </script>
 
 <style scoped>

--- a/frontend/src/components/TaskPane.vue
+++ b/frontend/src/components/TaskPane.vue
@@ -4,12 +4,16 @@
       <div class="task-title-row">
         <span class="task-phase-badge" :class="task.phase">{{ task.phase || 'execute' }}</span>
         <span class="task-name">{{ task.name || task.description?.slice(0, 60) }}</span>
-        <span class="task-state-badge" :class="stateClass">{{ tasksStore.stateLabel(task.state) }}</span>
+        <span class="task-state-badge" :class="stateClass">{{
+          tasksStore.stateLabel(task.state)
+        }}</span>
       </div>
       <div class="task-meta">
         <span class="task-id">{{ task.id }}</span>
         <span v-if="task.branch" class="task-branch">⌥ {{ task.branch }}</span>
-        <a v-if="task.pr_url" :href="task.pr_url" target="_blank" rel="noopener" class="pr-link">PR →</a>
+        <a v-if="task.pr_url" :href="task.pr_url" target="_blank" rel="noopener" class="pr-link"
+          >PR →</a
+        >
         <span class="task-time">{{ formatTime(task.created_at) }}</span>
       </div>
     </div>
@@ -24,7 +28,9 @@
         >
           <span class="log-ts">{{ formatTs(entry.timestamp) }}</span>
           <span class="log-text" :class="lineClass(entry.line)">{{ entry.line }}</span>
-          <span v-if="entry.detail" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
+          <span v-if="entry.detail" class="log-expand-icon">{{
+            expandedIdx === i ? '▲' : '▼'
+          }}</span>
         </div>
         <div v-if="entry.detail && expandedIdx === i" class="log-detail">
           <template v-if="entry.detail.toolType === 'tool_use'">
@@ -68,7 +74,11 @@
         />
       </div>
       <div class="redirect-actions">
-        <button class="pixel-btn redirect-btn" @click="sendRedirect" :disabled="!redirectText.trim() || redirecting">
+        <button
+          class="pixel-btn redirect-btn"
+          @click="sendRedirect"
+          :disabled="!redirectText.trim() || redirecting"
+        >
           {{ redirecting ? '…' : '↩ Redirect' }}
         </button>
         <button class="pixel-btn cancel-task-btn" @click="cancelTask" :disabled="cancelling">
@@ -97,12 +107,14 @@
         />
       </div>
       <div class="followup-actions">
-        <button class="pixel-btn followup-btn" @click="sendFollowup" :disabled="!followupText.trim()">
+        <button
+          class="pixel-btn followup-btn"
+          @click="sendFollowup"
+          :disabled="!followupText.trim()"
+        >
           ↺ Follow-up
         </button>
-        <button class="pixel-btn finalize-btn" @click="finalizeTask">
-          ✓ Finalize
-        </button>
+        <button class="pixel-btn finalize-btn" @click="finalizeTask">✓ Finalize</button>
       </div>
     </div>
   </div>
@@ -126,10 +138,14 @@ const cancelling = ref(false)
 const redirecting = ref(false)
 const expandedIdx = ref<number | null>(null)
 
-const task = computed<Partial<Task>>(() => tasksStore.tasks.find(t => t.id === props.taskId) || ({} as Partial<Task>))
+const task = computed<Partial<Task>>(
+  () => tasksStore.tasks.find((t) => t.id === props.taskId) || ({} as Partial<Task>),
+)
 const logs = computed(() => tasksStore.taskLogs[props.taskId] || [])
 
-const stateClass = computed(() => `state-${(task.value.state || 'pending').replace(/[^a-z]/g, '-')}`)
+const stateClass = computed(
+  () => `state-${(task.value.state || 'pending').replace(/[^a-z]/g, '-')}`,
+)
 
 const isWorkerTask = computed(() => task.value.worker_id && task.value.worker_id !== 'foreman')
 
@@ -145,10 +161,14 @@ onMounted(async () => {
   }
 })
 
-watch(logs, async () => {
-  await nextTick()
-  if (logsEl.value) logsEl.value.scrollTop = logsEl.value.scrollHeight
-}, { deep: true })
+watch(
+  logs,
+  async () => {
+    await nextTick()
+    if (logsEl.value) logsEl.value.scrollTop = logsEl.value.scrollHeight
+  },
+  { deep: true },
+)
 
 async function sendFollowup() {
   const text = followupText.value.trim()
@@ -162,8 +182,6 @@ async function sendFollowup() {
     console.error('Follow-up failed', e)
   }
 }
-
-
 
 async function finalizeTask() {
   const guildId = guildStore.currentGuild?.id
@@ -221,12 +239,21 @@ function lineClass(line: string) {
 
 function formatTime(iso?: string) {
   if (!iso) return ''
-  return new Date(iso).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+  return new Date(iso).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 function formatTs(iso?: string) {
   if (!iso) return ''
-  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+  return new Date(iso).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
 }
 </script>
 
@@ -271,10 +298,22 @@ function formatTs(iso?: string) {
   letter-spacing: 1px;
   flex-shrink: 0;
 }
-.task-phase-badge.plan { color: var(--color-blue); border-color: var(--color-blue); }
-.task-phase-badge.execute { color: var(--color-teal); border-color: var(--color-teal); }
-.task-phase-badge.review { color: var(--color-amber); border-color: var(--color-amber); }
-.task-phase-badge.followup { color: var(--color-orange); border-color: var(--color-orange); }
+.task-phase-badge.plan {
+  color: var(--color-blue);
+  border-color: var(--color-blue);
+}
+.task-phase-badge.execute {
+  color: var(--color-teal);
+  border-color: var(--color-teal);
+}
+.task-phase-badge.review {
+  color: var(--color-amber);
+  border-color: var(--color-amber);
+}
+.task-phase-badge.followup {
+  color: var(--color-orange);
+  border-color: var(--color-orange);
+}
 
 .task-state-badge {
   font-family: var(--font-pixel);
@@ -283,18 +322,49 @@ function formatTs(iso?: string) {
   border: 1px solid;
   flex-shrink: 0;
 }
-.state-pending { color: var(--color-text-dim); border-color: var(--color-text-dim); }
-.state-planning { color: var(--color-blue); border-color: var(--color-blue); }
-.state-working { color: var(--color-green); border-color: var(--color-green); animation: statePulse 1s infinite; }
-.state-awaiting-review { color: var(--color-amber); border-color: var(--color-amber); }
-.state-done { color: var(--color-teal); border-color: var(--color-teal); }
-.state-failed { color: var(--color-red); border-color: var(--color-red); }
-.state-cancelled { color: var(--color-red); border-color: var(--color-red); opacity: 0.7; }
-.state-follow-up { color: var(--color-orange); border-color: var(--color-orange); }
+.state-pending {
+  color: var(--color-text-dim);
+  border-color: var(--color-text-dim);
+}
+.state-planning {
+  color: var(--color-blue);
+  border-color: var(--color-blue);
+}
+.state-working {
+  color: var(--color-green);
+  border-color: var(--color-green);
+  animation: statePulse 1s infinite;
+}
+.state-awaiting-review {
+  color: var(--color-amber);
+  border-color: var(--color-amber);
+}
+.state-done {
+  color: var(--color-teal);
+  border-color: var(--color-teal);
+}
+.state-failed {
+  color: var(--color-red);
+  border-color: var(--color-red);
+}
+.state-cancelled {
+  color: var(--color-red);
+  border-color: var(--color-red);
+  opacity: 0.7;
+}
+.state-follow-up {
+  color: var(--color-orange);
+  border-color: var(--color-orange);
+}
 
 @keyframes statePulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 .task-meta {
@@ -328,7 +398,9 @@ function formatTs(iso?: string) {
   padding: 2px 6px;
   border: 1px solid var(--color-teal);
 }
-.pr-link:hover { background: rgba(0,187,170,0.15); }
+.pr-link:hover {
+  background: rgba(0, 187, 170, 0.15);
+}
 
 .task-time {
   font-size: 10px;
@@ -363,7 +435,10 @@ function formatTs(iso?: string) {
   opacity: 0.6;
 }
 
-.log-entry { display: flex; flex-direction: column; }
+.log-entry {
+  display: flex;
+  flex-direction: column;
+}
 
 .log-line {
   display: flex;
@@ -375,7 +450,9 @@ function formatTs(iso?: string) {
   cursor: pointer;
   border-radius: 2px;
 }
-.log-line--expandable:hover { background: rgba(255,255,255,0.04); }
+.log-line--expandable:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
 
 .log-expand-icon {
   font-size: 8px;
@@ -399,8 +476,12 @@ function formatTs(iso?: string) {
   margin-bottom: 4px;
   margin-top: 6px;
 }
-.log-detail-label:first-child { margin-top: 0; }
-.log-detail-label--new { color: var(--color-green); }
+.log-detail-label:first-child {
+  margin-top: 0;
+}
+.log-detail-label--new {
+  color: var(--color-green);
+}
 
 .log-detail-body {
   margin: 0 0 2px;
@@ -411,28 +492,44 @@ function formatTs(iso?: string) {
   word-break: break-all;
   max-height: 300px;
   overflow-y: auto;
-  background: rgba(0,0,0,0.2);
+  background: rgba(0, 0, 0, 0.2);
   border: 1px solid var(--color-brass-dark);
   padding: 6px 8px;
 }
 .log-detail-old {
-  background: rgba(180,30,30,0.08);
-  border-color: rgba(220,50,50,0.3);
+  background: rgba(180, 30, 30, 0.08);
+  border-color: rgba(220, 50, 50, 0.3);
   color: #c07070;
 }
 .log-detail-new {
-  background: rgba(0,120,60,0.08);
-  border-color: rgba(0,187,100,0.3);
+  background: rgba(0, 120, 60, 0.08);
+  border-color: rgba(0, 187, 100, 0.3);
   color: #70c090;
 }
 
-.log-text { word-break: break-all; white-space: pre-wrap; }
-.log-success { color: var(--color-green); }
-.log-error { color: var(--color-red); }
-.log-worker { color: var(--color-brass); }
-.log-tool { color: var(--color-teal); }
-.log-result { color: var(--color-text-dim); }
-.log-thinking { color: var(--color-blue); font-style: italic; }
+.log-text {
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+.log-success {
+  color: var(--color-green);
+}
+.log-error {
+  color: var(--color-red);
+}
+.log-worker {
+  color: var(--color-brass);
+}
+.log-tool {
+  color: var(--color-teal);
+}
+.log-result {
+  color: var(--color-text-dim);
+}
+.log-thinking {
+  color: var(--color-blue);
+  font-style: italic;
+}
 
 /* ── Redirect panel ── */
 .redirect-panel {
@@ -468,9 +565,12 @@ function formatTs(iso?: string) {
 }
 .redirect-input:focus {
   border-color: var(--color-blue);
-  box-shadow: 0 0 8px rgba(80,120,255,0.2);
+  box-shadow: 0 0 8px rgba(80, 120, 255, 0.2);
 }
-.redirect-input::placeholder { color: var(--color-text-dim); font-style: italic; }
+.redirect-input::placeholder {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
 
 .redirect-actions {
   display: flex;
@@ -478,17 +578,20 @@ function formatTs(iso?: string) {
 }
 
 .redirect-btn {
-  background: linear-gradient(180deg, rgba(80,120,255,0.2) 0%, rgba(50,80,200,0.3) 100%);
+  background: linear-gradient(180deg, rgba(80, 120, 255, 0.2) 0%, rgba(50, 80, 200, 0.3) 100%);
   border-color: var(--color-blue);
   color: var(--color-blue);
   font-size: 8px;
   padding: 5px 12px;
 }
 .redirect-btn:hover:not(:disabled) {
-  background: linear-gradient(180deg, rgba(80,120,255,0.4) 0%, rgba(60,100,220,0.5) 100%);
-  box-shadow: 0 0 8px rgba(80,120,255,0.3);
+  background: linear-gradient(180deg, rgba(80, 120, 255, 0.4) 0%, rgba(60, 100, 220, 0.5) 100%);
+  box-shadow: 0 0 8px rgba(80, 120, 255, 0.3);
 }
-.redirect-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+.redirect-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
 
 /* ── Cancel panel ── */
 .cancel-panel {
@@ -500,17 +603,20 @@ function formatTs(iso?: string) {
 }
 
 .cancel-task-btn {
-  background: linear-gradient(180deg, rgba(220,50,50,0.15) 0%, rgba(160,30,30,0.25) 100%);
+  background: linear-gradient(180deg, rgba(220, 50, 50, 0.15) 0%, rgba(160, 30, 30, 0.25) 100%);
   border-color: var(--color-red);
   color: var(--color-red);
   font-size: 8px;
   padding: 4px 10px;
 }
 .cancel-task-btn:hover:not(:disabled) {
-  background: linear-gradient(180deg, rgba(220,50,50,0.35) 0%, rgba(180,40,40,0.45) 100%);
-  box-shadow: 0 0 8px rgba(220,50,50,0.3);
+  background: linear-gradient(180deg, rgba(220, 50, 50, 0.35) 0%, rgba(180, 40, 40, 0.45) 100%);
+  box-shadow: 0 0 8px rgba(220, 50, 50, 0.3);
 }
-.cancel-task-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+.cancel-task-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
 
 /* ── Follow-up panel ── */
 .followup-panel {
@@ -546,9 +652,12 @@ function formatTs(iso?: string) {
 }
 .followup-input:focus {
   border-color: var(--color-amber);
-  box-shadow: 0 0 8px rgba(255,204,0,0.2);
+  box-shadow: 0 0 8px rgba(255, 204, 0, 0.2);
 }
-.followup-input::placeholder { color: var(--color-text-dim); font-style: italic; }
+.followup-input::placeholder {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
 
 .followup-actions {
   display: flex;
@@ -556,27 +665,30 @@ function formatTs(iso?: string) {
 }
 
 .followup-btn {
-  background: linear-gradient(180deg, rgba(255,204,0,0.2) 0%, rgba(180,140,0,0.3) 100%);
+  background: linear-gradient(180deg, rgba(255, 204, 0, 0.2) 0%, rgba(180, 140, 0, 0.3) 100%);
   border-color: var(--color-amber);
   color: var(--color-amber);
   font-size: 8px;
   padding: 5px 12px;
 }
 .followup-btn:hover:not(:disabled) {
-  background: linear-gradient(180deg, rgba(255,204,0,0.4) 0%, rgba(200,160,0,0.5) 100%);
-  box-shadow: 0 0 8px rgba(255,204,0,0.3);
+  background: linear-gradient(180deg, rgba(255, 204, 0, 0.4) 0%, rgba(200, 160, 0, 0.5) 100%);
+  box-shadow: 0 0 8px rgba(255, 204, 0, 0.3);
 }
-.followup-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+.followup-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
 
 .finalize-btn {
-  background: linear-gradient(180deg, rgba(0,187,170,0.2) 0%, rgba(0,120,110,0.3) 100%);
+  background: linear-gradient(180deg, rgba(0, 187, 170, 0.2) 0%, rgba(0, 120, 110, 0.3) 100%);
   border-color: var(--color-teal);
   color: var(--color-teal);
   font-size: 8px;
   padding: 5px 12px;
 }
 .finalize-btn:hover {
-  background: linear-gradient(180deg, rgba(0,187,170,0.4) 0%, rgba(0,150,140,0.5) 100%);
-  box-shadow: 0 0 8px rgba(0,187,170,0.3);
+  background: linear-gradient(180deg, rgba(0, 187, 170, 0.4) 0%, rgba(0, 150, 140, 0.5) 100%);
+  box-shadow: 0 0 8px rgba(0, 187, 170, 0.3);
 }
 </style>

--- a/frontend/src/components/TerminalPane.vue
+++ b/frontend/src/components/TerminalPane.vue
@@ -17,10 +17,12 @@
 
     <div class="terminal-body" ref="terminalEl">
       <div class="terminal-welcome">
-        <pre>╔══════════════════════════════════════╗
+        <pre>
+╔══════════════════════════════════════╗
 ║    PIONEER SQUARE TERMINAL v1.0      ║
 ║    Agent: {{ padName(agent?.name) }}      ║
-╚══════════════════════════════════════╝</pre>
+╚══════════════════════════════════════╝</pre
+        >
       </div>
       <div v-if="logs.length === 0" class="terminal-empty">
         <span class="cursor-blink">_</span> Waiting for output...
@@ -106,13 +108,12 @@
         :disabled="!runPrompt.trim()"
         @click="handleRun"
         title="Run agent"
-      >▶ RUN</button>
-      <button
-        v-else
-        class="stop-btn pixel-btn"
-        @click="handleStop"
-        title="Stop agent"
-      >■ STOP</button>
+      >
+        ▶ RUN
+      </button>
+      <button v-else class="stop-btn pixel-btn" @click="handleStop" title="Stop agent">
+        ■ STOP
+      </button>
     </div>
 
     <div v-if="runError" class="run-error">{{ runError }}</div>
@@ -133,7 +134,7 @@ const guildStore = useGuildStore()
 const terminalEl = ref<HTMLElement | null>(null)
 const expandedIdx = ref<number | null>(null)
 
-const agent = computed(() => agentsStore.agents.find(a => a.id === props.agentId))
+const agent = computed(() => agentsStore.agents.find((a) => a.id === props.agentId))
 
 function toggleDetail(i: number) {
   expandedIdx.value = expandedIdx.value === i ? null : i
@@ -144,7 +145,12 @@ onMounted(async () => {
   if (guildId) await agentsStore.fetchAgentLogs(guildId, props.agentId)
 })
 const logs = computed(() => agent.value?.logs || [])
-const isRunning = computed(() => agent.value?.state === 'working' || agent.value?.state === 'thinking' || agent.value?.state === 'busy')
+const isRunning = computed(
+  () =>
+    agent.value?.state === 'working' ||
+    agent.value?.state === 'thinking' ||
+    agent.value?.state === 'busy',
+)
 
 const runTool = ref('claude')
 const runPrompt = ref('')
@@ -177,7 +183,7 @@ function linkify(text: string): string {
     .replace(/"/g, '&quot;')
   return escaped.replace(
     /(https?:\/\/[^\s<>"]+)/g,
-    '<a href="$1" target="_blank" rel="noopener noreferrer" class="terminal-link">$1</a>'
+    '<a href="$1" target="_blank" rel="noopener noreferrer" class="terminal-link">$1</a>',
   )
 }
 
@@ -199,7 +205,7 @@ async function handleRun() {
       tool: runTool.value,
       prompt: runPrompt.value.trim(),
       model: runModel.value.trim(),
-      provider: runProvider.value.trim()
+      provider: runProvider.value.trim(),
     })
     runPrompt.value = ''
   } catch (e: any) {
@@ -216,12 +222,16 @@ async function handleStop() {
   }
 }
 
-watch(logs, async () => {
-  await nextTick()
-  if (terminalEl.value) {
-    terminalEl.value.scrollTop = terminalEl.value.scrollHeight
-  }
-}, { deep: true })
+watch(
+  logs,
+  async () => {
+    await nextTick()
+    if (terminalEl.value) {
+      terminalEl.value.scrollTop = terminalEl.value.scrollHeight
+    }
+  },
+  { deep: true },
+)
 </script>
 
 <style scoped>
@@ -271,11 +281,26 @@ watch(logs, async () => {
   letter-spacing: 1px;
 }
 
-.agent-state-badge.idle    { background: rgba(154,128,96,0.2); color: var(--color-text-dim); }
-.agent-state-badge.thinking{ background: rgba(68,153,255,0.2); color: var(--color-blue); }
-.agent-state-badge.working { background: rgba(0,255,136,0.2);  color: var(--color-green); }
-.agent-state-badge.busy    { background: rgba(255,136,68,0.2); color: var(--color-orange); }
-.agent-state-badge.error   { background: rgba(255,51,51,0.2);  color: var(--color-red); }
+.agent-state-badge.idle {
+  background: rgba(154, 128, 96, 0.2);
+  color: var(--color-text-dim);
+}
+.agent-state-badge.thinking {
+  background: rgba(68, 153, 255, 0.2);
+  color: var(--color-blue);
+}
+.agent-state-badge.working {
+  background: rgba(0, 255, 136, 0.2);
+  color: var(--color-green);
+}
+.agent-state-badge.busy {
+  background: rgba(255, 136, 68, 0.2);
+  color: var(--color-orange);
+}
+.agent-state-badge.error {
+  background: rgba(255, 51, 51, 0.2);
+  color: var(--color-red);
+}
 
 .live-indicator {
   font-size: 11px;
@@ -287,8 +312,13 @@ watch(logs, async () => {
 }
 
 @keyframes livePulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 .terminal-body {
@@ -315,7 +345,10 @@ watch(logs, async () => {
   gap: 4px;
 }
 
-.terminal-entry { display: flex; flex-direction: column; }
+.terminal-entry {
+  display: flex;
+  flex-direction: column;
+}
 
 .terminal-line {
   display: flex;
@@ -328,7 +361,9 @@ watch(logs, async () => {
   cursor: pointer;
   border-radius: 2px;
 }
-.terminal-line--expandable:hover { background: rgba(255,255,255,0.04); }
+.terminal-line--expandable:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
 
 .log-expand-icon {
   font-size: 8px;
@@ -352,8 +387,12 @@ watch(logs, async () => {
   margin-bottom: 4px;
   margin-top: 6px;
 }
-.log-detail-label:first-child { margin-top: 0; }
-.log-detail-label--new { color: var(--color-green); }
+.log-detail-label:first-child {
+  margin-top: 0;
+}
+.log-detail-label--new {
+  color: var(--color-green);
+}
 
 .log-detail-body {
   margin: 0 0 2px;
@@ -364,18 +403,18 @@ watch(logs, async () => {
   word-break: break-all;
   max-height: 300px;
   overflow-y: auto;
-  background: rgba(0,0,0,0.3);
+  background: rgba(0, 0, 0, 0.3);
   border: 1px solid #2a1a05;
   padding: 6px 8px;
 }
 .log-detail-old {
-  background: rgba(180,30,30,0.08);
-  border-color: rgba(220,50,50,0.3);
+  background: rgba(180, 30, 30, 0.08);
+  border-color: rgba(220, 50, 50, 0.3);
   color: #c07070;
 }
 .log-detail-new {
-  background: rgba(0,120,60,0.08);
-  border-color: rgba(0,187,100,0.3);
+  background: rgba(0, 120, 60, 0.08);
+  border-color: rgba(0, 187, 100, 0.3);
   color: #70c090;
 }
 
@@ -385,13 +424,30 @@ watch(logs, async () => {
   font-size: 11px;
 }
 
-.log-content         { color: var(--color-green);    word-break: break-all; }
-.log-content.log-success { color: var(--color-teal); }
-.log-content.log-error   { color: var(--color-red);  }
-.log-content.log-tool    { color: var(--color-amber); }
-.log-content.log-result  { color: var(--color-text-dim); }
-.log-content.log-meta    { color: var(--color-brass-dark); }
-.terminal-link { color: var(--color-teal); text-decoration: underline; cursor: pointer; }
+.log-content {
+  color: var(--color-green);
+  word-break: break-all;
+}
+.log-content.log-success {
+  color: var(--color-teal);
+}
+.log-content.log-error {
+  color: var(--color-red);
+}
+.log-content.log-tool {
+  color: var(--color-amber);
+}
+.log-content.log-result {
+  color: var(--color-text-dim);
+}
+.log-content.log-meta {
+  color: var(--color-brass-dark);
+}
+.terminal-link {
+  color: var(--color-teal);
+  text-decoration: underline;
+  cursor: pointer;
+}
 
 .terminal-prompt {
   margin-top: 8px;
@@ -401,10 +457,19 @@ watch(logs, async () => {
   gap: 2px;
 }
 
-.prompt-user   { color: var(--color-green); }
-.prompt-sep    { color: var(--color-text-dim); }
-.prompt-path   { color: var(--color-blue); }
-.prompt-dollar { color: var(--color-text); margin: 0 4px; }
+.prompt-user {
+  color: var(--color-green);
+}
+.prompt-sep {
+  color: var(--color-text-dim);
+}
+.prompt-path {
+  color: var(--color-blue);
+}
+.prompt-dollar {
+  color: var(--color-text);
+  margin: 0 4px;
+}
 
 .cursor-blink {
   color: var(--color-amber);
@@ -412,8 +477,13 @@ watch(logs, async () => {
 }
 
 @keyframes blink {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
 }
 
 /* ── Run bar ──────────────────────────────────────────────────── */
@@ -520,8 +590,13 @@ watch(logs, async () => {
 }
 
 @keyframes stopPulse {
-  0%, 100% { box-shadow: 0 0 0 rgba(255,51,51,0); }
-  50%       { box-shadow: 0 0 8px rgba(255,51,51,0.4); }
+  0%,
+  100% {
+    box-shadow: 0 0 0 rgba(255, 51, 51, 0);
+  }
+  50% {
+    box-shadow: 0 0 8px rgba(255, 51, 51, 0.4);
+  }
 }
 
 .run-error {

--- a/frontend/src/components/WorkerTerminalPane.vue
+++ b/frontend/src/components/WorkerTerminalPane.vue
@@ -7,7 +7,10 @@
       </div>
       <div class="terminal-meta">
         <span v-if="worker" class="state-badge" :class="worker.state">{{ worker.state }}</span>
-        <span class="live-indicator" :class="{ active: worker && !['idle', 'offline'].includes(worker.state) }">
+        <span
+          class="live-indicator"
+          :class="{ active: worker && !['idle', 'offline'].includes(worker.state) }"
+        >
           {{ worker && !['idle', 'offline'].includes(worker.state) ? '● LIVE' : '○ IDLE' }}
         </span>
       </div>
@@ -15,10 +18,12 @@
 
     <div class="terminal-body" ref="terminalEl">
       <div class="terminal-welcome">
-        <pre>╔══════════════════════════════════════╗
+        <pre>
+╔══════════════════════════════════════╗
 ║    PIONEER SQUARE TERMINAL v1.0      ║
 ║    Worker: {{ padName(worker?.name) }}   ║
-╚══════════════════════════════════════╝</pre>
+╚══════════════════════════════════════╝</pre
+        >
       </div>
       <div v-if="logs.length === 0" class="terminal-empty">
         <span class="cursor-blink">_</span> Waiting for output...
@@ -85,7 +90,7 @@ const guildStore = useGuildStore()
 const terminalEl = ref<HTMLElement | null>(null)
 const expandedIdx = ref<number | null>(null)
 
-const worker = computed(() => agentsStore.workers.find(w => w.id === props.workerId))
+const worker = computed(() => agentsStore.workers.find((w) => w.id === props.workerId))
 const logs = computed(() => agentsStore.workerLogs[props.workerId] || [])
 
 function toggleDetail(i: number) {
@@ -115,10 +120,14 @@ function lineClass(line: string) {
   return ''
 }
 
-watch(logs, async () => {
-  await nextTick()
-  if (terminalEl.value) terminalEl.value.scrollTop = terminalEl.value.scrollHeight
-}, { deep: true })
+watch(
+  logs,
+  async () => {
+    await nextTick()
+    if (terminalEl.value) terminalEl.value.scrollTop = terminalEl.value.scrollHeight
+  },
+  { deep: true },
+)
 </script>
 
 <style scoped>
@@ -149,7 +158,9 @@ watch(logs, async () => {
   font-size: 13px;
 }
 
-.term-icon { color: var(--color-teal); }
+.term-icon {
+  color: var(--color-teal);
+}
 
 .terminal-meta {
   display: flex;
@@ -165,11 +176,26 @@ watch(logs, async () => {
   font-family: var(--font-pixel);
   letter-spacing: 1px;
 }
-.state-badge.idle    { background: rgba(154,128,96,0.2); color: var(--color-text-dim); }
-.state-badge.working { background: rgba(0,255,136,0.2);  color: var(--color-green); }
-.state-badge.busy    { background: rgba(255,136,68,0.2); color: var(--color-orange); }
-.state-badge.error   { background: rgba(255,51,51,0.2);  color: var(--color-red); }
-.state-badge.offline { background: rgba(100,100,100,0.2); color: var(--color-text-dim); }
+.state-badge.idle {
+  background: rgba(154, 128, 96, 0.2);
+  color: var(--color-text-dim);
+}
+.state-badge.working {
+  background: rgba(0, 255, 136, 0.2);
+  color: var(--color-green);
+}
+.state-badge.busy {
+  background: rgba(255, 136, 68, 0.2);
+  color: var(--color-orange);
+}
+.state-badge.error {
+  background: rgba(255, 51, 51, 0.2);
+  color: var(--color-red);
+}
+.state-badge.offline {
+  background: rgba(100, 100, 100, 0.2);
+  color: var(--color-text-dim);
+}
 
 .live-indicator {
   font-size: 11px;
@@ -179,7 +205,15 @@ watch(logs, async () => {
   color: var(--color-teal);
   animation: livePulse 1.5s infinite;
 }
-@keyframes livePulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+@keyframes livePulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
 
 .terminal-body {
   flex: 1;
@@ -205,7 +239,10 @@ watch(logs, async () => {
   gap: 4px;
 }
 
-.terminal-entry { display: flex; flex-direction: column; }
+.terminal-entry {
+  display: flex;
+  flex-direction: column;
+}
 
 .terminal-line {
   display: flex;
@@ -218,7 +255,9 @@ watch(logs, async () => {
   cursor: pointer;
   border-radius: 2px;
 }
-.terminal-line--expandable:hover { background: rgba(255,255,255,0.04); }
+.terminal-line--expandable:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
 
 .log-expand-icon {
   font-size: 8px;
@@ -242,8 +281,12 @@ watch(logs, async () => {
   margin-bottom: 4px;
   margin-top: 6px;
 }
-.log-detail-label:first-child { margin-top: 0; }
-.log-detail-label--new { color: var(--color-green); }
+.log-detail-label:first-child {
+  margin-top: 0;
+}
+.log-detail-label--new {
+  color: var(--color-green);
+}
 
 .log-detail-body {
   margin: 0 0 2px;
@@ -254,18 +297,18 @@ watch(logs, async () => {
   word-break: break-all;
   max-height: 300px;
   overflow-y: auto;
-  background: rgba(0,0,0,0.3);
+  background: rgba(0, 0, 0, 0.3);
   border: 1px solid #2a1a05;
   padding: 6px 8px;
 }
 .log-detail-old {
-  background: rgba(180,30,30,0.08);
-  border-color: rgba(220,50,50,0.3);
+  background: rgba(180, 30, 30, 0.08);
+  border-color: rgba(220, 50, 50, 0.3);
   color: #c07070;
 }
 .log-detail-new {
-  background: rgba(0,120,60,0.08);
-  border-color: rgba(0,187,100,0.3);
+  background: rgba(0, 120, 60, 0.08);
+  border-color: rgba(0, 187, 100, 0.3);
   color: #70c090;
 }
 
@@ -275,10 +318,20 @@ watch(logs, async () => {
   font-size: 11px;
 }
 
-.log-content         { color: var(--color-green); word-break: break-all; white-space: pre-wrap; }
-.log-content.log-success { color: var(--color-teal); }
-.log-content.log-error   { color: var(--color-red); }
-.log-content.log-meta    { color: var(--color-brass-dark); }
+.log-content {
+  color: var(--color-green);
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+.log-content.log-success {
+  color: var(--color-teal);
+}
+.log-content.log-error {
+  color: var(--color-red);
+}
+.log-content.log-meta {
+  color: var(--color-brass-dark);
+}
 
 .terminal-prompt {
   margin-top: 8px;
@@ -287,14 +340,31 @@ watch(logs, async () => {
   align-items: center;
   gap: 2px;
 }
-.prompt-user   { color: var(--color-teal); }
-.prompt-sep    { color: var(--color-text-dim); }
-.prompt-path   { color: var(--color-blue); }
-.prompt-dollar { color: var(--color-text); margin: 0 4px; }
+.prompt-user {
+  color: var(--color-teal);
+}
+.prompt-sep {
+  color: var(--color-text-dim);
+}
+.prompt-path {
+  color: var(--color-blue);
+}
+.prompt-dollar {
+  color: var(--color-text);
+  margin: 0 4px;
+}
 
 .cursor-blink {
   color: var(--color-teal);
   animation: blink 1s step-end infinite;
 }
-@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
 </style>

--- a/frontend/src/components/sprites/RobotWorker.vue
+++ b/frontend/src/components/sprites/RobotWorker.vue
@@ -7,7 +7,6 @@
   >
     <!-- HEAD GROUP — tilt/shake animations target this whole group -->
     <g class="head-group">
-
       <!-- Crown (foreman only) — three prongs with gem accents -->
       <g v-if="type === 'foreman'" class="crown">
         <rect x="9" y="3" width="22" height="2" rx="1" fill="var(--color-gold, #ffd644)" />
@@ -15,7 +14,7 @@
         <rect x="18" y="-4" width="4" height="8" rx="1" fill="var(--color-gold, #ffd644)" />
         <rect x="24" y="-1" width="4" height="5" rx="1" fill="var(--color-gold, #ffd644)" />
         <circle cx="14" cy="-0.5" r="1.2" fill="var(--color-red, #ee3322)" />
-        <circle cx="20" cy="-3"   r="1.2" fill="var(--color-blue, #44aaee)" />
+        <circle cx="20" cy="-3" r="1.2" fill="var(--color-blue, #44aaee)" />
         <circle cx="26" cy="-0.5" r="1.2" fill="var(--color-green, #88dd22)" />
       </g>
 
@@ -26,8 +25,17 @@
       </template>
 
       <!-- Head box -->
-      <rect class="head-box" x="9" y="5" width="22" height="18" rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
+      <rect
+        class="head-box"
+        x="9"
+        y="5"
+        width="22"
+        height="18"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
 
       <!-- Eyes -->
       <rect class="eye" x="12" y="10" width="6" height="5" rx="1" />
@@ -47,67 +55,158 @@
     <rect x="16" y="23" width="8" height="3" rx="1" fill="var(--agent-color)" opacity="0.45" />
 
     <!-- Body -->
-    <rect x="7" y="26" width="26" height="18" rx="2"
-          fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
+    <rect
+      x="7"
+      y="26"
+      width="26"
+      height="18"
+      rx="2"
+      fill="rgba(18,9,0,0.93)"
+      stroke="var(--agent-color)"
+      stroke-width="1.5"
+    />
     <!-- Chest panel recess -->
-    <rect x="13" y="29" width="14" height="12" rx="1"
-          fill="rgba(0,0,0,0.65)" stroke="var(--agent-color)" stroke-width="0.75" />
+    <rect
+      x="13"
+      y="29"
+      width="14"
+      height="12"
+      rx="1"
+      fill="rgba(0,0,0,0.65)"
+      stroke="var(--agent-color)"
+      stroke-width="0.75"
+    />
     <!-- LED indicator -->
     <circle class="led" cx="20" cy="35" r="3.5" />
     <!-- Shoulder rivets -->
-    <circle cx="9"  cy="28" r="1.5" fill="var(--agent-color)" opacity="0.85" />
+    <circle cx="9" cy="28" r="1.5" fill="var(--agent-color)" opacity="0.85" />
     <circle cx="31" cy="28" r="1.5" fill="var(--agent-color)" opacity="0.85" />
     <!-- Side exhaust vents -->
     <rect x="29" y="33" width="3.5" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.55" />
     <rect x="29" y="36" width="3.5" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.55" />
     <rect x="29" y="39" width="3.5" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.55" />
     <!-- Belt line -->
-    <rect x="7" y="42" width="26" height="2" rx="0"
-          fill="rgba(0,0,0,0.35)" stroke="var(--agent-color)" stroke-width="0.5" />
+    <rect
+      x="7"
+      y="42"
+      width="26"
+      height="2"
+      rx="0"
+      fill="rgba(0,0,0,0.35)"
+      stroke="var(--agent-color)"
+      stroke-width="0.5"
+    />
 
     <!-- Left arm -->
     <g class="left-arm">
-      <rect x="1"  y="27" width="6" height="12" rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
+      <rect
+        x="1"
+        y="27"
+        width="6"
+        height="12"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
       <circle cx="4" cy="31" r="1.5" fill="var(--agent-color)" opacity="0.7" />
-      <rect x="0"  y="38" width="8"  height="5"  rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
+      <rect
+        x="0"
+        y="38"
+        width="8"
+        height="5"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
     </g>
 
     <!-- Right arm -->
     <g class="right-arm">
-      <rect x="33" y="27" width="6" height="12" rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
+      <rect
+        x="33"
+        y="27"
+        width="6"
+        height="12"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
       <circle cx="36" cy="31" r="1.5" fill="var(--agent-color)" opacity="0.7" />
-      <rect x="32"  y="38" width="8"  height="5"  rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
+      <rect
+        x="32"
+        y="38"
+        width="8"
+        height="5"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
     </g>
 
     <!-- Left leg + foot -->
     <g class="left-leg">
-      <rect x="10" y="44" width="9" height="10" rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
-      <rect x="8"  y="51" width="13" height="5" rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
+      <rect
+        x="10"
+        y="44"
+        width="9"
+        height="10"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
+      <rect
+        x="8"
+        y="51"
+        width="13"
+        height="5"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
     </g>
     <!-- Right leg + foot -->
     <g class="right-leg">
-      <rect x="21" y="44" width="9" height="10" rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
-      <rect x="19" y="51" width="13" height="5" rx="2"
-            fill="rgba(18,9,0,0.93)" stroke="var(--agent-color)" stroke-width="1.5" />
+      <rect
+        x="21"
+        y="44"
+        width="9"
+        height="10"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
+      <rect
+        x="19"
+        y="51"
+        width="13"
+        height="5"
+        rx="2"
+        fill="rgba(18,9,0,0.93)"
+        stroke="var(--agent-color)"
+        stroke-width="1.5"
+      />
     </g>
   </svg>
 </template>
 
 <script setup lang="ts">
-withDefaults(defineProps<{
-  state: string
-  type: string
-  walking?: boolean
-}>(), {
-  walking: false,
-})
+withDefaults(
+  defineProps<{
+    state: string
+    type: string
+    walking?: boolean
+  }>(),
+  {
+    walking: false,
+  },
+)
 </script>
 
 <style scoped>
@@ -119,7 +218,9 @@ withDefaults(defineProps<{
 }
 
 /* ── Eyes ─────────────────────────────────────────────── */
-.eye { fill: var(--color-cream, #ffe8c0); }
+.eye {
+  fill: var(--color-cream, #ffe8c0);
+}
 
 .robot-sprite.thinking .eye {
   fill: var(--color-blue, #44aaee);
@@ -133,34 +234,75 @@ withDefaults(defineProps<{
   filter: drop-shadow(0 0 2px var(--color-red, #ee3322));
 }
 
-.robot-sprite.idle .eye { animation: eyeBlink 6s infinite; }
+.robot-sprite.idle .eye {
+  animation: eyeBlink 6s infinite;
+}
 @keyframes eyeBlink {
-  0%, 82%, 100% { opacity: 1; }
-  86%           { opacity: 0.05; }
-  90%           { opacity: 1; }
-  93%           { opacity: 0.05; }
-  97%           { opacity: 1; }
+  0%,
+  82%,
+  100% {
+    opacity: 1;
+  }
+  86% {
+    opacity: 0.05;
+  }
+  90% {
+    opacity: 1;
+  }
+  93% {
+    opacity: 0.05;
+  }
+  97% {
+    opacity: 1;
+  }
 }
 
 /* ── LED ──────────────────────────────────────────────── */
-.led { fill: var(--color-text-dim, #554433); }
+.led {
+  fill: var(--color-text-dim, #554433);
+}
 
-.robot-sprite.thinking .led { fill: var(--color-blue,   #44aaee); filter: drop-shadow(0 0 4px var(--color-blue,   #44aaee)); }
-.robot-sprite.working  .led { fill: var(--color-green,  #88dd22); filter: drop-shadow(0 0 4px var(--color-green,  #88dd22));
-                               transform-box: fill-box; transform-origin: center; animation: ledPulse 0.5s infinite alternate; }
-.robot-sprite.busy     .led { fill: var(--color-orange, #ff7700); filter: drop-shadow(0 0 4px var(--color-orange, #ff7700)); }
-.robot-sprite.error    .led { fill: var(--color-red,    #ee3322); filter: drop-shadow(0 0 4px var(--color-red,    #ee3322)); }
+.robot-sprite.thinking .led {
+  fill: var(--color-blue, #44aaee);
+  filter: drop-shadow(0 0 4px var(--color-blue, #44aaee));
+}
+.robot-sprite.working .led {
+  fill: var(--color-green, #88dd22);
+  filter: drop-shadow(0 0 4px var(--color-green, #88dd22));
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: ledPulse 0.5s infinite alternate;
+}
+.robot-sprite.busy .led {
+  fill: var(--color-orange, #ff7700);
+  filter: drop-shadow(0 0 4px var(--color-orange, #ff7700));
+}
+.robot-sprite.error .led {
+  fill: var(--color-red, #ee3322);
+  filter: drop-shadow(0 0 4px var(--color-red, #ee3322));
+}
 
 @keyframes ledPulse {
-  from { transform: scale(1); }
-  to   { transform: scale(1.55); }
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.55);
+  }
 }
 
 /* ── Antenna pulse when thinking ─────────────────────── */
-.robot-sprite.thinking .antenna-ball { animation: antennaPulse 1.5s infinite alternate; }
+.robot-sprite.thinking .antenna-ball {
+  animation: antennaPulse 1.5s infinite alternate;
+}
 @keyframes antennaPulse {
-  from { opacity: 0.5; }
-  to   { opacity: 1; filter: drop-shadow(0 0 3px var(--agent-color)); }
+  from {
+    opacity: 0.5;
+  }
+  to {
+    opacity: 1;
+    filter: drop-shadow(0 0 3px var(--agent-color));
+  }
 }
 
 /* ── Foreman head highlight ───────────────────────────── */
@@ -177,14 +319,25 @@ withDefaults(defineProps<{
   animation: tiltHead 1.5s infinite ease-in-out;
 }
 @keyframes tiltHead {
-  0%, 100% { transform: rotate(-5deg); }
-  50%       { transform: rotate(5deg); }
+  0%,
+  100% {
+    transform: rotate(-5deg);
+  }
+  50% {
+    transform: rotate(5deg);
+  }
 }
 
-.robot-sprite.working { animation: workBounce 0.4s infinite alternate; }
+.robot-sprite.working {
+  animation: workBounce 0.4s infinite alternate;
+}
 @keyframes workBounce {
-  from { transform: translateY(0); }
-  to   { transform: translateY(-4px); }
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-4px);
+  }
 }
 
 .robot-sprite.busy .left-arm {
@@ -198,26 +351,49 @@ withDefaults(defineProps<{
   animation: rightArmSwing 0.5s infinite alternate;
 }
 @keyframes leftArmSwing {
-  from { transform: rotate(-22deg); }
-  to   { transform: rotate(22deg); }
+  from {
+    transform: rotate(-22deg);
+  }
+  to {
+    transform: rotate(22deg);
+  }
 }
 @keyframes rightArmSwing {
-  from { transform: rotate(22deg); }
-  to   { transform: rotate(-22deg); }
+  from {
+    transform: rotate(22deg);
+  }
+  to {
+    transform: rotate(-22deg);
+  }
 }
 
-.robot-sprite.error .head-group { animation: shake 0.22s infinite; }
+.robot-sprite.error .head-group {
+  animation: shake 0.22s infinite;
+}
 @keyframes shake {
-  0%, 100% { transform: translateX(0); }
-  25%       { transform: translateX(-3px); }
-  75%       { transform: translateX(3px); }
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-3px);
+  }
+  75% {
+    transform: translateX(3px);
+  }
 }
 
 /* ── Walking ──────────────────────────────────────────── */
-.robot-sprite.walking { animation: walkBob 0.36s infinite alternate ease-in-out; }
+.robot-sprite.walking {
+  animation: walkBob 0.36s infinite alternate ease-in-out;
+}
 @keyframes walkBob {
-  from { transform: translateY(0px); }
-  to   { transform: translateY(-3px); }
+  from {
+    transform: translateY(0px);
+  }
+  to {
+    transform: translateY(-3px);
+  }
 }
 
 .robot-sprite.walking .left-leg {
@@ -231,12 +407,20 @@ withDefaults(defineProps<{
   animation: legSwingB 0.36s infinite alternate ease-in-out;
 }
 @keyframes legSwingA {
-  from { transform: translateX(-3px) rotate(-10deg); }
-  to   { transform: translateX(3px)  rotate(10deg); }
+  from {
+    transform: translateX(-3px) rotate(-10deg);
+  }
+  to {
+    transform: translateX(3px) rotate(10deg);
+  }
 }
 @keyframes legSwingB {
-  from { transform: translateX(3px)  rotate(10deg); }
-  to   { transform: translateX(-3px) rotate(-10deg); }
+  from {
+    transform: translateX(3px) rotate(10deg);
+  }
+  to {
+    transform: translateX(-3px) rotate(-10deg);
+  }
 }
 
 .robot-sprite.walking .left-arm {

--- a/frontend/src/composables/useWebRTC.ts
+++ b/frontend/src/composables/useWebRTC.ts
@@ -7,7 +7,7 @@ export function useWebRTC(sendSignal: (payload: SignalPayload) => void) {
   const dataChannels = ref<Record<string, RTCDataChannel>>({})
 
   const config: RTCConfiguration = {
-    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
   }
 
   function createPeerConnection(peerId: string) {
@@ -73,6 +73,6 @@ export function useWebRTC(sendSignal: (payload: SignalPayload) => void) {
     handleOffer,
     handleAnswer,
     handleIceCandidate,
-    sendDataChannelMessage
+    sendDataChannelMessage,
   }
 }

--- a/frontend/src/composables/useWebSocket.ts
+++ b/frontend/src/composables/useWebSocket.ts
@@ -9,7 +9,9 @@ export function useWebSocket(url: string, onMessage?: (data: any) => void) {
   function connect() {
     if (ws.value) ws.value.close()
     ws.value = new WebSocket(url)
-    ws.value.onopen = () => { isConnected.value = true }
+    ws.value.onopen = () => {
+      isConnected.value = true
+    }
     ws.value.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data)
@@ -24,7 +26,9 @@ export function useWebSocket(url: string, onMessage?: (data: any) => void) {
         reconnectTimer = setTimeout(connect, 2000)
       }
     }
-    ws.value.onerror = () => { isConnected.value = false }
+    ws.value.onerror = () => {
+      isConnected.value = false
+    }
   }
 
   function send(data: any) {

--- a/frontend/src/stores/__tests__/guild.spec.ts
+++ b/frontend/src/stores/__tests__/guild.spec.ts
@@ -39,7 +39,9 @@ class FakeWebSocket {
   }
 
   simulateMessage(data: any) {
-    this.onmessage?.({ data: typeof data === 'string' ? data : JSON.stringify(data) } as MessageEvent)
+    this.onmessage?.({
+      data: typeof data === 'string' ? data : JSON.stringify(data),
+    } as MessageEvent)
   }
 
   simulateClose(opts: { wasClean?: boolean; code?: number; reason?: string } = {}) {
@@ -117,7 +119,10 @@ describe('useGuildStore', () => {
     it('updates currentGuild and guilds list on guild-updated', () => {
       const store = useGuildStore()
       store.currentGuild = { id: 'g-1', name: 'old' }
-      store.guilds = [{ id: 'g-1', name: 'old' }, { id: 'g-2', name: 'other' }]
+      store.guilds = [
+        { id: 'g-1', name: 'old' },
+        { id: 'g-2', name: 'other' },
+      ]
 
       store.connectWebSocket('g-1')
       const ws = FakeWebSocket.instances[0]

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -69,7 +69,7 @@ export const useAgentsStore = defineStore('agents', () => {
 
   function registerAgent(agentData: RegisterAgentData) {
     if (agentData.agentType === 'foreman') return
-    const existing = agents.value.find(a => a.id === agentData.agentId)
+    const existing = agents.value.find((a) => a.id === agentData.agentId)
     if (existing) {
       existing.state = agentData.state || 'idle'
       existing.name = agentData.agentName || existing.name
@@ -82,20 +82,20 @@ export const useAgentsStore = defineStore('agents', () => {
         workerId: agentData.workerId || null,
         state: agentData.state || 'idle',
         logs: [],
-        joinedAt: agentData.joinedAt || new Date().toISOString()
+        joinedAt: agentData.joinedAt || new Date().toISOString(),
       })
     }
   }
 
   function updateAgentState(agentId: string, state: AgentState, activity?: AgentActivity | null) {
-    const agent = agents.value.find(a => a.id === agentId)
+    const agent = agents.value.find((a) => a.id === agentId)
     if (!agent) return
     agent.state = state
     if (activity !== undefined) agent.activity = activity
   }
 
   function addLog(agentId: string, line: string, timestamp?: string, detail?: any) {
-    const agent = agents.value.find(a => a.id === agentId)
+    const agent = agents.value.find((a) => a.id === agentId)
     if (agent && line) {
       const ts = timestamp || new Date().toISOString()
       agent.logs.push({ line, timestamp: ts, detail: detail || null })
@@ -143,7 +143,7 @@ export const useAgentsStore = defineStore('agents', () => {
       type: 'chat',
       from: 'user',
       to: agentId,
-      content
+      content,
     })
   }
 
@@ -159,7 +159,12 @@ export const useAgentsStore = defineStore('agents', () => {
     const res = await fetch(`${API_BASE}/guilds/${guildId}/agents/${agentId}/run`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ..._authHeaders() },
-      body: JSON.stringify({ tool, prompt, model: model || undefined, provider: provider || undefined })
+      body: JSON.stringify({
+        tool,
+        prompt,
+        model: model || undefined,
+        provider: provider || undefined,
+      }),
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
@@ -184,7 +189,10 @@ export const useAgentsStore = defineStore('agents', () => {
     return res.json()
   }
 
-  async function assignTask(workerId: string, { description, issueNumber, issueRepo }: AssignTaskOpts) {
+  async function assignTask(
+    workerId: string,
+    { description, issueNumber, issueRepo }: AssignTaskOpts,
+  ) {
     const guildStore = useGuildStore()
     const guildId = guildStore.currentGuild?.id
     if (!guildId) throw new Error('No active guild')
@@ -196,7 +204,7 @@ export const useAgentsStore = defineStore('agents', () => {
         description,
         issue_number: issueNumber || null,
         issue_repo: issueRepo || null,
-      })
+      }),
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
@@ -213,7 +221,7 @@ export const useAgentsStore = defineStore('agents', () => {
     const res = await fetch(`${API_BASE}/guilds/${guildId}/workers/${workerId}/message`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ..._authHeaders() },
-      body: JSON.stringify({ message })
+      body: JSON.stringify({ message }),
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
@@ -223,17 +231,15 @@ export const useAgentsStore = defineStore('agents', () => {
   }
 
   function firstIdleWorker() {
-    const workerAgents = agents.value.filter(
-      a => a.workerId && a.state !== 'offline'
-    )
+    const workerAgents = agents.value.filter((a) => a.workerId && a.state !== 'offline')
     const idleAgent =
-      workerAgents.find(a => a.state === 'idle') ||
-      workerAgents.find(a => !['working', 'awaiting-review', 'error'].includes(a.state)) ||
+      workerAgents.find((a) => a.state === 'idle') ||
+      workerAgents.find((a) => !['working', 'awaiting-review', 'error'].includes(a.state)) ||
       workerAgents[0]
     if (idleAgent) return { id: idleAgent.workerId, name: idleAgent.name, state: idleAgent.state }
 
-    const legacy = agents.value.filter(a => a.id.startsWith('w-') && a.state !== 'offline')
-    return legacy.find(a => a.state === 'idle') || legacy[0] || null
+    const legacy = agents.value.filter((a) => a.id.startsWith('w-') && a.state !== 'offline')
+    return legacy.find((a) => a.state === 'idle') || legacy[0] || null
   }
 
   function clearAgents() {
@@ -271,7 +277,7 @@ export const useAgentsStore = defineStore('agents', () => {
           timestamp: r.timestamp,
           detail: r.detail || null,
         }))
-        const agent = agents.value.find(a => a.id === agentId)
+        const agent = agents.value.find((a) => a.id === agentId)
         if (agent) {
           const existing = agent.logs
           agent.logs = [...historical, ...existing]
@@ -287,15 +293,18 @@ export const useAgentsStore = defineStore('agents', () => {
     if (data.type === 'agent-joined') {
       registerAgent(data as RegisterAgentData)
     } else if (data.type === 'agent-state') {
-      updateAgentState(data.agentId, data.state,
-        'activity' in data ? (data.activity as AgentActivity | null) : undefined)
+      updateAgentState(
+        data.agentId,
+        data.state,
+        'activity' in data ? (data.activity as AgentActivity | null) : undefined,
+      )
     } else if (data.type === 'terminal-output') {
       // Route to per-agent log buffer (includes task logs for agent-tab view)
       if (data.agentId) addLog(data.agentId, data.line, data.timestamp, data.detail)
       // Route to per-worker log buffer; fall back to agent's workerId if backend didn't send it
-      const wid = data.workerId || (data.agentId
-        ? agents.value.find(a => a.id === data.agentId)?.workerId
-        : null)
+      const wid =
+        data.workerId ||
+        (data.agentId ? agents.value.find((a) => a.id === data.agentId)?.workerId : null)
       if (wid) addWorkerLog(wid, data.line, data.timestamp, data.detail)
     }
   }
@@ -325,6 +334,6 @@ export const useAgentsStore = defineStore('agents', () => {
     messageWorker,
     firstIdleWorker,
     clearAgents,
-    handleWebSocketMessage
+    handleWebSocketMessage,
   }
 })

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -11,9 +11,7 @@ export const useAuthStore = defineStore('auth', () => {
   const isLoggedIn = computed(() => !!loginToken.value && !!user.value)
 
   function authHeaders(): Record<string, string> {
-    return loginToken.value
-      ? { Authorization: `Bearer ${loginToken.value}` }
-      : {}
+    return loginToken.value ? { Authorization: `Bearer ${loginToken.value}` } : {}
   }
 
   async function loginWithGitHub() {

--- a/frontend/src/stores/github.ts
+++ b/frontend/src/stores/github.ts
@@ -34,9 +34,12 @@ export const useGitHubStore = defineStore('github', () => {
     if (!token.value) return []
     loading.value = true
     try {
-      const res = await fetch(`${GH_API}/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator`, {
-        headers: ghHeaders(token.value),
-      })
+      const res = await fetch(
+        `${GH_API}/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator`,
+        {
+          headers: ghHeaders(token.value),
+        },
+      )
       if (!res.ok) throw new Error(`GitHub error ${res.status}`)
       repos.value = await res.json()
       return repos.value
@@ -61,20 +64,35 @@ export const useGitHubStore = defineStore('github', () => {
         selectedRepos.value.map(async (repoName) => {
           const res = await fetch(
             `${GH_API}/repos/${repoName}/issues?state=open&per_page=30&sort=created&direction=desc`,
-            { headers: ghHeaders(token.value) }
+            { headers: ghHeaders(token.value) },
           )
           if (!res.ok) return [] as GitHubIssue[]
           const data = await res.json()
           return data
             .filter((i: any) => !i.pull_request)
             .map((i: any) => ({ ...i, repo: repoName })) as GitHubIssue[]
-        })
+        }),
       )
       issues.value = allIssues.flat().sort((a, b) => {
-        const priorityLabels = ['priority: high', 'high priority', 'priority:high', 'p0', 'p1', 'urgent', 'critical']
-        const aPriority = a.labels.some(l => priorityLabels.includes(l.name.toLowerCase())) ? 0 : 1
-        const bPriority = b.labels.some(l => priorityLabels.includes(l.name.toLowerCase())) ? 0 : 1
-        return aPriority - bPriority || (new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+        const priorityLabels = [
+          'priority: high',
+          'high priority',
+          'priority:high',
+          'p0',
+          'p1',
+          'urgent',
+          'critical',
+        ]
+        const aPriority = a.labels.some((l) => priorityLabels.includes(l.name.toLowerCase()))
+          ? 0
+          : 1
+        const bPriority = b.labels.some((l) => priorityLabels.includes(l.name.toLowerCase()))
+          ? 0
+          : 1
+        return (
+          aPriority - bPriority ||
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        )
       })
       return issues.value
     } catch (e: any) {

--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -36,7 +36,10 @@ export const useGuildStore = defineStore('guild', () => {
   async function loadGuilds() {
     try {
       const res = await fetch(`${API_BASE}/guilds`, { headers: _authHeaders() })
-      if (!res.ok) { guilds.value = []; return }
+      if (!res.ok) {
+        guilds.value = []
+        return
+      }
       guilds.value = await res.json()
     } catch (e) {
       console.error('Failed to load guilds', e)
@@ -47,17 +50,20 @@ export const useGuildStore = defineStore('guild', () => {
     return updateGuild(guildId, { name })
   }
 
-  async function updateGuild(guildId: string, updates: { name?: string; primary_repo?: string | null }) {
+  async function updateGuild(
+    guildId: string,
+    updates: { name?: string; primary_repo?: string | null },
+  ) {
     const res = await fetch(`${API_BASE}/guilds/${guildId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', ..._authHeaders() },
-      body: JSON.stringify(updates)
+      body: JSON.stringify(updates),
     })
     if (!res.ok) throw new Error('Failed to update guild')
     if (currentGuild.value && currentGuild.value.id === guildId) {
       currentGuild.value = { ...currentGuild.value, ...updates }
     }
-    const idx = guilds.value.findIndex(g => g.id === guildId)
+    const idx = guilds.value.findIndex((g) => g.id === guildId)
     if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], ...updates }
     return await res.json()
   }
@@ -66,7 +72,7 @@ export const useGuildStore = defineStore('guild', () => {
     const res = await fetch(`${API_BASE}/guilds`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ..._authHeaders() },
-      body: JSON.stringify({ name })
+      body: JSON.stringify({ name }),
     })
     const guild: Guild = await res.json()
     guilds.value.unshift(guild)
@@ -94,14 +100,20 @@ export const useGuildStore = defineStore('guild', () => {
       reconnectTimer = null
     }
     if (ws) {
-      try { ws.close() } catch { /* ignore */ }
+      try {
+        ws.close()
+      } catch {
+        /* ignore */
+      }
     }
 
     let socket: WebSocket
     try {
       const wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
       const authStore = useAuthStore()
-      const tokenParam = authStore.loginToken ? `?token=${encodeURIComponent(authStore.loginToken)}` : ''
+      const tokenParam = authStore.loginToken
+        ? `?token=${encodeURIComponent(authStore.loginToken)}`
+        : ''
       socket = new WebSocket(`${wsProto}//${window.location.host}/ws/${guildId}${tokenParam}`)
     } catch (e) {
       console.error('Failed to construct WebSocket', e)
@@ -131,12 +143,16 @@ export const useGuildStore = defineStore('guild', () => {
           if (currentGuild.value && currentGuild.value.id === data.id) {
             currentGuild.value = { ...currentGuild.value, name: data.name }
           }
-          const idx = guilds.value.findIndex(g => g.id === data.id)
+          const idx = guilds.value.findIndex((g) => g.id === data.id)
           if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], name: data.name }
         }
         if (onMessage) onMessage(data)
-        messageHandlers.value.forEach(h => {
-          try { h(data) } catch (err) { console.error('WS message handler error', err) }
+        messageHandlers.value.forEach((h) => {
+          try {
+            h(data)
+          } catch (err) {
+            console.error('WS message handler error', err)
+          }
         })
       } catch (e) {
         console.error('Error processing WS message', e)
@@ -165,7 +181,9 @@ export const useGuildStore = defineStore('guild', () => {
     }
     const delay = _backoffDelay(reconnectAttempt.value)
     reconnectAttempt.value += 1
-    console.info(`WebSocket reconnect attempt ${reconnectAttempt.value}/${MAX_RETRIES} in ${delay}ms`)
+    console.info(
+      `WebSocket reconnect attempt ${reconnectAttempt.value}/${MAX_RETRIES} in ${delay}ms`,
+    )
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null
       connectWebSocket(guildId, onMessage)
@@ -179,7 +197,11 @@ export const useGuildStore = defineStore('guild', () => {
       reconnectTimer = null
     }
     if (ws) {
-      try { ws.close() } catch { /* ignore */ }
+      try {
+        ws.close()
+      } catch {
+        /* ignore */
+      }
       ws = null
     }
     isConnected.value = false
@@ -205,7 +227,7 @@ export const useGuildStore = defineStore('guild', () => {
   }
 
   function removeMessageHandler(handler: MessageHandler) {
-    messageHandlers.value = messageHandlers.value.filter(h => h !== handler)
+    messageHandlers.value = messageHandlers.value.filter((h) => h !== handler)
   }
 
   return {
@@ -223,6 +245,6 @@ export const useGuildStore = defineStore('guild', () => {
     disconnectWebSocket,
     sendMessage,
     addMessageHandler,
-    removeMessageHandler
+    removeMessageHandler,
   }
 })

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -97,7 +97,7 @@ export const useTasksStore = defineStore('tasks', () => {
   }
 
   function _upsertTask(data: Task) {
-    const idx = tasks.value.findIndex(t => t.id === data.id)
+    const idx = tasks.value.findIndex((t) => t.id === data.id)
     if (idx >= 0) {
       Object.assign(tasks.value[idx], data)
     } else {
@@ -117,7 +117,7 @@ export const useTasksStore = defineStore('tasks', () => {
         created_at: data.createdAt,
       })
     } else if (data.type === 'task-assigned') {
-      const existing = tasks.value.find(t => t.id === data.taskId)
+      const existing = tasks.value.find((t) => t.id === data.taskId)
       _upsertTask({
         id: data.taskId,
         name: data.name || (data.description || '').slice(0, 60),
@@ -129,7 +129,7 @@ export const useTasksStore = defineStore('tasks', () => {
         ...(existing ? {} : { created_at: new Date().toISOString() }),
       })
     } else if (data.type === 'task-update') {
-      const task = tasks.value.find(t => t.id === data.taskId)
+      const task = tasks.value.find((t) => t.id === data.taskId)
       if (task) {
         if (data.state) task.state = data.state
         if (data.branch) task.branch = data.branch
@@ -138,13 +138,13 @@ export const useTasksStore = defineStore('tasks', () => {
         if (data.worktreePath) task.worktree_path = data.worktreePath
       }
     } else if (data.type === 'task-complete') {
-      const task = tasks.value.find(t => t.id === data.taskId)
+      const task = tasks.value.find((t) => t.id === data.taskId)
       if (task) {
         task.state = 'awaiting-review'
         if (data.branch) task.branch = data.branch
       }
     } else if (data.type === 'task-followup-done') {
-      const task = tasks.value.find(t => t.id === data.taskId)
+      const task = tasks.value.find((t) => t.id === data.taskId)
       if (task) task.state = 'awaiting-review'
     } else if (data.type === 'terminal-output' && data.taskId) {
       const { taskId, line, timestamp, detail } = data
@@ -176,8 +176,12 @@ export const useTasksStore = defineStore('tasks', () => {
     openedTaskIds.value = []
   }
 
-  function stateLabel(state: TaskState | string) { return STATE_LABELS[state] || state }
-  function stateColor(state: TaskState | string) { return STATE_COLORS[state] || 'dim' }
+  function stateLabel(state: TaskState | string) {
+    return STATE_LABELS[state] || state
+  }
+  function stateColor(state: TaskState | string) {
+    return STATE_COLORS[state] || 'dim'
+  }
 
   return {
     tasks,

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -55,7 +55,8 @@
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   height: 100%;
   background: var(--color-bg);
   color: var(--color-text);
@@ -124,7 +125,9 @@ html, body {
 
 .pixel-btn:hover {
   background: linear-gradient(180deg, #ffe880 0%, var(--color-brass) 100%);
-  box-shadow: 0 0 10px var(--color-brass-light), 0 0 20px rgba(255, 214, 68, 0.3);
+  box-shadow:
+    0 0 10px var(--color-brass-light),
+    0 0 20px rgba(255, 214, 68, 0.3);
   transform: translateY(-1px);
 }
 

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -4,7 +4,11 @@
     <MainView />
     <ChatPane />
     <nav class="mobile-tab-bar">
-      <button class="tab-btn" :class="{ active: activeTab === 'tasks' }" @click="activeTab = 'tasks'">
+      <button
+        class="tab-btn"
+        :class="{ active: activeTab === 'tasks' }"
+        @click="activeTab = 'tasks'"
+      >
         <span class="tab-icon">≡</span>
         <span class="tab-label">Tasks</span>
       </button>
@@ -35,7 +39,9 @@ import ChatPane from '../components/ChatPane.vue'
 const props = defineProps<{ guildId?: string }>()
 
 const activeTab = ref<'tasks' | 'work' | 'chat'>('chat')
-provide('switchMobileTab', (tab: 'tasks' | 'work' | 'chat') => { activeTab.value = tab })
+provide('switchMobileTab', (tab: 'tasks' | 'work' | 'chat') => {
+  activeTab.value = tab
+})
 
 const router = useRouter()
 const guildStore = useGuildStore()
@@ -75,15 +81,17 @@ async function initGuild(guildId: string) {
 
   if (guild.agents) {
     guild.agents
-      .filter(a => a.state !== 'offline')
-      .forEach(a => agentsStore.registerAgent({
-        agentId: a.id,
-        agentName: a.name,
-        agentType: a.type,
-        workerId: a.worker_id || null,
-        state: a.state,
-        joinedAt: a.joined_at,
-      }))
+      .filter((a) => a.state !== 'offline')
+      .forEach((a) =>
+        agentsStore.registerAgent({
+          agentId: a.id,
+          agentName: a.name,
+          agentType: a.type,
+          workerId: a.worker_id || null,
+          state: a.state,
+          joinedAt: a.joined_at,
+        }),
+      )
   }
 
   const clientId = getClientId()
@@ -119,18 +127,22 @@ onUnmounted(() => {
   document.title = 'Pioneer Square'
 })
 
-watch(() => props.guildId, async (newId) => {
-  if (newId) {
-    await initGuild(newId)
-  }
-}, { immediate: true })
+watch(
+  () => props.guildId,
+  async (newId) => {
+    if (newId) {
+      await initGuild(newId)
+    }
+  },
+  { immediate: true },
+)
 
 watch(
   () => guildStore.currentGuild?.name,
   (name) => {
     document.title = name ? `${name} — Pioneer Square` : 'Pioneer Square'
   },
-  { immediate: true }
+  { immediate: true },
 )
 </script>
 
@@ -172,7 +184,9 @@ watch(
     border-right: 1px solid var(--color-brass-dark);
     cursor: pointer;
     color: var(--color-text-dim);
-    transition: color 0.12s, background 0.12s;
+    transition:
+      color 0.12s,
+      background 0.12s;
     padding: 4px 0;
   }
 
@@ -214,8 +228,14 @@ watch(
     display: none !important;
   }
 
-  .app-layout[data-tab="tasks"] .sidebar { display: flex !important; }
-  .app-layout[data-tab="work"]  .main-view { display: flex !important; }
-  .app-layout[data-tab="chat"]  .chat-pane { display: flex !important; }
+  .app-layout[data-tab='tasks'] .sidebar {
+    display: flex !important;
+  }
+  .app-layout[data-tab='work'] .main-view {
+    display: flex !important;
+  }
+  .app-layout[data-tab='chat'] .chat-pane {
+    display: flex !important;
+  }
 }
 </style>

--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -54,7 +54,9 @@
           <div class="login-card">
             <div class="login-icon">⚙</div>
             <div class="login-title">SIGN IN TO GET STARTED</div>
-            <div class="login-sub">Connect your GitHub account to create guilds and run agents.</div>
+            <div class="login-sub">
+              Connect your GitHub account to create guilds and run agents.
+            </div>
             <button class="pixel-btn login-btn" :disabled="loggingIn" @click="handleLogin">
               {{ loggingIn ? 'Redirecting...' : 'SIGN IN WITH GITHUB' }}
             </button>
@@ -86,7 +88,10 @@
                 <div class="card-top">
                   <span class="card-id">{{ guild.id }}</span>
                   <span class="card-agents">
-                    <span class="agent-dot" :class="guild.agent_count > 0 ? 'active' : 'empty'"></span>
+                    <span
+                      class="agent-dot"
+                      :class="guild.agent_count > 0 ? 'active' : 'empty'"
+                    ></span>
                     {{ guild.agent_count || 0 }} agent{{ guild.agent_count !== 1 ? 's' : '' }}
                   </span>
                 </div>
@@ -97,7 +102,8 @@
             </div>
           </div>
         </template>
-      </div><!-- end main-panel -->
+      </div>
+      <!-- end main-panel -->
     </div>
 
     <!-- New Session Modal -->
@@ -260,7 +266,8 @@ function sparkleStyle(n: number) {
   border: 6px solid var(--color-brass-dark);
   opacity: 0.12;
 }
-.gear::before, .gear::after {
+.gear::before,
+.gear::after {
   content: '';
   position: absolute;
   background: var(--color-brass-dark);
@@ -282,7 +289,12 @@ function sparkleStyle(n: number) {
 
 .pipe {
   position: absolute;
-  background: linear-gradient(180deg, var(--color-brass-dark) 0%, #6b4f00 50%, var(--color-brass-dark) 100%);
+  background: linear-gradient(
+    180deg,
+    var(--color-brass-dark) 0%,
+    #6b4f00 50%,
+    var(--color-brass-dark) 100%
+  );
   opacity: 0.15;
 }
 .pipe-h {
@@ -290,8 +302,12 @@ function sparkleStyle(n: number) {
   left: 0;
   right: 0;
 }
-.pipe-top { top: 0; }
-.pipe-bottom { bottom: 0; }
+.pipe-top {
+  top: 0;
+}
+.pipe-bottom {
+  bottom: 0;
+}
 
 .sparkle {
   position: absolute;
@@ -302,10 +318,21 @@ function sparkleStyle(n: number) {
   animation: twinkle 2s ease-in-out infinite;
 }
 
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 @keyframes twinkle {
-  0%, 100% { opacity: 0.1; transform: scale(1); }
-  50% { opacity: 0.9; transform: scale(1.6); }
+  0%,
+  100% {
+    opacity: 0.1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.9;
+    transform: scale(1.6);
+  }
 }
 
 /* ── Content ── */
@@ -404,7 +431,9 @@ function sparkleStyle(n: number) {
   font-family: var(--font-pixel);
   font-size: 22px;
   color: var(--color-brass-light);
-  text-shadow: 0 0 20px rgba(255, 214, 68, 0.5), 0 0 40px rgba(255, 214, 68, 0.2);
+  text-shadow:
+    0 0 20px rgba(255, 214, 68, 0.5),
+    0 0 40px rgba(255, 214, 68, 0.2);
   letter-spacing: 4px;
   margin-bottom: 8px;
 }
@@ -626,8 +655,13 @@ function sparkleStyle(n: number) {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 .card-name {


### PR DESCRIPTION
Stacked on top of #114.

## Summary
- One-time mass format with the project's Prettier config (no semis, single quotes, trailing commas, 100-col, no Vue script/style indent) — 23 files touched.
- CI gains a `Format check` step (`npm run format:check`) after the lint step in the `frontend` job, so future drift is caught at PR time.

## Why a separate PR
The Prettier config landed in #114 but running `prettier --write` across the existing tree would have buried the meaningful changes there in cosmetic noise. Stacking keeps the format diff isolated and easy to skip past during review (it's all whitespace, quote style, trailing commas, and line wrapping — no logic moves).

## Test plan
- [x] `npm run format:check` clean
- [x] `npm run lint:check` clean
- [x] `npm run type-check` clean
- [x] `npm test` — 43 passing (no behavior changes)
- [ ] CI green on the new `Format check` step

https://claude.ai/code/session_013EpiNayXMMFhBKvBowXNRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013EpiNayXMMFhBKvBowXNRQ)_