### PR TITLE
Foreman only sees online workers

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -47,6 +47,9 @@ Be concise — one short paragraph maximum unless detail is requested.\
 """
 
 
+_EMPTY_WORKERS_BLOCKS = {"[]", "[\n]"}
+
+
 def build_system_prompt(
     workers_block: str,
     tasks_block: str,
@@ -60,9 +63,17 @@ def build_system_prompt(
         if primary_repo
         else ""
     )
+    if workers_block.strip() in _EMPTY_WORKERS_BLOCKS:
+        workers_section = (
+            "## Current workers\n"
+            "_No workers are currently online. Tell the human that no workers are "
+            "available and wait for one to come online before assigning work._\n\n"
+        )
+    else:
+        workers_section = f"## Current workers\n```json\n{workers_block}\n```\n\n"
     parts = [
         f"{FOREMAN_SYSTEM}{repo_line}\n\n",
-        f"## Current workers\n```json\n{workers_block}\n```\n\n",
+        workers_section,
         f"## Recent tasks\n```json\n{tasks_block}\n```",
     ]
     if extra_context:

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -356,6 +356,35 @@ def reset_foreman_poll(guild_id: str) -> None:
     _poll_tasks[guild_id] = task
 
 
+async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
+    """Return workers visible to the Foreman: only those whose ``state == 'online'``.
+
+    Offline workers can't accept task assignments, so listing them in the system
+    prompt just invites bad routing decisions. Orphan agents (no ``worker_id``)
+    that are non-offline are still surfaced for legacy compatibility.
+    """
+    from sqlalchemy import text
+
+    result = await db.execute(
+        text(
+            "SELECT w.id, w.repos, w.state as worker_state,"
+            " COUNT(a.id) as agent_count,"
+            " GROUP_CONCAT(a.id || ':' || a.state) as agents"
+            " FROM workers w"
+            " LEFT JOIN agents a ON a.worker_id = w.id AND a.state != 'offline'"
+            " WHERE w.guild_id = :guild_id AND w.state = 'online'"
+            " GROUP BY w.id"
+            " UNION ALL"
+            " SELECT a.id, '[]', a.state, 1, a.id || ':' || a.state"
+            " FROM agents a"
+            " WHERE a.guild_id = :guild_id AND a.type = 'worker'"
+            " AND a.worker_id IS NULL AND a.state != 'offline'"
+        ),
+        {"guild_id": guild_id},
+    )
+    return [dict(r._mapping) for r in result.fetchall()]
+
+
 async def run_foreman_ai(
     guild_id: str,
     human_message: str,
@@ -381,8 +410,6 @@ async def run_foreman_ai(
         user_id = await _get_guild_user_id(guild_id) or guild_id
 
     # Build live context for the system prompt
-    from sqlalchemy import text
-
     db = await get_db()
     try:
         guild_result = await db.execute(
@@ -391,24 +418,7 @@ async def run_foreman_ai(
         guild_row = guild_result.one_or_none()
         primary_repo = guild_row.primary_repo if guild_row else None
 
-        result = await db.execute(
-            text(
-                "SELECT w.id, w.repos, w.state as worker_state,"
-                " COUNT(a.id) as agent_count,"
-                " GROUP_CONCAT(a.id || ':' || a.state) as agents"
-                " FROM workers w"
-                " LEFT JOIN agents a ON a.worker_id = w.id AND a.state != 'offline'"
-                " WHERE w.guild_id = :guild_id"
-                " GROUP BY w.id"
-                " UNION ALL"
-                " SELECT a.id, '[]', a.state, 1, a.id || ':' || a.state"
-                " FROM agents a"
-                " WHERE a.guild_id = :guild_id AND a.type = 'worker'"
-                " AND a.worker_id IS NULL AND a.state != 'offline'"
-            ),
-            {"guild_id": guild_id},
-        )
-        worker_rows = [dict(r._mapping) for r in result.fetchall()]
+        worker_rows = await _fetch_online_workers(db, guild_id)
         task_result = await db.execute(
             select(
                 Task.id,

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -170,6 +170,87 @@ class TestBuildSystemPrompt:
         prompt = build_system_prompt('["w1"]', '["t1"]')
         assert prompt.startswith(FOREMAN_SYSTEM)
 
+    def test_empty_workers_renders_no_workers_message(self):
+        prompt = build_system_prompt("[]", "[]")
+        assert "## Current workers" in prompt
+        assert "No workers are currently online" in prompt
+        # Should not render an empty JSON code block when there are no workers
+        assert "```json\n[]\n```" not in prompt.split("## Recent tasks", 1)[0]
+
+    def test_pretty_printed_empty_workers_renders_no_workers_message(self):
+        # json.dumps([], indent=2) produces "[]" but be defensive about whitespace
+        prompt = build_system_prompt("[\n]", "[]")
+        assert "No workers are currently online" in prompt
+
+    def test_non_empty_workers_renders_json_block(self):
+        workers = '[{"id": "w-abc", "state": "online"}]'
+        prompt = build_system_prompt(workers, "[]")
+        assert workers in prompt
+        assert "No workers are currently online" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# 1b. _fetch_online_workers (filters workers by state=='online')
+# ---------------------------------------------------------------------------
+
+
+def _insert_worker_with_state(db_path: str, guild_id: str, worker_id: str, state: str) -> None:
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO workers (id, guild_id, repos, state, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (worker_id, guild_id, "[]", state, now),
+        )
+        conn.commit()
+
+
+class TestFetchOnlineWorkers:
+    @pytest.mark.asyncio
+    async def test_excludes_offline_workers(self, db_session):
+        from foreman.runner import _fetch_online_workers
+
+        guild_id = "g-fetch1"
+        insert_guild(db_session, guild_id)
+        _insert_worker_with_state(db_session, guild_id, "w-online1", "online")
+        _insert_worker_with_state(db_session, guild_id, "w-offline1", "offline")
+        _insert_worker_with_state(db_session, guild_id, "w-idle1", "idle")
+
+        async with database_module.AsyncSessionLocal() as db:
+            rows = await _fetch_online_workers(db, guild_id)
+
+        ids = {row["id"] for row in rows}
+        assert ids == {"w-online1"}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_online_workers(self, db_session):
+        from foreman.runner import _fetch_online_workers
+
+        guild_id = "g-fetch2"
+        insert_guild(db_session, guild_id)
+        _insert_worker_with_state(db_session, guild_id, "w-offline2", "offline")
+
+        async with database_module.AsyncSessionLocal() as db:
+            rows = await _fetch_online_workers(db, guild_id)
+
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_scopes_to_guild(self, db_session):
+        from foreman.runner import _fetch_online_workers
+
+        guild_a = "g-fetch3a"
+        guild_b = "g-fetch3b"
+        insert_guild(db_session, guild_a)
+        insert_guild(db_session, guild_b)
+        _insert_worker_with_state(db_session, guild_a, "w-a", "online")
+        _insert_worker_with_state(db_session, guild_b, "w-b", "online")
+
+        async with database_module.AsyncSessionLocal() as db:
+            rows = await _fetch_online_workers(db, guild_a)
+
+        assert {row["id"] for row in rows} == {"w-a"}
+
 
 # ---------------------------------------------------------------------------
 # 2. _serialize_content (runner helper)


### PR DESCRIPTION
## Summary
- Filter the Foreman's worker context to only workers with `state == 'online'` so offline workers are completely absent from the system prompt
- Extracted the worker query into `_fetch_online_workers()` for testability
- When no workers are online, render a clear "no workers available" message in the system prompt instead of an empty `[]` JSON block, so the Foreman tells the human and waits rather than trying to assign tasks
- Added tests covering the SQL filter (offline/idle excluded, online included, scoped per-guild) and the empty-workers prompt rendering

Closes #162

## Test plan
- [x] `python -m pytest` in `backend/` (171 passed)
- [x] `ruff check . --fix && ruff format .` from repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)