### PR TITLE
Full user model with guild permissions and worker user flag (#66)

### DIFF
--- a/backend/alembic/versions/f4a5b6c7d8e9_add_users_and_guild_members.py
+++ b/backend/alembic/versions/f4a5b6c7d8e9_add_users_and_guild_members.py
@@ -9,7 +9,7 @@ Backfill notes:
 - Every existing guild with ``github_user_id`` set gets an ``owner`` membership.
 
 Revision ID: f4a5b6c7d8e9
-Revises: e3f4a5b6c7d8
+Revises: d5e6f7a8b9c0
 Create Date: 2026-05-02 00:00:00.000000
 
 """
@@ -20,7 +20,7 @@ from alembic import op
 
 
 revision: str = "f4a5b6c7d8e9"
-down_revision: Union[str, Sequence[str], None] = "e3f4a5b6c7d8"
+down_revision: Union[str, Sequence[str], None] = "d5e6f7a8b9c0"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/f4a5b6c7d8e9_add_users_and_guild_members.py
+++ b/backend/alembic/versions/f4a5b6c7d8e9_add_users_and_guild_members.py
@@ -1,0 +1,83 @@
+"""add_users_and_guild_members
+
+Adds a canonical ``users`` table and a ``guild_members`` table with a per-guild
+role (owner/member/viewer). Also adds ``workers.user_id`` so a worker process
+can attribute its actions to a specific human.
+
+Backfill notes:
+- Every existing ``github_tokens`` row becomes a ``users`` row (id == github_user_id).
+- Every existing guild with ``github_user_id`` set gets an ``owner`` membership.
+
+Revision ID: f4a5b6c7d8e9
+Revises: e3f4a5b6c7d8
+Create Date: 2026-05-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "f4a5b6c7d8e9"
+down_revision: Union[str, Sequence[str], None] = "e3f4a5b6c7d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("github_id", sa.Text(), nullable=False),
+        sa.Column("github_login", sa.Text(), nullable=True),
+        sa.Column("email", sa.Text(), nullable=True),
+        sa.Column("display_name", sa.Text(), nullable=True),
+        sa.Column("avatar_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("github_id"),
+    )
+
+    op.create_table(
+        "guild_members",
+        sa.Column("guild_id", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), server_default="member", nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("guild_id", "user_id"),
+    )
+
+    with op.batch_alter_table("workers") as batch_op:
+        batch_op.add_column(sa.Column("user_id", sa.Text(), nullable=True))
+
+    # Backfill users from github_tokens (one row per known GitHub user).
+    op.execute(
+        """
+        INSERT INTO users (id, github_id, github_login, created_at, updated_at)
+        SELECT github_user_id, github_user_id, github_username, created_at, updated_at
+        FROM github_tokens
+        WHERE github_user_id IS NOT NULL
+        """
+    )
+
+    # Backfill owner membership for guilds that already have a linked user.
+    op.execute(
+        """
+        INSERT INTO guild_members (guild_id, user_id, role, created_at)
+        SELECT g.id, g.github_user_id, 'owner', g.created_at
+        FROM guilds g
+        WHERE g.github_user_id IS NOT NULL
+          AND g.github_user_id IN (SELECT id FROM users)
+        """
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workers") as batch_op:
+        batch_op.drop_column("user_id")
+    op.drop_table("guild_members")
+    op.drop_table("users")

--- a/backend/main.py
+++ b/backend/main.py
@@ -399,9 +399,7 @@ async def _ensure_membership(db, guild_id: str, user_id: str) -> str:
     on the guild row and no member rows; treat that owner as a member so the
     pre-migration UI keeps working without a manual repair step.
     """
-    g_res = await db.execute(
-        select(Guild.id, Guild.github_user_id).where(Guild.id == guild_id)
-    )
+    g_res = await db.execute(select(Guild.id, Guild.github_user_id).where(Guild.id == guild_id))
     grow = g_res.first()
     if not grow:
         raise HTTPException(status_code=404, detail="Guild not found")
@@ -427,9 +425,7 @@ async def _resolve_user_identifier(db, identifier: str) -> str | None:
     ident = (identifier or "").strip()
     if not ident:
         return None
-    res = await db.execute(
-        select(User.id).where((User.id == ident) | (User.github_login == ident))
-    )
+    res = await db.execute(select(User.id).where((User.id == ident) | (User.github_login == ident)))
     return res.scalar_one_or_none()
 
 
@@ -676,6 +672,57 @@ async def get_me(github_user_id: str = Depends(require_user)):
         await db.close()
 
 
+@app.get("/api/me")
+async def api_me(github_user_id: str = Depends(require_user)):
+    """Return the current user's profile + their guild memberships.
+
+    Includes legacy guilds owned via ``guilds.github_user_id`` even when no
+    ``guild_members`` row exists, so the UI never sees a logged-in owner with
+    zero guilds just because their backfill row is missing.
+    """
+    db = await get_db()
+    try:
+        u_res = await db.execute(select(User).where(User.id == github_user_id))
+        user = u_res.scalar_one_or_none()
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        explicit = await db.execute(
+            select(GuildMember.guild_id, GuildMember.role, Guild.name)
+            .join(Guild, Guild.id == GuildMember.guild_id)
+            .where(GuildMember.user_id == github_user_id)
+        )
+        memberships = {
+            row.guild_id: {
+                "guild_id": row.guild_id,
+                "guild_name": row.name,
+                "role": row.role,
+            }
+            for row in explicit.fetchall()
+        }
+        legacy = await db.execute(
+            select(Guild.id, Guild.name).where(Guild.github_user_id == github_user_id)
+        )
+        for row in legacy.fetchall():
+            memberships.setdefault(
+                row.id,
+                {"guild_id": row.id, "guild_name": row.name, "role": "owner"},
+            )
+        return {
+            "user": {
+                "id": user.id,
+                "github_id": user.github_id,
+                "github_login": user.github_login,
+                "email": user.email,
+                "display_name": user.display_name,
+                "avatar_url": user.avatar_url,
+            },
+            "memberships": list(memberships.values()),
+        }
+    finally:
+        await db.close()
+
+
 @app.delete("/auth/logout")
 async def logout(credentials: HTTPAuthorizationCredentials = Depends(_http_bearer)):
     """Invalidate the current login_token."""
@@ -749,8 +796,7 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
             .select_from(Guild)
             .outerjoin(
                 GuildMember,
-                (GuildMember.guild_id == Guild.id)
-                & (GuildMember.user_id == github_user_id),
+                (GuildMember.guild_id == Guild.id) & (GuildMember.user_id == github_user_id),
             )
             .outerjoin(
                 Agent,
@@ -759,8 +805,7 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
                 & (Agent.state != "offline"),
             )
             .where(
-                (GuildMember.user_id == github_user_id)
-                | (Guild.github_user_id == github_user_id)
+                (GuildMember.user_id == github_user_id) | (Guild.github_user_id == github_user_id)
             )
             .group_by(Guild.id)
             .order_by(Guild.created_at.desc())
@@ -829,6 +874,163 @@ async def get_guild(guild_id: str, github_user_id: str = Depends(require_member(
             "agents": [_row(a) for a in agents],
             "messages": [_row(m) for m in reversed(messages)],
         }
+    finally:
+        await db.close()
+
+
+class MemberCreate(BaseModel):
+    # Either a users.id (numeric GitHub id as text) or a github_login.
+    user: str
+    role: str = "member"  # owner | member | viewer
+
+
+class MemberUpdate(BaseModel):
+    role: str  # owner | member | viewer
+
+
+_VALID_ROLES = {"owner", "member", "viewer"}
+
+
+@app.get("/api/guilds/{guild_id}/members")
+async def list_guild_members(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+):
+    """List members of a guild (caller must be a member)."""
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(
+                GuildMember.user_id,
+                GuildMember.role,
+                GuildMember.created_at,
+                User.github_login,
+                User.display_name,
+                User.avatar_url,
+            )
+            .outerjoin(User, User.id == GuildMember.user_id)
+            .where(GuildMember.guild_id == guild_id)
+            .order_by(GuildMember.created_at.asc())
+        )
+        return [dict(r._mapping) for r in result.fetchall()]
+    finally:
+        await db.close()
+
+
+@app.post("/api/guilds/{guild_id}/members")
+async def add_guild_member(
+    guild_id: str,
+    data: MemberCreate,
+    github_user_id: str = Depends(require_member("owner")),
+):
+    """Add a member to a guild by users.id or github_login (owner only)."""
+    if data.role not in _VALID_ROLES:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid role; must be one of {sorted(_VALID_ROLES)}"
+        )
+    db = await get_db()
+    try:
+        target_id = await _resolve_user_identifier(db, data.user)
+        if not target_id:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"User '{data.user}' not found. They must log in to Pioneer Square once "
+                    "before they can be added."
+                ),
+            )
+        now = datetime.now(UTC).isoformat()
+        stmt = sqlite_insert(GuildMember).values(
+            guild_id=guild_id,
+            user_id=target_id,
+            role=data.role,
+            created_at=now,
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["guild_id", "user_id"],
+            set_={"role": stmt.excluded.role},
+        )
+        await db.execute(stmt)
+        await db.commit()
+        return {"guild_id": guild_id, "user_id": target_id, "role": data.role}
+    finally:
+        await db.close()
+
+
+@app.patch("/api/guilds/{guild_id}/members/{user_id}")
+async def update_guild_member(
+    guild_id: str,
+    user_id: str,
+    data: MemberUpdate,
+    github_user_id: str = Depends(require_member("owner")),
+):
+    """Change a member's role (owner only)."""
+    if data.role not in _VALID_ROLES:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid role; must be one of {sorted(_VALID_ROLES)}"
+        )
+    db = await get_db()
+    try:
+        res = await db.execute(
+            select(GuildMember).where(
+                GuildMember.guild_id == guild_id, GuildMember.user_id == user_id
+            )
+        )
+        member = res.scalar_one_or_none()
+        if not member:
+            raise HTTPException(status_code=404, detail="Member not found")
+        # Don't let the last owner demote themselves and lock the guild.
+        if member.role == "owner" and data.role != "owner":
+            owner_count = await db.execute(
+                select(func.count())
+                .select_from(GuildMember)
+                .where(GuildMember.guild_id == guild_id, GuildMember.role == "owner")
+            )
+            if (owner_count.scalar() or 0) <= 1:
+                raise HTTPException(
+                    status_code=400, detail="Cannot demote the last owner of a guild"
+                )
+        member.role = data.role
+        await db.commit()
+        return {"guild_id": guild_id, "user_id": user_id, "role": data.role}
+    finally:
+        await db.close()
+
+
+@app.delete("/api/guilds/{guild_id}/members/{user_id}")
+async def remove_guild_member(
+    guild_id: str,
+    user_id: str,
+    github_user_id: str = Depends(require_member("owner")),
+):
+    """Remove a member from a guild (owner only)."""
+    db = await get_db()
+    try:
+        res = await db.execute(
+            select(GuildMember).where(
+                GuildMember.guild_id == guild_id, GuildMember.user_id == user_id
+            )
+        )
+        member = res.scalar_one_or_none()
+        if not member:
+            raise HTTPException(status_code=404, detail="Member not found")
+        if member.role == "owner":
+            owner_count = await db.execute(
+                select(func.count())
+                .select_from(GuildMember)
+                .where(GuildMember.guild_id == guild_id, GuildMember.role == "owner")
+            )
+            if (owner_count.scalar() or 0) <= 1:
+                raise HTTPException(
+                    status_code=400, detail="Cannot remove the last owner of a guild"
+                )
+        await db.execute(
+            delete(GuildMember).where(
+                GuildMember.guild_id == guild_id, GuildMember.user_id == user_id
+            )
+        )
+        await db.commit()
+        return {"status": "removed", "user_id": user_id}
     finally:
         await db.close()
 
@@ -1048,11 +1250,17 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 # A standalone worker process is announcing/refreshing its config.
                 worker_id = data.get("workerId")
                 repos = data.get("repos") or []
+                user_ident = data.get("user")
                 if worker_id:
+                    update_vals: dict = {"repos": json.dumps(repos)}
+                    if user_ident:
+                        resolved = await _resolve_user_identifier(db, user_ident)
+                        if resolved:
+                            update_vals["user_id"] = resolved
                     await db.execute(
                         update(Worker)
                         .where(Worker.id == worker_id, Worker.guild_id == guild_id)
-                        .values(repos=json.dumps(repos))
+                        .values(**update_vals)
                     )
                     await db.commit()
 
@@ -1551,7 +1759,12 @@ def _parse_event(tool: str, event: dict, pi_last_text: str) -> str | None:
 
 
 @app.post("/guilds/{guild_id}/agents/{agent_id}/run")
-async def start_agent_run(guild_id: str, agent_id: str, req: RunAgentRequest):
+async def start_agent_run(
+    guild_id: str,
+    agent_id: str,
+    req: RunAgentRequest,
+    github_user_id: str = Depends(require_member()),
+):
     """Spawn an AI coding agent subprocess and stream its output over WebSocket."""
     old = running_processes.get(agent_id)
     if old:
@@ -1565,7 +1778,11 @@ async def start_agent_run(guild_id: str, agent_id: str, req: RunAgentRequest):
 
 
 @app.delete("/guilds/{guild_id}/agents/{agent_id}/run")
-async def stop_agent_run(guild_id: str, agent_id: str):
+async def stop_agent_run(
+    guild_id: str,
+    agent_id: str,
+    github_user_id: str = Depends(require_member()),
+):
     """Terminate a running agent subprocess."""
     proc = running_processes.get(agent_id)
     if not proc:
@@ -1703,7 +1920,11 @@ def _build_spawn_worker_env(
 
 
 @app.post("/guilds/{guild_id}/spawn-worker")
-async def spawn_worker_container(guild_id: str, data: SpawnWorkerRequest):
+async def spawn_worker_container(
+    guild_id: str,
+    data: SpawnWorkerRequest,
+    github_user_id: str = Depends(require_member()),
+):
     """Start a new worker container via Docker. Requires the Docker socket to be mounted."""
     try:
         import docker as docker_sdk
@@ -1773,7 +1994,10 @@ async def spawn_worker_container(guild_id: str, data: SpawnWorkerRequest):
 
 
 @app.get("/guilds/{guild_id}/pending-auth")
-async def get_pending_auth(guild_id: str):
+async def get_pending_auth(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+):
     """Return workers currently waiting for a Claude auth code.
 
     The frontend calls this on mount so the auth panel is restored after a
@@ -1784,7 +2008,10 @@ async def get_pending_auth(guild_id: str):
 
 
 @app.get("/guilds/{guild_id}/workers")
-async def list_workers(guild_id: str):
+async def list_workers(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+):
     db = await get_db()
     try:
         result = await db.execute(
@@ -1796,7 +2023,12 @@ async def list_workers(guild_id: str):
 
 
 @app.post("/guilds/{guild_id}/workers/{worker_id}/tasks")
-async def assign_task(guild_id: str, worker_id: str, data: TaskCreate):
+async def assign_task(
+    guild_id: str,
+    worker_id: str,
+    data: TaskCreate,
+    github_user_id: str = Depends(require_member()),
+):
     """Persist a task and broadcast a task-assigned event for the worker process."""
     task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
     created_at = datetime.now(UTC).isoformat()
@@ -1867,7 +2099,12 @@ class WorkerMessage(BaseModel):
 
 
 @app.post("/guilds/{guild_id}/workers/{worker_id}/message")
-async def message_worker(guild_id: str, worker_id: str, data: WorkerMessage):
+async def message_worker(
+    guild_id: str,
+    worker_id: str,
+    data: WorkerMessage,
+    github_user_id: str = Depends(require_member()),
+):
     """Forward a message to a worker process via its guild WebSocket."""
     text_msg = data.message.strip()
     if not text_msg:
@@ -1891,7 +2128,10 @@ async def message_worker(guild_id: str, worker_id: str, data: WorkerMessage):
 
 
 @app.get("/guilds/{guild_id}/tasks")
-async def list_guild_tasks(guild_id: str):
+async def list_guild_tasks(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+):
     """List all tasks for a guild, most recent first."""
     db = await get_db()
     try:
@@ -1922,7 +2162,11 @@ async def list_guild_tasks(guild_id: str):
 
 
 @app.get("/guilds/{guild_id}/tasks/{task_id}/logs")
-async def get_task_logs(guild_id: str, task_id: str):
+async def get_task_logs(
+    guild_id: str,
+    task_id: str,
+    github_user_id: str = Depends(require_member()),
+):
     """Get all saved log lines for a task."""
     db = await get_db()
     try:
@@ -1959,6 +2203,7 @@ async def get_guild_logs(
     worker_id: str | None = None,
     agent_id: str | None = None,
     task_id: str | None = None,
+    github_user_id: str = Depends(require_member()),
 ):
     """Get task_logs filtered by worker_id, agent_id, or task_id."""
     if not (worker_id or agent_id or task_id):
@@ -2004,7 +2249,12 @@ class FollowupCreate(BaseModel):
 
 
 @app.post("/guilds/{guild_id}/tasks/{task_id}/followup")
-async def create_task_followup(guild_id: str, task_id: str, data: FollowupCreate):
+async def create_task_followup(
+    guild_id: str,
+    task_id: str,
+    data: FollowupCreate,
+    github_user_id: str = Depends(require_member()),
+):
     """Send follow-up instructions to a worker — executed in the same worktree/branch."""
     db = await get_db()
     try:
@@ -2033,7 +2283,11 @@ async def create_task_followup(guild_id: str, task_id: str, data: FollowupCreate
 
 
 @app.post("/guilds/{guild_id}/tasks/{task_id}/finalize")
-async def finalize_task_endpoint(guild_id: str, task_id: str):
+async def finalize_task_endpoint(
+    guild_id: str,
+    task_id: str,
+    github_user_id: str = Depends(require_member()),
+):
     """Signal a worker to finalize a task — no more follow-ups."""
     db = await get_db()
     try:
@@ -2071,7 +2325,11 @@ async def finalize_task_endpoint(guild_id: str, task_id: str):
 
 
 @app.post("/guilds/{guild_id}/tasks/{task_id}/cancel")
-async def cancel_task_endpoint(guild_id: str, task_id: str):
+async def cancel_task_endpoint(
+    guild_id: str,
+    task_id: str,
+    github_user_id: str = Depends(require_member()),
+):
     """Cancel a running or pending task — terminates the worker's Claude subprocess."""
     db = await get_db()
     try:
@@ -2118,7 +2376,12 @@ class RedirectCreate(BaseModel):
 
 
 @app.post("/guilds/{guild_id}/tasks/{task_id}/redirect")
-async def redirect_task_endpoint(guild_id: str, task_id: str, data: RedirectCreate):
+async def redirect_task_endpoint(
+    guild_id: str,
+    task_id: str,
+    data: RedirectCreate,
+    github_user_id: str = Depends(require_member()),
+):
     """Redirect a running task: SIGTERM the Claude subprocess and resume it with new instructions."""
     instructions = data.instructions.strip()
     if not instructions:
@@ -2166,7 +2429,7 @@ async def redirect_task_endpoint(guild_id: str, task_id: str, data: RedirectCrea
 @app.get("/guilds/{guild_id}/foreman/context")
 async def get_foreman_context(
     guild_id: str,
-    github_user_id: str = Depends(require_user),
+    github_user_id: str = Depends(require_member()),
 ):
     """Return the stored foreman conversation turns for this guild+user (debug view)."""
     db = await get_db()
@@ -2183,7 +2446,7 @@ async def get_foreman_context(
 @app.post("/guilds/{guild_id}/foreman/clear-context")
 async def clear_foreman_context(
     guild_id: str,
-    github_user_id: str = Depends(require_user),
+    github_user_id: str = Depends(require_member()),
 ):
     """Delete all stored foreman turns for this guild+user. Chat history in messages table is preserved."""
     db = await get_db()

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,9 +22,11 @@ from models import (
     ClaudeCredentials,
     GithubToken,
     Guild,
+    GuildMember,
     Message,
     Task,
     TaskLog,
+    User,
     UserSession,
     Worker,
 )
@@ -297,6 +299,10 @@ class WorkerCreate(BaseModel):
     repos: list[str]  # ["owner/repo", ...]
     github_token: str | None = None
     hostname: str | None = None
+    # Either a users.id (numeric GitHub id as text) or a github_login. The
+    # backend resolves it to a User row; mismatches are dropped silently
+    # (workers without a known user run as unattributed).
+    user: str | None = None
 
 
 class SpawnWorkerRequest(BaseModel):
@@ -386,6 +392,66 @@ async def require_user(
         await db.close()
 
 
+async def _ensure_membership(db, guild_id: str, user_id: str) -> str:
+    """Return the role of *user_id* in *guild_id* or raise HTTP 403/404.
+
+    Legacy guilds created before guild_members existed have a ``github_user_id``
+    on the guild row and no member rows; treat that owner as a member so the
+    pre-migration UI keeps working without a manual repair step.
+    """
+    g_res = await db.execute(
+        select(Guild.id, Guild.github_user_id).where(Guild.id == guild_id)
+    )
+    grow = g_res.first()
+    if not grow:
+        raise HTTPException(status_code=404, detail="Guild not found")
+
+    res = await db.execute(
+        select(GuildMember.role).where(
+            GuildMember.guild_id == guild_id, GuildMember.user_id == user_id
+        )
+    )
+    role = res.scalar_one_or_none()
+    if role:
+        return role
+    if grow.github_user_id and grow.github_user_id == user_id:
+        return "owner"
+    raise HTTPException(status_code=403, detail="Not a member of this guild")
+
+
+async def _resolve_user_identifier(db, identifier: str) -> str | None:
+    """Look up a User by either id (numeric github id as text) or github_login.
+
+    Returns the canonical ``users.id`` or ``None`` if no match.
+    """
+    ident = (identifier or "").strip()
+    if not ident:
+        return None
+    res = await db.execute(
+        select(User.id).where((User.id == ident) | (User.github_login == ident))
+    )
+    return res.scalar_one_or_none()
+
+
+def require_member(*allowed_roles: str):
+    """FastAPI dependency factory: caller must be a member (optionally with one of the given roles)."""
+
+    async def _dep(guild_id: str, github_user_id: str = Depends(require_user)) -> str:
+        db = await get_db()
+        try:
+            role = await _ensure_membership(db, guild_id, github_user_id)
+        finally:
+            await db.close()
+        if allowed_roles and role not in allowed_roles:
+            raise HTTPException(
+                status_code=403,
+                detail=f"This action requires one of: {', '.join(allowed_roles)}",
+            )
+        return github_user_id
+
+    return _dep
+
+
 # ---------------------------------------------------------------------------
 # GitHub OAuth endpoints
 # ---------------------------------------------------------------------------
@@ -435,6 +501,9 @@ async def _gh_create_session(code: str, state: str) -> dict:
 
     github_user_id = str(user_data["id"])
     github_username = user_data.get("login", "")
+    display_name = user_data.get("name") or ""
+    avatar_url = user_data.get("avatar_url") or ""
+    email = user_data.get("email") or None
     login_token = secrets.token_urlsafe(32)
     now = datetime.now(UTC).isoformat()
 
@@ -460,6 +529,28 @@ async def _gh_create_session(code: str, state: str) -> dict:
             },
         )
         await db.execute(stmt)
+
+        user_stmt = sqlite_insert(User).values(
+            id=github_user_id,
+            github_id=github_user_id,
+            github_login=github_username,
+            email=email,
+            display_name=display_name or None,
+            avatar_url=avatar_url or None,
+            created_at=now,
+            updated_at=now,
+        )
+        user_stmt = user_stmt.on_conflict_do_update(
+            index_elements=["id"],
+            set_={
+                "github_login": user_stmt.excluded.github_login,
+                "email": user_stmt.excluded.email,
+                "display_name": user_stmt.excluded.display_name,
+                "avatar_url": user_stmt.excluded.avatar_url,
+                "updated_at": user_stmt.excluded.updated_at,
+            },
+        )
+        await db.execute(user_stmt)
         db.add(UserSession(token=login_token, github_user_id=github_user_id, created_at=now))
         await db.commit()
     finally:
@@ -621,6 +712,15 @@ async def create_guild(
                         github_user_id=github_user_id,
                     )
                 )
+                await db.flush()
+                db.add(
+                    GuildMember(
+                        guild_id=guild_id,
+                        user_id=github_user_id,
+                        role="owner",
+                        created_at=created_at,
+                    )
+                )
                 await db.commit()
                 break
             except IntegrityError:
@@ -637,6 +737,8 @@ async def create_guild(
 async def list_guilds(github_user_id: str = Depends(require_user)):
     db = await get_db()
     try:
+        # Union: guilds the user explicitly belongs to, plus legacy guilds
+        # whose github_user_id matches but never got a guild_members row.
         result = await db.execute(
             select(
                 Guild.id,
@@ -646,12 +748,20 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
             )
             .select_from(Guild)
             .outerjoin(
+                GuildMember,
+                (GuildMember.guild_id == Guild.id)
+                & (GuildMember.user_id == github_user_id),
+            )
+            .outerjoin(
                 Agent,
                 (Agent.guild_id == Guild.id)
                 & (Agent.type != "foreman")
                 & (Agent.state != "offline"),
             )
-            .where(Guild.github_user_id == github_user_id)
+            .where(
+                (GuildMember.user_id == github_user_id)
+                | (Guild.github_user_id == github_user_id)
+            )
             .group_by(Guild.id)
             .order_by(Guild.created_at.desc())
         )
@@ -664,13 +774,11 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
 async def update_guild(
     guild_id: str,
     data: GuildUpdate,
-    github_user_id: str = Depends(require_user),
+    github_user_id: str = Depends(require_member("owner")),
 ):
     db = await get_db()
     try:
-        result = await db.execute(
-            select(Guild).where(Guild.id == guild_id, Guild.github_user_id == github_user_id)
-        )
+        result = await db.execute(select(Guild).where(Guild.id == guild_id))
         guild = result.scalar_one_or_none()
         if not guild:
             raise HTTPException(status_code=404, detail="Guild not found")
@@ -694,7 +802,7 @@ async def update_guild(
 
 
 @app.get("/guilds/{guild_id}")
-async def get_guild(guild_id: str):
+async def get_guild(guild_id: str, github_user_id: str = Depends(require_member())):
     db = await get_db()
     try:
         result = await db.execute(select(Guild).where(Guild.id == guild_id))
@@ -1484,6 +1592,7 @@ async def create_worker(guild_id: str, data: WorkerCreate):
 
     db = await get_db()
     try:
+        resolved_user_id = await _resolve_user_identifier(db, data.user) if data.user else None
         db.add(
             Worker(
                 id=worker_id,
@@ -1491,6 +1600,7 @@ async def create_worker(guild_id: str, data: WorkerCreate):
                 repos=json.dumps(data.repos),
                 state="offline",
                 created_at=created_at,
+                user_id=resolved_user_id,
             )
         )
         stmt = sqlite_insert(Agent).values(

--- a/backend/models.py
+++ b/backend/models.py
@@ -57,6 +57,9 @@ class Worker(Base):
     state = Column(Text, nullable=False, server_default="idle")
     created_at = Column(Text, nullable=False)
     last_seen = Column(Text, nullable=True)
+    # Identity of the human user this worker process runs on behalf of.
+    # NULL for legacy/unattributed workers.
+    user_id = Column(Text, ForeignKey("users.id"), nullable=True)
 
 
 class Task(Base):
@@ -97,6 +100,32 @@ class UserSession(Base):
 
     token = Column(Text, primary_key=True)
     github_user_id = Column(Text, ForeignKey("github_tokens.github_user_id"), nullable=False)
+    created_at = Column(Text, nullable=False)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    # Canonical user id == GitHub numeric id, kept as Text for FK compatibility
+    # with the existing github_user_id columns (messages.user_id,
+    # guilds.github_user_id, etc).
+    id = Column(Text, primary_key=True)
+    github_id = Column(Text, nullable=False, unique=True)
+    github_login = Column(Text)
+    email = Column(Text)
+    display_name = Column(Text)
+    avatar_url = Column(Text)
+    created_at = Column(Text, nullable=False)
+    updated_at = Column(Text, nullable=False)
+
+
+class GuildMember(Base):
+    __tablename__ = "guild_members"
+
+    guild_id = Column(Text, ForeignKey("guilds.id"), primary_key=True)
+    user_id = Column(Text, ForeignKey("users.id"), primary_key=True)
+    # owner | member | viewer
+    role = Column(Text, nullable=False, server_default="member")
     created_at = Column(Text, nullable=False)
 
 

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -44,12 +44,51 @@ def make_auth_token(db_path: str, user_id: str = "gh-user-test", username: str =
     return token
 
 
-def insert_guild(db_path: str, guild_id: str, name: str = "Test Guild") -> None:
-    """Insert a guild row directly into *db_path*."""
+def insert_guild(
+    db_path: str,
+    guild_id: str,
+    name: str = "Test Guild",
+    owner_user_id: str | None = "gh-user-test",
+) -> None:
+    """Insert a guild row directly into *db_path*.
+
+    By default also inserts ``owner_user_id`` as an ``owner`` member so the
+    default ``make_auth_token()`` user satisfies ``require_member`` checks.
+    Pass ``owner_user_id=None`` to skip that.
+    """
     now = datetime.now(UTC).isoformat()
     with sqlite3.connect(db_path) as conn:
         conn.execute(
-            "INSERT OR IGNORE INTO guilds (id, created_at, name) VALUES (?, ?, ?)",
-            (guild_id, now, name),
+            "INSERT OR IGNORE INTO guilds (id, created_at, name, github_user_id) "
+            "VALUES (?, ?, ?, ?)",
+            (guild_id, now, name, owner_user_id),
+        )
+        if owner_user_id:
+            conn.execute(
+                "INSERT OR IGNORE INTO users (id, github_id, github_login, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                (owner_user_id, owner_user_id, owner_user_id, now, now),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO guild_members (guild_id, user_id, role, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (guild_id, owner_user_id, "owner", now),
+            )
+        conn.commit()
+
+
+def insert_member(db_path: str, guild_id: str, user_id: str, role: str = "member") -> None:
+    """Add a user as a member of a guild (creating a users row if needed)."""
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO users (id, github_id, github_login, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (user_id, user_id, user_id, now, now),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO guild_members (guild_id, user_id, role, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (guild_id, user_id, role, now),
         )
         conn.commit()

--- a/backend/tests/test_foreman_context_api.py
+++ b/backend/tests/test_foreman_context_api.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime, timezone
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
-from helpers import insert_guild, make_auth_token
+from helpers import insert_guild, insert_member, make_auth_token
 
 
 def _insert_foreman_turn(
@@ -76,6 +76,8 @@ def test_get_foreman_context_returns_only_requesting_users_turns(client):
     insert_guild(db_path, "g-scope")
     token_a = make_auth_token(db_path, user_id="user-alice", username="alice")
     token_b = make_auth_token(db_path, user_id="user-bob", username="bob")
+    insert_member(db_path, "g-scope", "user-alice", role="member")
+    insert_member(db_path, "g-scope", "user-bob", role="member")
 
     _insert_foreman_turn(db_path, "g-scope", "user-alice", "user", "Hello from Alice")
     _insert_foreman_turn(db_path, "g-scope", "user-bob", "user", "Hello from Bob")
@@ -121,6 +123,8 @@ def test_clear_foreman_context_only_clears_requesting_users_turns(client):
     insert_guild(db_path, "g-clear")
     token_a = make_auth_token(db_path, user_id="user-alice2", username="alice2")
     token_b = make_auth_token(db_path, user_id="user-bob2", username="bob2")
+    insert_member(db_path, "g-clear", "user-alice2", role="member")
+    insert_member(db_path, "g-clear", "user-bob2", role="member")
 
     _insert_foreman_turn(db_path, "g-clear", "user-alice2", "user", "Alice message")
     _insert_foreman_turn(db_path, "g-clear", "user-bob2", "user", "Bob message")

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -9,22 +9,47 @@ sys.path.insert(0, os.path.dirname(__file__))
 from helpers import insert_guild, make_auth_token
 
 
-def test_get_guild_not_found(client):
+def test_get_guild_requires_auth(client):
     test_client, _ = client
-    resp = test_client.get("/guilds/doesnotexist")
-    assert resp.status_code == 404
+    resp = test_client.get("/guilds/anything")
+    assert resp.status_code == 401
+
+
+def test_get_guild_not_found(client):
+    test_client, db_path = client
+    token = make_auth_token(db_path)
+    resp = test_client.get(
+        "/guilds/doesnotexist",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code in (403, 404)
 
 
 def test_get_guild_found(client):
     test_client, db_path = client
     insert_guild(db_path, "abc123", name="My Guild")
-    resp = test_client.get("/guilds/abc123")
+    token = make_auth_token(db_path)
+    resp = test_client.get(
+        "/guilds/abc123",
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert data["id"] == "abc123"
     assert data["name"] == "My Guild"
     assert "agents" in data
     assert "messages" in data
+
+
+def test_get_guild_forbidden_for_non_member(client):
+    test_client, db_path = client
+    insert_guild(db_path, "private01", name="Private")
+    other_token = make_auth_token(db_path, user_id="other-user", username="outsider")
+    resp = test_client.get(
+        "/guilds/private01",
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert resp.status_code == 403
 
 
 def test_create_guild_requires_auth(client):
@@ -98,7 +123,7 @@ def test_update_guild_name(client):
     assert patch_resp.status_code == 200
     assert patch_resp.json()["name"] == "New Name"
 
-    get_resp = test_client.get(f"/guilds/{guild_id}")
+    get_resp = test_client.get(f"/guilds/{guild_id}", headers=headers)
     assert get_resp.json()["name"] == "New Name"
 
 
@@ -110,7 +135,7 @@ def test_update_guild_not_found(client):
         json={"name": "X"},
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert resp.status_code == 404
+    assert resp.status_code in (403, 404)
 
 
 def test_update_guild_primary_repo(client):
@@ -129,7 +154,7 @@ def test_update_guild_primary_repo(client):
     assert patch_resp.status_code == 200
     assert patch_resp.json()["primary_repo"] == "owner/myrepo"
 
-    get_resp = test_client.get(f"/guilds/{guild_id}")
+    get_resp = test_client.get(f"/guilds/{guild_id}", headers=headers)
     assert get_resp.json()["primary_repo"] == "owner/myrepo"
 
 

--- a/backend/tests/test_user_members_api.py
+++ b/backend/tests/test_user_members_api.py
@@ -1,0 +1,176 @@
+"""Tests for /api/me and the guild member management endpoints."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import insert_guild, insert_member, make_auth_token
+
+
+def _seed_user(db_path: str, user_id: str, login: str) -> None:
+    """Insert a users row directly so it can be referenced as a member."""
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO users "
+            "(id, github_id, github_login, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (user_id, user_id, login, now, now),
+        )
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# /api/me
+# ---------------------------------------------------------------------------
+
+
+def test_api_me_requires_auth(client):
+    test_client, _ = client
+    resp = test_client.get("/api/me")
+    assert resp.status_code == 401
+
+
+def test_api_me_returns_profile_and_memberships(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-1", name="My Guild")
+    _seed_user(db_path, "gh-user-test", "testuser")
+    token = make_auth_token(db_path)
+    resp = test_client.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["user"]["github_login"] == "testuser"
+    guild_ids = [m["guild_id"] for m in data["memberships"]]
+    assert "gm-1" in guild_ids
+    membership = next(m for m in data["memberships"] if m["guild_id"] == "gm-1")
+    assert membership["role"] == "owner"
+
+
+# ---------------------------------------------------------------------------
+# Member management
+# ---------------------------------------------------------------------------
+
+
+def test_list_members_requires_membership(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-list")
+    other = make_auth_token(db_path, user_id="other-user", username="outsider")
+    resp = test_client.get(
+        "/api/guilds/gm-list/members",
+        headers={"Authorization": f"Bearer {other}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_list_members_returns_owner(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-list2")
+    token = make_auth_token(db_path)
+    resp = test_client.get(
+        "/api/guilds/gm-list2/members",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    members = resp.json()
+    assert len(members) == 1
+    assert members[0]["user_id"] == "gh-user-test"
+    assert members[0]["role"] == "owner"
+
+
+def test_add_member_resolves_login(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-add")
+    _seed_user(db_path, "user-99", "octocat")
+    token = make_auth_token(db_path)
+    resp = test_client.post(
+        "/api/guilds/gm-add/members",
+        json={"user": "octocat", "role": "member"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user_id"] == "user-99"
+    assert body["role"] == "member"
+
+
+def test_add_member_unknown_user_is_404(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-unknown")
+    token = make_auth_token(db_path)
+    resp = test_client.post(
+        "/api/guilds/gm-unknown/members",
+        json={"user": "noone-here", "role": "member"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_add_member_requires_owner(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-perm")
+    insert_member(db_path, "gm-perm", "user-bob", role="member")
+    bob_token = make_auth_token(db_path, user_id="user-bob", username="bob")
+    _seed_user(db_path, "user-99", "octocat")
+    resp = test_client.post(
+        "/api/guilds/gm-perm/members",
+        json={"user": "octocat", "role": "member"},
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_update_member_role(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-role")
+    insert_member(db_path, "gm-role", "user-bob", role="member")
+    token = make_auth_token(db_path)
+    resp = test_client.patch(
+        "/api/guilds/gm-role/members/user-bob",
+        json={"role": "viewer"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["role"] == "viewer"
+
+
+def test_cannot_demote_last_owner(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-last")
+    token = make_auth_token(db_path)
+    resp = test_client.patch(
+        "/api/guilds/gm-last/members/gh-user-test",
+        json={"role": "member"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_remove_member(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-del")
+    insert_member(db_path, "gm-del", "user-bob", role="member")
+    token = make_auth_token(db_path)
+    resp = test_client.delete(
+        "/api/guilds/gm-del/members/user-bob",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_invalid_role_rejected(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gm-bad")
+    _seed_user(db_path, "user-99", "octocat")
+    token = make_auth_token(db_path)
+    resp = test_client.post(
+        "/api/guilds/gm-bad/members",
+        json={"user": "octocat", "role": "admin"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -8,6 +8,12 @@ import sys
 sys.path.insert(0, os.path.dirname(__file__))
 from helpers import insert_guild, make_auth_token
 
+
+def _auth(db_path: str) -> dict:
+    """Helper: return Authorization header for the default test user."""
+    return {"Authorization": f"Bearer {make_auth_token(db_path)}"}
+
+
 # ---------------------------------------------------------------------------
 # Workers
 # ---------------------------------------------------------------------------
@@ -16,7 +22,7 @@ from helpers import insert_guild, make_auth_token
 def test_list_workers_empty(client):
     test_client, db_path = client
     insert_guild(db_path, "guild01")
-    resp = test_client.get("/guilds/guild01/workers")
+    resp = test_client.get("/guilds/guild01/workers", headers=_auth(db_path))
     assert resp.status_code == 200
     assert resp.json() == []
 
@@ -39,7 +45,7 @@ def test_create_worker_appears_in_list(client):
     test_client, db_path = client
     insert_guild(db_path, "guild03")
     test_client.post("/guilds/guild03/workers", json={"repos": ["org/backend"]})
-    resp = test_client.get("/guilds/guild03/workers")
+    resp = test_client.get("/guilds/guild03/workers", headers=_auth(db_path))
     assert resp.status_code == 200
     workers = resp.json()
     assert len(workers) == 1
@@ -51,8 +57,35 @@ def test_create_multiple_workers(client):
     insert_guild(db_path, "guild04")
     test_client.post("/guilds/guild04/workers", json={"repos": []})
     test_client.post("/guilds/guild04/workers", json={"repos": ["x/y"]})
-    resp = test_client.get("/guilds/guild04/workers")
+    resp = test_client.get("/guilds/guild04/workers", headers=_auth(db_path))
     assert len(resp.json()) == 2
+
+
+def test_create_worker_attributes_to_user(client):
+    """Worker registration with `user` resolves to a users.id and stores it on workers.user_id."""
+    import sqlite3
+
+    from helpers import insert_member
+
+    test_client, db_path = client
+    insert_guild(db_path, "guildusr")
+    insert_member(db_path, "guildusr", "user-bob", role="member")
+    # Bob's users row was created by insert_member; reference by login should also work.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE users SET github_login = ? WHERE id = ?",
+            ("bobby", "user-bob"),
+        )
+        conn.commit()
+    resp = test_client.post(
+        "/guilds/guildusr/workers",
+        json={"repos": [], "user": "bobby"},
+    )
+    assert resp.status_code == 200
+    worker_id = resp.json()["id"]
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT user_id FROM workers WHERE id = ?", (worker_id,)).fetchone()
+    assert row[0] == "user-bob"
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +113,7 @@ def test_assign_task_unknown_worker(client):
     resp = test_client.post(
         "/guilds/guild06/workers/w-nosuch/tasks",
         json={"description": "do something", "tool": "claude"},
+        headers=_auth(db_path),
     )
     assert resp.status_code == 404
 
@@ -92,6 +126,7 @@ def test_assign_task_returns_pending(client):
     resp = test_client.post(
         f"/guilds/guild07/workers/{worker_id}/tasks",
         json={"description": "Write a hello-world script", "tool": "claude"},
+        headers=_auth(db_path),
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -104,14 +139,17 @@ def test_assign_task_appears_in_list(client):
     test_client, db_path = client
     insert_guild(db_path, "guild08")
     worker_id = _create_worker(test_client, "guild08")
+    headers = _auth(db_path)
 
     test_client.post(
         f"/guilds/guild08/workers/{worker_id}/tasks",
         json={"description": "Task one", "tool": "claude"},
+        headers=headers,
     )
     test_client.post(
         f"/guilds/guild08/workers/{worker_id}/tasks",
         json={"description": "Task two", "tool": "codex"},
+        headers=headers,
     )
 
     resp = test_client.get(f"/guilds/guild08/workers/{worker_id}/tasks")
@@ -268,15 +306,20 @@ def test_guild_task_list(client):
     insert_guild(db_path, "guild09")
     w1 = _create_worker(test_client, "guild09")
     w2 = _create_worker(test_client, "guild09")
+    headers = _auth(db_path)
 
     test_client.post(
-        f"/guilds/guild09/workers/{w1}/tasks", json={"description": "Alpha", "tool": "claude"}
+        f"/guilds/guild09/workers/{w1}/tasks",
+        json={"description": "Alpha", "tool": "claude"},
+        headers=headers,
     )
     test_client.post(
-        f"/guilds/guild09/workers/{w2}/tasks", json={"description": "Beta", "tool": "claude"}
+        f"/guilds/guild09/workers/{w2}/tasks",
+        json={"description": "Beta", "tool": "claude"},
+        headers=headers,
     )
 
-    resp = test_client.get("/guilds/guild09/tasks")
+    resp = test_client.get("/guilds/guild09/tasks", headers=headers)
     assert resp.status_code == 200
     descriptions = {t["description"] for t in resp.json()}
     assert "Alpha" in descriptions

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -11,6 +11,10 @@ guild_id = "abc123"
 # Optional human-readable name shown in the UI. Auto-generated if absent.
 # worker_name = "Builder"
 
+# Identity of the human this worker runs on behalf of. Either a numeric
+# GitHub user id (as a string) or a github_login. Also reads WORKER_USER.
+# user = "octocat"
+
 # Pull repos in the background every N seconds while idle.
 pull_interval = 300
 

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -30,6 +30,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # Identity
     parser.add_argument("--worker-name", help="Display name for this worker.")
+    parser.add_argument(
+        "--user",
+        help=(
+            "User identity to attribute this worker's actions to "
+            "(numeric GitHub id or login; also reads WORKER_USER env var)."
+        ),
+    )
 
     # GitHub
     parser.add_argument("--github-token", help="GitHub personal access token.")
@@ -92,6 +99,7 @@ def main(argv: list[str] | None = None) -> int:
             "backend_url": args.backend_url,
             "guild_id": args.guild_id,
             "worker_name": args.worker_name,
+            "user": args.user,
             "github_token": args.github_token,
             "repos": args.repos,
             "repos_dir": args.repos_dir,

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -22,6 +22,10 @@ class Config:
     worker_id: str | None = None
     worker_name: str | None = None
     github_token: str | None = None
+    # Identity of the human this worker runs on behalf of.
+    # Either a numeric GitHub user id (text) or a github_login.
+    # The backend resolves it to a users.id row and stores workers.user_id.
+    user: str | None = None
     repos_dir: str = "src"
     work_dir: str = "worktrees"
     claude_path: str = "claude"
@@ -130,6 +134,10 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         worker_name=overrides.get("worker_name")
         or raw.get("worker_name")
         or os.environ.get("PIONEER_WORKER_NAME"),
+        user=overrides.get("user")
+        or raw.get("user")
+        or os.environ.get("WORKER_USER")
+        or os.environ.get("PIONEER_WORKER_USER"),
         github_token=token,
         repos_dir=os.path.abspath(
             overrides.get("repos_dir") or paths_block.get("repos_dir", "/tmp/pioneer-repos")

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -86,12 +86,18 @@ class Worker:
                     "repos": self.cfg.repos,
                     "github_token": None,
                     "hostname": socket.gethostname(),
+                    "user": self.cfg.user,
                 },
             )
             resp.raise_for_status()
             wid = resp.json()["id"]
         self.cfg.worker_id = wid
-        logger.info("Registered as worker %s (%d agents)", wid, len(self.slots))
+        logger.info(
+            "Registered as worker %s (%d agents) user=%s",
+            wid,
+            len(self.slots),
+            self.cfg.user or "<unattributed>",
+        )
 
     async def _fetch_github_token_if_needed(self) -> None:
         if self.cfg.github_token:
@@ -593,6 +599,7 @@ class Worker:
                 "type": "worker-register",
                 "workerId": self.cfg.worker_id,
                 "repos": self.cfg.repos,
+                **({"user": self.cfg.user} if self.cfg.user else {}),
             }
         )
 


### PR DESCRIPTION
## Summary

Adds a canonical user model, per-guild memberships with roles, and worker-side user attribution.

### Database
- New `users` and `guild_members` tables. Alembic migration `f4a5b6c7d8e9` (descends from `d5e6f7a8b9c0`) creates the tables and backfills `users` from `github_tokens` + `owner` memberships from existing `guilds.github_user_id`.
- New nullable `workers.user_id` column.

### Auth
- GitHub OAuth callback now upserts a `User` row alongside the `GithubToken`.
- `POST /guilds` seeds the creator as the guild's `owner` member.
- `require_member()` dependency factory checks `guild_members` (with a legacy fallback to `guilds.github_user_id`); applied to all user-facing guild-scoped REST routes — `GET /guilds/{id}`, `PATCH /guilds/{id}` (owner only), worker/task/log/foreman endpoints, spawn-worker, etc.

### API
- `GET /api/me` — returns the caller's profile and guild memberships (role per guild).
- `GET /api/guilds/{id}/members` — list members (any member).
- `POST /api/guilds/{id}/members` — add a member by `github_login` or numeric id (owner only).
- `PATCH /api/guilds/{id}/members/{user_id}` — change role; refuses to demote the last owner.
- `DELETE /api/guilds/{id}/members/{user_id}` — remove member; refuses to remove the last owner.

### Worker
- `--user <id_or_login>` flag (also `WORKER_USER` / `PIONEER_WORKER_USER` env vars; `user = "..."` in TOML).
- Worker sends the identifier on `POST /guilds/{id}/workers` and on `worker-register`. The backend resolves it via `users.id` or `users.github_login` and stores it on the worker row.

### Tests
- New `backend/tests/test_user_members_api.py` covers `/api/me`, member CRUD, role validation, last-owner protection, and permission boundaries.
- Existing guild/worker tests updated to authenticate; `helpers.insert_guild` now seeds an owner member by default and a new `helpers.insert_member` helper is available for multi-user fixtures.
- 185 backend tests pass; 67 worker tests pass.

### Out of scope (deferred)
- Frontend Members UI — not in this PR per scope; the API is in place for it.

Closes #66

## Test plan

- [x] `cd backend && python -m pytest -q` (185 passed)
- [x] `cd worker && python -m pytest -q` (67 passed)
- [x] `ruff check . --fix && ruff format .` (clean)
- [ ] Manual: log in via GitHub OAuth, confirm `/api/me` returns profile + owner membership for the just-created guild
- [ ] Manual: invite a second user via `POST /api/guilds/{id}/members`, verify they can `GET /guilds/{id}` and a non-member gets 403
- [ ] Manual: start a worker with `--user <login>`, verify `workers.user_id` is set in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)