### PR TITLE
feat(frontend): add top navigation bar

### DIFF
--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -1,42 +1,7 @@
 <template>
   <aside class="sidebar panel-bg">
-    <div v-if="currentGuild" class="guild-name-bar">
-      <template v-if="renamingGuild">
-        <input
-          ref="renameInput"
-          v-model="renameValue"
-          class="guild-rename-input"
-          @keydown.enter="commitRename"
-          @keydown.escape="cancelRename"
-          @blur="commitRename"
-        />
-      </template>
-      <template v-else>
-        <span class="guild-name-text" @click="startRename" title="Click to rename">{{ currentGuild.name }}</span>
-        <button class="rename-btn" @click="startRename" title="Rename guild">✎</button>
-      </template>
-    </div>
-
-    <div v-if="currentGuild" class="primary-repo-bar">
-      <span class="primary-repo-bar-label">Primary repo:</span>
-      <select
-        v-model="primaryRepoValue"
-        class="primary-repo-bar-select"
-        @change="savePrimaryRepo"
-      >
-        <option value="">— select primary repo —</option>
-        <option v-for="repo in ghStore.repos" :key="repo.full_name" :value="repo.full_name">
-          {{ repo.full_name }}
-        </option>
-      </select>
-      <span v-if="saveStatus" class="primary-repo-save-status" :class="'save-status-' + saveStatus">
-        {{ saveStatus === 'saved' ? 'Saved' : 'Error' }}
-      </span>
-    </div>
-
     <div class="sidebar-header">
       <span class="sidebar-title">Tasks</span>
-      <button class="pixel-btn new-btn" @click="goHome">⌂ Home</button>
     </div>
 
     <div class="tasks-list">
@@ -141,19 +106,20 @@
     </div>
 
     <div class="sidebar-footer">
-      <div class="gh-block" @click="showGitHubModal = true" :title="authStore.user ? 'GitHub: ' + authStore.user.login : 'Configure GitHub'">
-        <div class="gh-inner" :class="{ configured: authStore.isLoggedIn }">
-          <img v-if="authStore.isLoggedIn" :src="authStore.user?.avatar_url" class="gh-avatar" alt="gh" />
-          <span v-else class="gh-icon">⚙</span>
-          <div class="gh-text">
-            <span v-if="authStore.isLoggedIn" class="gh-login">{{ authStore.user?.login }}</span>
-            <span v-else class="gh-setup">Connect GitHub</span>
-            <span class="gh-repos" v-if="authStore.isLoggedIn && ghStore.selectedRepos.length > 0">
-              {{ ghStore.selectedRepos.length }} repo{{ ghStore.selectedRepos.length !== 1 ? 's' : '' }}
-            </span>
-          </div>
-        </div>
-      </div>
+      <button
+        v-if="authStore.isLoggedIn"
+        class="gh-config-btn"
+        @click="showGitHubModal = true"
+        :title="'GitHub: ' + authStore.user?.login"
+      >
+        <span class="gh-icon">⚙</span>
+        <span class="gh-text">
+          Configure GitHub
+          <span v-if="ghStore.selectedRepos.length > 0" class="gh-repos">
+            ({{ ghStore.selectedRepos.length }} repo{{ ghStore.selectedRepos.length !== 1 ? 's' : '' }})
+          </span>
+        </span>
+      </button>
 
       <div class="connection-status" :class="{ connected: isConnected }">
         <span class="status-dot"></span>
@@ -166,8 +132,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, inject, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, computed, inject, onMounted } from 'vue'
 import { useGuildStore } from '../stores/guild'
 import { useGitHubStore } from '../stores/github'
 import { useAuthStore } from '../stores/auth'
@@ -178,7 +143,6 @@ import GitHubConfigModal from './GitHubConfigModal.vue'
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
 
-const router = useRouter()
 const guildStore = useGuildStore()
 const ghStore = useGitHubStore()
 const authStore = useAuthStore()
@@ -244,64 +208,11 @@ async function launchWorker() {
   }
 }
 
-const primaryRepoValue = ref('')
-const saveStatus = ref('')
-let saveStatusTimer: ReturnType<typeof setTimeout> | null = null
-
-watch(currentGuild, (guild) => {
-  primaryRepoValue.value = guild?.primary_repo ?? ''
-}, { immediate: true })
-
-async function savePrimaryRepo() {
-  if (!currentGuild.value) return
-  try {
-    await guildStore.updateGuild(currentGuild.value.id, {
-      primary_repo: primaryRepoValue.value || null,
-    })
-    saveStatus.value = 'saved'
-  } catch (e) {
-    console.error('Failed to save primary repo', e)
-    saveStatus.value = 'error'
-  } finally {
-    if (saveStatusTimer) clearTimeout(saveStatusTimer)
-    saveStatusTimer = setTimeout(() => { saveStatus.value = '' }, 2000)
-  }
-}
-
 onMounted(async () => {
   if (ghStore.repos.length === 0 && ghStore.token) {
     await ghStore.fetchRepos()
   }
 })
