### PR TITLE
Track worker liveness via app-level ping/pong, sweep stale workers offline

### DIFF
--- a/backend/alembic/versions/d5e6f7a8b9c0_add_last_seen_to_workers_and_agents.py
+++ b/backend/alembic/versions/d5e6f7a8b9c0_add_last_seen_to_workers_and_agents.py
@@ -1,0 +1,40 @@
+"""add_last_seen_to_workers_and_agents
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-05-02 00:00:00.000000
+
+"""
+
+from datetime import UTC, datetime
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: Union[str, Sequence[str], None] = "c4d5e6f7a8b9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.add_column(sa.Column("last_seen", sa.Text(), nullable=True))
+    with op.batch_alter_table("workers") as batch_op:
+        batch_op.add_column(sa.Column("last_seen", sa.Text(), nullable=True))
+
+    # Backfill existing rows with the migration timestamp so the stale-worker
+    # sweeper doesn't mark every pre-existing worker offline the moment it
+    # runs. Real workers will refresh this within seconds via their
+    # heartbeat; ones that don't reconnect will age out naturally.
+    now = datetime.now(UTC).isoformat()
+    op.execute(sa.text("UPDATE workers SET last_seen = :now").bindparams(now=now))
+    op.execute(sa.text("UPDATE agents SET last_seen = :now").bindparams(now=now))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workers") as batch_op:
+        batch_op.drop_column("last_seen")
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.drop_column("last_seen")

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from database import AsyncSessionLocal, get_db
@@ -60,6 +60,14 @@ def _row(obj) -> dict:
     return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
 
 
+# How long an agent/worker can go without sending any WebSocket message before
+# the sweeper marks it offline. Workers send an application-level `ping` every
+# ~25s, so 90s = three missed heartbeats.
+WORKER_OFFLINE_AFTER_SECONDS = float(os.environ.get("WORKER_OFFLINE_AFTER_SECONDS", "90"))
+# How often the sweeper task wakes up to look for stale agents.
+WORKER_SWEEP_INTERVAL_SECONDS = float(os.environ.get("WORKER_SWEEP_INTERVAL_SECONDS", "30"))
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
@@ -74,7 +82,15 @@ async def lifespan(app: FastAPI):
         foreman_log.addHandler(_h)
     foreman_log.propagate = False
     foreman_log.info("foreman logger active (level=DEBUG)")
-    yield
+    sweeper = asyncio.create_task(_stale_worker_sweeper())
+    try:
+        yield
+    finally:
+        sweeper.cancel()
+        try:
+            await sweeper
+        except (asyncio.CancelledError, Exception):
+            pass
 
 
 app = FastAPI(title="Pioneer Square", lifespan=lifespan)
@@ -139,6 +155,113 @@ async def init_db():
             .values(state="offline")
         )
         await db.commit()
