### PR TITLE
fix(backend): exclude offline agents from guild list count

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -521,7 +521,12 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
                 func.count(Agent.id).label("agent_count"),
             )
             .select_from(Guild)
-            .outerjoin(Agent, (Agent.guild_id == Guild.id) & (Agent.type != "foreman"))
+            .outerjoin(
+                Agent,
+                (Agent.guild_id == Guild.id)
+                & (Agent.type != "foreman")
+                & (Agent.state != "offline"),
+            )
             .where(Guild.github_user_id == github_user_id)
             .group_by(Guild.id)
             .order_by(Guild.created_at.desc())


### PR DESCRIPTION
The Home Screen agent count on each guild card was including agents in
the offline state. Filter the outer join in /guilds to only count agents
that are currently connected, matching the filter already used by
/guilds/{guild_id}.

https://claude.ai/code/session_01BSYs19XWotnKHQHLRbEzPM