### PR TITLE
worker: fix Claude auth in headless containers via setup-token + PTY

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1409,6 +1409,9 @@ async def spawn_worker_container(guild_id: str, data: SpawnWorkerRequest):
     }
     if data.name:
         env["PIONEER_WORKER_NAME"] = data.name
+    worker_log_level = os.environ.get("WORKER_LOG_LEVEL")
+    if worker_log_level:
+        env["PIONEER_WORKER_LOG_LEVEL"] = worker_log_level
 
     # Join the same Docker network as the backend so the worker can reach it
     network = None

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,7 +1,16 @@
-# Runs the frontend in Vite dev mode with HMR instead of the nginx production build.
+# Runs the frontend in Vite dev mode with HMR instead of the nginx production build,
+# and runs the backend with --reload for auto-restart on code changes.
 # Docker Compose loads this file automatically alongside docker-compose.yml.
 # To use the production build instead, start with: docker compose -f docker-compose.yml up
 services:
+  backend:
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+
+  # To run the worker with verbose logging, either set WORKER_LOG_LEVEL=DEBUG
+  # in your shell/.env, or uncomment the override below.
+  # worker:
+  #   command: pioneer-worker --config /config/pioneer-worker.toml --log-level DEBUG
+
   frontend:
     image: node:24-slim
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,14 @@ services:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       WORKER_IMAGE: ${WORKER_IMAGE:-pioneer-square-worker}
       WORKER_BACKEND_URL: ${WORKER_BACKEND_URL:-http://backend:8000}
+      # When set (e.g. DEBUG), backend-spawned worker containers are launched
+      # with PIONEER_WORKER_LOG_LEVEL=<this value>, raising worker verbosity.
+      WORKER_LOG_LEVEL: ${WORKER_LOG_LEVEL:-}
     volumes:
       - backend-data:/data
       - ./backend:/app
       - /var/run/docker.sock:/var/run/docker.sock
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
     restart: unless-stopped
 
   frontend:
@@ -39,11 +42,16 @@ services:
     environment:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      WORKER_LOG_LEVEL: ${WORKER_LOG_LEVEL:-INFO}
     volumes:
       # Provide pioneer-worker.toml at ./worker/pioneer-worker.toml
       - ./worker/pioneer-worker.toml:/config/pioneer-worker.toml:ro
       - worker-repos:/work/repos
       - worker-worktrees:/work/worktrees
+    # Re-declare the entrypoint so we can interpolate WORKER_LOG_LEVEL at compose
+    # time. Run with WORKER_LOG_LEVEL=DEBUG to see verbose worker logs:
+    #   WORKER_LOG_LEVEL=DEBUG docker compose --profile worker up worker
+    command: pioneer-worker --config /config/pioneer-worker.toml --log-level ${WORKER_LOG_LEVEL:-INFO}
     depends_on:
       - backend
     restart: unless-stopped

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
+ruff = "latest"
 uv = "latest"

--- a/worker/AUTH_NOTES.md
+++ b/worker/AUTH_NOTES.md
@@ -1,0 +1,248 @@
+# Claude auth in the worker — investigation notes
+
+Context for the change in commit `0b29af1` (worker: fix Claude auth in
+headless containers via setup-token + PTY) and a sketch of what would
+be needed to upgrade to a full-scope login.
+
+## The original symptom
+
+A worker container kicked off `claude auth login`, printed the OAuth
+URL, the user authenticated and pasted the `code#state` into the
+foreman UI, and then the worker hung forever. The pasted code reached
+the worker (`worker-auth-response received` and `Auth code queued`
+both logged) but claude never reacted.
+
+## How we narrowed it down
+
+1. Added logger.info around every step of `_run_claude_login` (queue
+   dequeue, stdin write, drain). All the writes succeeded; claude
+   simply did nothing afterwards.
+2. `strace -p <claude>` showed claude in `do_epoll_wait` with **zero
+   `read()` syscalls on stdin**. The bytes we wrote were sitting in
+   the kernel pipe buffer untouched.
+3. First hypothesis: the prompt library checks `process.stdin.isTTY`
+   and refuses to read from a pipe. Switched to a PTY pair on stdin —
+   no change.
+4. `cat /proc/<claude>/stat` field 7 was `0` — claude had **no
+   controlling terminal**. The CLI opens `/dev/tty` directly (not
+   stdin), so the slave PTY needed to be the child's ctty, not just
+   plumbed into stdin.
+5. Added `setsid()` + `ioctl(slave_fd, TIOCSCTTY, 0)` in a `preexec_fn`
+   so the slave PTY became the child's controlling terminal. Confirmed
+   `tty_nr=34816` and `session=pid` after — still hung.
+6. Strace then showed claude reading on `/dev/pts/0` *only* when we
+   forced a write through gdb (`call write(6, ...)` on the parent's
+   master fd). So claude *was* reachable through the PTY — but the
+   `claude auth login` CLI command produced just two
+   `process.stdout.write` calls (the URL) and then awaited a Promise
+   that nothing in the CLI path ever resolves.
+7. Spelunking the binary's strings showed the **paste prompt**
+   ("Paste code here if prompted > ") lives inside an Ink/React TUI:
+   `<TextInput value=… onSubmit=… mask=…>`. That React tree is mounted
+   only by `claude setup-token` and the in-session `/login` slash
+   command — *not* by `claude auth login`. The CLI `auth login`
+   function literally only has `process.stdout.write` for the URL and
+   `await waitForAuthorizationCode(...)`, where the only way to
+   resolve that promise is either a hit on the localhost OAuth
+   callback listener (which needs an auto-opened browser) or
+   `handleManualAuthCodeInput()` (which is only called from the React
+   `onSubmit`).
+
+So `claude auth login` is genuinely unsupported in headless contexts:
+no browser → no localhost callback → no resolver → eternal wait.
+
+## The fix that landed
+
+Switched to `claude setup-token`, which mounts the Ink TUI with the
+paste prompt. To make Ink mount and accept input we needed all of:
+
+- A PTY pair attached to **stdin, stdout, *and* stderr** of the child
+  (Ink mounts only when stdout is a TTY).
+- The slave PTY made the child's **controlling terminal**, via
+  `setsid()` + `ioctl(TIOCSCTTY)` between fork and exec, so the
+  prompt's `open("/dev/tty")` resolves to our slave.
+- The auth code written in **two writes**: the paste, ~200 ms sleep,
+  then a CR alone. Including the CR in the same write as the paste
+  makes Ink batch them as a single paste event and never fire
+  `onSubmit`.
+- A regex stripper for the ANSI/CSI escapes Ink emits, so the URL and
+  the resulting token can be located in the rendered byte stream.
+- Token extraction anchored on the literal "Store this token securely"
+  marker — the token is the longest `[A-Za-z0-9_-]{40,}` run in the
+  ~400 chars before that marker, which reliably picks up the
+  `sk-ant-oat01-…` value.
+
+The token is then placed in `os.environ["CLAUDE_CODE_OAUTH_TOKEN"]`
+(inherited by every spawned `claude`) and persisted to the backend as
+a base64 JSON `{"oauth_token": "..."}` blob using the existing
+`/auth/claude/credentials` endpoint. The startup restore path detects
+JSON vs the legacy tarball format.
+
+## Trade-off
+
+`setup-token` issues an **inference-only** token (`scope=user:inference`)
+rather than the full claude.ai scope (`org:create_api_key`,
+`user:profile`, `user:inference`, `user:sessions:claude_code`,
+`user:mcp_servers`, `user:file_upload`) that `claude auth login`
+*would* produce.
+
+For the worker's day job — running `claude` against a task description
+and capturing the model output — the inference scope is sufficient.
+Features that won't work with this credential:
+
+- File upload tools inside Claude Code sessions
+- MCP servers requiring claude.ai-scoped auth
+- Remote Control / `claude.ai/code` browser bridge
+- Anything checking for `user:sessions:claude_code` scope
+
+If a future task needs any of those, the worker has to acquire the
+full-scope token instead.
+
+## How a full-scope `/login` flow could work
+
+The full-scope React/Ink login lives inside an interactive `claude`
+session, behind the `/login` slash command. There is no CLI subcommand
+that triggers it directly, so the worker would need to drive the
+interactive REPL.
+
+### Option A — drive `claude` interactive + `/login`
+
+Highest fidelity to the validated harness. Sketch:
+
+1. Spawn `claude` (no `-p`) under the same PTY + ctty harness as
+   `setup-token`. Set `claude_path` env, repo root for cwd, etc.
+2. Wait for the interactive prompt to settle. Tricky parts:
+   - Onboarding wizards on first run (model selection, theme, etc.)
+     may run before any prompt. The worker may need to send Enter or
+     skip them. Empirically check what a fresh ctty `claude` opens
+     with under a non-onboarded `~/.claude/`.
+   - Trust dialogs for the working directory.
+   - "Tip of the day" / version banner that scrolls past.
+3. Send `/login\r` to the master fd. Same two-write idiom isn't
+   strictly required for a 6-byte string but matches setup-token.
+4. The same OAuth URL detection logic from `_run_claude_login` works
+   here — strip ANSI, regex for `https://claude.com/cai/oauth/...state=…`.
+5. Wait for the paste-code from the worker's `_auth_code_queue` (same
+   path the UI already uses). Send paste + 200ms sleep + CR.
+6. Wait for the success indicator. From the binary strings the React
+   tree transitions `waiting_for_login → processing → success` and
+   shows "Claude Code login successful". Treat that as the signal.
+7. **Critically different from setup-token:** `/login` runs `tGH(M)`,
+   which writes the full credentials to `~/.claude/credentials.json`.
+   The worker should:
+   - Send `/quit\r` (or send Ctrl-D / Ctrl-C) to exit the REPL
+     cleanly.
+   - Tar up `~/.claude/` (legacy path) **or** read
+     `~/.claude/credentials.json` and serialize that single file.
+   - POST to `/auth/claude/credentials` so the next worker startup
+     restores the full creds.
+8. With creds on disk, `CLAUDE_CODE_OAUTH_TOKEN` is no longer the
+   auth source — claude reads from the keychain/credentials file.
+   Either continue setting the env var (if extractable) or rely on
+   the file-based path. Restore should preserve permissions
+   (`~/.claude/credentials.json` is 0600 on disk).
+
+Risks / unknowns specific to Option A:
+
+- Onboarding state machines change between Claude Code versions; the
+  driver becomes a brittle scraper.
+- The `/login` prompt may sub-prompt for "claude.ai vs Console" or
+  "select organization" — those would each need detection + canned
+  responses, exposed via the foreman UI when human input is needed.
+- We need to be conservative about leaving an interactive `claude`
+  process running after auth. Sending `/quit` and waiting for clean
+  exit is required.
+
+### Option B — SDK control protocol (`claude_authenticate`)
+
+Cleaner, less brittle, but requires more upfront work to plumb the
+control protocol. From the binary, the SDK protocol exposes:
+
+```js
+// pseudo-code from minified strings:
+{type:"control_request", request:{subtype:"claude_authenticate",
+  loginWithClaudeAi: true}}
+// response: {manualUrl, automaticUrl}
+
+{type:"control_request", request:{subtype:"claude_oauth_callback",
+  authorizationCode: <code>, state: <state>}}
+// internally calls handleManualAuthCodeInput()
+
+{type:"control_request", request:{subtype:"claude_oauth_wait_for_completion"}}
+// resolves when the flow settles, returns the account info
+```
+
+To use it the worker would:
+
+1. Spawn `claude --print --input-format stream-json --output-format stream-json`
+   (or similar — confirm the right flags via `claude --help` and the
+   binary's argv parser).
+2. Send a JSON-Lines control request `claude_authenticate` over the
+   child's stdin pipe. No PTY required because everything is JSON.
+3. Receive both URLs in the response; prefer `manualUrl` (the user is
+   not on the same machine).
+4. Wait for the user paste; split on `#` into `authorizationCode` /
+   `state`; send `claude_oauth_callback` request.
+5. Wait for `claude_oauth_wait_for_completion` resolution.
+6. The flow internally calls `tGH(M)` so creds end up in
+   `~/.claude/credentials.json` and disk-tar persistence works as
+   before.
+7. Tear down the child process cleanly.
+
+Pros: structured I/O, no TUI parsing, identical credentials shape to
+the legacy `claude auth login` path. Cons: the protocol is not
+well-documented externally, so a chunk of work goes into mapping out
+the request/response envelopes (`type`, `request_id`, `subtype`,
+field names) by reading the binary strings and probably tcpdumping a
+local SDK session that's known-good.
+
+### Option C (don't recommend) — spoof the localhost callback
+
+We considered this and it's a dead end: the token exchange uses a
+redirect_uri that depends on which resolver fired. Hitting
+`localhost:<port>/callback` makes claude send
+`redirect_uri=http://localhost:<port>/callback` to Anthropic's token
+endpoint, which won't match the original auth request that used the
+manual URL (`https://platform.claude.com/oauth/code/callback`).
+Anthropic rejects with a redirect_uri mismatch.
+
+We could only make this work by also opening claude's auth flow with
+the *automatic* URL (so the original request used the localhost
+redirect) and then somehow getting the user's browser to redirect to
+that localhost listener — which it can't reach across the docker
+boundary. Not worth the complexity.
+
+## Recommendation
+
+Go with **Option B** (SDK control protocol) when full-scope auth is
+needed. The PTY/Ink driver from `setup-token` is good enough for now,
+but interactive `/login` scraping (Option A) is fragile across Claude
+Code versions and onboarding changes; the SDK protocol is the
+designed-for-machines interface and produces credentials in the same
+shape as `claude auth login`, so the existing tarball persistence path
+just works.
+
+## Diagnostic harness
+
+`worker/test_pty_login.py` is a standalone reproduction of the worker's
+PTY+ctty harness, useful for debugging future Claude Code auth changes
+without rebuilding the worker image:
+
+```bash
+docker cp worker/test_pty_login.py <worker-container>:/tmp/
+docker exec -it <worker-container> python3 /tmp/test_pty_login.py \
+    claude setup-token            # or `claude auth login`, or `claude`
+```
+
+If the script can't read input directly (e.g. it's running detached),
+you can inject bytes via gdb on the parent process:
+
+```bash
+gdb -p <python-pid> --batch -nh \
+  -ex 'call (long)write(6, "<paste>", <len>)' \
+  -ex 'call (long)write(6, "\r", 1)' \
+  -ex detach -ex quit
+```
+
+That's how we narrowed down the two-write idiom — the master fd is
+fd 6 in the test script.

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 import sys
 
 from . import __version__
