### PR TITLE
Add shutdown_worker tool to the Foreman (#153)

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -12,6 +12,8 @@ additional work in the same worktree, or finalize_task when done
 - Message workers mid-task via message_worker for context
 - Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
 - Cancel tasks that are going wrong or are no longer needed via cancel_task
+- Shut down a misbehaving or no-longer-needed worker process via shutdown_worker \
+(graceful: idle agents exit immediately, busy agents finish their current task)
 - Summarise status and outcomes when asked
 - Escalate to the human only when genuinely stuck
 
@@ -41,6 +43,7 @@ the worker's PR references the issue automatically.
 Use get_task_status to verify a task is making progress — it returns the current state,
 the active agent and its state, and the last log lines. If a task looks stalled, use
 redirect_task to course-correct or cancel_task if it's going in the wrong direction.
+If an entire worker is wedged or no longer needed, use shutdown_worker to stop the process.
 
 Workers are configured with repos. Prefer workers whose repos cover the task.
 Be concise — one short paragraph maximum unless detail is requested.\

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -181,6 +181,30 @@ FOREMAN_TOOLS = [
         },
     },
     {
+        "name": "shutdown_worker",
+        "description": (
+            "Send a shutdown signal to a worker agent, causing it to gracefully stop. "
+            "Idle agents exit immediately; busy agents finish their current task and skip "
+            "the follow-up window. The worker process disconnects and transitions to offline. "
+            "Use when a worker is misbehaving, the operator is winding down, or a host needs "
+            "to be freed up — prefer cancel_task for stopping a single bad task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "worker_id": {
+                    "type": "string",
+                    "description": "Worker agent ID (e.g. w-abc123).",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Optional reason for shutdown.",
+                },
+            },
+            "required": ["worker_id"],
+        },
+    },
+    {
         "name": "list_github_issues",
         "description": (
             "List GitHub issues for a repo. Use this to discover work that needs to be done."
@@ -703,6 +727,23 @@ async def exec_tools(guild_id: str, tool_uses: list) -> list:
                             result_text = f"Task {task_id} cancelled." + (
                                 f" Reason: {reason}" if reason else ""
                             )
+
+                elif tu.name == "shutdown_worker":
+                    wid = inp["worker_id"]
+                    reason = inp.get("reason", "")
+                    worker_result = await db.execute(
+                        select(Worker.id).where(Worker.id == wid, Worker.guild_id == guild_id)
+                    )
+                    if worker_result.scalar_one_or_none() is None:
+                        result_text = f"Worker {wid} not found."
+                    else:
+                        message: dict = {"type": "worker-shutdown", "workerId": wid}
+                        if reason:
+                            message["reason"] = reason
+                        await broadcast(guild_id, message)
+                        result_text = f"Shutdown signal sent to {wid}." + (
+                            f" Reason: {reason}" if reason else ""
+                        )
 
                 elif tu.name == "get_task_status":
                     task_id = inp["task_id"]

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -557,6 +557,53 @@ class TestExecToolsDispatching:
             row = conn.execute("SELECT state FROM tasks WHERE id='t-cpend'").fetchone()
         assert row[0] == "cancelled"
 
+    async def test_shutdown_worker_not_found(self, db_session):
+        insert_guild(db_session, "g-sd-missing")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-sd-missing",
+                [_fake_tool_use("shutdown_worker", {"worker_id": "w-nosuch"})],
+            )
+        assert "not found" in results[0]["content"].lower()
+
+    async def test_shutdown_worker_broadcasts_signal(self, db_session):
+        insert_guild(db_session, "g-sd-ok")
+        _insert_worker(db_session, "g-sd-ok", "w-sd")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock) as mock_bcast:
+            results = await exec_tools(
+                "g-sd-ok",
+                [
+                    _fake_tool_use(
+                        "shutdown_worker",
+                        {"worker_id": "w-sd", "reason": "winding down"},
+                    )
+                ],
+            )
+        assert "shutdown signal sent" in results[0]["content"].lower()
+        assert "winding down" in results[0]["content"]
+        # The handler must broadcast a worker-shutdown message targeting the worker.
+        shutdown_calls = [
+            c for c in mock_bcast.await_args_list if c.args[1].get("type") == "worker-shutdown"
+        ]
+        assert len(shutdown_calls) == 1
+        payload = shutdown_calls[0].args[1]
+        assert payload["workerId"] == "w-sd"
+        assert payload.get("reason") == "winding down"
+
+    async def test_shutdown_worker_omits_reason_when_blank(self, db_session):
+        insert_guild(db_session, "g-sd-noreason")
+        _insert_worker(db_session, "g-sd-noreason", "w-sd2")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock) as mock_bcast:
+            await exec_tools(
+                "g-sd-noreason",
+                [_fake_tool_use("shutdown_worker", {"worker_id": "w-sd2"})],
+            )
+        shutdown_calls = [
+            c for c in mock_bcast.await_args_list if c.args[1].get("type") == "worker-shutdown"
+        ]
+        assert len(shutdown_calls) == 1
+        assert "reason" not in shutdown_calls[0].args[1]
+
     async def test_get_task_status_not_found(self, db_session):
         insert_guild(db_session, "g-status-missing")
         with patch("foreman.tools.broadcast", new_callable=AsyncMock):


### PR DESCRIPTION
## Summary
- Adds a `shutdown_worker` tool to the Foreman AI that broadcasts a `worker-shutdown` WS message targeting a specific worker. The worker already handles this signal — idle agents exit immediately, busy agents finish their current task and skip the follow-up window, then the process disconnects and the worker transitions to `offline`.
- Documents the new tool in the Foreman system prompt alongside `cancel_task`, including when to prefer worker-level shutdown over per-task cancellation.
- Adds unit tests covering the not-found path, a successful broadcast (with reason), and the no-reason variant.

Closes #153

## Test plan
- [x] `cd backend && python -m pytest` (174 passed)
- [x] `ruff check . && ruff format .` (clean)
- [ ] Manual smoke: from the foreman chat, ask it to shut down a worker and verify the worker's `agent-state` flips to `offline` and the process exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)