### PR TITLE
worker: harden Claude auth detection so Mac startup doesn't stall

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -112,26 +112,66 @@ class Worker:
             logger.warning("Could not fetch GitHub token: %s", exc)
 
     async def _claude_is_authenticated(self) -> bool:
-        """Return True if `claude auth status` exits 0 (works on macOS keychain and Linux)."""
+        """Return True if `claude auth status --json` reports loggedIn=true.
+
+        Works on macOS keychain and Linux. The exit code alone is unreliable
+        (the CLI returns 0 even when not logged in, just emits ``loggedIn:
+        false``), so we parse the JSON. A timeout guards against macOS keychain
+        access prompts that can hang the subprocess indefinitely when invoked
+        without a controlling TTY.
+        """
+        import json as _json
+
         try:
             proc = await asyncio.create_subprocess_exec(
                 self.cfg.claude_path,
                 "auth",
                 "status",
+                "--json",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
-            stdout, _ = await proc.communicate()
-            result = proc.returncode == 0
-            logger.info(
-                "claude auth status rc=%s output=%s",
-                proc.returncode,
-                stdout.decode(errors="replace").strip()[:200],
-            )
-            return result
-        except Exception as exc:
-            logger.warning("claude auth status failed: %s", exc)
+        except FileNotFoundError as exc:
+            logger.warning("claude binary not found at %r: %s", self.cfg.claude_path, exc)
             return False
+        except Exception as exc:
+            logger.warning("claude auth status spawn failed: %s", exc)
+            return False
+
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        except TimeoutError:
+            logger.warning(
+                "claude auth status timed out after 10s — keychain prompt? killing pid=%s",
+                proc.pid,
+            )
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            return False
+
+        raw = stdout.decode(errors="replace").strip()
+        logger.info("claude auth status rc=%s output=%s", proc.returncode, raw[:200])
+        if proc.returncode != 0:
+            return False
+        try:
+            parsed = _json.loads(raw)
+        except _json.JSONDecodeError:
+            # Older claude versions returned plain text; fall back to rc=0 == authed.
+            logger.info("claude auth status output is not JSON; treating rc=0 as authed")
+            return True
+        logged_in = bool(parsed.get("loggedIn"))
+        if logged_in:
+            logger.info(
+                "Claude auth detected (method=%s provider=%s)",
+                parsed.get("authMethod"),
+                parsed.get("apiProvider"),
+            )
+        else:
+            logger.info("claude auth status reports loggedIn=false")
+        return logged_in
 
     async def _check_claude_auth(self) -> None:
         """Ensure Claude is authenticated. Restores stored credentials or runs login flow."""
@@ -167,7 +207,6 @@ class Worker:
                 blob = resp.json().get("credentials_blob", "")
                 if blob:
                     raw = base64.b64decode(blob)
-                    restored = False
                     try:
                         payload = json.loads(raw)
                         token = payload.get("oauth_token")
@@ -177,15 +216,17 @@ class Worker:
                                 "Restored CLAUDE_CODE_OAUTH_TOKEN from backend (len=%d)",
                                 len(token),
                             )
-                            restored = True
+                            # The env var is inherited by every spawned claude;
+                            # no need to re-verify with `claude auth status`,
+                            # which can spuriously fail on macOS keychain hosts.
+                            return
                     except (json.JSONDecodeError, UnicodeDecodeError):
                         pass  # fall through to legacy tarball path
-                    if not restored:
-                        claude_dir = Path.home() / ".claude"
-                        claude_dir.mkdir(parents=True, exist_ok=True)
-                        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tar:
-                            tar.extractall(path=Path.home())
-                        logger.info("Restored Claude credentials tarball from backend (legacy)")
+                    claude_dir = Path.home() / ".claude"
+                    claude_dir.mkdir(parents=True, exist_ok=True)
+                    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tar:
+                        tar.extractall(path=Path.home())
+                    logger.info("Restored Claude credentials tarball from backend (legacy)")
                     if await self._claude_is_authenticated():
                         return
                     logger.warning("Restored credentials blob but auth status still fails")

--- a/worker/tests/test_auth_check.py
+++ b/worker/tests/test_auth_check.py
@@ -1,0 +1,97 @@
+"""Tests for Worker._claude_is_authenticated.
+
+Covers the JSON-parsing path used to detect Claude credentials, plus the
+timeout guard that prevents macOS keychain prompts from hanging worker
+startup forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_cfg() -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="test-guild",
+        worker_id="w-test01",
+        max_agents=1,
+        pull_interval=3600.0,
+    )
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: bytes, *, hang: bool = False) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._hang = hang
+        self.pid = 12345
+        self.killed = False
+
+    async def communicate(self):
+        if self._hang:
+            await asyncio.sleep(3600)
+        return (self._stdout, b"")
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+async def test_authenticated_when_logged_in_true():
+    worker = Worker(_make_cfg())
+    proc = _FakeProc(0, b'{"loggedIn": true, "authMethod": "claude_login"}')
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        assert await worker._claude_is_authenticated() is True
+
+
+async def test_not_authenticated_when_logged_in_false():
+    """Regression: rc=0 with loggedIn:false must NOT be treated as authed."""
+    worker = Worker(_make_cfg())
+    proc = _FakeProc(0, b'{"loggedIn": false}')
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        assert await worker._claude_is_authenticated() is False
+
+
+async def test_not_authenticated_when_nonzero_rc():
+    worker = Worker(_make_cfg())
+    proc = _FakeProc(2, b"unknown command")
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        assert await worker._claude_is_authenticated() is False
+
+
+async def test_legacy_non_json_output_falls_back_to_rc():
+    """Older claude versions returned plain text; rc=0 should still mean authed."""
+    worker = Worker(_make_cfg())
+    proc = _FakeProc(0, b"You are logged in.")
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        assert await worker._claude_is_authenticated() is True
+
+
+async def test_timeout_returns_false_and_kills_process():
+    """If `claude auth status` hangs (e.g. macOS keychain prompt), don't block startup."""
+    worker = Worker(_make_cfg())
+    proc = _FakeProc(0, b"", hang=True)
+
+    async def fake_wait_for(coro, timeout):
+        coro.close()  # avoid "coroutine was never awaited" warning
+        raise TimeoutError()
+
+    with (
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        patch("asyncio.wait_for", fake_wait_for),
+    ):
+        assert await worker._claude_is_authenticated() is False
+    assert proc.killed is True
+
+
+async def test_missing_claude_binary_returns_false():
+    worker = Worker(_make_cfg())
+    with patch("asyncio.create_subprocess_exec", AsyncMock(side_effect=FileNotFoundError())):
+        assert await worker._claude_is_authenticated() is False


### PR DESCRIPTION
Two issues caused the worker to register but never start tasks on macOS:

1. `_claude_is_authenticated` only checked rc==0, but `claude auth status`
   returns 0 even when `loggedIn: false` (it just emits the JSON status). We
   now parse `--json` output and verify `loggedIn` is true. Falls back to the
   rc==0 heuristic when the output isn't JSON (older claude versions).

2. The same call had no timeout. On macOS, keychain access from a non-TTY
   subprocess can prompt for permission and block forever, leaving
   `_check_claude_auth` (and therefore `_join`) hanging — the worker showed
   as registered but agents never went idle, so no tasks ran. Added a 10s
   timeout that kills the process and treats it as unauthenticated.

Also stop re-verifying with `claude auth status` after restoring an OAuth
token from the backend: the env var is inherited by every spawned claude,
so the verification step only added another point of macOS-specific failure.

https://claude.ai/code/session_01AretXRZSi8dAg99zEw9tti