@@ -59,11 +60,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "--claude-max-turns", type=int, help="Max turns for claude runs (default: 50)."
     )
 
+    env_log_level = os.environ.get("PIONEER_WORKER_LOG_LEVEL", "").strip().upper()
+    log_level_choices = ["DEBUG", "INFO", "WARNING", "ERROR"]
+    default_log_level = env_log_level if env_log_level in log_level_choices else "INFO"
     parser.add_argument(
         "--log-level",
-        default="INFO",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        help="Logging verbosity (default: INFO).",
+        default=default_log_level,
+        choices=log_level_choices,
+        help="Logging verbosity (default: INFO; can also set PIONEER_WORKER_LOG_LEVEL).",
     )
     parser.add_argument(
         "--version",

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -137,6 +137,7 @@ class Worker:
         """Ensure Claude is authenticated. Restores stored credentials or runs login flow."""
         import base64
         import io
+        import json
         import tarfile
         from pathlib import Path
 
@@ -144,11 +145,18 @@ class Worker:
             logger.info("ANTHROPIC_API_KEY set — skipping Claude login flow")
             return
 
+        if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
+            logger.info("CLAUDE_CODE_OAUTH_TOKEN already in env — skipping login")
+            return
+
         if await self._claude_is_authenticated():
             logger.info("Claude credentials already present")
             return
 
-        # Try restoring credentials stored in the backend
+        # Try restoring credentials stored in the backend. Two formats are
+        # supported: the new JSON {"oauth_token": "..."} blob produced by
+        # `claude setup-token`, and the legacy base64(tar.gz of ~/.claude)
+        # blob produced by older versions running `claude auth login`.
         try:
             async with await self._http() as client:
                 resp = await client.get(
@@ -158,12 +166,26 @@ class Worker:
             if resp.status_code == 200:
                 blob = resp.json().get("credentials_blob", "")
                 if blob:
-                    claude_dir = Path.home() / ".claude"
-                    claude_dir.mkdir(parents=True, exist_ok=True)
-                    tar_bytes = base64.b64decode(blob)
-                    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as tar:
-                        tar.extractall(path=Path.home())
-                    logger.info("Restored Claude credentials from backend")
+                    raw = base64.b64decode(blob)
+                    restored = False
+                    try:
+                        payload = json.loads(raw)
+                        token = payload.get("oauth_token")
+                        if token:
+                            os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = token
+                            logger.info(
+                                "Restored CLAUDE_CODE_OAUTH_TOKEN from backend (len=%d)",
+                                len(token),
+                            )
+                            restored = True
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        pass  # fall through to legacy tarball path
+                    if not restored:
+                        claude_dir = Path.home() / ".claude"
+                        claude_dir.mkdir(parents=True, exist_ok=True)
+                        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tar:
+                            tar.extractall(path=Path.home())
+                        logger.info("Restored Claude credentials tarball from backend (legacy)")
                     if await self._claude_is_authenticated():
                         return
                     logger.warning("Restored credentials blob but auth status still fails")
@@ -174,84 +196,265 @@ class Worker:
         await self._run_claude_login()
 
     async def _run_claude_login(self) -> None:
-        """Run `claude auth login`, surface the URL to the UI, wait for the code, then persist credentials."""
+        """Drive `claude setup-token` to completion and persist the resulting OAuth token.
+
+        Why ``setup-token`` and not ``claude auth login``: the CLI ``auth login``
+        command has no manual paste path — its only way to receive the auth
+        code is via a localhost HTTP callback fired by the auto-opened browser,
+        which fails in headless containers. ``setup-token`` runs an Ink
+        (React-for-CLI) TUI that *does* prompt with "Paste code here if
+        prompted >" and accepts the code over stdin. The trade-off is scope:
+        the resulting token is ``user:inference`` only (sufficient for running
+        Claude Code tasks, but not for Remote Control / file_upload / mcp).
+
+        Mechanics: Ink mounts only when stdout is a real TTY and reads input
+        only when it has a controlling terminal, so we allocate a PTY pair,
+        plumb it into all three standard streams of the child, and use
+        setsid + TIOCSCTTY in a preexec to make the slave PTY the child's
+        ctty. The auth code must be written in two writes (paste, ~150ms
+        delay, CR alone) — a single ``code\\r`` write doesn't fire onSubmit
+        because Ink batches the CR into the paste event.
+        """
         import base64
-        import io
-        import tarfile
-        from pathlib import Path
+        import fcntl
+        import json
+        import os
+        import pty
+        import re
+        import termios
 
         self._auth_code_queue = asyncio.Queue()
-        logger.info("Starting claude auth login — auth_code_queue is now open")
+        logger.info("Starting claude setup-token — auth_code_queue is now open")
+
+        master_fd, slave_fd = pty.openpty()
+        # Disable input echo so the auth code we write isn't reflected onto
+        # stdout (which would put the secret into our logs).
+        try:
+            attrs = termios.tcgetattr(slave_fd)
+            attrs[3] &= ~termios.ECHO  # lflags
+            termios.tcsetattr(slave_fd, termios.TCSANOW, attrs)
+        except termios.error as exc:
+            logger.debug("Could not disable PTY echo: %s", exc)
+
+        def _attach_controlling_tty() -> None:
+            os.setsid()
+            fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+
         proc = await asyncio.create_subprocess_exec(
             self.cfg.claude_path,
-            "auth",
-            "login",
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+            "setup-token",
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            preexec_fn=_attach_controlling_tty,
         )
-        assert proc.stdout is not None
-        assert proc.stdin is not None
+        os.close(slave_fd)
+        logger.info(
+            "claude setup-token started pid=%s (PTY mode, master_fd=%d, ctty=slave)",
+            proc.pid,
+            master_fd,
+        )
 
+        loop = asyncio.get_event_loop()
+        reader = asyncio.StreamReader()
+        reader_protocol = asyncio.StreamReaderProtocol(reader)
+        master_pipe = os.fdopen(master_fd, "rb", buffering=0)
+        await loop.connect_read_pipe(lambda: reader_protocol, master_pipe)
+
+        # Strip ANSI/CSI escape sequences so we can grep Ink's output. Match
+        # the common cursor/SGR/erase forms claude emits.
+        ansi_re = re.compile(rb"\x1b\[[0-?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]|\x1b\][^\x07\x1b]*[\x07\x1b]")
+
+        def _clean(b: bytes) -> str:
+            return ansi_re.sub(b"", b).decode(errors="replace")
+
+        captured = bytearray()  # full raw output for token extraction at end
+        url_seen = False
         code_sent = False
+        post_submit_watchdog: asyncio.Task | None = None
         try:
-            async for raw_line in proc.stdout:
-                line = raw_line.decode(errors="replace").rstrip()
-                logger.info("[claude login] %s", line)
-                await self._emit(f"[auth] {line}")
+            while True:
+                try:
+                    chunk = await reader.read(4096)
+                except Exception as exc:
+                    logger.warning("PTY read error: %s", exc)
+                    break
+                if not chunk:
+                    break
+                captured.extend(chunk)
+                cleaned = _clean(chunk)
+                for line in cleaned.splitlines():
+                    line = line.rstrip()
+                    if line:
+                        logger.info("[claude setup-token] %s", line)
+                        await self._emit(f"[auth] {line}")
 
-                if not code_sent and "https://" in line:
-                    url = next((w for w in line.split() if w.startswith("https://")), line.strip())
-                    await self._send(
-                        {
-                            "type": "claude-auth-required",
-                            "workerId": self.cfg.worker_id,
-                            "url": url,
-                        }
+                # Detect the OAuth URL once it's been emitted. Ink word-wraps
+                # the URL across multiple lines (often after each ~80 chars),
+                # so we strip whitespace from the running buffer first and
+                # then look for the URL ending at the OAuth state parameter.
+                if not url_seen:
+                    full_no_ws = re.sub(r"\s+", "", _clean(bytes(captured)))
+                    m = re.search(
+                        r"https://claude\.com/cai/oauth/authorize\?[A-Za-z0-9=&%_.\-]+state=[A-Za-z0-9_\-]+",
+                        full_no_ws,
                     )
-                    await self._emit(
-                        "[auth] Waiting for auth code — paste it into the auth panel in the UI or type it into the Foreman Comms input..."
-                    )
-                    try:
-                        code = await asyncio.wait_for(self._auth_code_queue.get(), timeout=300.0)
-                        await self._emit("[auth] Code received — submitting to Claude CLI...")
-                        proc.stdin.write((code.strip() + "\n").encode())
-                        await proc.stdin.drain()
-                        proc.stdin.close()
-                        code_sent = True
-                    except TimeoutError:
-                        await self._emit(
-                            "[auth] Timed out waiting for auth code — restart the worker to retry"
+                    if m:
+                        url = m.group(0)
+                        url_seen = True
+                        await self._send(
+                            {
+                                "type": "claude-auth-required",
+                                "workerId": self.cfg.worker_id,
+                                "url": url,
+                            }
                         )
-                        proc.kill()
-                        await proc.wait()
-                        return
+                        await self._emit(
+                            "[auth] Waiting for auth code — paste it into the auth panel in the UI..."
+                        )
+                        logger.info("Auth login: awaiting code from queue (timeout=300s)")
+                        try:
+                            code = await asyncio.wait_for(
+                                self._auth_code_queue.get(), timeout=300.0
+                            )
+                        except TimeoutError:
+                            logger.warning("Auth login: timed out waiting for code from queue")
+                            await self._emit(
+                                "[auth] Timed out waiting for auth code — restart the worker to retry"
+                            )
+                            proc.kill()
+                            await proc.wait()
+                            return
+                        logger.info(
+                            "Auth login: code dequeued (len=%d, pid_alive=%s)",
+                            len(code),
+                            proc.returncode is None,
+                        )
+                        await self._emit("[auth] Code received — submitting to Claude CLI...")
+                        try:
+                            os.write(master_fd, code.strip().encode())
+                            # Ink batches consecutive bytes into one paste
+                            # event; a CR included in the same write is
+                            # swallowed and never fires onSubmit. Sending CR
+                            # in a separate write after a short sleep makes
+                            # Ink treat it as a distinct keypress.
+                            await asyncio.sleep(0.2)
+                            os.write(master_fd, b"\r")
+                        except OSError as exc:
+                            logger.warning("Auth login: PTY write failed: %s", exc)
+                            await self._emit(f"[auth] Failed to send code to Claude: {exc}")
+                            proc.kill()
+                            await proc.wait()
+                            return
+                        logger.info("Auth login: wrote code + CR (separate writes) to PTY")
+                        code_sent = True
+                        post_submit_watchdog = asyncio.create_task(
+                            self._auth_login_watchdog(proc)
+                        )
         finally:
             self._auth_code_queue = None
+            if post_submit_watchdog is not None and not post_submit_watchdog.done():
+                post_submit_watchdog.cancel()
+            try:
+                master_pipe.close()
+            except OSError:
+                pass
 
+        logger.info(
+            "setup-token: PTY EOF reached (code_sent=%s); waiting for claude to exit",
+            code_sent,
+        )
         await proc.wait()
-        logger.info("claude auth login exited with rc=%s", proc.returncode)
+        logger.info("claude setup-token exited with rc=%s", proc.returncode)
 
-        if not await self._claude_is_authenticated():
-            await self._emit("[auth] Login may have failed — claude auth status returned non-zero")
+        # Extract the token from the captured Ink output. After Ink renders
+        # the success view there's a contiguous run of the token characters
+        # near "Store this token securely" / "export CLAUDE_CODE_OAUTH_TOKEN".
+        cleaned_full = _clean(bytes(captured))
+        token = self._extract_oauth_token(cleaned_full)
+        if not token:
+            await self._emit(
+                "[auth] Login finished but could not extract OAuth token from output — please retry"
+            )
+            logger.warning("Could not locate OAuth token in setup-token output")
             return
 
-        claude_dir = Path.home() / ".claude"
+        os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = token
+        logger.info("Captured CLAUDE_CODE_OAUTH_TOKEN (len=%d) and set in env", len(token))
+        await self._emit("[auth] Token captured — saving to backend so future workers can reuse it")
+
         try:
-            buf = io.BytesIO()
-            with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-                tar.add(str(claude_dir), arcname=".claude")
-            blob = base64.b64encode(buf.getvalue()).decode()
+            blob = base64.b64encode(json.dumps({"oauth_token": token}).encode()).decode()
             async with await self._http() as client:
                 await client.post(
                     "/auth/claude/credentials",
                     json={"guild_id": self.cfg.guild_id, "credentials_blob": blob},
                 )
-            await self._emit("[auth] Credentials saved — future workers will skip login")
-            logger.info("Posted Claude credentials to backend")
+            await self._emit("[auth] Credentials saved")
+            logger.info("Posted OAuth token to backend credentials store")
         except Exception as exc:
             logger.warning("Could not store Claude credentials: %s", exc)
             await self._emit(f"[auth] Warning: could not store credentials: {exc}")
+
+    @staticmethod
+    def _extract_oauth_token(cleaned_output: str) -> str | None:
+        """Locate the OAuth token in Ink's success-screen output.
+
+        The Ink TUI renders the token amid lots of surrounding text and ASCII
+        art; after stripping ANSI escapes it shows up as a long alphanumeric
+        run (40-100 chars from `[A-Za-z0-9_-]`) somewhere near the marker
+        "Store this token securely" / "Use this token by setting".
+
+        We anchor on those markers and pick the longest token-like run that
+        appears near them.
+        """
+        import re
+
+        text = cleaned_output
+        # Filter out spaces/newlines that Ink injects between glyphs in its
+        # box-layout, which would otherwise split the token character run.
+        compact = re.sub(r"[\s]+", "", text)
+        # The marker text gets compacted too.
+        marker_idx = compact.find("Storethistokensecurely")
+        if marker_idx < 0:
+            marker_idx = compact.find("UsethistokenbysettingexportCLAUDE_CODE_OAUTH_TOKEN")
+        if marker_idx < 0:
+            return None
+        # Search the 400 chars before the marker for the longest token-shaped run.
+        window = compact[max(0, marker_idx - 400) : marker_idx]
+        candidates = re.findall(r"[A-Za-z0-9_\-]{40,200}", window)
+        if not candidates:
+            return None
+        # Prefer the run closest to the marker (latest in the window).
+        return candidates[-1]
+
+    async def _auth_login_watchdog(self, proc: asyncio.subprocess.Process) -> None:
+        """Periodically log that we're still waiting on claude after the code was submitted.
+
+        Helps diagnose hangs where the async-for loop is blocked because claude
+        produced no further output (no newline, no exit) after stdin was sent.
+        """
+        ticks = 0
+        try:
+            while True:
+                await asyncio.sleep(15.0)
+                ticks += 1
+                if proc.returncode is not None:
+                    logger.info(
+                        "Auth login watchdog: claude exited rc=%s (after %ds)",
+                        proc.returncode,
+                        ticks * 15,
+                    )
+                    return
+                logger.warning(
+                    "Auth login watchdog: still waiting on claude stdout %ds after code submission (pid=%s, rc=%s)",
+                    ticks * 15,
+                    proc.pid,
+                    proc.returncode,
+                )
+        except asyncio.CancelledError:
+            logger.debug("Auth login watchdog cancelled")
+            raise
 
     async def _fetch_pending_tasks(self) -> list[dict]:
         async with await self._http() as client:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -263,7 +263,9 @@ class Worker:
 
         # Strip ANSI/CSI escape sequences so we can grep Ink's output. Match
         # the common cursor/SGR/erase forms claude emits.
-        ansi_re = re.compile(rb"\x1b\[[0-?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]|\x1b\][^\x07\x1b]*[\x07\x1b]")
+        ansi_re = re.compile(
+            rb"\x1b\[[0-?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]|\x1b\][^\x07\x1b]*[\x07\x1b]"
+        )
 
         def _clean(b: bytes) -> str:
             return ansi_re.sub(b"", b).decode(errors="replace")
@@ -348,9 +350,7 @@ class Worker:
                             return
                         logger.info("Auth login: wrote code + CR (separate writes) to PTY")
                         code_sent = True
-                        post_submit_watchdog = asyncio.create_task(
-                            self._auth_login_watchdog(proc)
-                        )
+                        post_submit_watchdog = asyncio.create_task(self._auth_login_watchdog(proc))
         finally:
             self._auth_code_queue = None
             if post_submit_watchdog is not None and not post_submit_watchdog.done():

--- a/worker/test_pty_login.py
+++ b/worker/test_pty_login.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Standalone test for the claude auth PTY flow.
+
+Runs `claude setup-token` (or whatever command is given) under the same
+PTY-with-controlling-tty setup the worker uses, then waits for the OAuth URL,
+asks the human operator to paste the code#state value, and writes it to the
+PTY. Logs every step so we can see whether claude actually consumes input.
+
+Usage (inside the worker container, where `claude` is on PATH):
+    docker exec -it pioneer-worker-nyoyny-debug python3 /work/test_pty_login.py
+or copy the file in:
+    docker cp test_pty_login.py pioneer-worker-nyoyny-debug:/tmp/
+    docker exec -it pioneer-worker-nyoyny-debug python3 /tmp/test_pty_login.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import logging
+import os
+import pty
+import re
+import sys
+import termios
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("pty-test")
+
+ANSI_RE = re.compile(rb"\x1b\[[0-?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]")
+
+
+def clean(b: bytes) -> str:
+    return ANSI_RE.sub(b"", b).decode(errors="replace")
+
+
+async def run(cmd: list[str], code_input: str | None = None) -> int:
+    master_fd, slave_fd = pty.openpty()
+    try:
+        attrs = termios.tcgetattr(slave_fd)
+        attrs[3] &= ~termios.ECHO
+        termios.tcsetattr(slave_fd, termios.TCSANOW, attrs)
+    except termios.error as exc:
+        log.warning("could not turn off echo: %s", exc)
+
+    def attach_ctty() -> None:
+        os.setsid()
+        fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        preexec_fn=attach_ctty,
+    )
+    os.close(slave_fd)
+    log.info("spawned pid=%s cmd=%s (full-pty, ctty=slave)", proc.pid, " ".join(cmd))
+
+    loop = asyncio.get_event_loop()
+    reader = asyncio.StreamReader()
+    proto = asyncio.StreamReaderProtocol(reader)
+    pipe = os.fdopen(master_fd, "rb", buffering=0)
+    await loop.connect_read_pipe(lambda: proto, pipe)
+
+    code_sent = False
+    saw_url = False
+    raw_buf = bytearray()
+
+    async def watchdog() -> None:
+        ticks = 0
+        while True:
+            await asyncio.sleep(5)
+            ticks += 1
+            if proc.returncode is not None:
+                return
+            log.info("watchdog: claude still alive %ds (rc=%s)", ticks * 5, proc.returncode)
+
+    wd_task = asyncio.create_task(watchdog())
+
+    try:
+        while True:
+            chunk = await reader.read(4096)
+            if not chunk:
+                log.info("EOF on PTY")
+                break
+            raw_buf.extend(chunk)
+            text = clean(chunk)
+            sys.stdout.write(text)
+            sys.stdout.flush()
+
+            cleaned_all = clean(bytes(raw_buf))
+            if not saw_url and "https://" in cleaned_all:
+                saw_url = True
+                log.info("URL detected in output")
+
+            if not code_sent and saw_url and code_input:
+                # Wait briefly for the React UI to mount, then paste
+                await asyncio.sleep(2.0)
+                payload = code_input.strip() + "\r"
+                n = os.write(master_fd, payload.encode())
+                log.info("wrote %d bytes (code+CR) to PTY master", n)
+                code_sent = True
+    finally:
+        wd_task.cancel()
+        try:
+            pipe.close()
+        except OSError:
+            pass
+
+    rc = await proc.wait()
+    log.info("exit rc=%s", rc)
+    return rc
+
+
+async def main() -> None:
+    cmd = sys.argv[1:] or ["claude", "setup-token"]
+    code = os.environ.get("CLAUDE_CODE_PASTE")
+    if code:
+        log.info("will auto-paste code from $CLAUDE_CODE_PASTE (len=%d)", len(code))
+    else:
+        log.info(
+            "no $CLAUDE_CODE_PASTE — will not auto-paste; you can also do it "
+            "manually by typing into this terminal."
+        )
+    rc = await run(cmd, code)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
  Summary                                                                                                                                                                                                    
                                                                                                                                                                                                             
  - Replace claude auth login with claude setup-token in the worker's auth flow, since the CLI auth login command has no manual paste path (only auto-browser → localhost callback) and hangs forever in     
  headless containers.                                                                                                                                                                                       
  - Drive setup-token through a PTY pair attached to stdin/stdout/stderr with setsid + TIOCSCTTY in a preexec, so the slave PTY becomes the child's controlling terminal — Ink/React only mounts the paste   
  prompt when stdout is a TTY and only reads input via /dev/tty.                                                                                                                                             
  - Send the auth code in two writes (paste, ~200 ms, CR alone), capture the resulting sk-ant-oat01-… token from Ink's rendered output, set CLAUDE_CODE_OAUTH_TOKEN in the worker env (inherited by every    
  spawned claude), and persist as a base64 JSON {"oauth_token": …} blob via the existing /auth/claude/credentials endpoint. Restore on startup detects JSON vs the legacy tarball format.                    
  - Wire WORKER_LOG_LEVEL host → backend → spawned worker as PIONEER_WORKER_LOG_LEVEL, so DEBUG logging can be turned on from compose without code changes.                                                  
  - Add worker/test_pty_login.py as a standalone PTY harness and worker/AUTH_NOTES.md documenting the investigation + a sketch of two paths to a full-scope login (SDK control protocol recommended).        
                                                                                                                                                                                                             
  Trade-off                                                                                                                                                                                                  
                                                                                                                                                                                                             
  setup-token issues a user:inference-only token, not the full claude.ai scope (org:create_api_key, user:profile, user:sessions:claude_code, user:mcp_servers, user:file_upload) that auth login would       
  produce. Sufficient for the worker's task-running use case; insufficient for file-upload tools, MCP servers, or Remote Control. See worker/AUTH_NOTES.md for the recommended path to full-scope auth.      
                                                                                                                                                                                                             
  Test plan                                                                                                                                                                                                  
                                                                                                                                                                                                             
  - Backend-spawned worker hits the new setup-token flow end-to-end (guild nyoyny): URL surfaces, paste reaches the worker, Ink's onSubmit fires, 107-char sk-ant-oat01-… token captured, env var set, blob  
  POSTed, worker joins guild and starts agent loops.                                                                                                                                                         
  - Restore path: stop worker, delete ~/.claude/, restart — verify JSON blob fetch, env var set, agent loops start without re-authenticating.                                                                
  - Legacy tarball blob still restores via fallback path.                                                                                                                                                    
  - Actual claude task invocation succeeds (verify token works for inference, not just auth status).                                                                                                         
  - WORKER_LOG_LEVEL=DEBUG docker compose up -d --force-recreate backend propagates PIONEER_WORKER_LOG_LEVEL=DEBUG to the next backend-spawned worker.                                                       
