### PR TITLE
Increase foreman recent tasks list to 20 (#170)

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -432,7 +432,7 @@ async def run_foreman_ai(
             )
             .where(Task.guild_id == guild_id)
             .order_by(Task.created_at.desc())
-            .limit(10)
+            .limit(20)
         )
         task_rows = [
             {**dict(r._mapping), "description": dict(r._mapping).get("description") or ""}
@@ -459,7 +459,7 @@ async def run_foreman_ai(
     summarized_tasks = [
         s for row in task_rows if (s := _summarize_task(row, cutoff_ts)) is not None
     ]
-    tasks_block = json.dumps(summarized_tasks[:6], indent=2)
+    tasks_block = json.dumps(summarized_tasks[:20], indent=2)
     system = build_system_prompt(
         workers_block, tasks_block, extra_context, primary_repo=primary_repo
     )


### PR DESCRIPTION
## Summary
- Bumps the foreman system prompt's "Recent tasks" cap from 6 to 20 by widening both the SQL `LIMIT` (10 → 20) and the in-memory slice (`[:6]` → `[:20]`) in `backend/foreman/runner.py`.

Closes #170

## Test plan
- [ ] `cd backend && python -m pytest tests/test_foreman.py tests/test_guild_api.py`
- [ ] Manually verify with >6 recent tasks that the foreman system prompt now lists up to 20 in the `## Recent tasks` JSON block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)