+
+
+async def _touch_agent(
+    db, guild_id: str, agent_id: str | None, worker_id: str | None = None
+) -> None:
+    """Refresh ``last_seen`` for the agent (and its worker) so the sweeper
+    knows the connection is still alive. Called for every inbound WS frame.
+
+    If *worker_id* isn't passed we look it up from the agent row so messages
+    that only carry an ``agentId`` (most of them) still keep the worker fresh.
+    Once we know the worker, we also refresh every other agent owned by it —
+    a single worker process owns all its slots over one socket, so any
+    inbound frame proves the whole worker is alive.
+    """
+    if not agent_id and not worker_id:
+        return
+    now = datetime.now(UTC).isoformat()
+    if agent_id and worker_id is None:
+        res = await db.execute(select(Agent.worker_id).where(Agent.id == agent_id))
+        worker_id = res.scalar_one_or_none()
+    if worker_id:
+        await db.execute(
+            update(Worker)
+            .where(Worker.id == worker_id, Worker.guild_id == guild_id)
+            .values(last_seen=now)
+        )
+        await db.execute(
+            update(Agent)
+            .where(Agent.worker_id == worker_id, Agent.guild_id == guild_id)
+            .values(last_seen=now)
+        )
+    elif agent_id:
+        await db.execute(
+            update(Agent)
+            .where(Agent.id == agent_id, Agent.guild_id == guild_id)
+            .values(last_seen=now)
+        )
+    await db.commit()
+
+
+async def _stale_worker_sweeper() -> None:
+    """Background task: mark workers/agents offline if they haven't pinged recently.
+
+    Runs forever (cancelled at app shutdown). The websocket library's own
+    ping/pong catches dead TCP connections, but a worker process could be
+    stuck in a way that still answers protocol pings; the application-level
+    `ping` heartbeat is what this sweeper actually relies on.
+    """
+    logger.info(
+        "Stale-worker sweeper started: threshold=%.1fs interval=%.1fs",
+        WORKER_OFFLINE_AFTER_SECONDS,
+        WORKER_SWEEP_INTERVAL_SECONDS,
+    )
+    while True:
+        try:
+            await asyncio.sleep(WORKER_SWEEP_INTERVAL_SECONDS)
+            await _sweep_stale_workers_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Stale-worker sweeper iteration failed")
+
+
+async def _sweep_stale_workers_once() -> int:
+    """One pass of the stale-worker sweep. Returns the number of agents
+    marked offline. Extracted for direct testing."""
+    cutoff = (datetime.now(UTC) - timedelta(seconds=WORKER_OFFLINE_AFTER_SECONDS)).isoformat()
+    async with AsyncSessionLocal() as db:
+        stale_agents = (
+            await db.execute(
+                select(Agent.id, Agent.guild_id, Agent.worker_id)
+                .where(Agent.state != "offline")
+                .where(Agent.last_seen.isnot(None))
+                .where(Agent.last_seen < cutoff)
+            )
+        ).all()
+        if not stale_agents:
+            return 0
+        stale_worker_keys: set[tuple[str, str]] = set()
+        for row in stale_agents:
+            await db.execute(
+                update(Agent)
+                .where(Agent.id == row.id, Agent.guild_id == row.guild_id)
+                .values(state="offline", activity=None)
+            )
+            if row.worker_id:
+                stale_worker_keys.add((row.worker_id, row.guild_id))
+            agent_owners.pop(row.id, None)
+        for worker_id, gid in stale_worker_keys:
+            await db.execute(
+                update(Worker)
+                .where(Worker.id == worker_id, Worker.guild_id == gid)
+                .values(state="offline")
+            )
+        await db.commit()
+    for row in stale_agents:
+        logger.warning(
+            "Marking %s offline: no ping in over %.0fs (guild=%s)",
+            row.id,
+            WORKER_OFFLINE_AFTER_SECONDS,
+            row.guild_id,
+        )
+        await broadcast(
+            row.guild_id,
+            {"type": "agent-state", "agentId": row.id, "state": "offline"},
+        )
+    return len(stale_agents)
 
 
 def generate_guild_id():
@@ -633,6 +756,20 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
             data = await websocket.receive_json()
             msg_type = data.get("type")
 
+            # Refresh last_seen for any inbound frame so the sweeper knows
+            # this worker is still alive. Cheap no-op for browser users
+            # (they don't carry an agentId/workerId).
+            await _touch_agent(db, guild_id, data.get("agentId"), data.get("workerId"))
+
+            if msg_type == "ping":
+                # Application-level heartbeat. Workers send this on an idle
+                # timer so quiet workers stay marked online; reply with pong
+                # so the worker can detect a half-open socket too.
+                await websocket.send_json(
+                    {"type": "pong", "timestamp": datetime.now(UTC).isoformat()}
+                )
+                continue
+
             if msg_type == "join":
                 agent_id = data.get("agentId")
                 agent_name = data.get("agentName", "Unknown")
@@ -647,6 +784,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     type=agent_type,
                     state="idle",
                     joined_at=joined_at,
+                    last_seen=joined_at,
                 )
                 stmt = stmt.on_conflict_do_update(
                     index_elements=["id"],
@@ -657,6 +795,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                         "type": stmt.excluded.type,
                         "state": stmt.excluded.state,
                         "joined_at": stmt.excluded.joined_at,
+                        "last_seen": stmt.excluded.last_seen,
                     },
                 )
                 await db.execute(stmt)
@@ -665,7 +804,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     await db.execute(
                         update(Worker)
                         .where(Worker.id == worker_id, Worker.guild_id == guild_id)
-                        .values(state="online")
+                        .values(state="online", last_seen=joined_at)
                     )
                 await db.commit()
                 if agent_id:

--- a/backend/models.py
+++ b/backend/models.py
@@ -27,6 +27,10 @@ class Agent(Base):
     state = Column(Text, nullable=False, server_default="idle")
     activity = Column(Text, nullable=True)
     joined_at = Column(Text, nullable=False)
+    # ISO-8601 UTC timestamp of the last message received from this agent over
+    # the WebSocket. Refreshed by every inbound frame (incl. application-level
+    # `ping`); the sweeper marks the agent offline when this gets stale.
+    last_seen = Column(Text, nullable=True)
 
 
 class Message(Base):