-
-const renamingGuild = ref(false)
-const renameValue = ref('')
-const renameInput = ref<HTMLInputElement | null>(null)
-
-async function startRename() {
-  if (!currentGuild.value) return
-  renameValue.value = currentGuild.value.name || ''
-  renamingGuild.value = true
-  await nextTick()
-  renameInput.value?.select()
-}
-
-async function commitRename() {
-  if (!renamingGuild.value) return
-  renamingGuild.value = false
-  const trimmed = renameValue.value.trim()
-  if (trimmed && currentGuild.value && trimmed !== currentGuild.value.name) {
-    try {
-      await guildStore.renameGuild(currentGuild.value.id, trimmed)
-    } catch (e) {
-      console.error('Failed to rename guild', e)
-    }
-  }
-}
-
-function cancelRename() {
-  renamingGuild.value = false
-}
 
 const groupedTasks = computed(() => {
   const now = new Date()
@@ -329,10 +240,6 @@ const groupedTasks = computed(() => {
 
   return Array.from(groupMap.entries()).map(([label, tasks]) => ({ label, tasks }))
 })
-
-function goHome() {
-  router.push('/')
-}
 
 function openTask(taskId: string) {
   tasksStore.selectTask(taskId)
@@ -378,70 +285,6 @@ function formatTime(isoStr?: string) {
   overflow: hidden;
 }
 
-.guild-name-bar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 10px 6px;
-  border-bottom: 1px solid var(--color-brass-dark);
-  background: var(--color-bg);
-  flex-shrink: 0;
-  min-height: 32px;
-}
-
-.guild-name-text {
-  font-family: var(--font-pixel);
-  font-size: 8px;
-  color: var(--color-brass);
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  cursor: pointer;
-  text-shadow: 0 0 6px rgba(255, 214, 68, 0.3);
-  transition: color 0.12s;
-}
-
-.guild-name-text:hover {
-  color: var(--color-brass-light);
-}
-
-.rename-btn {
-  background: none;
-  border: none;
-  color: var(--color-brass-dark);
-  cursor: pointer;
-  font-size: 12px;
-  padding: 1px 3px;
-  border-radius: 2px;
-  line-height: 1;
-  opacity: 0.5;
-  transition: opacity 0.12s, background 0.12s;
-  flex-shrink: 0;
-}
-
-.rename-btn:hover {
-  opacity: 1;
-  background: rgba(232, 170, 0, 0.1);
-}
-
-.guild-rename-input {
-  flex: 1;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-brass);
-  color: var(--color-brass-light);
-  font-family: var(--font-pixel);
-  font-size: 8px;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  padding: 3px 6px;
-  outline: none;
-  border-radius: 2px;
-  min-width: 0;
-}
-
 .sidebar-header {
   padding: 12px 10px;
   border-bottom: 2px solid var(--color-brass-dark);
@@ -459,11 +302,6 @@ function formatTime(isoStr?: string) {
   letter-spacing: 2px;
   text-transform: uppercase;
   text-shadow: 0 0 6px rgba(255, 214, 68, 0.4);
-}
-
-.new-btn {
-  font-size: 7px;
-  padding: 4px 7px;
 }
 
 /* ── Unified task list ── */
@@ -760,53 +598,6 @@ function formatTime(isoStr?: string) {
   text-overflow: ellipsis;
 }
 
-.primary-repo-bar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-bottom: 1px solid var(--color-brass-dark);
-  background: var(--color-bg-secondary);
-  flex-shrink: 0;
-  min-height: 26px;
-}
-
-.primary-repo-bar-label {
-  font-family: var(--font-pixel);
-  font-size: 6px;
-  color: var(--color-brass-dark);
-  letter-spacing: 0.5px;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.primary-repo-bar-select {
-  flex: 1;
-  background: var(--color-bg);
-  border: 1px solid var(--color-brass-dark);
-  color: var(--color-text);
-  font-size: 9px;
-  padding: 2px 4px;
-  outline: none;
-  border-radius: 2px;
-  min-width: 0;
-}
-
-.primary-repo-bar-select:focus {
-  border-color: var(--color-brass);
-}
-
-.primary-repo-save-status {
-  font-family: var(--font-pixel);
-  font-size: 6px;
-  letter-spacing: 0.5px;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.save-status-saved { color: var(--color-green); }
-.save-status-error { color: var(--color-red); }
-
 /* Worker top-level row */
 .worker-row {
   display: flex;
@@ -924,63 +715,38 @@ function formatTime(isoStr?: string) {
   flex-shrink: 0;
 }
 
-/* ── GitHub block ── */
-.gh-block {
-  cursor: pointer;
-  border: 1px solid var(--color-brass-dark);
-  transition: all 0.15s;
-  border-radius: 2px;
-}
-
-.gh-block:hover {
-  border-color: var(--color-brass);
-  background: rgba(232, 170, 0, 0.06);
-}
-
-.gh-inner {
+/* ── GitHub config button ── */
+.gh-config-btn {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 7px 9px;
+  background: transparent;
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: all 0.15s;
+  width: 100%;
+  text-align: left;
 }
 
-.gh-inner.configured {
-  border-left: 3px solid var(--color-teal);
-}
-
-.gh-avatar {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  border: 1px solid var(--color-teal);
-  flex-shrink: 0;
+.gh-config-btn:hover {
+  border-color: var(--color-brass);
+  background: rgba(232, 170, 0, 0.06);
 }
 
 .gh-icon {
-  font-size: 16px;
+  font-size: 14px;
   color: var(--color-brass-dark);
   flex-shrink: 0;
 }
 
 .gh-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  overflow: hidden;
-}
-
-.gh-login {
-  font-family: var(--font-pixel);
-  font-size: 7px;
-  color: var(--color-teal);
+  font-size: 11px;
+  color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.gh-setup {
-  font-size: 10px;
-  color: var(--color-text-dim);
 }
 
 .gh-repos {

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -1,0 +1,443 @@
+<template>
+  <header class="top-bar">
+    <button class="home-btn pixel-btn" @click="goHome" title="Back to guilds">
+      <span class="home-icon">⌂</span>
+      <span class="home-label">Home</span>
+    </button>
+
+    <div class="guild-block" v-if="currentGuild">
+      <span class="guild-name" :title="currentGuild.name">{{ currentGuild.name || 'Unnamed Guild' }}</span>
+      <span class="guild-id">#{{ currentGuild.id }}</span>
+    </div>
+    <div class="guild-block guild-block--empty" v-else>
+      <span class="guild-name">Pioneer Square</span>
+    </div>
+
+    <div class="top-bar-spacer"></div>
+
+    <div
+      v-if="authStore.isLoggedIn"
+      class="user-pill"
+      :title="'Signed in as ' + authStore.user?.login"
+    >
+      <img v-if="authStore.user?.avatar_url" :src="authStore.user.avatar_url" class="user-avatar" alt="" />
+      <span class="user-login">{{ authStore.user?.login }}</span>
+    </div>
+
+    <button
+      v-if="currentGuild"
+      class="settings-btn"
+      :class="{ active: showSettings }"
+      @click="toggleSettings"
+      title="Guild settings"
+      ref="settingsBtnRef"
+    >
+      <span class="settings-icon">⚙</span>
+    </button>
+
+    <div v-if="showSettings && currentGuild" class="settings-popover" ref="popoverRef">
+      <div class="settings-header">Guild Settings</div>
+
+      <div class="settings-field">
+        <label class="settings-label">Name</label>
+        <div class="settings-row">
+          <input
+            v-model="renameValue"
+            class="settings-input"
+            @keydown.enter="commitRename"
+            @keydown.escape="closeSettings"
+          />
+          <button
+            class="pixel-btn settings-save-btn"
+            :disabled="renameValue.trim() === (currentGuild.name || '') || !renameValue.trim()"
+            @click="commitRename"
+          >
+            Save
+          </button>
+        </div>
+        <span v-if="renameStatus" class="save-status" :class="'save-status-' + renameStatus">
+          {{ renameStatus === 'saved' ? 'Saved' : 'Error' }}
+        </span>
+      </div>
+
+      <div class="settings-field">
+        <label class="settings-label">Primary Repo</label>
+        <div class="settings-row">
+          <select v-model="primaryRepoValue" class="settings-input" @change="savePrimaryRepo">
+            <option value="">— select primary repo —</option>
+            <option v-for="repo in ghStore.repos" :key="repo.full_name" :value="repo.full_name">
+              {{ repo.full_name }}
+            </option>
+          </select>
+          <span v-if="repoStatus" class="save-status" :class="'save-status-' + repoStatus">
+            {{ repoStatus === 'saved' ? 'Saved' : 'Error' }}
+          </span>
+        </div>
+      </div>
+
+      <div class="settings-field settings-meta">
+        <span class="settings-meta-label">Session ID</span>
+        <code class="settings-meta-value">{{ currentGuild.id }}</code>
+      </div>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { useRouter } from 'vue-router'
+import { useGuildStore } from '../stores/guild'
+import { useGitHubStore } from '../stores/github'
+import { useAuthStore } from '../stores/auth'
+
+const router = useRouter()
+const guildStore = useGuildStore()
+const ghStore = useGitHubStore()
+const authStore = useAuthStore()
+
+const currentGuild = computed(() => guildStore.currentGuild)
+
+const showSettings = ref(false)
+const settingsBtnRef = ref<HTMLElement | null>(null)
+const popoverRef = ref<HTMLElement | null>(null)
+
+const renameValue = ref('')
+const primaryRepoValue = ref('')
+const renameStatus = ref<'' | 'saved' | 'error'>('')
+const repoStatus = ref<'' | 'saved' | 'error'>('')
+let renameStatusTimer: ReturnType<typeof setTimeout> | null = null
+let repoStatusTimer: ReturnType<typeof setTimeout> | null = null
+
+watch(currentGuild, (guild) => {
+  renameValue.value = guild?.name ?? ''
+  primaryRepoValue.value = guild?.primary_repo ?? ''
+}, { immediate: true })
+
+async function toggleSettings() {
+  showSettings.value = !showSettings.value
+  if (showSettings.value) {
+    renameValue.value = currentGuild.value?.name ?? ''
+    primaryRepoValue.value = currentGuild.value?.primary_repo ?? ''
+    if (ghStore.repos.length === 0 && ghStore.token) {
+      await ghStore.fetchRepos()
+    }
+  }
+}
+
+function closeSettings() {
+  showSettings.value = false
+}
+
+function onDocClick(e: MouseEvent) {
+  if (!showSettings.value) return
+  const target = e.target as Node
+  if (popoverRef.value?.contains(target)) return
+  if (settingsBtnRef.value?.contains(target)) return
+  showSettings.value = false
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', onDocClick)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', onDocClick)
+  if (renameStatusTimer) clearTimeout(renameStatusTimer)
+  if (repoStatusTimer) clearTimeout(repoStatusTimer)
+})
+
+async function commitRename() {
+  if (!currentGuild.value) return
+  const trimmed = renameValue.value.trim()
+  if (!trimmed || trimmed === currentGuild.value.name) return
+  try {
+    await guildStore.renameGuild(currentGuild.value.id, trimmed)
+    renameStatus.value = 'saved'
+  } catch (e) {
+    console.error('Failed to rename guild', e)
+    renameStatus.value = 'error'
+  } finally {
+    if (renameStatusTimer) clearTimeout(renameStatusTimer)
+    renameStatusTimer = setTimeout(() => { renameStatus.value = '' }, 2000)
+  }
+}
+
+async function savePrimaryRepo() {
+  if (!currentGuild.value) return
+  try {
+    await guildStore.updateGuild(currentGuild.value.id, {
+      primary_repo: primaryRepoValue.value || null,
+    })
+    repoStatus.value = 'saved'
+  } catch (e) {
+    console.error('Failed to save primary repo', e)
+    repoStatus.value = 'error'
+  } finally {
+    if (repoStatusTimer) clearTimeout(repoStatusTimer)
+    repoStatusTimer = setTimeout(() => { repoStatus.value = '' }, 2000)
+  }
+  await nextTick()
+}
+
+function goHome() {
+  router.push('/')
+}
+</script>
+
+<style scoped>
+.top-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 44px;
+  padding: 0 12px;
+  background: var(--color-bg-tertiary);
+  border-bottom: 2px solid var(--color-brass-dark);
+  flex-shrink: 0;
+  z-index: 100;
+}
+
+.home-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 7px;
+  padding: 6px 10px;
+}
+
+.home-icon {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.home-label {
+  letter-spacing: 1px;
+}
+
+.guild-block {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+  padding-left: 4px;
+  border-left: 1px solid var(--color-brass-dark);
+  padding-right: 4px;
+}
+
+.guild-block--empty {
+  border-left: none;
+}
+
+.guild-name {
+  font-family: var(--font-pixel);
+  font-size: 9px;
+  color: var(--color-brass-light);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-shadow: 0 0 6px rgba(255, 214, 68, 0.3);
+}
+
+.guild-id {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--color-text-dim);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.top-bar-spacer {
+  flex: 1;
+  min-width: 0;
+}
+
+.user-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px 3px 4px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.user-avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1px solid var(--color-teal);
+}
+
+.user-login {
+  font-size: 11px;
+  color: var(--color-teal);
+  white-space: nowrap;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.settings-btn {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-brass);
+  cursor: pointer;
+  width: 30px;
+  height: 30px;
+  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  flex-shrink: 0;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+
+.settings-btn:hover,
+.settings-btn.active {
+  border-color: var(--color-brass);
+  background: rgba(232, 170, 0, 0.1);
+  color: var(--color-brass-light);
+}
+
+.settings-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 12px;
+  width: 320px;
+  background: var(--color-bg-secondary);
+  border: 2px solid var(--color-brass);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5), 0 0 16px rgba(232, 170, 0, 0.15);
+  z-index: 250;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+}
+
+.settings-header {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  color: var(--color-brass-light);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--color-brass-dark);
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.settings-label {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass-dark);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-input {
+  flex: 1;
+  background: var(--color-bg);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  padding: 5px 7px;
+  outline: none;
+  border-radius: 2px;
+  min-width: 0;
+}
+
+.settings-input:focus {
+  border-color: var(--color-brass);
+}
+
+.settings-save-btn {
+  font-size: 7px;
+  padding: 5px 9px;
+  flex-shrink: 0;
+}
+
+.settings-save-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.save-status {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.save-status-saved { color: var(--color-green); }
+.save-status-error { color: var(--color-red); }
+
+.settings-meta {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-top: 1px solid var(--color-brass-dark);
+  padding-top: 10px;
+}
+
+.settings-meta-label {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass-dark);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.settings-meta-value {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-brass);
+  background: var(--color-bg);
+  border: 1px solid var(--color-brass-dark);
+  padding: 2px 6px;
+  border-radius: 2px;
+}
+
+@media (max-width: 600px) {
+  .home-label {
+    display: none;
+  }
+
+  .guild-id {
+    display: none;
+  }
+
+  .user-login {
+    display: none;
+  }
+
+  .settings-popover {
+    right: 8px;
+    width: calc(100vw - 16px);
+    max-width: 320px;
+  }
+}
+</style>

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="app-layout" :data-tab="activeTab">
-    <GuildSidebar />
-    <MainView />
-    <ChatPane />
+    <TopBar />
+    <div class="app-body">
+      <GuildSidebar />
+      <MainView />
+      <ChatPane />
+    </div>
     <nav class="mobile-tab-bar">
       <button class="tab-btn" :class="{ active: activeTab === 'tasks' }" @click="activeTab = 'tasks'">
         <span class="tab-icon">≡</span>
@@ -31,6 +34,7 @@ import { useTasksStore } from '../stores/tasks'
 import GuildSidebar from '../components/GuildSidebar.vue'
 import MainView from '../components/MainView.vue'
 import ChatPane from '../components/ChatPane.vue'
+import TopBar from '../components/TopBar.vue'
 
 const props = defineProps<{ guildId?: string }>()
 
@@ -137,10 +141,18 @@ watch(
 <style>
 .app-layout {
   display: flex;
+  flex-direction: column;
   height: 100vh;
   width: 100vw;
   overflow: hidden;
   background: var(--color-bg);
+}
+
+.app-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .mobile-tab-bar {
@@ -197,20 +209,20 @@ watch(
     text-transform: uppercase;
   }
 
-  /* Each pane takes the full screen (minus tab bar) and is hidden unless active */
+  /* Each pane takes the full screen (minus top bar + bottom tab bar) and is hidden unless active */
   .sidebar,
   .main-view,
   .chat-pane {
     position: fixed !important;
-    top: 0;
+    top: 44px;
     left: 0;
     right: 0;
     bottom: 52px;
     width: 100vw !important;
     min-width: 0 !important;
     max-width: 100vw !important;
-    height: calc(100dvh - 52px) !important;
-    max-height: calc(100dvh - 52px) !important;
+    height: calc(100dvh - 96px) !important;
+    max-height: calc(100dvh - 96px) !important;
     display: none !important;
   }
 


### PR DESCRIPTION
Introduces a persistent TopBar with the home button, guild name + session
id, the signed-in user, and a settings popover for renaming the guild and
choosing the primary repo. Removes the equivalent controls from the
sidebar so each piece of guild metadata lives in one place, and adjusts
the responsive layout to account for the new 44px top strip.

https://claude.ai/code/session_01XZ2HsoH9MnyY2g7aqUGVvN