### PR TITLE
Add authentication headers to all API requests

### DIFF
--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -224,7 +224,7 @@ describe('useTasksStore', () => {
       const store = useTasksStore()
       await store.fetchTasks('g-1')
       expect(store.tasks).toEqual(fakeTasks)
-      expect(fetch).toHaveBeenCalledWith('/guilds/g-1/tasks')
+      expect(fetch).toHaveBeenCalledWith('/guilds/g-1/tasks', expect.objectContaining({ headers: expect.any(Object) }))
     })
 
     it('fetchTasks short-circuits on empty guildId', async () => {
@@ -261,12 +261,12 @@ describe('useTasksStore', () => {
       await store.finalizeTask('g-1', 't-1')
       await store.cancelTask('g-1', 't-1')
 
-      expect(fetchMock).toHaveBeenNthCalledWith(1, '/guilds/g-1/tasks/t-1/finalize', {
+      expect(fetchMock).toHaveBeenNthCalledWith(1, '/guilds/g-1/tasks/t-1/finalize', expect.objectContaining({
         method: 'POST',
-      })
-      expect(fetchMock).toHaveBeenNthCalledWith(2, '/guilds/g-1/tasks/t-1/cancel', {
+      }))
+      expect(fetchMock).toHaveBeenNthCalledWith(2, '/guilds/g-1/tasks/t-1/cancel', expect.objectContaining({
         method: 'POST',
-      })
+      }))
     })
 
     it('throws when the API returns non-2xx', async () => {

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -247,7 +247,7 @@ export const useAgentsStore = defineStore('agents', () => {
 
   async function fetchWorkerLogs(guildId: string, workerId: string) {
     try {
-      const res = await fetch(`${API_BASE}/guilds/${guildId}/logs?worker_id=${workerId}`)
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/logs?worker_id=${workerId}`, { headers: _authHeaders() })
       if (res.ok) {
         const raw = await res.json()
         workerLogs.value[workerId] = raw.map((r: any) => ({
@@ -263,7 +263,7 @@ export const useAgentsStore = defineStore('agents', () => {
 
   async function fetchAgentLogs(guildId: string, agentId: string) {
     try {
-      const res = await fetch(`${API_BASE}/guilds/${guildId}/logs?agent_id=${agentId}`)
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/logs?agent_id=${agentId}`, { headers: _authHeaders() })
       if (res.ok) {
         const raw = await res.json()
         const historical: LogEntry[] = raw.map((r: any) => ({

--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -75,7 +75,7 @@ export const useGuildStore = defineStore('guild', () => {
 
   async function joinGuild(guildId: string): Promise<Guild | null> {
     try {
-      const res = await fetch(`${API_BASE}/guilds/${guildId}`)
+      const res = await fetch(`${API_BASE}/guilds/${guildId}`, { headers: _authHeaders() })
       if (!res.ok) throw new Error('Guild not found')
       const guild: Guild = await res.json()
       currentGuild.value = guild

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -1,8 +1,13 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { useAuthStore } from './auth'
 import type { LogEntry, Task, TaskState, WSMessage } from '../types'
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
+
+function _authHeaders(): Record<string, string> {
+  return useAuthStore().authHeaders()
+}
 
 const STATE_LABELS: Record<string, string> = {
   pending: 'pending',
@@ -35,7 +40,7 @@ export const useTasksStore = defineStore('tasks', () => {
   async function fetchTasks(guildId: string) {
     if (!guildId) return
     try {
-      const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks`)
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks`, { headers: _authHeaders() })
       if (res.ok) tasks.value = await res.json()
     } catch (e) {
       console.error('Failed to fetch tasks', e)
@@ -44,7 +49,7 @@ export const useTasksStore = defineStore('tasks', () => {
 
   async function fetchTaskLogs(guildId: string, taskId: string) {
     try {
-      const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/logs`)
+      const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/logs`, { headers: _authHeaders() })
       if (!res.ok) return []
       const raw = await res.json()
       const logs: LogEntry[] = raw.map((r: any) => ({
@@ -63,7 +68,7 @@ export const useTasksStore = defineStore('tasks', () => {
   async function sendFollowup(guildId: string, taskId: string, instructions: string) {
     const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/followup`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ instructions }),
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -73,6 +78,7 @@ export const useTasksStore = defineStore('tasks', () => {
   async function finalizeTask(guildId: string, taskId: string) {
     const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/finalize`, {
       method: 'POST',
+      headers: _authHeaders(),
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     return res.json()
@@ -81,6 +87,7 @@ export const useTasksStore = defineStore('tasks', () => {
   async function cancelTask(guildId: string, taskId: string) {
     const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/cancel`, {
       method: 'POST',
+      headers: _authHeaders(),
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     return res.json()
@@ -89,7 +96,7 @@ export const useTasksStore = defineStore('tasks', () => {
   async function redirectTask(guildId: string, taskId: string, instructions: string) {
     const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks/${taskId}/redirect`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ instructions }),
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)


### PR DESCRIPTION
## Summary
This PR adds authentication headers to all API fetch requests across the frontend stores to ensure proper authorization for protected endpoints.

## Key Changes
- Created a `_authHeaders()` helper function in `tasks.ts` that retrieves authentication headers from the auth store
- Updated all fetch calls in `tasks.ts` to include authentication headers:
  - `fetchTasks()` - GET request for task list
  - `fetchTaskLogs()` - GET request for task logs
  - `sendFollowup()` - POST request with merged headers
  - `finalizeTask()` - POST request
  - `cancelTask()` - POST request
  - `redirectTask()` - POST request with merged headers
- Updated fetch calls in `agents.ts` to include authentication headers:
  - `fetchWorkerLogs()` - GET request for worker logs
  - `fetchAgentLogs()` - GET request for agent logs
- Updated fetch call in `guild.ts`:
  - `joinGuild()` - GET request for guild data
- Updated test expectations in `tasks.spec.ts` to verify that headers are passed to fetch calls using `expect.objectContaining()`

## Implementation Details
- The `_authHeaders()` helper function uses the existing `useAuthStore()` to retrieve authentication headers, centralizing the auth header logic
- For POST requests with existing headers (like `Content-Type`), headers are merged using the spread operator (`...`)
- For GET and POST requests without existing headers, the auth headers are passed directly
- Tests were updated to use `expect.objectContaining()` to verify headers are present without being overly strict about their exact structure

https://claude.ai/code/session_01Cvahwk7kcM63w269S6qs3M