@@ -52,6 +56,7 @@ class Worker(Base):
     repos = Column(Text, nullable=False, server_default="[]")
     state = Column(Text, nullable=False, server_default="idle")
     created_at = Column(Text, nullable=False)
+    last_seen = Column(Text, nullable=True)
 
 
 class Task(Base):

--- a/backend/tests/test_liveness.py
+++ b/backend/tests/test_liveness.py
@@ -1,0 +1,320 @@
+"""Tests for WebSocket liveness tracking.
+
+Covers:
+  - inbound frames refresh ``last_seen`` on the agent and worker rows
+  - the ``ping`` message is answered with ``pong``
+  - the stale-worker sweeper marks workers offline once ``last_seen`` is
+    older than the configured threshold and broadcasts the state change
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+from starlette.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module  # noqa: E402
+import main as main_module  # noqa: E402
+from helpers import create_db as _create_db  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    """Module-scoped TestClient — one client per module to dodge the
+    starlette/anyio hang seen when a second TestClient is started against the
+    same singleton FastAPI app instance."""
+    tmp_path = tmp_path_factory.mktemp("liveness_db")
+    db_path = str(tmp_path / "test.db")
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+
+    os.environ["DATABASE_URL"] = db_url
+    _create_db(db_path)
+
+    new_engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+    new_session = async_sessionmaker(new_engine, expire_on_commit=False, class_=AsyncSession)
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(database_module, "AsyncSessionLocal", new_session)
+    mp.setattr(main_module, "AsyncSessionLocal", new_session)
+
+    async def _stubbed_init_db() -> None:
+        pass
+
+    mp.setattr(main_module, "init_db", _stubbed_init_db)
+    mp.setenv("DATABASE_URL", db_url)
+    mp.setenv("DB_PATH", db_path)
+
+    with TestClient(main_module.app) as c:
+        yield c, db_path
+
+    mp.undo()
+    os.environ.pop("DATABASE_URL", None)
+
+
+def _setup_guild_and_worker(db_path: str, guild_id: str, worker_id: str) -> None:
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO guilds (id, created_at, name) VALUES (?, ?, ?)",
+            (guild_id, now, "Test Guild"),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO workers (id, guild_id, repos, state, created_at)"
+            " VALUES (?, ?, '[]', 'online', ?)",
+            (worker_id, guild_id, now),
+        )
+        conn.commit()
+
+
+def _read_last_seen(db_path: str, agent_id: str, worker_id: str) -> tuple[str | None, str | None]:
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        agent = conn.execute("SELECT last_seen FROM agents WHERE id = ?", (agent_id,)).fetchone()
+        worker = conn.execute("SELECT last_seen FROM workers WHERE id = ?", (worker_id,)).fetchone()
+    return (agent["last_seen"] if agent else None, worker["last_seen"] if worker else None)
+
+
+def test_join_initialises_last_seen(client):
+    """A worker join sets last_seen on both the agent and worker rows."""
+    test_client, db_path = client
+    guild_id = "lvg001"
+    worker_id = "w-lva001"
+    agent_id = "a-lva001"
+
+    _setup_guild_and_worker(db_path, guild_id, worker_id)
+    before = datetime.now(UTC)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+        ws.send_json(
+            {
+                "type": "join",
+                "agentId": agent_id,
+                "agentName": "Test",
+                "agentType": "worker",
+                "workerId": worker_id,
+            }
+        )
+        ws.receive_json()  # agent-joined broadcast
+
+    agent_seen, worker_seen = _read_last_seen(db_path, agent_id, worker_id)
+    assert agent_seen is not None
+    assert worker_seen is not None
+    assert datetime.fromisoformat(agent_seen) >= before - timedelta(seconds=5)
+    assert datetime.fromisoformat(worker_seen) >= before - timedelta(seconds=5)
+
+
+def test_ping_message_replies_pong_and_refreshes_last_seen(client):
+    """Application-level ping is acknowledged with pong and bumps last_seen."""
+    test_client, db_path = client
+    guild_id = "lvg002"
+    worker_id = "w-lvb002"
+    agent_id = "a-lvb002"
+
+    _setup_guild_and_worker(db_path, guild_id, worker_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+        ws.send_json(
+            {
+                "type": "join",
+                "agentId": agent_id,
+                "agentName": "Test",
+                "agentType": "worker",
+                "workerId": worker_id,
+            }
+        )
+        ws.receive_json()  # agent-joined
+
+        # Force last_seen artificially old so we can detect the refresh.
+        old_ts = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("UPDATE agents SET last_seen = ? WHERE id = ?", (old_ts, agent_id))
+            conn.execute("UPDATE workers SET last_seen = ? WHERE id = ?", (old_ts, worker_id))
+            conn.commit()
+
+        # Heartbeat ping carries only workerId — backend looks up agents from
+        # the worker_id and refreshes them all together.
+        ws.send_json({"type": "ping", "workerId": worker_id})
+        reply = ws.receive_json()
+        assert reply["type"] == "pong"
+        assert "timestamp" in reply
+
+    agent_seen, worker_seen = _read_last_seen(db_path, agent_id, worker_id)
+    assert agent_seen is not None and agent_seen != old_ts
+    assert worker_seen is not None and worker_seen != old_ts
+
+
+def test_any_inbound_frame_touches_sibling_agents(client):
+    """A ping carrying agent slot 0's id must also refresh sibling slot rows
+    so that idle slots aren't swept offline while their parent worker is alive."""
+    test_client, db_path = client
+    guild_id = "lvg003"
+    worker_id = "w-lvc003"
+    slot0 = "a-lvc0a3"
+    slot1 = "a-lvc0b3"
+
+    _setup_guild_and_worker(db_path, guild_id, worker_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+        for aid in (slot0, slot1):
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": aid,
+                    "agentName": "Test",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # broadcast for each join
+
+        old_ts = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("UPDATE agents SET last_seen = ? WHERE worker_id = ?", (old_ts, worker_id))
+            conn.commit()
+
+        ws.send_json({"type": "ping", "workerId": worker_id})
+        ws.receive_json()  # pong
+
+    seen0, _ = _read_last_seen(db_path, slot0, worker_id)
+    seen1, _ = _read_last_seen(db_path, slot1, worker_id)
+    assert seen0 != old_ts, "slot 0 should be refreshed via the worker_id ping"
+    assert seen1 != old_ts, "slot 1 should be refreshed via the worker_id ping"
+
+
+def test_stale_sweeper_marks_silent_workers_offline(client, monkeypatch):
+    """The sweeper marks any agent whose last_seen is past the cutoff offline,
+    cascades to the worker row, and emits an agent-state offline broadcast."""
+    test_client, db_path = client
+    guild_id = "lvg004"
+    worker_id = "w-lvd004"
+    agent_id = "a-lvd004"
+
+    _setup_guild_and_worker(db_path, guild_id, worker_id)
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO agents "
+            "(id, guild_id, worker_id, name, type, state, joined_at, last_seen) "
+            "VALUES (?, ?, ?, 'Test', 'worker', 'idle', ?, ?)",
+            (agent_id, guild_id, worker_id, now, now),
+        )
+        # Backdate last_seen so the sweeper considers it stale.
+        old = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+        conn.execute("UPDATE agents SET last_seen = ? WHERE id = ?", (old, agent_id))
+        conn.execute("UPDATE workers SET last_seen = ? WHERE id = ?", (old, worker_id))
+        conn.commit()
+
+    # Open an observer connection to capture the offline broadcast.
+    with test_client.websocket_connect(f"/ws/{guild_id}") as observer:
+        # Tighten the threshold so the sweep triggers immediately for this test.
+        monkeypatch.setattr(main_module, "WORKER_OFFLINE_AFTER_SECONDS", 1.0)
+
+        async def _drive() -> int:
+            return await main_module._sweep_stale_workers_once()
+
+        marked = asyncio.run(_drive())
+        assert marked == 1
+
+        offline_msg = observer.receive_json()
+        assert offline_msg["type"] == "agent-state"
+        assert offline_msg["agentId"] == agent_id
+        assert offline_msg["state"] == "offline"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        a = conn.execute("SELECT state FROM agents WHERE id = ?", (agent_id,)).fetchone()
+        w = conn.execute("SELECT state FROM workers WHERE id = ?", (worker_id,)).fetchone()
+    assert a["state"] == "offline"
+    assert w["state"] == "offline"
+
+
+def test_migration_backfills_last_seen_for_existing_rows(tmp_path, monkeypatch):
+    """Pre-existing workers/agents must be stamped with last_seen when the
+    migration runs so the sweeper doesn't immediately mark them offline."""
+    import sqlite3
+
+    from alembic import command
+    from alembic.config import Config as AlembicConfig
+
+    db_path = str(tmp_path / "premigrate.db")
+    sync_url = f"sqlite+aiosqlite:///{db_path}"
+    alembic_ini = os.path.join(os.path.dirname(__file__), "..", "alembic.ini")
+
+    # alembic/env.py reads DATABASE_URL ahead of alembic.ini, so override it
+    # for both stages of the migration.
+    monkeypatch.setenv("DATABASE_URL", sync_url)
+
+    # Bring the DB only up to the previous head, then insert legacy rows that
+    # have no last_seen column yet.
+    cfg = AlembicConfig(alembic_ini)
+    command.upgrade(cfg, "c4d5e6f7a8b9")
+
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO guilds (id, created_at, name) VALUES ('mig001', ?, 'Mig')",
+            (now,),
+        )
+        conn.execute(
+            "INSERT INTO workers (id, guild_id, repos, state, created_at) "
+            "VALUES ('w-mig001', 'mig001', '[]', 'online', ?)",
+            (now,),
+        )
+        conn.execute(
+            "INSERT INTO agents (id, guild_id, worker_id, name, type, state, joined_at) "
+            "VALUES ('a-mig001', 'mig001', 'w-mig001', 'M', 'worker', 'idle', ?)",
+            (now,),
+        )
+        conn.commit()
+
+    # Apply the new head migration on the same DB.
+    command.upgrade(cfg, "head")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        w = conn.execute("SELECT last_seen FROM workers WHERE id = 'w-mig001'").fetchone()
+        a = conn.execute("SELECT last_seen FROM agents WHERE id = 'a-mig001'").fetchone()
+    assert w["last_seen"] is not None, "worker.last_seen should be backfilled by the migration"
+    assert a["last_seen"] is not None, "agent.last_seen should be backfilled by the migration"
+    # Stamped ~now (within a generous window for slow CI machines).
+    assert datetime.fromisoformat(w["last_seen"]) >= datetime.now(UTC) - timedelta(minutes=5)
+
+
+def test_sweeper_skips_fresh_workers(client):
+    """Agents whose last_seen is recent must not be touched by the sweeper."""
+    test_client, db_path = client
+    guild_id = "lvg005"
+    worker_id = "w-lve005"
+    agent_id = "a-lve005"
+
+    _setup_guild_and_worker(db_path, guild_id, worker_id)
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO agents "
+            "(id, guild_id, worker_id, name, type, state, joined_at, last_seen) "
+            "VALUES (?, ?, ?, 'Test', 'worker', 'idle', ?, ?)",
+            (agent_id, guild_id, worker_id, now, now),
+        )
+        conn.commit()
+
+    async def _drive() -> int:
+        return await main_module._sweep_stale_workers_once()
+
+    marked = asyncio.run(_drive())
+    assert marked == 0
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        a = conn.execute("SELECT state FROM agents WHERE id = ?", (agent_id,)).fetchone()
+    assert a["state"] == "idle"

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -680,6 +680,38 @@ class Worker:
         logger.info("Received %s — initiating graceful shutdown (signal again to force)", sig.name)
         loop.create_task(self._initiate_shutdown(f"signal {sig.name}"))
 
