### PR TITLE
Better branch names & Claude-authored PRs

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -28,8 +28,8 @@ _HUMAN_TURN_WINDOW = 5  # how many non-tool-response user turns to load from DB
 _TERMINAL_STATES = frozenset({"done", "failed", "cancelled"})
 _24H_SECS = 86_400
 
-POLL_MIN_SECS = 60      # initial poll interval: 1 minute
-POLL_MAX_SECS = 3600    # maximum poll interval: 60 minutes
+POLL_MIN_SECS = 60  # initial poll interval: 1 minute
+POLL_MAX_SECS = 3600  # maximum poll interval: 60 minutes
 
 # Per-guild background poll task registry
 _poll_tasks: dict[str, "asyncio.Task[None]"] = {}
@@ -323,9 +323,7 @@ async def _poll_loop(guild_id: str) -> None:
         )
 
         if active_tasks:
-            task_summary = "; ".join(
-                f"{t['id']} ({t['state']})" for t in active_tasks[:8]
-            )
+            task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active_tasks[:8])
             msg = (
                 f"[periodic-check] Automated status poll — {n} non-terminal "
                 f"task(s): {task_summary}. Check whether any are stalled. "

--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -44,6 +44,47 @@ async def push_branch(
     return True
 
 
+async def find_existing_pr(
+    *,
+    branch: str,
+    worktree_path: str,
+    token: str | None,
+) -> str | None:
+    """Return the HTML URL of an open PR for *branch*, or None."""
+    if not token:
+        return None
+
+    repo_full = None
+    rc, url, _ = await git_ops.run_git(["remote", "get-url", "origin"], cwd=worktree_path)
+    if rc == 0:
+        m = re.search(r"github\.com[:/](.+?/[^/\s]+?)(?:\.git)?$", url.strip())
+        if m:
+            repo_full = m.group(1)
+    if not repo_full:
+        return None
+
+    owner = repo_full.split("/")[0]
+
+    def _list_prs() -> list:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo_full}/pulls?head={owner}:{branch}&state=open",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.v3+json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+
+    try:
+        pulls = await asyncio.to_thread(_list_prs)
+        if pulls:
+            return pulls[0].get("html_url")
+    except Exception:
+        pass
+    return None
+
+
 async def open_pr(
     *,
     task: dict,
@@ -68,11 +109,17 @@ async def open_pr(
         await emit("[worker] Could not determine repo — skipping PR")
         return None
 
-    issue_ref = f"\n\nCloses #{task['issue_number']}" if task.get("issue_number") else ""
-    body = f"Automated by Pioneer Square worker agent.{issue_ref}"
+    task_name = task.get("name") or task.get("description") or ""
+    task_id = task.get("id") or ""
+    closes_line = f"\n\nCloses #{task['issue_number']}" if task.get("issue_number") else ""
+    body = (
+        f"**Task:** {task_name}\n"
+        f"**Task ID:** `{task_id}`\n\n"
+        f"Automated by Pioneer Square worker agent.{closes_line}"
+    )
     payload = json.dumps(
         {
-            "title": (task.get("description") or "")[:72],
+            "title": task_name[:72] or (task.get("description") or "")[:72],
             "body": body,
             "head": branch,
             "base": "main",

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -30,7 +30,7 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _slug(text: str, max_len: int = 45) -> str:
+def _slug(text: str, max_len: int = 60) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text[:max_len].lower()).strip("-")
 
 
@@ -771,6 +771,7 @@ class Worker:
                         "id": task_id,
                         "worker_id": self.cfg.worker_id,
                         "guild_id": self.cfg.guild_id,
+                        "name": msg.get("name", ""),
                         "description": msg.get("description", ""),
                         "tool": msg.get("tool", "claude"),
                         "issue_number": msg.get("issueNumber"),
@@ -1045,6 +1046,16 @@ class Worker:
         try:
             # ── Main execution with redirect loop ──────────────────────────
             current_desc = desc
+            if tool == "claude":
+                pr_title = (task.get("name") or desc)[:72].replace('"', "'")
+                closes = f" Closes #{task['issue_number']}" if task.get("issue_number") else ""
+                current_desc = (
+                    f"{desc}\n\n"
+                    f"After completing your changes, commit, push, and open a PR:\n"
+                    f'  git add -A && git commit -m "<concise commit message>"\n'
+                    f"  git push origin {branch}\n"
+                    f'  gh pr create --title "{pr_title}" --body "<summary of changes>{closes}"\n'
+                )
             success = False
             stop_reason = "no_events"
             last_msg = ""
@@ -1124,7 +1135,15 @@ class Worker:
             pr_url: str | None = None
 
             if success:
-                if push_ok:
+                existing_pr = await github_pr.find_existing_pr(
+                    branch=branch,
+                    worktree_path=primary_wt,
+                    token=token,
+                )
+                if existing_pr:
+                    pr_url = existing_pr
+                    await emit(f"[worker] ✓ Claude-authored PR: {pr_url}")
+                elif push_ok:
                     pr_url = await github_pr.open_pr(
                         task=task,
                         branch=branch,
@@ -1132,7 +1151,7 @@ class Worker:
                         token=token,
                         emit=emit,
                     )
-                logger.info("Task %s: pushed pr_url=%s", task_id, pr_url)
+                logger.info("Task %s: pr_url=%s", task_id, pr_url)
 
                 await self._task_update(
                     task_id,
@@ -1270,13 +1289,22 @@ class Worker:
                         # Originally-failed tasks never opened a PR; do it now
                         # that we have something worth reviewing.
                         if not pr_url:
-                            pr_url = await github_pr.open_pr(
-                                task=task,
+                            existing_pr = await github_pr.find_existing_pr(
                                 branch=branch,
                                 worktree_path=primary_wt,
                                 token=token,
-                                emit=emit,
                             )
+                            if existing_pr:
+                                pr_url = existing_pr
+                                await emit(f"[worker] ✓ Claude-authored PR: {pr_url}")
+                            else:
+                                pr_url = await github_pr.open_pr(
+                                    task=task,
+                                    branch=branch,
+                                    worktree_path=primary_wt,
+                                    token=token,
+                                    emit=emit,
+                                )
 
                     await self._send(
                         {


### PR DESCRIPTION
## Summary

- **Branch slug from task name** (`worker.py`): `_slug()` max length raised from 45 → 60 chars; `name` field is now propagated from `task-assigned` WS messages so the branch reflects the human-readable task name (with description as fallback).
- **Claude instructed to push+PR in-session** (`worker.py`): when `tool == "claude"`, the prompt sent to Claude is augmented with explicit `git add -A && git commit`, `git push origin <branch>`, and `gh pr create` commands — including the real branch name and `Closes #N` when an issue number is present.
- **Worker fallback checks for existing PR** (`worker.py`): after Claude exits, `find_existing_pr()` is called before falling back to `github_pr.open_pr()`. If Claude already opened a PR in-session, the worker reuses that URL and skips the fallback. This applies to both the initial run and the follow-up loop.
- **Richer fallback PR body** (`github_pr.py`): `find_existing_pr()` added as a new public function. `open_pr()` now uses the task `name` as the PR title (falling back to description), and the body includes the task name, task ID, and `Closes #N` when `issue_number` is set.

Closes #148