### PR TITLE
feat(foreman): filter issues to primary repo and add periodic refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ npm run format      # prettier --write
 
 Config lives at `ruff.toml` (root) and `frontend/eslint.config.js` + `frontend/.prettierrc.json`. There is no CI wired up yet — these are local guards.
 
+**Always run `ruff check . --fix && ruff format .` from the repo root before committing Python changes.**
+
 ## Architecture
 
 ### Three-process model

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -126,9 +126,7 @@ def strip_orphaned_tool_results(messages: list[dict]) -> list[dict]:
         content = out[0].get("content")
         if isinstance(content, list):
             new_content = [
-                b
-                for b in content
-                if not (isinstance(b, dict) and b.get("type") == "tool_result")
+                b for b in content if not (isinstance(b, dict) and b.get("type") == "tool_result")
             ]
             if not new_content:
                 out.pop(0)

--- a/backend/tests/test_tool_use_parser.py
+++ b/backend/tests/test_tool_use_parser.py
@@ -11,7 +11,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from foreman.runner import strip_orphaned_tool_results
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -83,7 +82,9 @@ class TestOrphanedToolResult:
         for m in result:
             content = m.get("content")
             if isinstance(content, list):
-                assert not any(b.get("type") == "tool_result" for b in content if isinstance(b, dict))
+                assert not any(
+                    b.get("type") == "tool_result" for b in content if isinstance(b, dict)
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -151,8 +152,8 @@ class TestMixedCase:
         # stops there, and the subsequent valid pair survives.
         messages = [
             _user(_tool_result("ORPHAN")),
-            _asst(_text("summary")),          # text-only: removed by start-with-user fix
-            _user_text("please continue"),    # valid plain-text — cascade stops here
+            _asst(_text("summary")),  # text-only: removed by start-with-user fix
+            _user_text("please continue"),  # valid plain-text — cascade stops here
             _asst(_tool_use("VALID")),
             _user(_tool_result("VALID")),
             _asst(_text("done")),

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -73,7 +73,7 @@
       <!-- Issues tab -->
       <template v-else-if="activeTab === 'issues'">
         <div class="issues-toolbar">
-          <button class="pixel-btn refresh-btn" @click="refreshIssues" :disabled="ghStore.loading">
+          <button class="pixel-btn refresh-btn" @click="() => refreshIssues()" :disabled="ghStore.loading">
             {{ ghStore.loading ? '...' : '↻' }}
           </button>
           <span class="issues-count">{{ ghStore.issues.length }} open</span>

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -77,7 +77,7 @@
             {{ ghStore.loading ? '...' : '↻' }}
           </button>
           <span class="issues-count">{{ ghStore.issues.length }} open</span>
-          <span class="issues-repos">{{ ghStore.selectedRepos.length }} repo{{ ghStore.selectedRepos.length !== 1 ? 's' : '' }}</span>
+          <span class="issues-repos">{{ guildStore.currentGuild?.primary_repo ?? (ghStore.selectedRepos.length + ' repo' + (ghStore.selectedRepos.length !== 1 ? 's' : '')) }}</span>
         </div>
 
         <div class="issues-list" ref="issuesEl">
@@ -228,6 +228,9 @@ const debugContext = ref<any[]>([])
 const debugLoading = ref(false)
 const debugClearing = ref(false)
 
+const ISSUE_REFRESH_MS = 3 * 60 * 1000
+let issueRefreshInterval: ReturnType<typeof setInterval> | null = null
+
 const messages = computed(() => guildStore.messages)
 const foreman = computed(() => agentsStore.agents.find(a => a.type === 'foreman'))
 
@@ -365,8 +368,18 @@ onMounted(async () => {
       console.warn('Could not fetch pending auth state', e)
     }
   }
+
+  if (ghStore.isConfigured) {
+    issueRefreshInterval = setInterval(() => refreshIssues(true), ISSUE_REFRESH_MS)
+  }
 })
-onUnmounted(() => guildStore.removeMessageHandler(handleTaskEvent))
+onUnmounted(() => {
+  guildStore.removeMessageHandler(handleTaskEvent)
+  if (issueRefreshInterval !== null) {
+    clearInterval(issueRefreshInterval)
+    issueRefreshInterval = null
+  }
+})
 
 function isToolResponseMsg(msg: { role: string; content: unknown }) {
   return msg.role === 'user' && Array.isArray(msg.content) && (msg.content as { type: string }[]).every(b => b.type === 'tool_result')
@@ -415,15 +428,20 @@ async function clearContext() {
   }
 }
 
+function _primaryRepoList(): string[] | undefined {
+  const repo = guildStore.currentGuild?.primary_repo
+  return repo ? [repo] : undefined
+}
+
 async function switchToIssues() {
   activeTab.value = 'issues'
   if (ghStore.issues.length === 0 && !ghStore.loading) {
-    await ghStore.fetchIssues()
+    await ghStore.fetchIssues(_primaryRepoList())
   }
 }
 
-async function refreshIssues() {
-  await ghStore.fetchIssues()
+async function refreshIssues(silent = false) {
+  await ghStore.fetchIssues(_primaryRepoList(), silent)
 }
 
 function assignIssue(issue: GitHubIssue) {

--- a/frontend/src/stores/github.ts
+++ b/frontend/src/stores/github.ts
@@ -53,12 +53,13 @@ export const useGitHubStore = defineStore('github', () => {
     localStorage.setItem('gh_repos', JSON.stringify(repoFullNames))
   }
 
-  async function fetchIssues() {
-    if (!token.value || selectedRepos.value.length === 0) return []
-    loading.value = true
+  async function fetchIssues(repos?: string[], silent = false) {
+    const reposToFetch = repos ?? selectedRepos.value
+    if (!token.value || reposToFetch.length === 0) return []
+    if (!silent) loading.value = true
     try {
       const allIssues = await Promise.all(
-        selectedRepos.value.map(async (repoName) => {
+        reposToFetch.map(async (repoName) => {
           const res = await fetch(
             `${GH_API}/repos/${repoName}/issues?state=open&per_page=30&sort=created&direction=desc`,
             { headers: ghHeaders(token.value) }
@@ -81,7 +82,7 @@ export const useGitHubStore = defineStore('github', () => {
       error.value = e.message
       return []
     } finally {
-      loading.value = false
+      if (!silent) loading.value = false
     }
   }
 


### PR DESCRIPTION
## Summary

- **Closes #123** — `fetchIssues()` now accepts an optional `repos` override. `ChatPane` passes `guild.primary_repo` (read from guild config, never hardcoded) as a single-element list, so only that repo's issues are fetched. Falls back to `selectedRepos` when no primary repo is set. The issues toolbar label now shows the primary repo name instead of a generic count.
- **Closes #124** — A 3-minute `setInterval` is started in `onMounted` (only when GitHub is configured) and clears itself in `onUnmounted` to avoid leaks. Background ticks call `refreshIssues(true)` which passes `silent = true` to `fetchIssues`, skipping `loading.value = true/false` so the existing issue list stays visible with no flicker.

## Test plan

- [ ] Set a primary repo in Guild Settings; open the Issues tab — only issues from that repo appear
- [ ] Clear primary repo — issues tab falls back to all `selectedRepos`
- [ ] Toolbar label shows `owner/repo` when primary repo is set, count otherwise
- [ ] Wait 3 minutes with the Issues tab open — list refreshes without a loading flash
- [ ] Navigate away (unmount component) — no interval fires after unmount (verify via devtools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)