+    # Interval between application-level pings sent to the backend. Three
+    # missed heartbeats (~75s) is enough to trip the backend's 90s sweeper.
+    HEARTBEAT_INTERVAL_SECONDS: float = 25.0
+
+    async def _heartbeat(self) -> None:
+        """Send an application-level ping to the backend on a steady cadence.
+
+        The websockets library handles transport-level ping/pong on its own,
+        but the backend can't see those frames — its liveness tracking runs
+        on application messages. Without this loop a worker that finishes
+        all its tasks would go silent and the sweeper would mark it offline
+        even though the connection is healthy.
+        """
+        while not self._shutdown_event.is_set():
+            try:
+                await self._send(
+                    {
+                        "type": "ping",
+                        "workerId": self.cfg.worker_id,
+                        "timestamp": _now_iso(),
+                    }
+                )
+            except Exception as exc:
+                logger.debug("Heartbeat send failed (ignored): %s", exc)
+            try:
+                await asyncio.wait_for(
+                    self._shutdown_event.wait(), timeout=self.HEARTBEAT_INTERVAL_SECONDS
+                )
+                return  # shutdown event fired
+            except TimeoutError:
+                continue
+
     async def _notify_offline(self) -> None:
         """Send an explicit worker-disconnect message before the WebSocket closes.
 
@@ -756,11 +788,12 @@ class Worker:
 
         runners = [asyncio.create_task(self._agent_loop(slot)) for slot in self.slots]
         puller = asyncio.create_task(self._idle_puller())
+        heartbeat = asyncio.create_task(self._heartbeat())
         try:
-            # Wait for either: all runners exit (graceful shutdown), or the
-            # listener/puller crashes (unexpected).
+            # Wait for either: all runners exit (graceful shutdown), or one of
+            # the auxiliary tasks crashes (unexpected).
             done, _pending = await asyncio.wait(
-                [listener, puller, *runners],
+                [listener, puller, heartbeat, *runners],
                 return_when=asyncio.FIRST_COMPLETED,
             )
             # Surface any non-cancellation exception that fired first.
@@ -781,8 +814,9 @@ class Worker:
             # Stop the auxiliary tasks; the agent loops drain themselves.
             listener.cancel()
             puller.cancel()
+            heartbeat.cancel()
 
-            await asyncio.gather(listener, puller, *runners, return_exceptions=True)
+            await asyncio.gather(listener, puller, heartbeat, *runners, return_exceptions=True)
 
             if first_exc is not None:
                 raise first_exc
@@ -798,6 +832,10 @@ class Worker:
         async for msg in self.ws.messages():
             mtype = msg.get("type")
             logger.debug("WS message: type=%s keys=%s", mtype, list(msg.keys()))
+
+            if mtype == "pong":
+                # Heartbeat reply from the backend; nothing to do.
+                continue
 
             if mtype == "task-assigned":
                 if msg.get("workerId") != self.cfg.worker_id:

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -159,3 +159,59 @@ async def test_set_state_tracks_state_on_slot():
 
     await worker._set_state("awaiting-review", slot)
     assert slot.state == "awaiting-review"
+
+
+async def test_heartbeat_sends_ping_messages(monkeypatch):
+    """The heartbeat task must send periodic ping frames carrying worker_id +
+    slot 0's agent_id so the backend can refresh last_seen."""
+    monkeypatch.setattr(Worker, "HEARTBEAT_INTERVAL_SECONDS", 0.05)
+    worker = Worker(_make_cfg())
+    sent: list[dict] = []
+    worker._send = AsyncMock(side_effect=lambda p: sent.append(p))
+
+    task = asyncio.create_task(worker._heartbeat())
+    await asyncio.sleep(0.2)
+    worker._shutdown_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    pings = [m for m in sent if m.get("type") == "ping"]
+    assert pings, f"Expected at least one ping, got: {sent}"
+    first = pings[0]
+    assert first["workerId"] == "w-test01"
+    assert "timestamp" in first
+    # Heartbeat is a worker-level signal; it must not be tied to any agent slot.
+    assert "agentId" not in first
+
+
+async def test_heartbeat_stops_when_shutdown_signalled():
+    """_heartbeat must exit promptly once the shutdown event fires."""
+    worker = Worker(_make_cfg())
+    worker._send = AsyncMock()
+
+    worker._shutdown_event.set()
+    # Should return without hanging since shutdown is already signalled.
+    await asyncio.wait_for(worker._heartbeat(), timeout=2.0)
+
+
+async def test_heartbeat_swallows_send_failures(monkeypatch):
+    """A transient send failure must not kill the heartbeat loop."""
+    monkeypatch.setattr(Worker, "HEARTBEAT_INTERVAL_SECONDS", 0.02)
+    worker = Worker(_make_cfg())
+    calls = 0
+
+    async def flaky(_payload: dict) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("transient")
+
+    worker._send = flaky
+
+    async def stop_soon() -> None:
+        await asyncio.sleep(0.1)
+        worker._shutdown_event.set()
+
+    asyncio.create_task(stop_soon())
+    # Should not raise even though the first send failed.
+    await asyncio.wait_for(worker._heartbeat(), timeout=2.0)
+    assert calls >= 2, f"Loop should keep going after send failure, got {calls} calls"


### PR DESCRIPTION
Backend now records last_seen on every inbound WebSocket frame and runs a
periodic sweeper (default: 90s threshold, 30s interval) that marks any
worker — and all of its agent slots — offline if they haven't been heard
from. Workers send a workerId-only `ping` every 25s so quiet workers stay
alive between tasks; the backend replies with `pong`. The migration
backfills last_seen=now() for existing rows so a freshly-upgraded backend
doesn't immediately flag everyone offline.

https://claude.ai/code/session_01DXCERfG1piWAQLJdusJ6Mh