### PR TITLE
feat: move Debug tab to TopBar button with full sidebar

### DIFF
--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -28,11 +28,6 @@
           Issues
           <span v-if="ghStore.issues.length" class="badge">{{ ghStore.issues.length }}</span>
         </button>
-        <button
-          class="tab-btn"
-          :class="{ active: activeTab === 'debug' }"
-          @click.stop="switchToDebug"
-        >Debug</button>
       </div>
 
       <!-- Chat tab -->
@@ -111,59 +106,6 @@
         </div>
       </template>
 
-      <!-- Debug tab -->
-      <template v-else-if="activeTab === 'debug'">
-        <div class="debug-toolbar">
-          <span class="debug-count">{{ debugContext.length }} msg{{ debugContext.length !== 1 ? 's' : '' }} in context</span>
-          <button class="pixel-btn refresh-btn" @click="refreshDebug" :disabled="debugLoading">
-            {{ debugLoading ? '...' : '↻' }}
-          </button>
-          <button class="pixel-btn clear-btn" @click="clearContext" :disabled="debugClearing">
-            {{ debugClearing ? '...' : 'CLR CTX' }}
-          </button>
-        </div>
-        <div class="debug-messages" ref="debugEl">
-          <div v-if="debugContext.length === 0 && !debugLoading" class="chat-empty">
-            No context — foreman hasn't run yet.
-          </div>
-          <div v-if="debugLoading" class="chat-empty">Loading...</div>
-          <div
-            v-for="(msg, i) in debugContext"
-            :key="i"
-            class="debug-msg"
-            :class="msg.role === 'assistant' ? 'debug-assistant' : isToolResponseMsg(msg) ? 'debug-tool-response' : 'debug-user'"
-          >
-            <span class="debug-role">{{ isToolResponseMsg(msg) ? 'TOOL RESPONSE' : msg.role.toUpperCase() }}</span>
-            <template v-if="typeof msg.content === 'string'">
-              <span class="debug-text">{{ msg.content }}</span>
-            </template>
-            <template v-else>
-              <div
-                v-for="(block, bi) in msg.content"
-                :key="bi"
-                class="debug-block"
-                :class="`debug-block-${block.type}`"
-              >
-                <span class="debug-block-type">{{ block.type }}</span>
-                <template v-if="block.type === 'text'">
-                  <span class="debug-text">{{ block.text }}</span>
-                </template>
-                <template v-else-if="block.type === 'tool_use'">
-                  <span class="debug-tool-name">{{ block.name }}</span>
-                  <pre class="debug-pre">{{ JSON.stringify(block.input, null, 2) }}</pre>
-                </template>
-                <template v-else-if="block.type === 'tool_result'">
-                  <span class="debug-tool-id">id:{{ block.tool_use_id?.slice(-6) }}</span>
-                  <pre class="debug-pre">{{ typeof block.content === 'string' ? block.content : JSON.stringify(block.content) }}</pre>
-                </template>
-                <template v-else>
-                  <pre class="debug-pre">{{ JSON.stringify(block) }}</pre>
-                </template>
-              </div>
-            </template>
-          </div>
-        </div>
-      </template>
     </div>
   </div>
 
@@ -221,12 +163,7 @@ const authCodeInput = ref('')
 const claudeAuthPending = ref<{ workerId: string; url: string } | null>(null)
 const messagesEl = ref<HTMLElement | null>(null)
 const issuesEl = ref<HTMLElement | null>(null)
-const debugEl = ref<HTMLElement | null>(null)
-const activeTab = ref<'chat' | 'issues' | 'debug'>('chat')
-
-const debugContext = ref<any[]>([])
-const debugLoading = ref(false)
-const debugClearing = ref(false)
+const activeTab = ref<'chat' | 'issues'>('chat')
 
 const messages = computed(() => guildStore.messages)
 const foreman = computed(() => agentsStore.agents.find(a => a.type === 'foreman'))
@@ -367,53 +304,6 @@ onMounted(async () => {
   }
 })
 onUnmounted(() => guildStore.removeMessageHandler(handleTaskEvent))
