### PR TITLE
fix: improve link contrast on agent tab

### DIFF
--- a/frontend/src/components/LogPane.vue
+++ b/frontend/src/components/LogPane.vue
@@ -923,7 +923,7 @@ function lineClass(line: string) {
   font-style: italic;
 }
 .terminal-link {
-  color: var(--color-teal);
+  color: var(--color-blue);
   text-decoration: underline;
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary

- Changes `.terminal-link` color from `var(--color-teal)` (`#00bbaa`) to `var(--color-blue)` (`#44aaee`) in `LogPane.vue`
- The teal color was shared with `log-success` text, making links visually indistinct
- `--color-blue` is an existing palette variable, provides ~8:1 contrast ratio on the dark pane background (`#080500`), and reads as conventional link blue

Closes #132

## Test plan

- [ ] Open the agent tab and trigger any log output containing a URL
- [ ] Verify links appear in a bright blue that's clearly distinguishable from surrounding log text
- [ ] Confirm no other link styles (PR subheader `.sub-pr-link`, auth banner `.auth-link`) were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)