### PR TITLE
foreman: enable prompt caching on the system prefix

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -63,19 +63,26 @@ Be concise — one short paragraph maximum unless detail is requested.\
 _EMPTY_WORKERS_BLOCKS = {"[]", "[\n]"}
 
 
-def build_system_prompt(
+def _build_system_parts(
     workers_block: str,
     tasks_block: str,
-    extra_context: str = "",
-    primary_repo: str | None = None,
-) -> str:
-    """Assemble the full system prompt from live worker/task context."""
+    extra_context: str,
+    primary_repo: str | None,
+) -> tuple[str, str]:
+    """Split the system prompt into (stable_prefix, volatile_suffix).
+
+    The stable prefix is identical across calls for a given guild and is the
+    cache-control breakpoint. The volatile suffix carries live worker/task
+    state and per-call context.
+    """
     repo_line = (
         f"\n\nThe primary repository for this guild is `{primary_repo}`."
         " Check it first when searching for issues."
         if primary_repo
         else ""
     )
+    stable = f"{FOREMAN_SYSTEM}{repo_line}\n\n"
+
     if workers_block.strip() in _EMPTY_WORKERS_BLOCKS:
         workers_section = (
             "## Current workers\n"
@@ -84,11 +91,39 @@ def build_system_prompt(
         )
     else:
         workers_section = f"## Current workers\n```json\n{workers_block}\n```\n\n"
-    parts = [
-        f"{FOREMAN_SYSTEM}{repo_line}\n\n",
-        workers_section,
-        f"## Recent tasks\n```json\n{tasks_block}\n```",
-    ]
+
+    volatile = f"{workers_section}## Recent tasks\n```json\n{tasks_block}\n```"
     if extra_context:
-        parts.append(f"\n\n## Context\n{extra_context}")
-    return "".join(parts)
+        volatile += f"\n\n## Context\n{extra_context}"
+    return stable, volatile
+
+
+def build_system_prompt(
+    workers_block: str,
+    tasks_block: str,
+    extra_context: str = "",
+    primary_repo: str | None = None,
+) -> str:
+    """Assemble the full system prompt from live worker/task context."""
+    stable, volatile = _build_system_parts(workers_block, tasks_block, extra_context, primary_repo)
+    return stable + volatile
+
+
+def build_system_blocks(
+    workers_block: str,
+    tasks_block: str,
+    extra_context: str = "",
+    primary_repo: str | None = None,
+) -> list[dict]:
+    """Return the system prompt as cache-controlled text blocks.
+
+    The stable prefix (constants + per-guild repo line) carries an ephemeral
+    cache_control breakpoint so it — and the tools rendered before it —
+    cache across calls. The volatile suffix (workers/tasks/extra_context)
+    follows uncached.
+    """
+    stable, volatile = _build_system_parts(workers_block, tasks_block, extra_context, primary_repo)
+    return [
+        {"type": "text", "text": stable, "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": volatile},
+    ]

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -10,7 +10,7 @@ from events import broadcast
 from models import ForemanTurn, Guild, Message, Task, live_tasks_filter
 from sqlalchemy import delete, select
 
-from foreman.prompt import build_system_prompt
+from foreman.prompt import build_system_blocks, build_system_prompt
 from foreman.tools import FOREMAN_TOOLS, exec_tools
 
 try:
@@ -464,6 +464,9 @@ async def run_foreman_ai(
     system = build_system_prompt(
         workers_block, tasks_block, extra_context, primary_repo=primary_repo
     )
+    system_blocks = build_system_blocks(
+        workers_block, tasks_block, extra_context, primary_repo=primary_repo
+    )
 
     logger.info(
         "guild=%s run_foreman_ai: workers=%d tasks_in_context=%d "
@@ -506,16 +509,22 @@ async def run_foreman_ai(
             resp = await client.messages.create(
                 model="claude-sonnet-4-6",
                 max_tokens=1024,
-                system=system,
+                system=system_blocks,
                 messages=messages,
                 tools=FOREMAN_TOOLS,
             )
+            usage = resp.usage
             logger.info(
-                "guild=%s run_foreman_ai round %d: stop_reason=%s content_blocks=%d",
+                "guild=%s run_foreman_ai round %d: stop_reason=%s content_blocks=%d "
+                "input=%d cache_read=%d cache_write=%d output=%d",
                 guild_id,
                 round_num,
                 resp.stop_reason,
                 len(resp.content),
+                getattr(usage, "input_tokens", 0) or 0,
+                getattr(usage, "cache_read_input_tokens", 0) or 0,
+                getattr(usage, "cache_creation_input_tokens", 0) or 0,
+                getattr(usage, "output_tokens", 0) or 0,
             )
 
             # Persist assistant turn and append to local messages


### PR DESCRIPTION
Split the foreman system prompt into a stable prefix (constants +
per-guild repo line) and a volatile suffix (workers/tasks/extra_context),
and add an ephemeral cache_control breakpoint on the stable block.
Tools render before system, so the FOREMAN_TOOLS schema is cached too.
Log usage.cache_read_input_tokens / cache_creation_input_tokens per
round so cache hits are visible.

https://claude.ai/code/session_01R1XSopP43N72dNjSGFzR8M