-
-function isToolResponseMsg(msg: { role: string; content: unknown }) {
-  return msg.role === 'user' && Array.isArray(msg.content) && (msg.content as { type: string }[]).every(b => b.type === 'tool_result')
-}
-
-async function switchToDebug() {
-  activeTab.value = 'debug'
-  await refreshDebug()
-}
-
-async function refreshDebug() {
-  const guildId = guildStore.currentGuild?.id
-  if (!guildId) return
-  debugLoading.value = true
-  try {
-    const res = await fetch(`${API_BASE}/guilds/${guildId}/foreman/context`, {
-      headers: authStore.authHeaders()
-    })
-    if (res.ok) {
-      const data = await res.json()
-      debugContext.value = data.messages || []
-    }
-  } catch (e) {
-    console.error('Failed to load foreman context', e)
-  } finally {
-    debugLoading.value = false
-    await nextTick()
-    if (debugEl.value) debugEl.value.scrollTop = debugEl.value.scrollHeight
-  }
-}
-
-async function clearContext() {
-  const guildId = guildStore.currentGuild?.id
-  if (!guildId) return
-  debugClearing.value = true
-  try {
-    await fetch(`${API_BASE}/guilds/${guildId}/foreman/clear-context`, {
-      method: 'POST',
-      headers: authStore.authHeaders()
-    })
-    debugContext.value = []
-  } catch (e) {
-    console.error('Failed to clear foreman context', e)
-  } finally {
-    debugClearing.value = false
-  }
-}
 
 async function switchToIssues() {
   activeTab.value = 'issues'
@@ -824,143 +714,6 @@ watch(messages, async () => {
   color: var(--color-text-dim);
 }
 
-/* ── Debug tab ── */
-.debug-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 10px;
-  border-bottom: 1px solid var(--color-brass-dark);
-  flex-shrink: 0;
-}
-
-.debug-count {
-  font-size: 10px;
-  color: var(--color-text-dim);
-  flex: 1;
-}
-
-.clear-btn {
-  font-size: 7px;
-  padding: 3px 6px;
-  border-color: var(--color-red, #c0392b);
-  color: var(--color-red, #c0392b);
-}
-
-.clear-btn:hover {
-  background: rgba(192, 57, 43, 0.15);
-}
-
-.debug-messages {
-  flex: 1;
-  overflow-y: auto;
-  padding: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-height: 180px;
-  max-height: 380px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-}
-
-.debug-msg {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  padding: 5px 8px;
-  border-radius: 2px;
-}
-
-.debug-assistant {
-  background: rgba(0, 187, 170, 0.06);
-  border-left: 3px solid var(--color-teal);
-}
-
-.debug-user {
-  background: rgba(232, 170, 0, 0.06);
-  border-left: 3px solid var(--color-brass-dark);
-}
-
-.debug-tool-response {
-  background: rgba(80, 200, 120, 0.06);
-  border-left: 3px solid #50c878;
-}
-
-.debug-role {
-  font-family: var(--font-pixel);
-  font-size: 6px;
-  letter-spacing: 1px;
-  color: var(--color-text-dim);
-  margin-bottom: 2px;
-}
-
-.debug-assistant .debug-role { color: var(--color-teal); }
-.debug-user .debug-role { color: var(--color-brass); }
-.debug-tool-response .debug-role { color: #50c878; }
-
-.debug-text {
-  color: var(--color-text);
-  line-height: 1.4;
-  word-break: break-word;
-  white-space: pre-wrap;
-}
-
-.debug-block {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 3px 5px;
-  border-radius: 2px;
-  margin-top: 2px;
-}
-
-.debug-block-tool_use {
-  background: rgba(255, 140, 0, 0.1);
-  border: 1px solid rgba(255, 140, 0, 0.25);
-}
-
-.debug-block-tool_result {
-  background: rgba(80, 200, 120, 0.07);
-  border: 1px solid rgba(80, 200, 120, 0.2);
-}
-
-.debug-block-text {
-  background: transparent;
-}
-
-.debug-block-type {
-  font-family: var(--font-pixel);
-  font-size: 5px;
-  letter-spacing: 1px;
-  color: var(--color-text-dim);
-  text-transform: uppercase;
-}
-
-.debug-block-tool_use .debug-block-type { color: #ff8c00; }
-.debug-block-tool_result .debug-block-type { color: #50c878; }
-
-.debug-tool-name {
-  font-weight: bold;
-  color: #ff8c00;
-  font-size: 11px;
-}
-
-.debug-tool-id {
-  font-size: 9px;
-  color: #50c878;
-}
-
-.debug-pre {
-  margin: 0;
-  white-space: pre-wrap;
-  word-break: break-all;
-  color: var(--color-text-dim);
-  font-size: 9px;
-  max-height: 80px;
-  overflow-y: auto;
-}
-
 /* ── Claude auth modal (teleported to body) ── */
 .auth-modal-overlay {
   position: fixed;
@@ -1094,11 +847,6 @@ watch(messages, async () => {
   }
 
   .issues-list {
-    min-height: 0;
-    max-height: none;
-  }
-
-  .debug-messages {
     min-height: 0;
     max-height: none;
   }

--- a/frontend/src/components/DebugSidebar.vue
+++ b/frontend/src/components/DebugSidebar.vue
@@ -1,0 +1,335 @@
+<template>
+  <div class="debug-sidebar-overlay" @click.self="emit('close')">
+    <div class="debug-sidebar">
+      <div class="debug-sidebar-header">
+        <span class="debug-sidebar-title">⚙ FOREMAN DEBUG</span>
+        <div class="debug-sidebar-actions">
+          <span class="debug-count">{{ debugContext.length }} msg{{ debugContext.length !== 1 ? 's' : '' }} in context</span>
+          <button class="pixel-btn refresh-btn" @click="refreshDebug" :disabled="debugLoading">
+            {{ debugLoading ? '...' : '↻' }}
+          </button>
+          <button class="pixel-btn clear-btn" @click="clearContext" :disabled="debugClearing">
+            {{ debugClearing ? '...' : 'CLR CTX' }}
+          </button>
+          <button class="close-btn" @click="emit('close')" title="Close">✕</button>
+        </div>
+      </div>
+
+      <div class="debug-messages" ref="debugEl">
+        <div v-if="debugContext.length === 0 && !debugLoading" class="debug-empty">
+          No context — foreman hasn't run yet.
+        </div>
+        <div v-if="debugLoading" class="debug-empty">Loading...</div>
+        <div
+          v-for="(msg, i) in debugContext"
+          :key="i"
+          class="debug-msg"
+          :class="msg.role === 'assistant' ? 'debug-assistant' : isToolResponseMsg(msg) ? 'debug-tool-response' : 'debug-user'"
+        >
+          <span class="debug-role">{{ isToolResponseMsg(msg) ? 'TOOL RESPONSE' : msg.role.toUpperCase() }}</span>
+          <template v-if="typeof msg.content === 'string'">
+            <span class="debug-text">{{ msg.content }}</span>
+          </template>
+          <template v-else>
+            <div
+              v-for="(block, bi) in msg.content"
+              :key="bi"
+              class="debug-block"
+              :class="`debug-block-${block.type}`"
+            >
+              <span class="debug-block-type">{{ block.type }}</span>
+              <template v-if="block.type === 'text'">
+                <span class="debug-text">{{ block.text }}</span>
+              </template>
+              <template v-else-if="block.type === 'tool_use'">
+                <span class="debug-tool-name">{{ block.name }}</span>
+                <pre class="debug-pre">{{ JSON.stringify(block.input, null, 2) }}</pre>
+              </template>
+              <template v-else-if="block.type === 'tool_result'">
+                <span class="debug-tool-id">id:{{ block.tool_use_id?.slice(-6) }}</span>
+                <pre class="debug-pre">{{ typeof block.content === 'string' ? block.content : JSON.stringify(block.content) }}</pre>
+              </template>
+              <template v-else>
+                <pre class="debug-pre">{{ JSON.stringify(block) }}</pre>
+              </template>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick, onMounted } from 'vue'
+import { useGuildStore } from '../stores/guild'
+import { useAuthStore } from '../stores/auth'
+
+const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
+
+const emit = defineEmits<{ close: [] }>()
+
+const guildStore = useGuildStore()
+const authStore = useAuthStore()
+
+const debugContext = ref<any[]>([])
+const debugLoading = ref(false)
+const debugClearing = ref(false)
+const debugEl = ref<HTMLElement | null>(null)
+
+function isToolResponseMsg(msg: { role: string; content: unknown }) {
+  return msg.role === 'user' && Array.isArray(msg.content) && (msg.content as { type: string }[]).every(b => b.type === 'tool_result')
+}
+
+async function refreshDebug() {
+  const guildId = guildStore.currentGuild?.id
+  if (!guildId) return
+  debugLoading.value = true
+  try {
+    const res = await fetch(`${API_BASE}/guilds/${guildId}/foreman/context`, {
+      headers: authStore.authHeaders()
+    })
+    if (res.ok) {
+      const data = await res.json()
+      debugContext.value = data.messages || []
+    }
+  } catch (e) {
+    console.error('Failed to load foreman context', e)
+  } finally {
+    debugLoading.value = false
+    await nextTick()
+    if (debugEl.value) debugEl.value.scrollTop = debugEl.value.scrollHeight
+  }
+}
+
+async function clearContext() {
+  const guildId = guildStore.currentGuild?.id
+  if (!guildId) return
+  debugClearing.value = true
+  try {
+    await fetch(`${API_BASE}/guilds/${guildId}/foreman/clear-context`, {
+      method: 'POST',
+      headers: authStore.authHeaders()
+    })
+    debugContext.value = []
+  } catch (e) {
+    console.error('Failed to clear foreman context', e)
+  } finally {
+    debugClearing.value = false
+  }
+}
+
+onMounted(() => refreshDebug())
+</script>
+
+<style scoped>
+.debug-sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 300;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.debug-sidebar {
+  width: 520px;
+  max-width: 90vw;
+  height: 100%;
+  background: var(--color-bg-secondary);
+  border-left: 2px solid var(--color-brass-dark);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.5);
+}
+
+.debug-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--color-bg-tertiary);
+  border-bottom: 2px solid var(--color-brass-dark);
+  flex-shrink: 0;
+  gap: 10px;
+}
+
+.debug-sidebar-title {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-brass-light);
+  letter-spacing: 2px;
+  text-shadow: 0 0 6px rgba(255, 214, 68, 0.4);
+  white-space: nowrap;
+}
+
+.debug-sidebar-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.debug-count {
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+
+.refresh-btn {
+  font-size: 10px;
+  padding: 3px 7px;
+}
+
+.refresh-btn:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.clear-btn {
+  font-size: 7px;
+  padding: 3px 6px;
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #c0392b);
+}
+
+.clear-btn:hover {
+  background: rgba(192, 57, 43, 0.15);
+}
+
+.clear-btn:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.close-btn {
+  background: none;
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text-dim);
+  cursor: pointer;
+  width: 26px;
+  height: 26px;
+  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  transition: border-color 0.12s, color 0.12s;
+}
+
+.close-btn:hover {
+  border-color: var(--color-brass);
+  color: var(--color-text);
+}
+
+.debug-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.debug-empty {
+  color: var(--color-text-dim);
+  font-size: 11px;
+  text-align: center;
+  margin-top: 20px;
+  font-style: italic;
+}
+
+.debug-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 6px 10px;
+  border-radius: 2px;
+}
+
+.debug-assistant {
+  background: rgba(0, 187, 170, 0.06);
+  border-left: 3px solid var(--color-teal);
+}
+
+.debug-user {
+  background: rgba(232, 170, 0, 0.06);
+  border-left: 3px solid var(--color-brass-dark);
+}
+
+.debug-tool-response {
+  background: rgba(80, 200, 120, 0.06);
+  border-left: 3px solid #50c878;
+}
+
+.debug-role {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 1px;
+  color: var(--color-text-dim);
+  margin-bottom: 2px;
+}
+
+.debug-assistant .debug-role { color: var(--color-teal); }
+.debug-user .debug-role { color: var(--color-brass); }
+.debug-tool-response .debug-role { color: #50c878; }
+
+.debug-text {
+  color: var(--color-text);
+  line-height: 1.4;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.debug-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 3px 5px;
+  border-radius: 2px;
+  margin-top: 2px;
+}
+
+.debug-block-tool_use {
+  background: rgba(255, 140, 0, 0.1);
+  border: 1px solid rgba(255, 140, 0, 0.25);
+}
+
+.debug-block-tool_result {
+  background: rgba(80, 200, 120, 0.07);
+  border: 1px solid rgba(80, 200, 120, 0.2);
+}
+
+.debug-block-type {
+  font-family: var(--font-pixel);
+  font-size: 5px;
+  letter-spacing: 1px;
+  color: var(--color-text-dim);
+  text-transform: uppercase;
+}
+
+.debug-block-tool_use .debug-block-type { color: #ff8c00; }
+.debug-block-tool_result .debug-block-type { color: #50c878; }
+
+.debug-tool-name {
+  font-weight: bold;
+  color: #ff8c00;
+  font-size: 12px;
+}
+
+.debug-tool-id {
+  font-size: 9px;
+  color: #50c878;
+}
+
+.debug-pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--color-text-dim);
+  font-size: 10px;
+  max-height: 120px;
+  overflow-y: auto;
+}
+</style>

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -27,6 +27,16 @@
 
     <button
       v-if="currentGuild"
+      class="debug-btn"
+      :class="{ active: debugActive }"
+      @click="emit('toggle-debug')"
+      title="Debug: foreman context"
+    >
+      <span class="debug-icon">⌥</span>
+    </button>
+
+    <button
+      v-if="currentGuild"
       class="settings-btn"
       :class="{ active: showSettings }"
       @click="toggleSettings"
@@ -93,6 +103,9 @@ import { useGuildStore } from '../stores/guild'
 import { useGitHubStore } from '../stores/github'
 import { useAuthStore } from '../stores/auth'
 import GitHubConfigModal from './GitHubConfigModal.vue'
+
+defineProps<{ debugActive?: boolean }>()
+const emit = defineEmits<{ 'toggle-debug': [] }>()
 
 const router = useRouter()
 const guildStore = useGuildStore()
@@ -292,6 +305,34 @@ function goHome() {
   max-width: 140px;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.debug-btn {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text-dim);
+  cursor: pointer;
+  width: 30px;
+  height: 30px;
+  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  flex-shrink: 0;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+
+.debug-btn:hover,
+.debug-btn.active {
+  border-color: var(--color-teal);
+  background: rgba(0, 187, 170, 0.1);
+  color: var(--color-teal);
+}
+
+.debug-icon {
+  font-size: 14px;
+  line-height: 1;
 }
 
 .settings-btn {

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="app-layout" :data-tab="activeTab">
-    <TopBar />
+    <TopBar :debug-active="showDebug" @toggle-debug="showDebug = !showDebug" />
     <div class="app-body">
       <GuildSidebar />
       <MainView />
       <ChatPane />
     </div>
+    <teleport to="body">
+      <DebugSidebar v-if="showDebug" @close="showDebug = false" />
+    </teleport>
     <nav class="mobile-tab-bar">
       <button class="tab-btn" :class="{ active: activeTab === 'tasks' }" @click="activeTab = 'tasks'">
         <span class="tab-icon">≡</span>
@@ -35,11 +38,14 @@ import GuildSidebar from '../components/GuildSidebar.vue'
 import MainView from '../components/MainView.vue'
 import ChatPane from '../components/ChatPane.vue'
 import TopBar from '../components/TopBar.vue'
+import DebugSidebar from '../components/DebugSidebar.vue'
 
 const props = defineProps<{ guildId?: string }>()
 
 const activeTab = ref<'tasks' | 'work' | 'chat'>('chat')
 provide('switchMobileTab', (tab: 'tasks' | 'work' | 'chat') => { activeTab.value = tab })
+
+const showDebug = ref(false)
 
 const router = useRouter()
 const guildStore = useGuildStore()


### PR DESCRIPTION
## Summary
- Removes the **Debug** tab from ChatPane's tab strip
- Adds a **Debug button (⌥)** to the TopBar, right of the user pill, left of Settings
- Clicking the button toggles a full-height right sidebar overlay showing foreman conversation context
- Sidebar has refresh (↻) and clear (CLR CTX) controls, closeable via ✕ button or clicking the backdrop

## Implementation
- New `DebugSidebar.vue` component — all debug logic extracted from `ChatPane.vue`
- `TopBar.vue` gains a `debug-btn` that emits `toggle-debug`; accepts `debugActive` prop for active state styling
- `AppView.vue` owns `showDebug` state, teleports `<DebugSidebar>` to body when active
- Sidebar uses `position: fixed; inset: 0` overlay with the panel right-anchored at 520px wide

## Test plan
- [ ] Debug button appears in TopBar when inside a guild
- [ ] Clicking Debug button opens sidebar and loads foreman context
- [ ] Backdrop click closes sidebar
- [ ] ✕ button closes sidebar
- [ ] Refresh / CLR CTX still work
- [ ] ChatPane no longer shows a Debug tab
- [ ] No TypeScript errors (`npx vue-tsc --noEmit`)
- [ ] No lint errors (`npm run lint`)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)