### PR TITLE
Soft-delete tasks (#177): ruff fixes + frontend deletedAt handling

### DIFF
--- a/backend/alembic/versions/a5b6c7d8e9f0_add_deleted_at_to_tasks.py
+++ b/backend/alembic/versions/a5b6c7d8e9f0_add_deleted_at_to_tasks.py
@@ -1,0 +1,32 @@
+"""add_deleted_at_to_tasks
+
+Adds a ``deleted_at`` column to the ``tasks`` table for soft-delete semantics.
+The column stores an ISO-8601 UTC timestamp (matching every other timestamp in
+the schema). When NULL the task is "live"; when set, the task is considered
+soft-deleted as soon as the wall clock passes that instant.
+
+Revision ID: a5b6c7d8e9f0
+Revises: f4a5b6c7d8e9
+Create Date: 2026-05-02 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "a5b6c7d8e9f0"
+down_revision: Union[str, Sequence[str], None] = "f4a5b6c7d8e9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.add_column(sa.Column("deleted_at", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.drop_column("deleted_at")

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -29,6 +29,16 @@ For complex work use phases:
 - After task-complete: call send_followup for further work (update tests, fix lint, add docs),
   or call finalize_task to mark it complete — don't leave tasks in limbo
 
+## Finalize expiry windows
+Every finalize_task call sets a soft-delete window via expires_in_seconds so the
+task table doesn't accumulate cruft. Pick the window by task type:
+- **Ephemeral tasks** (periodic-check, status-poll, automated health checks):
+  expires_in_seconds = 1200 (20 minutes)
+- **Code tasks** (execute / review / followup phases): omit the field to use
+  the default 3 days, or pass expires_in_seconds = 259200
+- **Error / failed tasks**: expires_in_seconds = 86400 (1 day)
+Pass deleted_at instead if you need an exact ISO-8601 timestamp.
+
 ## GitHub access
 You have direct GitHub access via list_github_issues, get_github_issue, list_github_prs,
 search_github_issues, create_github_issue, and claim_github_issue.

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from database import get_db
 from events import broadcast
-from models import ForemanTurn, Guild, Message, Task
+from models import ForemanTurn, Guild, Message, Task, live_tasks_filter
 from sqlalchemy import delete, select
 
 from foreman.prompt import build_system_prompt
@@ -307,6 +307,7 @@ async def _poll_loop(guild_id: str) -> None:
                 select(Task.id, Task.state, Task.name).where(
                     Task.guild_id == guild_id,
                     ~Task.state.in_(list(_TERMINAL_STATES)),
+                    live_tasks_filter(),
                 )
             )
             active_tasks = [dict(r._mapping) for r in result.fetchall()]
@@ -430,7 +431,7 @@ async def run_foreman_ai(
                 Task.pr_url,
                 Task.finished_at,
             )
-            .where(Task.guild_id == guild_id)
+            .where(Task.guild_id == guild_id, live_tasks_filter())
             .order_by(Task.created_at.desc())
             .limit(10)
         )

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -8,12 +8,46 @@ import string
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from database import get_db
 from events import broadcast, emit_terminal_line
 from models import Agent, GithubToken, Guild, Task, TaskLog, Worker
 from sqlalchemy import select, update
+
+# Default soft-delete window (seconds) when finalize_task is called without
+# an explicit expiry. Mirrors backend.main.DEFAULT_FINALIZE_TTL.
+DEFAULT_FINALIZE_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
+
+
+def _resolve_finalize_deleted_at(inp: dict) -> tuple[str, str | None]:
+    """Compute the soft-delete instant for a finalize_task tool call.
+
+    Returns ``(deleted_at_iso, error)`` — error is non-None when the inputs
+    were malformed. Honours an explicit ``deleted_at`` first, then
+    ``expires_in_seconds``, otherwise falls back to the default 3-day window.
+    """
+    raw = inp.get("deleted_at")
+    if raw:
+        try:
+            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError as exc:
+            return "", f"Invalid deleted_at: {exc}"
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC).isoformat(), None
+    seconds = inp.get("expires_in_seconds")
+    if seconds is not None:
+        try:
+            secs = int(seconds)
+        except (TypeError, ValueError):
+            return "", f"Invalid expires_in_seconds: {seconds!r}"
+        if secs < 0:
+            return "", "expires_in_seconds must be >= 0"
+        return (datetime.now(UTC) + timedelta(seconds=secs)).isoformat(), None
+    default = datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS)
+    return default.isoformat(), None
+
 
 FOREMAN_TOOLS = [
     {
@@ -121,12 +155,34 @@ FOREMAN_TOOLS = [
         "name": "finalize_task",
         "description": (
             "Mark a task complete with no further follow-up needed. "
-            "Call after reviewing a completed task when no additional work is required."
+            "Call after reviewing a completed task when no additional work is required. "
+            "Tasks are soft-deleted after their expiry window so the table doesn't "
+            "accumulate cruft. Pick the window by task type:\n"
+            "  - Ephemeral tasks (periodic-check, status-poll, automated health "
+            "checks): expires_in_seconds = 1200 (20 minutes)\n"
+            "  - Code tasks (execute / review / followup phases): omit the field "
+            "to use the default 3 days, or pass expires_in_seconds = 259200\n"
+            "  - Error / failed tasks: expires_in_seconds = 86400 (1 day)\n"
+            "Pass deleted_at instead if you need an exact ISO-8601 timestamp."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "task_id": {"type": "string", "description": "Task ID to finalize."},
+                "expires_in_seconds": {
+                    "type": "integer",
+                    "description": (
+                        "Seconds from now until the task is soft-deleted. "
+                        "Defaults to 259200 (3 days) when omitted."
+                    ),
+                },
+                "deleted_at": {
+                    "type": "string",
+                    "description": (
+                        "ISO-8601 UTC timestamp at which the task is soft-deleted. "
+                        "Takes precedence over expires_in_seconds when both are set."
+                    ),
+                },
             },
             "required": ["task_id"],
         },
@@ -598,38 +654,52 @@ async def exec_tools(guild_id: str, tool_uses: list) -> list:
 
                 elif tu.name == "finalize_task":
                     task_id = inp["task_id"]
-                    result = await db.execute(
-                        select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
-                    )
-                    worker_id_val = result.scalar_one_or_none()
-                    if not worker_id_val:
-                        result_text = f"Task {task_id} not found."
+                    deleted_at, err = _resolve_finalize_deleted_at(inp)
+                    if err:
+                        result_text = err
+                        is_error = True
                     else:
-                        finished_at = datetime.now(UTC).isoformat()
-                        await db.execute(
-                            update(Task)
-                            .where(Task.id == task_id)
-                            .values(state="done", finished_at=finished_at)
+                        result = await db.execute(
+                            select(Task.worker_id).where(
+                                Task.id == task_id, Task.guild_id == guild_id
+                            )
                         )
-                        await db.commit()
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "task-finalize",
-                                "workerId": worker_id_val,
-                                "taskId": task_id,
-                            },
-                        )
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "task-update",
-                                "taskId": task_id,
-                                "state": "done",
-                                "finishedAt": finished_at,
-                            },
-                        )
-                        result_text = f"Task {task_id} finalized."
+                        worker_id_val = result.scalar_one_or_none()
+                        if not worker_id_val:
+                            result_text = f"Task {task_id} not found."
+                        else:
+                            finished_at = datetime.now(UTC).isoformat()
+                            await db.execute(
+                                update(Task)
+                                .where(Task.id == task_id)
+                                .values(
+                                    state="done",
+                                    finished_at=finished_at,
+                                    deleted_at=deleted_at,
+                                )
+                            )
+                            await db.commit()
+                            await broadcast(
+                                guild_id,
+                                {
+                                    "type": "task-finalize",
+                                    "workerId": worker_id_val,
+                                    "taskId": task_id,
+                                },
+                            )
+                            await broadcast(
+                                guild_id,
+                                {
+                                    "type": "task-update",
+                                    "taskId": task_id,
+                                    "state": "done",
+                                    "finishedAt": finished_at,
+                                    "deletedAt": deleted_at,
+                                },
+                            )
+                            result_text = (
+                                f"Task {task_id} finalized; soft-delete at {deleted_at}."
+                            )
 
                 elif tu.name == "message_worker":
                     wid = inp["worker_id"]

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -697,9 +697,7 @@ async def exec_tools(guild_id: str, tool_uses: list) -> list:
                                     "deletedAt": deleted_at,
                                 },
                             )
-                            result_text = (
-                                f"Task {task_id} finalized; soft-delete at {deleted_at}."
-                            )
+                            result_text = f"Task {task_id} finalized; soft-delete at {deleted_at}."
 
                 elif tu.name == "message_worker":
                     wid = inp["worker_id"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,6 +29,7 @@ from models import (
     User,
     UserSession,
     Worker,
+    live_tasks_filter,
 )
 from pydantic import BaseModel
 from sqlalchemy import delete, func, select, update
@@ -2086,7 +2087,11 @@ async def list_tasks(guild_id: str, worker_id: str):
     try:
         result = await db.execute(
             select(Task)
-            .where(Task.worker_id == worker_id, Task.guild_id == guild_id)
+            .where(
+                Task.worker_id == worker_id,
+                Task.guild_id == guild_id,
+                live_tasks_filter(),
+            )
             .order_by(Task.created_at.desc())
         )
         return [_row(t) for t in result.scalars().all()]
@@ -2151,8 +2156,9 @@ async def list_guild_tasks(
                 Task.issue_repo,
                 Task.created_at,
                 Task.finished_at,
+                Task.deleted_at,
             )
-            .where(Task.guild_id == guild_id)
+            .where(Task.guild_id == guild_id, live_tasks_filter())
             .order_by(Task.created_at.desc())
             .limit(100)
         )
@@ -2171,7 +2177,11 @@ async def get_task_logs(
     db = await get_db()
     try:
         result = await db.execute(
-            select(Task.id).where(Task.id == task_id, Task.guild_id == guild_id)
+            select(Task.id).where(
+                Task.id == task_id,
+                Task.guild_id == guild_id,
+                live_tasks_filter(),
+            )
         )
         if not result.scalar_one_or_none():
             raise HTTPException(status_code=404, detail="Task not found")
@@ -2282,13 +2292,56 @@ async def create_task_followup(
     return {"status": "sent", "taskId": task_id}
 
 
+# Default soft-delete window for finalized tasks when the caller does not
+# specify one. 3 days lets the operator review recent work in the UI before
+# it disappears.
+DEFAULT_FINALIZE_TTL = timedelta(days=3)
+
+
+class FinalizeBody(BaseModel):
+    # Optional ISO-8601 timestamp at which to soft-delete this task.
+    deleted_at: str | None = None
+    # Optional convenience: seconds from now until soft-delete. If both fields
+    # are set, deleted_at wins.
+    expires_in_seconds: int | None = None
+
+
+def _resolve_finalize_deleted_at(body: FinalizeBody | None) -> str:
+    """Return an ISO-8601 UTC timestamp for the task's soft-delete instant.
+
+    Honours an explicit ``deleted_at`` first, then ``expires_in_seconds``,
+    and otherwise falls back to ``now + DEFAULT_FINALIZE_TTL``.
+    """
+    if body and body.deleted_at:
+        try:
+            parsed = datetime.fromisoformat(body.deleted_at.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid deleted_at: {exc}"
+            ) from exc
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC).isoformat()
+    if body and body.expires_in_seconds is not None:
+        if body.expires_in_seconds < 0:
+            raise HTTPException(status_code=400, detail="expires_in_seconds must be >= 0")
+        return (datetime.now(UTC) + timedelta(seconds=body.expires_in_seconds)).isoformat()
+    return (datetime.now(UTC) + DEFAULT_FINALIZE_TTL).isoformat()
+
+
 @app.post("/guilds/{guild_id}/tasks/{task_id}/finalize")
 async def finalize_task_endpoint(
     guild_id: str,
     task_id: str,
+    body: FinalizeBody | None = None,
     github_user_id: str = Depends(require_member()),
 ):
-    """Signal a worker to finalize a task — no more follow-ups."""
+    """Signal a worker to finalize a task — no more follow-ups.
+
+    The optional body may carry ``deleted_at`` (ISO-8601) or
+    ``expires_in_seconds`` to set the task's soft-delete window. If neither is
+    set, the task is soft-deleted ``DEFAULT_FINALIZE_TTL`` from now.
+    """
     db = await get_db()
     try:
         result = await db.execute(
@@ -2298,8 +2351,11 @@ async def finalize_task_endpoint(
         if not worker_id:
             raise HTTPException(status_code=404, detail="Task not found")
         finished_at = datetime.now(UTC).isoformat()
+        deleted_at = _resolve_finalize_deleted_at(body)
         await db.execute(
-            update(Task).where(Task.id == task_id).values(state="done", finished_at=finished_at)
+            update(Task)
+            .where(Task.id == task_id)
+            .values(state="done", finished_at=finished_at, deleted_at=deleted_at)
         )
         await db.commit()
     finally:
@@ -2319,9 +2375,10 @@ async def finalize_task_endpoint(
             "taskId": task_id,
             "state": "done",
             "finishedAt": finished_at,
+            "deletedAt": deleted_at,
         },
     )
-    return {"status": "finalized", "taskId": task_id}
+    return {"status": "finalized", "taskId": task_id, "deletedAt": deleted_at}
 
 
 @app.post("/guilds/{guild_id}/tasks/{task_id}/cancel")

--- a/backend/main.py
+++ b/backend/main.py
@@ -2316,9 +2316,7 @@ def _resolve_finalize_deleted_at(body: FinalizeBody | None) -> str:
         try:
             parsed = datetime.fromisoformat(body.deleted_at.replace("Z", "+00:00"))
         except ValueError as exc:
-            raise HTTPException(
-                status_code=400, detail=f"Invalid deleted_at: {exc}"
-            ) from exc
+            raise HTTPException(status_code=400, detail=f"Invalid deleted_at: {exc}") from exc
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
         return parsed.astimezone(UTC).isoformat()

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,9 +1,23 @@
-from sqlalchemy import Column, ForeignKey, Integer, Text
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, ForeignKey, Integer, Text, or_
 from sqlalchemy.orm import DeclarativeBase
 
 
 class Base(DeclarativeBase):
     pass
+
+
+def live_tasks_filter(now: str | None = None):
+    """SQL clause matching tasks that have not been soft-deleted.
+
+    A task is "live" when ``deleted_at`` is NULL or set to a future timestamp.
+    *now* defaults to the current UTC time as an ISO-8601 string; pass an
+    explicit value to make a query reproducible in tests.
+    """
+    if now is None:
+        now = datetime.now(UTC).isoformat()
+    return or_(Task.deleted_at.is_(None), Task.deleted_at > now)
 
 
 class Guild(Base):
@@ -81,6 +95,9 @@ class Task(Base):
     name = Column(Text)
     parent_task_id = Column(Text)
     phase = Column(Text, server_default="execute")
+    # ISO-8601 UTC timestamp at which this task is considered soft-deleted.
+    # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
+    deleted_at = Column(Text, nullable=True)
 
 
 class GithubToken(Base):

--- a/backend/tests/test_soft_delete_tasks.py
+++ b/backend/tests/test_soft_delete_tasks.py
@@ -1,0 +1,382 @@
+"""Tests for soft-delete on tasks (issue #177).
+
+Covers:
+- Migration adds the deleted_at column.
+- _resolve_finalize_deleted_at honours deleted_at, expires_in_seconds, default.
+- live_tasks_filter hides soft-deleted rows from the list endpoint.
+- The finalize endpoint persists deleted_at to the row.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import insert_guild, make_auth_token  # noqa: E402
+
+
+def _auth(db_path: str) -> dict:
+    return {"Authorization": f"Bearer {make_auth_token(db_path)}"}
+
+
+def _create_worker(test_client, guild_id: str) -> str:
+    return test_client.post(f"/guilds/{guild_id}/workers", json={"repos": []}).json()["id"]
+
+
+def _create_task(test_client, guild_id: str, worker_id: str, desc: str, db_path: str) -> str:
+    resp = test_client.post(
+        f"/guilds/{guild_id}/workers/{worker_id}/tasks",
+        json={"description": desc, "tool": "claude"},
+        headers=_auth(db_path),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+def _set_deleted_at(db_path: str, task_id: str, deleted_at: str | None) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE tasks SET deleted_at = ? WHERE id = ?", (deleted_at, task_id))
+        conn.commit()
+
+
+def _read_task(db_path: str, task_id: str) -> dict:
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    return dict(row) if row else {}
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+def test_migration_adds_deleted_at_column(client):
+    """The Alembic head must add tasks.deleted_at."""
+    _, db_path = client
+    with sqlite3.connect(db_path) as conn:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(tasks)").fetchall()]
+    assert "deleted_at" in cols
+
+
+# ---------------------------------------------------------------------------
+# _resolve_finalize_deleted_at (REST helper)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_finalize_default_window(monkeypatch):
+    from main import DEFAULT_FINALIZE_TTL, _resolve_finalize_deleted_at
+
+    fixed = datetime(2026, 1, 1, tzinfo=UTC)
+
+    class _FixedDT(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    monkeypatch.setattr("main.datetime", _FixedDT)
+    out = _resolve_finalize_deleted_at(None)
+    assert datetime.fromisoformat(out) == fixed + DEFAULT_FINALIZE_TTL
+
+
+def test_resolve_finalize_explicit_seconds(monkeypatch):
+    from main import FinalizeBody, _resolve_finalize_deleted_at
+
+    fixed = datetime(2026, 1, 1, tzinfo=UTC)
+
+    class _FixedDT(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    monkeypatch.setattr("main.datetime", _FixedDT)
+    out = _resolve_finalize_deleted_at(FinalizeBody(expires_in_seconds=1200))
+    assert datetime.fromisoformat(out) == fixed + timedelta(seconds=1200)
+
+
+def test_resolve_finalize_explicit_deleted_at_iso():
+    from main import FinalizeBody, _resolve_finalize_deleted_at
+
+    target = "2026-06-15T12:00:00+00:00"
+    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at=target))
+    assert datetime.fromisoformat(out) == datetime.fromisoformat(target)
+
+
+def test_resolve_finalize_deleted_at_naive_assumed_utc():
+    from main import FinalizeBody, _resolve_finalize_deleted_at
+
+    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at="2026-06-15T12:00:00"))
+    parsed = datetime.fromisoformat(out)
+    assert parsed.tzinfo is not None
+    assert parsed == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def test_resolve_finalize_deleted_at_z_suffix():
+    from main import FinalizeBody, _resolve_finalize_deleted_at
+
+    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at="2026-06-15T12:00:00Z"))
+    assert datetime.fromisoformat(out) == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def test_resolve_finalize_invalid_deleted_at_raises():
+    from fastapi import HTTPException
+
+    from main import FinalizeBody, _resolve_finalize_deleted_at
+
+    with pytest.raises(HTTPException) as excinfo:
+        _resolve_finalize_deleted_at(FinalizeBody(deleted_at="not-a-date"))
+    assert excinfo.value.status_code == 400
+
+
+def test_resolve_finalize_negative_seconds_raises():
+    from fastapi import HTTPException
+
+    from main import FinalizeBody, _resolve_finalize_deleted_at
+
+    with pytest.raises(HTTPException) as excinfo:
+        _resolve_finalize_deleted_at(FinalizeBody(expires_in_seconds=-1))
+    assert excinfo.value.status_code == 400
+
+
+def test_resolve_finalize_deleted_at_wins_over_seconds():
+    """If both fields are set, deleted_at takes precedence."""
+    from main import FinalizeBody, _resolve_finalize_deleted_at
+
+    out = _resolve_finalize_deleted_at(
+        FinalizeBody(deleted_at="2026-12-25T00:00:00Z", expires_in_seconds=60)
+    )
+    assert datetime.fromisoformat(out) == datetime(2026, 12, 25, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# live_tasks_filter — list endpoints hide soft-deleted rows
+# ---------------------------------------------------------------------------
+
+
+def test_list_guild_tasks_hides_past_deleted_at(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gsd01")
+    worker_id = _create_worker(test_client, "gsd01")
+    t_live = _create_task(test_client, "gsd01", worker_id, "live task", db_path)
+    t_dead = _create_task(test_client, "gsd01", worker_id, "dead task", db_path)
+    t_future = _create_task(test_client, "gsd01", worker_id, "future task", db_path)
+
+    past = (datetime.now(UTC) - timedelta(seconds=5)).isoformat()
+    future = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+    _set_deleted_at(db_path, t_dead, past)
+    _set_deleted_at(db_path, t_future, future)
+
+    resp = test_client.get("/guilds/gsd01/tasks", headers=_auth(db_path))
+    assert resp.status_code == 200
+    ids = {t["id"] for t in resp.json()}
+    assert t_live in ids
+    assert t_future in ids
+    assert t_dead not in ids
+
+
+def test_list_worker_tasks_hides_past_deleted_at(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gsd02")
+    worker_id = _create_worker(test_client, "gsd02")
+    t_live = _create_task(test_client, "gsd02", worker_id, "live", db_path)
+    t_dead = _create_task(test_client, "gsd02", worker_id, "dead", db_path)
+    _set_deleted_at(db_path, t_dead, (datetime.now(UTC) - timedelta(minutes=1)).isoformat())
+
+    resp = test_client.get(f"/guilds/gsd02/workers/{worker_id}/tasks")
+    assert resp.status_code == 200
+    ids = {t["id"] for t in resp.json()}
+    assert ids == {t_live}
+
+
+def test_get_task_logs_404_on_soft_deleted(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gsd03")
+    worker_id = _create_worker(test_client, "gsd03")
+    task_id = _create_task(test_client, "gsd03", worker_id, "task", db_path)
+    _set_deleted_at(db_path, task_id, (datetime.now(UTC) - timedelta(minutes=1)).isoformat())
+
+    resp = test_client.get(f"/guilds/gsd03/tasks/{task_id}/logs", headers=_auth(db_path))
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Finalize endpoint — persists deleted_at and supports overrides
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_endpoint_default_sets_three_day_window(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gsd04")
+    worker_id = _create_worker(test_client, "gsd04")
+    task_id = _create_task(test_client, "gsd04", worker_id, "task", db_path)
+
+    before = datetime.now(UTC)
+    resp = test_client.post(
+        f"/guilds/gsd04/tasks/{task_id}/finalize", headers=_auth(db_path)
+    )
+    assert resp.status_code == 200, resp.text
+    deleted_at = resp.json()["deletedAt"]
+    parsed = datetime.fromisoformat(deleted_at)
+    # Should be roughly 3 days from now (allow ±1 minute slack for slow machines).
+    assert timedelta(days=3, minutes=-1) <= parsed - before <= timedelta(days=3, minutes=1)
+    assert _read_task(db_path, task_id)["deleted_at"] == deleted_at
+
+
+def test_finalize_endpoint_explicit_expires_in_seconds(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gsd05")
+    worker_id = _create_worker(test_client, "gsd05")
+    task_id = _create_task(test_client, "gsd05", worker_id, "task", db_path)
+
+    before = datetime.now(UTC)
+    resp = test_client.post(
+        f"/guilds/gsd05/tasks/{task_id}/finalize",
+        json={"expires_in_seconds": 1200},
+        headers=_auth(db_path),
+    )
+    assert resp.status_code == 200, resp.text
+    parsed = datetime.fromisoformat(resp.json()["deletedAt"])
+    assert timedelta(seconds=1199) <= parsed - before <= timedelta(seconds=1260)
+
+
+def test_finalize_endpoint_explicit_deleted_at(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gsd06")
+    worker_id = _create_worker(test_client, "gsd06")
+    task_id = _create_task(test_client, "gsd06", worker_id, "task", db_path)
+
+    target = "2026-12-25T00:00:00+00:00"
+    resp = test_client.post(
+        f"/guilds/gsd06/tasks/{task_id}/finalize",
+        json={"deleted_at": target},
+        headers=_auth(db_path),
+    )
+    assert resp.status_code == 200
+    assert datetime.fromisoformat(resp.json()["deletedAt"]) == datetime.fromisoformat(target)
+
+
+def test_finalize_endpoint_rejects_bad_deleted_at(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gsd07")
+    worker_id = _create_worker(test_client, "gsd07")
+    task_id = _create_task(test_client, "gsd07", worker_id, "task", db_path)
+
+    resp = test_client.post(
+        f"/guilds/gsd07/tasks/{task_id}/finalize",
+        json={"deleted_at": "garbage"},
+        headers=_auth(db_path),
+    )
+    assert resp.status_code == 400
+
+
+def test_finalize_then_list_hides_after_window_passes(client):
+    """End-to-end: finalize with a tiny window, list excludes after it elapses."""
+    test_client, db_path = client
+    insert_guild(db_path, "gsd08")
+    worker_id = _create_worker(test_client, "gsd08")
+    task_id = _create_task(test_client, "gsd08", worker_id, "task", db_path)
+
+    test_client.post(
+        f"/guilds/gsd08/tasks/{task_id}/finalize",
+        json={"expires_in_seconds": 0},
+        headers=_auth(db_path),
+    )
+    # Backdate by 1 second so the strict `>` comparison hides it.
+    past = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+    _set_deleted_at(db_path, task_id, past)
+    resp = test_client.get("/guilds/gsd08/tasks", headers=_auth(db_path))
+    ids = {t["id"] for t in resp.json()}
+    assert task_id not in ids
+
+
+# ---------------------------------------------------------------------------
+# Foreman tool helper — _resolve_finalize_deleted_at in foreman/tools.py
+# ---------------------------------------------------------------------------
+
+
+def test_foreman_tool_resolver_default():
+    from foreman.tools import DEFAULT_FINALIZE_TTL_SECONDS, _resolve_finalize_deleted_at
+
+    before = datetime.now(UTC)
+    out, err = _resolve_finalize_deleted_at({})
+    assert err is None
+    delta = datetime.fromisoformat(out) - before
+    assert (
+        timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS - 60)
+        <= delta
+        <= timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS + 60)
+    )
+
+
+def test_foreman_tool_resolver_explicit_seconds():
+    from foreman.tools import _resolve_finalize_deleted_at
+
+    before = datetime.now(UTC)
+    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": 1200})
+    assert err is None
+    delta = datetime.fromisoformat(out) - before
+    assert timedelta(seconds=1199) <= delta <= timedelta(seconds=1260)
+
+
+def test_foreman_tool_resolver_invalid_seconds():
+    from foreman.tools import _resolve_finalize_deleted_at
+
+    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": "not-an-int"})
+    assert out == ""
+    assert err and "Invalid expires_in_seconds" in err
+
+
+def test_foreman_tool_resolver_negative_seconds():
+    from foreman.tools import _resolve_finalize_deleted_at
+
+    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": -5})
+    assert out == ""
+    assert err and ">=" in err
+
+
+def test_foreman_tool_resolver_explicit_deleted_at():
+    from foreman.tools import _resolve_finalize_deleted_at
+
+    target = "2026-12-25T00:00:00Z"
+    out, err = _resolve_finalize_deleted_at({"deleted_at": target})
+    assert err is None
+    assert datetime.fromisoformat(out) == datetime(2026, 12, 25, tzinfo=UTC)
+
+
+def test_foreman_tool_resolver_invalid_deleted_at():
+    from foreman.tools import _resolve_finalize_deleted_at
+
+    out, err = _resolve_finalize_deleted_at({"deleted_at": "garbage"})
+    assert out == ""
+    assert err and "Invalid deleted_at" in err
+
+
+def test_foreman_tool_definition_advertises_expiry_fields():
+    """Schema must expose expires_in_seconds and deleted_at on finalize_task."""
+    from foreman.tools import FOREMAN_TOOLS
+
+    finalize = next(t for t in FOREMAN_TOOLS if t["name"] == "finalize_task")
+    props = finalize["input_schema"]["properties"]
+    assert "expires_in_seconds" in props
+    assert props["expires_in_seconds"]["type"] == "integer"
+    assert "deleted_at" in props
+    assert props["deleted_at"]["type"] == "string"
+    # task_id is the only required field; expiry fields stay optional.
+    assert finalize["input_schema"]["required"] == ["task_id"]
+
+
+def test_foreman_prompt_documents_expiry_windows():
+    """The system prompt must mention each expiry window so the foreman picks them."""
+    from foreman.prompt import FOREMAN_SYSTEM
+
+    assert "1200" in FOREMAN_SYSTEM
+    assert "259200" in FOREMAN_SYSTEM
+    assert "86400" in FOREMAN_SYSTEM
+    assert "expires_in_seconds" in FOREMAN_SYSTEM

--- a/backend/tests/test_soft_delete_tasks.py
+++ b/backend/tests/test_soft_delete_tasks.py
@@ -127,7 +127,6 @@ def test_resolve_finalize_deleted_at_z_suffix():
 
 def test_resolve_finalize_invalid_deleted_at_raises():
     from fastapi import HTTPException
-
     from main import FinalizeBody, _resolve_finalize_deleted_at
 
     with pytest.raises(HTTPException) as excinfo:
@@ -137,7 +136,6 @@ def test_resolve_finalize_invalid_deleted_at_raises():
 
 def test_resolve_finalize_negative_seconds_raises():
     from fastapi import HTTPException
-
     from main import FinalizeBody, _resolve_finalize_deleted_at
 
     with pytest.raises(HTTPException) as excinfo:
@@ -218,9 +216,7 @@ def test_finalize_endpoint_default_sets_three_day_window(client):
     task_id = _create_task(test_client, "gsd04", worker_id, "task", db_path)
 
     before = datetime.now(UTC)
-    resp = test_client.post(
-        f"/guilds/gsd04/tasks/{task_id}/finalize", headers=_auth(db_path)
-    )
+    resp = test_client.post(f"/guilds/gsd04/tasks/{task_id}/finalize", headers=_auth(db_path))
     assert resp.status_code == 200, resp.text
     deleted_at = resp.json()["deletedAt"]
     parsed = datetime.fromisoformat(deleted_at)

--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useTasksStore } from '../tasks'
 
@@ -150,6 +150,115 @@ describe('useTasksStore', () => {
     it('is a no-op for unrelated message types', () => {
       const store = useTasksStore()
       store.handleWebSocketMessage({ type: 'agent-state', state: 'idle' })
+      expect(store.tasks).toHaveLength(0)
+    })
+  })
+
+  describe('soft-delete (deletedAt)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('stores deletedAt from task-update and drops the row when the timer fires', () => {
+      const store = useTasksStore()
+      store.tasks.push({ id: 't-1', state: 'working' })
+
+      const future = new Date(Date.now() + 60_000).toISOString()
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        state: 'done',
+        deletedAt: future,
+      })
+      expect(store.tasks[0].deleted_at).toBe(future)
+      expect(store.tasks).toHaveLength(1)
+
+      vi.advanceTimersByTime(60_001)
+      expect(store.tasks).toHaveLength(0)
+    })
+
+    it('drops a task immediately when deletedAt is already in the past', () => {
+      const store = useTasksStore()
+      store.tasks.push({ id: 't-1', state: 'done' })
+
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        deletedAt: new Date(Date.now() - 1000).toISOString(),
+      })
+      expect(store.tasks).toHaveLength(0)
+    })
+
+    it('liveTasks excludes rows whose deleted_at has passed even before the timer fires', () => {
+      const store = useTasksStore()
+      const past = new Date(Date.now() - 5_000).toISOString()
+      const future = new Date(Date.now() + 5_000).toISOString()
+      // Push directly (bypass the WS handler that would also schedule removal).
+      store.tasks.push({ id: 't-live', state: 'done' })
+      store.tasks.push({ id: 't-future', state: 'done', deleted_at: future })
+      store.tasks.push({ id: 't-past', state: 'done', deleted_at: past })
+
+      const ids = store.liveTasks.map(t => t.id)
+      expect(ids).toContain('t-live')
+      expect(ids).toContain('t-future')
+      expect(ids).not.toContain('t-past')
+    })
+
+    it('clearTasks cancels pending expiry timers', () => {
+      const store = useTasksStore()
+      store.tasks.push({ id: 't-1', state: 'done' })
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        deletedAt: new Date(Date.now() + 30_000).toISOString(),
+      })
+
+      store.clearTasks()
+      // If the timer were still live, advancing past it would throw because
+      // _removeTask would mutate cleared state — instead we just assert the
+      // store stays empty after the original window elapses.
+      vi.advanceTimersByTime(60_000)
+      expect(store.tasks).toEqual([])
+    })
+
+    it('reschedules when deletedAt changes on a subsequent task-update', () => {
+      const store = useTasksStore()
+      store.tasks.push({ id: 't-1', state: 'done' })
+
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        deletedAt: new Date(Date.now() + 1_000).toISOString(),
+      })
+      // Replace with a much later expiry before the first one fires.
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        deletedAt: new Date(Date.now() + 60_000).toISOString(),
+      })
+
+      vi.advanceTimersByTime(2_000)
+      expect(store.tasks).toHaveLength(1)
+      vi.advanceTimersByTime(60_000)
+      expect(store.tasks).toHaveLength(0)
+    })
+
+    it('fetchTasks schedules expiry for rows whose deleted_at is in the future', async () => {
+      const store = useTasksStore()
+      const future = new Date(Date.now() + 1_000).toISOString()
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve([{ id: 't-1', state: 'done', deleted_at: future }]),
+        }),
+      )
+      await store.fetchTasks('g-1')
+      expect(store.tasks).toHaveLength(1)
+      vi.advanceTimersByTime(2_000)
       expect(store.tasks).toHaveLength(0)
     })
   })

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -1,7 +1,11 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useAuthStore } from './auth'
 import type { LogEntry, Task, TaskState, WSMessage } from '../types'
