### PR TITLE
Move Configure GitHub to user pill in top bar

### DIFF
--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -122,21 +122,6 @@
     </div>
 
     <div class="sidebar-footer">
-      <button
-        v-if="authStore.isLoggedIn"
-        class="gh-config-btn"
-        @click="showGitHubModal = true"
-        :title="'GitHub: ' + authStore.user?.login"
-      >
-        <span class="gh-icon">⚙</span>
-        <span class="gh-text">
-          Configure GitHub
-          <span v-if="ghStore.selectedRepos.length > 0" class="gh-repos">
-            ({{ ghStore.selectedRepos.length }} repo{{ ghStore.selectedRepos.length !== 1 ? 's' : '' }})
-          </span>
-        </span>
-      </button>
-
       <div class="connection-status" :class="{ connected: isConnected }">
         <span class="status-dot"></span>
         {{ isConnected ? 'Connected' : 'Disconnected' }}
@@ -144,7 +129,6 @@
     </div>
   </aside>
 
-  <GitHubConfigModal v-if="showGitHubModal" @close="showGitHubModal = false" />
 </template>
 
 <script setup lang="ts">
@@ -155,7 +139,6 @@ import { useAuthStore } from '../stores/auth'
 import { useTasksStore } from '../stores/tasks'
 import { useAgentsStore } from '../stores/agents'
 import type { Task } from '../types'
-import GitHubConfigModal from './GitHubConfigModal.vue'
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
 
@@ -167,7 +150,6 @@ const agentsStore = useAgentsStore()
 
 const switchMobileTab = inject<(tab: string) => void>('switchMobileTab', () => {})
 
-const showGitHubModal = ref(false)
 const currentGuild = computed(() => guildStore.currentGuild)
 const isConnected = computed(() => guildStore.isConnected)
 const onlineWorkers = computed(() => agentsStore.workers.filter((w) => w.state !== 'offline'))
@@ -778,45 +760,6 @@ function formatTime(isoStr?: string) {
   border-top: 2px solid var(--color-brass-dark);
   background: var(--color-bg-tertiary);
   flex-shrink: 0;
-}
-
-/* ── GitHub config button ── */
-.gh-config-btn {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 9px;
-  background: transparent;
-  border: 1px solid var(--color-brass-dark);
-  border-radius: 2px;
-  cursor: pointer;
-  transition: all 0.15s;
-  width: 100%;
-  text-align: left;
-}
-
-.gh-config-btn:hover {
-  border-color: var(--color-brass);
-  background: rgba(232, 170, 0, 0.06);
-}
-
-.gh-icon {
-  font-size: 14px;
-  color: var(--color-brass-dark);
-  flex-shrink: 0;
-}
-
-.gh-text {
-  font-size: 11px;
-  color: var(--color-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.gh-repos {
-  font-size: 9px;
-  color: var(--color-text-dim);
 }
 
 /* ── Connection status ── */

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -15,14 +15,15 @@
 
     <div class="top-bar-spacer"></div>
 
-    <div
+    <button
       v-if="authStore.isLoggedIn"
       class="user-pill"
-      :title="'Signed in as ' + authStore.user?.login"
+      :title="'GitHub settings for ' + authStore.user?.login"
+      @click="showGitHubModal = true"
     >
       <img v-if="authStore.user?.avatar_url" :src="authStore.user.avatar_url" class="user-avatar" alt="" />
       <span class="user-login">{{ authStore.user?.login }}</span>
-    </div>
+    </button>
 
     <button
       v-if="currentGuild"
@@ -81,6 +82,8 @@
       </div>
     </div>
   </header>
+
+  <GitHubConfigModal v-if="showGitHubModal" @close="showGitHubModal = false" />
 </template>
 
 <script setup lang="ts">
@@ -89,6 +92,7 @@ import { useRouter } from 'vue-router'
 import { useGuildStore } from '../stores/guild'
 import { useGitHubStore } from '../stores/github'
 import { useAuthStore } from '../stores/auth'
+import GitHubConfigModal from './GitHubConfigModal.vue'
 
 const router = useRouter()
 const guildStore = useGuildStore()
@@ -97,6 +101,7 @@ const authStore = useAuthStore()
 
 const currentGuild = computed(() => guildStore.currentGuild)
 
+const showGitHubModal = ref(false)
 const showSettings = ref(false)
 const settingsBtnRef = ref<HTMLElement | null>(null)
 const popoverRef = ref<HTMLElement | null>(null)
@@ -264,6 +269,13 @@ function goHome() {
   border: 1px solid var(--color-brass-dark);
   border-radius: 2px;
   flex-shrink: 0;
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.user-pill:hover {
+  border-color: var(--color-brass);
+  background: rgba(232, 170, 0, 0.06);
 }
 
 .user-avatar {


### PR DESCRIPTION
## Summary

- The **Configure GitHub** button was in the sidebar footer, cluttering the task-centric left panel
- It now lives on the **user avatar/login pill** in the top bar — clicking your GitHub username/avatar opens the `GitHubConfigModal`
- This follows the standard UX convention: clicking your account avatar surfaces account-level settings
- The `GitHubConfigModal` component itself is unchanged; only where it's triggered moved

## Test plan

- [ ] Log in with GitHub — user pill (avatar + login) appears in top bar
- [ ] Click the user pill — GitHub config modal opens
- [ ] Close the modal — works via ✕ button or clicking the overlay
- [ ] Sidebar footer no longer shows a "Configure GitHub" button
- [ ] Spawning workers still works (the spawn form's repo list is populated from the github store, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)