### PR TITLE
feat: foreman periodic task-check with exponential backoff (#109)

### DIFF
--- a/backend/foreman/__init__.py
+++ b/backend/foreman/__init__.py
@@ -1,10 +1,16 @@
 """Foreman AI package — re-exports for convenient importing from main.py."""
 
-from foreman.runner import clear_foreman_history, get_foreman_history, run_foreman_ai
+from foreman.runner import (
+    clear_foreman_history,
+    get_foreman_history,
+    reset_foreman_poll,
+    run_foreman_ai,
+)
 from foreman.tools import maybe_post_plan_comment
 
 __all__ = [
     "run_foreman_ai",
+    "reset_foreman_poll",
     "clear_foreman_history",
     "get_foreman_history",
     "maybe_post_plan_comment",

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -1,5 +1,6 @@
 """Foreman AI runner: conversation management and main loop."""
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime
@@ -26,6 +27,12 @@ MAX_HISTORY_MESSAGES = 20  # sliding window cap on messages sent to Anthropic
 _HUMAN_TURN_WINDOW = 5  # how many non-tool-response user turns to load from DB
 _TERMINAL_STATES = frozenset({"done", "failed", "cancelled"})
 _24H_SECS = 86_400
+
+POLL_MIN_SECS = 60      # initial poll interval: 1 minute
+POLL_MAX_SECS = 3600    # maximum poll interval: 60 minutes
+
+# Per-guild background poll task registry
+_poll_tasks: dict[str, "asyncio.Task[None]"] = {}
 
 
 def truncate_tool_result(content: str, max_chars: int = MAX_TOOL_RESULT_CHARS) -> str:
@@ -272,6 +279,83 @@ async def _save_turn(
         return turn.id
     finally:
         await db.close()
+
+
+async def _poll_loop(guild_id: str) -> None:
+    """Background loop: check non-terminal tasks and call the foreman if any are found.
+
+    Interval doubles each cycle from POLL_MIN_SECS up to POLL_MAX_SECS.
+    Cancelled (via reset_foreman_poll) whenever a significant event arrives.
+    The foreman-poll-status broadcast is sent after each poll so the UI can
+    display the countdown to the *next* check.
+    """
+    interval = POLL_MIN_SECS
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            return
+
+        # Bail if this task was superseded by a reset.
+        if asyncio.current_task() is not _poll_tasks.get(guild_id):
+            return
+
+        # Query non-terminal tasks for this guild.
+        db = await get_db()
+        try:
+            result = await db.execute(
+                select(Task.id, Task.state, Task.name).where(
+                    Task.guild_id == guild_id,
+                    ~Task.state.in_(list(_TERMINAL_STATES)),
+                )
+            )
+            active_tasks = [dict(r._mapping) for r in result.fetchall()]
+        finally:
+            await db.close()
+
+        n = len(active_tasks)
+        next_interval = min(interval * 2, POLL_MAX_SECS)
+        logger.debug(
+            "guild=%s polling %d active tasks, next check in %.0fm",
+            guild_id,
+            n,
+            next_interval / 60,
+        )
+
+        if active_tasks:
+            task_summary = "; ".join(
+                f"{t['id']} ({t['state']})" for t in active_tasks[:8]
+            )
+            msg = (
+                f"[periodic-check] Automated status poll — {n} non-terminal "
+                f"task(s): {task_summary}. Check whether any are stalled. "
+                "Use get_task_status to inspect a task if it looks stuck. "
+                "If everything looks healthy, no action is needed."
+            )
+            asyncio.create_task(run_foreman_ai(guild_id, msg))
+
+        # Announce next check interval so the UI can display a countdown.
+        interval = next_interval
+        try:
+            await broadcast(
+                guild_id,
+                {"type": "foreman-poll-status", "nextCheckIn": interval},
+            )
+        except Exception:
+            pass
+
+
+def reset_foreman_poll(guild_id: str) -> None:
+    """Cancel any running poll loop for this guild and start a fresh one at POLL_MIN_SECS.
+
+    Call whenever a significant event occurs (human message, worker state change,
+    task transition) to reset the backoff so the next check happens in 1 minute.
+    """
+    old = _poll_tasks.pop(guild_id, None)
+    if old and not old.done():
+        old.cancel()
+    task = asyncio.create_task(_poll_loop(guild_id))
+    _poll_tasks[guild_id] = task
 
 
 async def run_foreman_ai(

--- a/backend/main.py
+++ b/backend/main.py
@@ -48,6 +48,7 @@ from foreman import (
     clear_foreman_history,
     get_foreman_history,
     maybe_post_plan_comment,
+    reset_foreman_poll,
     run_foreman_ai,
 )
 
@@ -680,6 +681,8 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     "joinedAt": joined_at,
                 }
                 await broadcast(guild_id, broadcast_msg)
+                if agent_type == "worker":
+                    reset_foreman_poll(guild_id)
 
             elif msg_type == "agent-state":
                 agent_id = data.get("agentId")
@@ -754,6 +757,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                         )
                     else:
                         asyncio.create_task(run_foreman_ai(guild_id, content, user_id=ws_user_id))
+                        reset_foreman_poll(guild_id)
 
             elif msg_type == "terminal-output":
                 msg_agent_id = data.get("agentId")
@@ -832,6 +836,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                             "state": "offline",
                         },
                     )