+
+// Cap on setTimeout delay to avoid the 32-bit overflow that fires the timer
+// immediately on long horizons (e.g. a 3-day finalize window).
+const MAX_TIMEOUT_MS = 2_147_483_647
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
 
@@ -37,11 +41,48 @@ export const useTasksStore = defineStore('tasks', () => {
   const selectedTaskId = ref<string | null>(null)
   const openedTaskIds = ref<string[]>([])
 
+  // Per-task timers that drop the row when its soft-delete window elapses.
+  const _expiryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  function _removeTask(taskId: string) {
+    const idx = tasks.value.findIndex(t => t.id === taskId)
+    if (idx >= 0) tasks.value.splice(idx, 1)
+    delete taskLogs.value[taskId]
+    closeTask(taskId)
+    const timer = _expiryTimers.get(taskId)
+    if (timer) {
+      clearTimeout(timer)
+      _expiryTimers.delete(taskId)
+    }
+  }
+
+  function _scheduleExpiry(taskId: string, deletedAt: string | null | undefined) {
+    const existing = _expiryTimers.get(taskId)
+    if (existing) {
+      clearTimeout(existing)
+      _expiryTimers.delete(taskId)
+    }
+    if (!deletedAt) return
+    const delay = new Date(deletedAt).getTime() - Date.now()
+    if (Number.isNaN(delay)) return
+    if (delay <= 0) {
+      _removeTask(taskId)
+      return
+    }
+    const timer = setTimeout(() => _removeTask(taskId), Math.min(delay, MAX_TIMEOUT_MS))
+    _expiryTimers.set(taskId, timer)
+  }
+
   async function fetchTasks(guildId: string) {
     if (!guildId) return
     try {
       const res = await fetch(`${API_BASE}/guilds/${guildId}/tasks`, { headers: _authHeaders() })
-      if (res.ok) tasks.value = await res.json()
+      if (res.ok) {
+        tasks.value = await res.json()
+        for (const t of tasks.value) {
+          if (t.deleted_at) _scheduleExpiry(t.id, t.deleted_at)
+        }
+      }
     } catch (e) {
       console.error('Failed to fetch tasks', e)
     }
@@ -143,6 +184,10 @@ export const useTasksStore = defineStore('tasks', () => {
         if (data.prUrl) task.pr_url = data.prUrl
         if (data.finishedAt) task.finished_at = data.finishedAt
         if (data.worktreePath) task.worktree_path = data.worktreePath
+        if (data.deletedAt !== undefined) {
+          task.deleted_at = data.deletedAt
+          _scheduleExpiry(task.id, data.deletedAt)
+        }
       }
     } else if (data.type === 'task-complete') {
       const task = tasks.value.find(t => t.id === data.taskId)
@@ -181,13 +226,28 @@ export const useTasksStore = defineStore('tasks', () => {
     taskLogs.value = {}
     selectedTaskId.value = null
     openedTaskIds.value = []
+    for (const timer of _expiryTimers.values()) clearTimeout(timer)
+    _expiryTimers.clear()
   }
+
+  // Tasks whose soft-delete window has not yet elapsed. Components that filter
+  // for display should prefer this over `tasks` so a row disappears the moment
+  // its `deleted_at` passes, even before the per-task timer fires.
+  const liveTasks = computed(() => {
+    const now = Date.now()
+    return tasks.value.filter(t => {
+      if (!t.deleted_at) return true
+      const ts = new Date(t.deleted_at).getTime()
+      return Number.isNaN(ts) || ts > now
+    })
+  })
 
   function stateLabel(state: TaskState | string) { return STATE_LABELS[state] || state }
   function stateColor(state: TaskState | string) { return STATE_COLORS[state] || 'dim' }
 
   return {
     tasks,
+    liveTasks,
     taskLogs,
     selectedTaskId,
     openedTaskIds,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -72,6 +72,7 @@ export interface Task {
   worktree_path?: string
   created_at?: string
   finished_at?: string
+  deleted_at?: string | null
 }
 
 export interface Guild {


### PR DESCRIPTION
## Summary

Closes the gaps found while reviewing `claude/soft-delete-tasks-with-foreman-controlled-expiry-177-ret-t-qhmj` against issue #177:

- **Ruff** — autofixed import sort in `tests/test_soft_delete_tasks.py` and reformatted `backend/foreman/tools.py`, `backend/main.py`, and `tests/test_soft_delete_tasks.py` so `ruff check .` and `ruff format --check .` both pass cleanly.
- **Frontend** — the soft-delete branch added `deletedAt` to the `task-update` / `task-finalize` WS payloads but the Pinia tasks store ignored them, so a finalized row would linger in the UI until the next REST refetch. This PR:
  - Adds `deleted_at` to the `Task` type.
  - Stores `deleted_at` from `task-update` events.
  - Schedules a per-task `setTimeout` that drops the row at its `deleted_at` instant; if the timestamp has already passed when the event arrives (or when `fetchTasks` returns), the row is removed immediately.
  - Caps the timer at INT32_MAX so a 3-day finalize horizon doesn't overflow and fire instantly.
  - Reschedules cleanly when a follow-up `task-update` changes `deletedAt`.
  - Cancels all pending timers in `clearTasks`.
  - Exposes a `liveTasks` computed for components that want a pre-filtered list (so a stale row disappears on the next reactive read even before its timer fires).

## Test plan

- [x] `ruff check .` and `ruff format --check .` clean.
- [x] `cd backend && python -m pytest` — 213 passed (25 new soft-delete cases).
- [x] `cd frontend && npm test` — 49 passed (6 new soft-delete cases covering WS handling, fetch-time scheduling, `liveTasks`, reschedule-on-update, clear-cancels-timers, immediate removal on past `deletedAt`).
- [x] `cd frontend && npm run type-check` — clean.
- [x] `cd frontend && npm run lint` — clean.

## Notes

This branch is built on top of the soft-delete branch (`claude/soft-delete-tasks-with-foreman-controlled-expiry-177-ret-t-qhmj`) since that branch has no PR yet. If reviewers prefer, the ruff + frontend commit can be cherry-picked onto the original branch.

https://claude.ai/code/session_01MrRMFtWui5WXrAdUYK5rk5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrRMFtWui5WXrAdUYK5rk5)_