### PR TITLE
feat: render Markdown in foreman chat messages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@types/dompurify": "^3.0.5",
+        "dompurify": "^3.4.2",
+        "marked": "^18.0.3",
         "pinia": "^3.0.4",
         "vue": "^3.5.32",
         "vue-router": "^5.0.6"
@@ -837,6 +840,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -867,6 +879,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
@@ -1985,6 +2003,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3253,6 +3280,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/merge2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@types/dompurify": "^3.0.5",
+    "dompurify": "^3.4.2",
+    "marked": "^18.0.3",
     "pinia": "^3.0.4",
     "vue": "^3.5.32",
     "vue-router": "^5.0.6"

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -52,7 +52,12 @@
             }"
           >
             <span class="msg-from">{{ msg.from === 'user' ? 'YOU' : msg.from === 'system' ? 'SYS' : msg.from }}</span>
-            <span class="msg-content">{{ msg.content }}</span>
+            <span
+              v-if="msg.from !== 'user' && msg.from !== 'system'"
+              class="msg-content msg-content--markdown"
+              v-html="renderMarkdown(msg.content)"
+            ></span>
+            <span v-else class="msg-content">{{ msg.content }}</span>
             <a v-if="msg.prUrl" :href="msg.prUrl" target="_blank" rel="noopener" class="pr-link">
               Open PR →
             </a>
@@ -202,6 +207,8 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch, onMounted, onUnmounted } from 'vue'
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import { useGuildStore } from '../stores/guild'
 import { useAgentsStore } from '../stores/agents'
 import { useGitHubStore } from '../stores/github'
@@ -233,6 +240,11 @@ const foreman = computed(() => agentsStore.agents.find(a => a.type === 'foreman'
 
 // Issue assignment pattern: "Work on issue #N in owner/repo: title"
 const ISSUE_PATTERN = /Work on issue #(\d+) in ([^:]+): "(.+)"/
+
+function renderMarkdown(text: string): string {
+  const html = marked.parse(text, { async: false }) as string
+  return DOMPurify.sanitize(html, { ADD_ATTR: ['target', 'rel'] })
+}
 
 function toggleMinimize() {
   minimized.value = !minimized.value
@@ -680,6 +692,73 @@ watch(messages, async () => {
   color: var(--color-text);
   line-height: 1.4;
   word-break: break-word;
+}
+
+.msg-content--markdown :deep(p) {
+  margin: 0 0 6px;
+}
+.msg-content--markdown :deep(p:last-child) {
+  margin-bottom: 0;
+}
+.msg-content--markdown :deep(ul),
+.msg-content--markdown :deep(ol) {
+  margin: 4px 0 6px;
+  padding-left: 18px;
+}
+.msg-content--markdown :deep(li) {
+  margin-bottom: 2px;
+}
+.msg-content--markdown :deep(code) {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--color-brass-dark);
+  padding: 0 4px;
+  border-radius: 2px;
+  color: var(--color-amber);
+}
+.msg-content--markdown :deep(pre) {
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid var(--color-brass-dark);
+  padding: 8px 10px;
+  overflow-x: auto;
+  margin: 4px 0;
+}
+.msg-content--markdown :deep(pre code) {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 10px;
+  color: var(--color-green);
+}
+.msg-content--markdown :deep(h1),
+.msg-content--markdown :deep(h2),
+.msg-content--markdown :deep(h3) {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  letter-spacing: 1px;
+  color: var(--color-teal);
+  margin: 6px 0 4px;
+  text-transform: uppercase;
+}
+.msg-content--markdown :deep(strong) {
+  color: var(--color-amber);
+  font-weight: bold;
+}
+.msg-content--markdown :deep(em) {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+.msg-content--markdown :deep(a) {
+  color: var(--color-teal);
+  text-decoration: underline;
+}
+.msg-content--markdown :deep(blockquote) {
+  border-left: 3px solid var(--color-brass-dark);
+  margin: 4px 0;
+  padding: 2px 8px;
+  color: var(--color-text-dim);
+  font-style: italic;
 }
 
 .msg-time {


### PR DESCRIPTION
## Summary

- Installs `marked` (lightweight Markdown parser) and `dompurify` (XSS sanitizer) as frontend dependencies
- In `ChatPane.vue`, foreman/agent messages are now parsed from Markdown and rendered via `v-html` — bold, italics, code blocks, bullet lists, and headers display correctly
- User and system messages are unchanged (rendered as plain text)
- Themed CSS `:deep()` rules style the rendered Markdown to match the steampunk terminal aesthetic (amber code, teal headings, monospace pre blocks)

## Test plan

- [ ] Start the dev server and connect a foreman; send a directive that returns a Markdown response — verify headers, lists, and code blocks render visually
- [ ] Confirm plain-text log lines in LogPane are unaffected
- [ ] Confirm user (`YOU`) and system (`SYS`) chat messages still render as plain text
- [ ] Verify no XSS: send `<script>alert(1)</script>` in a chat message and confirm it is escaped

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)