### PR TITLE
fix agent/worker name display in sidebar and tabs

### DIFF
--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -93,7 +93,7 @@
         <!-- Worker row -->
         <div class="worker-row" :class="worker.state" @click="agentsStore.selectWorker(worker.id)">
           <span class="worker-dot" :class="'wdot-' + worker.state"></span>
-          <span class="worker-row-name">{{ worker.id }}</span>
+          <span class="worker-row-name">{{ worker.name }}</span>
           <span class="worker-row-state">{{ worker.state }}</span>
         </div>
         <!-- Agent rows under this worker -->

--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -30,7 +30,7 @@
         @click="onWorkerTabClick($event, worker.id)"
       >
         <span class="state-dot" :class="worker.state"></span>
-        <span class="tab-label">{{ worker.id }}</span>
+        <span class="tab-label">{{ worker.name }}</span>
         <span class="tab-close">×</span>
       </button>
       <!-- Task tabs — only shown when explicitly opened -->

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -572,12 +572,18 @@ class Worker:
         split = 2 + sum(ord(c) for c in raw) % 3
         droid = f"{raw[:split]}-{raw[split:]}"
         name = self.cfg.worker_name or f"{host_prefix}/{droid}"
-        for slot in self.slots:
+        # Each slot needs a distinct display name. The frontend derives the
+        # worker name from any agent name by stripping a trailing /N suffix
+        # (see frontend/src/stores/agents.ts), so the convention is
+        # "<worker-name>/<slot-index>".
+        multi_slot = len(self.slots) > 1
+        for idx, slot in enumerate(self.slots, start=1):
+            agent_name = f"{name}/{idx}" if multi_slot else name
             await self._send(
                 {
                     "type": "join",
                     "agentId": slot.agent_id,
-                    "agentName": name,
+                    "agentName": agent_name,
                     "agentType": "worker",
                     "workerId": self.cfg.worker_id,
                 }

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -113,6 +113,37 @@ async def test_on_ws_reconnect_resends_join_and_register():
     assert {m["agentId"] for m in join_msgs} == {s.agent_id for s in worker.slots}
 
 
+async def test_join_assigns_distinct_names_per_slot():
+    """Each agent slot must get a distinct name so the UI can tell them apart.
+    The frontend strips a trailing /N to derive the worker name, so multi-slot
+    workers must send "<worker-name>/<slot-index>" per slot."""
+    cfg = _make_cfg(worker_name="mybot")
+    cfg.max_agents = 3
+    worker = Worker(cfg)
+    sent: list[dict] = []
+    worker._send = AsyncMock(side_effect=lambda p: sent.append(p))
+
+    await worker._join()
+
+    join_msgs = [m for m in sent if m.get("type") == "join"]
+    names = [m["agentName"] for m in join_msgs]
+    assert names == ["mybot/1", "mybot/2", "mybot/3"], names
+
+
+async def test_join_single_slot_uses_bare_worker_name():
+    """A single-slot worker shouldn't get a noisy /1 suffix."""
+    cfg = _make_cfg(worker_name="solo")
+    cfg.max_agents = 1
+    worker = Worker(cfg)
+    sent: list[dict] = []
+    worker._send = AsyncMock(side_effect=lambda p: sent.append(p))
+
+    await worker._join()
+
+    join_msgs = [m for m in sent if m.get("type") == "join"]
+    assert [m["agentName"] for m in join_msgs] == ["solo"]
+
+
 async def test_on_ws_reconnect_skips_join_before_auth():
     """A WS reconnect during the auth window must not register agents early."""
     worker = Worker(_make_cfg())


### PR DESCRIPTION
The worker was sending the same agent name (the worker name) for every
slot, so the sidebar showed identical names for all of a worker's agents.
The frontend already expects "<worker-name>/<index>" — its workers list
strips a trailing /N to derive the worker name — so emit per-slot indices
when a worker has more than one slot.

The MainView worker tabs and the sidebar worker rows were also rendering
worker.id ("w-abcdef") instead of worker.name, so even after the worker
sends a real name the human-readable label never showed up.