+                reset_foreman_poll(guild_id)
 
             elif msg_type == "task-update":
                 # Worker is reporting a task state change; persist + rebroadcast.
@@ -897,6 +902,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                                 "as done — no foreman action required.",
                             )
                         )
+                        reset_foreman_poll(guild_id)
                     else:
                         asyncio.create_task(
                             run_foreman_ai(
@@ -908,6 +914,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                                 "Otherwise call finalize_task to mark it complete.",
                             )
                         )
+                        reset_foreman_poll(guild_id)
 
             elif msg_type == "task-followup-done":
                 task_id = data.get("taskId")
@@ -926,6 +933,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                             "Decide: call send_followup for more work, or call finalize_task to mark it done.",
                         )
                     )
+                    reset_foreman_poll(guild_id)
 
             elif msg_type == "needs-input":
                 # Worker escalation: broadcast to frontend and loop the foreman in.

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -7,6 +7,7 @@
           <span class="status-dot" :class="foreman.state"></span>
           {{ foreman.state }}
         </span>
+        <span v-if="pollLabel" class="poll-indicator">⏱ {{ pollLabel }}</span>
         <span class="minimize-btn">{{ minimized ? '▲' : '▼' }}</span>
       </div>
     </div>
@@ -203,6 +204,21 @@ const activeTab = ref<'chat' | 'issues'>('chat')
 const ISSUE_REFRESH_MS = 3 * 60 * 1000
 let issueRefreshInterval: ReturnType<typeof setInterval> | null = null
 
+// Poll countdown: epoch ms when next foreman check fires, plus a tick counter
+// to force the computed to re-evaluate every 30 s.
+const nextPollAt = ref<number | null>(null)
+const pollTick = ref(0)
+let pollCountdownTimer: ReturnType<typeof setInterval> | null = null
+
+const pollLabel = computed(() => {
+  void pollTick.value  // subscribe so re-render fires on each tick
+  if (nextPollAt.value === null) return ''
+  const remaining = Math.max(0, Math.ceil((nextPollAt.value - Date.now()) / 1000))
+  if (remaining <= 0) return 'checking...'
+  const mins = Math.ceil(remaining / 60)
+  return `next check in ${mins}m`
+})
+
 const messages = computed(() => guildStore.messages)
 const foreman = computed(() => agentsStore.agents.find(a => a.type === 'foreman'))
 const expandedTool = ref<number | null>(null)
@@ -357,6 +373,9 @@ function handleTaskEvent(data: WSMessage) {
       content: `→ ${data.workerId} assigned: ${data.description}`,
       createdAt: new Date().toISOString(),
     })
+  } else if (data.type === 'foreman-poll-status') {
+    const secs = typeof data.nextCheckIn === 'number' ? data.nextCheckIn : null
+    nextPollAt.value = secs !== null ? Date.now() + secs * 1000 : null
   }
 }
 
@@ -385,12 +404,18 @@ onMounted(async () => {
   if (ghStore.isConfigured) {
     issueRefreshInterval = setInterval(() => refreshIssues(true), ISSUE_REFRESH_MS)
   }
+  // Increment tick every 30 s to keep the poll countdown label current.
+  pollCountdownTimer = setInterval(() => { pollTick.value++ }, 30_000)
 })
 onUnmounted(() => {
   guildStore.removeMessageHandler(handleTaskEvent)
   if (issueRefreshInterval !== null) {
     clearInterval(issueRefreshInterval)
     issueRefreshInterval = null
+  }
+  if (pollCountdownTimer !== null) {
+    clearInterval(pollCountdownTimer)
+    pollCountdownTimer = null
   }
 })
 
@@ -506,6 +531,13 @@ watch(messages, async () => {
 .status-dot.working { background: var(--color-green); }
 .status-dot.busy { background: var(--color-orange); }
 .status-dot.error { background: var(--color-red); }
+
+.poll-indicator {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  opacity: 0.7;
+  white-space: nowrap;
+}
 
 .minimize-btn {
   font-size: 10px;


### PR DESCRIPTION
## Summary

Closes #109.

- **Polling loop with exponential backoff** (`backend/foreman/runner.py`): a per-guild `_poll_loop` background task wakes up after an initial 1-minute delay, queries all non-terminal tasks, and invokes the foreman AI if any are found. The interval doubles on each cycle (1 min → 2 min → 4 min … capped at 60 min).
- **Reset on significant events** (`backend/main.py`): `reset_foreman_poll(guild_id)` cancels the current loop and starts a fresh one at 1 minute whenever a human message arrives, a worker joins/disconnects, a task completes (`task-complete`), or a follow-up finishes (`task-followup-done`). This keeps the backoff tight after real activity.
- **UI indicator** (`frontend/src/components/ChatPane.vue`): the backend emits a `foreman-poll-status` WS event after each poll containing `nextCheckIn` (seconds). The chat pane header displays a small `⏱ next check in Xm` label that refreshes every 30 s.

## Test plan

- [x] 148 backend tests pass (`python -m pytest` in `backend/`)
- [x] Frontend lint and type-check clean (`npm run lint && npm run type-check` in `frontend/`)
- [ ] Manual: start backend + frontend + worker, let a task finish, observe the poll indicator counting down and resetting on new chat messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)