### PR TITLE
assign_task system message: name only, not full description (#155)

### DIFF
--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -421,9 +421,10 @@ function handleTaskEvent(data: WSMessage) {
       createdAt: new Date().toISOString(),
     })
   } else if (data.type === 'task-assigned') {
+    const taskName = (data.name || (data.description || '')).slice(0, 60)
     guildStore.messages.push({
       type: 'chat', from: 'system', to: 'user',
-      content: `→ ${data.workerId} assigned: ${data.description}`,
+      content: `→ ${data.workerId} assigned: ${taskName}`,
       createdAt: new Date().toISOString(),
     })
   } else if (data.type === 'foreman-poll-status') {


### PR DESCRIPTION
## Summary

When the Foreman assigns a task, the chat banner now shows only the task name (≤60 chars) instead of the full description. The full description still reaches the worker unchanged via the task payload.

- `frontend/src/components/ChatPane.vue` (task-assigned handler): render `data.name` (falling back to a 60-char description slice for older events) instead of `data.description`.

The `task-assigned` WS payload from the backend already includes both `name` and `description`, so no backend or worker change is required — the worker still receives the full description.

Closes #155

## Test plan

- [ ] Foreman assigns a task: chat shows `→ w-xxxxxx assigned: <name>` (≤60 chars), not the full description.
- [ ] Worker still receives the full task description and runs it.
- [ ] Tasks list (sidebar) is unchanged.