### PR TITLE
Worker startup error if no repos configured (#161)

### DIFF
--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -113,6 +113,17 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     log.info("Config loaded from %s", cfg.config_path)
+
+    if not cfg.repos:
+        msg = (
+            "Worker cannot start: no repos configured. "
+            "Set [github].repos in pioneer-worker.toml, pass --repo OWNER/REPO, "
+            "or set PIONEER_REPOS."
+        )
+        log.error(msg)
+        print(f"error: {msg}", file=sys.stderr)
+        return 2
+
     worker = Worker(cfg)
     try:
         asyncio.run(worker.run())

--- a/worker/tests/test_cli.py
+++ b/worker/tests/test_cli.py
@@ -1,0 +1,57 @@
+"""Unit tests for pioneer_worker.cli startup validation."""
+
+from __future__ import annotations
+
+from pioneer_worker import cli
+
+
+def _write_toml(tmp_path, body: str):
+    p = tmp_path / "pioneer-worker.toml"
+    p.write_text(body)
+    return p
+
+
+def test_cli_exits_when_no_repos_configured(tmp_path, capsys, caplog):
+    """No repos in config -> exit 2 before constructing the Worker."""
+    toml_path = _write_toml(
+        tmp_path,
+        'backend_url = "ws://x:1"\nguild_id = "g"\n',
+    )
+    rc = cli.main(["--config", str(toml_path)])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "no repos configured" in err.lower()
+    assert any("no repos configured" in r.message.lower() for r in caplog.records)
+
+
+def test_cli_exits_when_repos_list_empty(tmp_path, capsys):
+    """Explicitly empty repos list also fails the check."""
+    toml_path = _write_toml(
+        tmp_path,
+        'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\nrepos = []\n',
+    )
+    rc = cli.main(["--config", str(toml_path)])
+    assert rc == 2
+    assert "no repos configured" in capsys.readouterr().err.lower()
+
+
+def test_cli_repos_check_passes_with_cli_override(tmp_path, monkeypatch):
+    """A --repo override satisfies the check; we stub Worker.run to avoid network."""
+    toml_path = _write_toml(
+        tmp_path,
+        'backend_url = "ws://x:1"\nguild_id = "g"\n',
+    )
+
+    captured = {}
+
+    class _FakeWorker:
+        def __init__(self, cfg):
+            captured["repos"] = list(cfg.repos)
+
+        async def run(self):
+            return None
+
+    monkeypatch.setattr(cli, "Worker", _FakeWorker)
+    rc = cli.main(["--config", str(toml_path), "--repo", "owner/repo"])
+    assert rc == 0
+    assert captured["repos"] == ["owner/repo"]


### PR DESCRIPTION
## Summary
- Validate `cfg.repos` during worker CLI startup; if empty, log `Worker cannot start: no repos configured` (with hints on how to fix), print to stderr, and exit `2` before constructing the `Worker` — so it never registers and never appears online.
- Added `worker/tests/test_cli.py` covering the empty-repos failure (missing block + explicit `repos = []`) and the happy path via `--repo` override.

## Test plan
- [x] `pytest` in `worker/` — 65 passed (was 62 + 3 new)
- [x] `ruff check . --fix && ruff format .` clean
- [ ] Manual: run `pioneer-worker` with a TOML missing `[github].repos` and confirm exit code 2 + clear error

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)