### PR TITLE
Review worker docs & define standard toolchain (#173)

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -5,15 +5,28 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     DEBIAN_FRONTEND=noninteractive
 
-# Base system tools needed to add external repos
+# Baseline system tools coding agents need to build, test, and lint typical
+# full-stack repos. Keep the list focused — only add things an agent would
+# otherwise have to bootstrap mid-task.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git curl ca-certificates gnupg \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        make \
+        openssh-client \
+        ripgrep \
+        unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Node.js 22 (setup script runs its own apt-get update)
+# Node.js 24 (setup script runs its own apt-get update). Corepack lets
+# repos pinned to pnpm/yarn via `packageManager` work without extra setup.
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable
 
 # GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -23,6 +36,22 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
+
+# Go toolchain — install the official tarball; the Debian package lags upstream.
+ARG GO_VERSION=1.23.4
+RUN ARCH=$(dpkg --print-architecture) \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" \
+        | tar -C /usr/local -xz
+ENV GOPATH=/home/worker/go \
+    PATH=/usr/local/go/bin:/home/worker/go/bin:/home/worker/.local/bin:$PATH
+
+# Shared Python tooling: ruff (lint/format), pytest (tests), uv (fast
+# resolver/installer), pipx (sandboxed CLI installs).
+RUN pip install --no-cache-dir \
+        ruff \
+        pytest \
+        uv \
+        pipx
 
 # AI coding CLIs — this layer is the one most likely to update
 RUN npm install -g \
@@ -37,7 +66,7 @@ COPY pioneer_worker ./pioneer_worker
 RUN pip install -e .
 
 RUN useradd --create-home --shell /bin/bash worker \
-    && mkdir -p /work/repos /work/worktrees /config \
+    && mkdir -p /work/repos /work/worktrees /config /home/worker/go \
     && chown -R worker:worker /work /config /home/worker
 
 USER worker

--- a/worker/README.md
+++ b/worker/README.md
@@ -20,6 +20,49 @@ pip install -e .
 
 This installs the `pioneer-worker` console script.
 
+## Expected toolchain
+
+A worker shells out to a coding agent (`claude`, `codex`, or `pi`), which in
+turn runs whatever the task needs — installing dependencies, running tests,
+linting, building, opening PRs. To keep agents from having to bootstrap a
+language runtime mid-task, every worker host should have the following
+pre-installed and on `PATH`:
+
+**Core**
+
+- `git`, `curl`, `jq`, `make`, `unzip`, `openssh-client`, `ripgrep`
+- A C/C++ toolchain (`build-essential` on Debian — needed to compile native
+  Python wheels and Node addons)
+- [`gh`](https://cli.github.com/) — used by agents to inspect issues and PRs
+
+**Python 3.11+**
+
+- `python3`, `pip`, `venv`
+- [`ruff`](https://docs.astral.sh/ruff/) (lint + format)
+- [`pytest`](https://docs.pytest.org/)
+- [`uv`](https://docs.astral.sh/uv/) (fast resolver/installer used by some repos)
+- [`pipx`](https://pipx.pypa.io/) (sandboxed CLI installs)
+
+**Node.js 24+**
+
+- `node`, `npm`, `npx`
+- `corepack` enabled, so repos pinned to `pnpm`/`yarn` via `packageManager` work
+- The agent CLIs themselves: `@anthropic-ai/claude-code`, `@openai/codex`,
+  `@mariozechner/pi-coding-agent`
+
+**Go 1.23+**
+
+- `go` on `PATH`, with `GOPATH` writable by the worker user
+
+The `worker/Dockerfile` provisions exactly this set, so anything `docker
+compose --profile worker up` builds is already correct. If you run the worker
+directly on a host, install the equivalents through your package manager
+(`apt`, `brew`, etc.) before launching it.
+
+Anything outside this baseline (Rust, Java, Ruby, .NET, Terraform, etc.) is
+expected to be installed on demand by the task itself, or added to the
+Dockerfile in a follow-up PR if it becomes a recurring need.
+
 ## Configure
 
 Copy the example config and edit it:


### PR DESCRIPTION
## Summary

Audits the worker image's pre-installed toolchain and fills the gaps that
came up in #173. Coding agents shouldn't have to install a language runtime
mid-task to run tests, lint, build, or open a PR.

### Dockerfile changes (`worker/Dockerfile`)

- Add `build-essential`, `jq`, `make`, `openssh-client`, `ripgrep`, `unzip`
  to the apt baseline (needed for native wheel/Node-addon builds, JSON
  munging, ssh git remotes, fast search, and unpacking artifacts).
- Add a Go toolchain (official tarball, `GO_VERSION` build arg, default
  `1.23.4`) with `GOPATH=/home/worker/go` on `PATH`.
- Add Python tooling globally: `ruff`, `pytest`, `uv`, `pipx`.
- Enable `corepack` so repos pinned to `pnpm`/`yarn` via `packageManager`
  work without extra setup.
- Fix a stale comment that said "Node.js 22" while installing `setup_24.x`.

### Documentation changes (`worker/README.md`)

- New **Expected toolchain** section listing the pre-installed Core /
  Python / Node.js / Go tooling, so operators running workers on bare
  metal know what to install, and agents know what they can rely on.
- Notes that anything outside the baseline (Rust, Java, Ruby, .NET, etc.)
  is expected to be bootstrapped per task or added in a follow-up if it
  becomes recurring.

Closes #173

## Test plan

- [ ] `docker compose --profile worker build worker` succeeds on linux/amd64
- [ ] `docker compose --profile worker build worker` succeeds on linux/arm64
- [ ] Inside the built image: `python3 --version`, `pip --version`,
      `ruff --version`, `pytest --version`, `uv --version`, `pipx --version`,
      `node --version`, `npm --version`, `npx --version`, `corepack --version`,
      `go version`, `git --version`, `gh --version`, `jq --version`,
      `make --version`, `rg --version`, `ssh -V`, `claude --version`,
      `codex --version`, `pi --version` all work
- [ ] As the `worker` user: `go install example.com/foo@latest` lands in
      `/home/worker/go/bin` and is on `PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)