### PR TITLE
review: address top-5 audit findings

### DIFF
--- a/backend/alembic/versions/b6c7d8e9f0a1_add_auth_token_to_workers.py
+++ b/backend/alembic/versions/b6c7d8e9f0a1_add_auth_token_to_workers.py
@@ -1,0 +1,36 @@
+"""add_auth_token_to_workers
+
+Adds an ``auth_token`` column to the ``workers`` table. Workers receive a
+fresh token at registration time and present it as a Bearer credential when
+fetching guild secrets (Claude credentials, GitHub OAuth tokens) so those
+endpoints stop being unauthenticated.
+
+Existing rows are left with NULL — they predate the auth requirement, and
+workers re-register on every process startup, so a NULL token simply means
+that worker hasn't reconnected yet under the new scheme.
+
+Revision ID: b6c7d8e9f0a1
+Revises: a5b6c7d8e9f0
+Create Date: 2026-05-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b6c7d8e9f0a1"
+down_revision: Union[str, Sequence[str], None] = "a5b6c7d8e9f0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("workers") as batch_op:
+        batch_op.add_column(sa.Column("auth_token", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workers") as batch_op:
+        batch_op.drop_column("auth_token")

--- a/backend/alembic/versions/c7d8e9f0a1b2_add_user_id_to_tasks.py
+++ b/backend/alembic/versions/c7d8e9f0a1b2_add_user_id_to_tasks.py
@@ -1,0 +1,35 @@
+"""add_user_id_to_tasks
+
+Records who initiated each task so worker-driven foreman events
+(task-complete, task-followup-done, needs-input, claude-auth-required) can
+route the resulting Claude conversation to the right user thread instead of
+defaulting to the guild owner. Without this column, multi-user guilds leak
+worker-event context across users.
+
+NULL on legacy rows; the foreman falls back to the guild owner for those.
+
+Revision ID: c7d8e9f0a1b2
+Revises: b6c7d8e9f0a1
+Create Date: 2026-05-03 00:00:01.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c7d8e9f0a1b2"
+down_revision: Union[str, Sequence[str], None] = "b6c7d8e9f0a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.add_column(sa.Column("user_id", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.drop_column("user_id")

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -622,7 +622,7 @@ async def run_foreman_ai(
                     },
                 )
 
-            tool_results = await exec_tools(guild_id, tool_uses)
+            tool_results = await exec_tools(guild_id, tool_uses, user_id=user_id)
             # Truncate verbose results before storing/sending
             trimmed = [
                 {**r, "content": truncate_tool_result(r["content"])} if r.get("content") else r

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -483,20 +483,127 @@ async def maybe_post_plan_comment(guild_id: str, task_id: str, last_text: str) -
 # ---------------------------------------------------------------------------
 
 
-async def exec_tools(guild_id: str, tool_uses: list) -> list:
-    """Execute tool calls from the foreman AI and return tool-result blocks."""
-    results = []
-    for tu in tool_uses:
-        inp = tu.input
-        result_text = ""
-        is_error = False
+async def exec_tools(guild_id: str, tool_uses: list, user_id: str | None = None) -> list:
+    """Execute tool calls from the foreman AI and return tool-result blocks.
+
+    Independent tool calls in the same batch run concurrently — each opens its
+    own DB session and the GitHub helpers already hop to a thread pool, so
+    parallelism is safe and reduces user-visible latency when Claude emits
+    several tools in one turn (a common case for read-only lookups).
+    Results are returned in the same order as *tool_uses* to match the
+    Anthropic API's tool_result contract.
+
+    *user_id* identifies the human whose foreman session is running. It's
+    stamped onto any tasks created by ``create_task`` / ``assign_task`` so
+    worker-driven events later route back to the same user thread.
+    """
+    coros = [_exec_one_tool(guild_id, tu, user_id) for tu in tool_uses]
+    return list(await asyncio.gather(*coros))
+
+
+async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
+    """Execute a single tool call and return its tool_result block."""
+    inp = tu.input
+    result_text = ""
+    is_error = False
+    try:
+        db = await get_db()
         try:
-            db = await get_db()
-            try:
-                if tu.name == "create_task":
-                    name = (inp.get("name") or "")[:80]
-                    desc = inp.get("description", name)
-                    phase = inp.get("phase", "execute")
+            if tu.name == "create_task":
+                name = (inp.get("name") or "")[:80]
+                desc = inp.get("description", name)
+                phase = inp.get("phase", "execute")
+                task_id = "t-" + "".join(
+                    random.choices(string.ascii_lowercase + string.digits, k=6)
+                )
+                created_at = datetime.now(UTC).isoformat()
+                db.add(
+                    Task(
+                        id=task_id,
+                        worker_id="foreman",
+                        guild_id=guild_id,
+                        name=name,
+                        description=desc,
+                        tool="claude",
+                        state="pending",
+                        phase=phase,
+                        created_at=created_at,
+                        user_id=user_id,
+                    )
+                )
+                await db.commit()
+                await broadcast(
+                    guild_id,
+                    {
+                        "type": "task-created",
+                        "taskId": task_id,
+                        "name": name,
+                        "description": desc,
+                        "phase": phase,
+                        "state": "pending",
+                        "createdAt": created_at,
+                    },
+                )
+                result_text = (
+                    f"Task {task_id} created: '{name}'. Reference this task_id in assign_task."
+                )
+
+            elif tu.name == "assign_task":
+                wid = inp["worker_id"]
+                desc = inp.get("description", "")
+                phase = inp.get("phase", "execute")
+                tool = inp.get("tool", "claude")
+                existing_task_id = inp.get("task_id")
+                worker_result = await db.execute(
+                    select(Worker.id).where(Worker.id == wid, Worker.guild_id == guild_id)
+                )
+                worker_row = worker_result.scalar_one_or_none()
+                if not worker_row:
+                    result_text = f"Worker {wid} not found — task NOT queued."
+                elif existing_task_id:
+                    name_override = inp.get("name")
+                    update_values: dict = {
+                        "worker_id": wid,
+                        "description": desc,
+                        "tool": tool,
+                        "phase": phase,
+                        "state": "pending",
+                    }
+                    if name_override:
+                        update_values["name"] = name_override
+                    if inp.get("issue_number") is not None:
+                        update_values["issue_number"] = inp["issue_number"]
+                    if inp.get("issue_repo"):
+                        update_values["issue_repo"] = inp["issue_repo"]
+                    await db.execute(
+                        update(Task)
+                        .where(Task.id == existing_task_id, Task.guild_id == guild_id)
+                        .values(**update_values)
+                    )
+                    await db.commit()
+                    name_result = await db.execute(
+                        select(Task.name).where(Task.id == existing_task_id)
+                    )
+                    task_name = name_result.scalar_one_or_none() or desc[:60]
+                    task_id = existing_task_id
+                    await broadcast(
+                        guild_id,
+                        {
+                            "type": "task-assigned",
+                            "workerId": wid,
+                            "taskId": task_id,
+                            "name": task_name,
+                            "description": desc,
+                            "tool": tool,
+                            "phase": phase,
+                            "issueNumber": inp.get("issue_number"),
+                            "issueRepo": inp.get("issue_repo"),
+                        },
+                    )
+                    result_text = f"Task {task_id} assigned to {wid}."
+                else:
+                    name = inp.get("name") or desc[:60]
+                    parent_task_id = inp.get("parent_task_id")
                     task_id = "t-" + "".join(
                         random.choices(string.ascii_lowercase + string.digits, k=6)
                     )
@@ -504,130 +611,72 @@ async def exec_tools(guild_id: str, tool_uses: list) -> list:
                     db.add(
                         Task(
                             id=task_id,
-                            worker_id="foreman",
+                            worker_id=wid,
                             guild_id=guild_id,
                             name=name,
                             description=desc,
-                            tool="claude",
+                            tool=tool,
+                            issue_number=inp.get("issue_number"),
+                            issue_repo=inp.get("issue_repo"),
                             state="pending",
                             phase=phase,
+                            parent_task_id=parent_task_id,
                             created_at=created_at,
+                            user_id=user_id,
                         )
                     )
                     await db.commit()
                     await broadcast(
                         guild_id,
                         {
-                            "type": "task-created",
+                            "type": "task-assigned",
+                            "workerId": wid,
                             "taskId": task_id,
                             "name": name,
                             "description": desc,
-                            "phase": phase,
-                            "state": "pending",
-                            "createdAt": created_at,
-                        },
-                    )
-                    result_text = (
-                        f"Task {task_id} created: '{name}'. Reference this task_id in assign_task."
-                    )
-
-                elif tu.name == "assign_task":
-                    wid = inp["worker_id"]
-                    desc = inp.get("description", "")
-                    phase = inp.get("phase", "execute")
-                    tool = inp.get("tool", "claude")
-                    existing_task_id = inp.get("task_id")
-                    worker_result = await db.execute(
-                        select(Worker.id).where(Worker.id == wid, Worker.guild_id == guild_id)
-                    )
-                    worker_row = worker_result.scalar_one_or_none()
-                    if not worker_row:
-                        result_text = f"Worker {wid} not found — task NOT queued."
-                    elif existing_task_id:
-                        name_override = inp.get("name")
-                        update_values: dict = {
-                            "worker_id": wid,
-                            "description": desc,
                             "tool": tool,
                             "phase": phase,
-                            "state": "pending",
-                        }
-                        if name_override:
-                            update_values["name"] = name_override
-                        if inp.get("issue_number") is not None:
-                            update_values["issue_number"] = inp["issue_number"]
-                        if inp.get("issue_repo"):
-                            update_values["issue_repo"] = inp["issue_repo"]
-                        await db.execute(
-                            update(Task)
-                            .where(Task.id == existing_task_id, Task.guild_id == guild_id)
-                            .values(**update_values)
-                        )
-                        await db.commit()
-                        name_result = await db.execute(
-                            select(Task.name).where(Task.id == existing_task_id)
-                        )
-                        task_name = name_result.scalar_one_or_none() or desc[:60]
-                        task_id = existing_task_id
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "task-assigned",
-                                "workerId": wid,
-                                "taskId": task_id,
-                                "name": task_name,
-                                "description": desc,
-                                "tool": tool,
-                                "phase": phase,
-                                "issueNumber": inp.get("issue_number"),
-                                "issueRepo": inp.get("issue_repo"),
-                            },
-                        )
-                        result_text = f"Task {task_id} assigned to {wid}."
-                    else:
-                        name = inp.get("name") or desc[:60]
-                        parent_task_id = inp.get("parent_task_id")
-                        task_id = "t-" + "".join(
-                            random.choices(string.ascii_lowercase + string.digits, k=6)
-                        )
-                        created_at = datetime.now(UTC).isoformat()
-                        db.add(
-                            Task(
-                                id=task_id,
-                                worker_id=wid,
-                                guild_id=guild_id,
-                                name=name,
-                                description=desc,
-                                tool=tool,
-                                issue_number=inp.get("issue_number"),
-                                issue_repo=inp.get("issue_repo"),
-                                state="pending",
-                                phase=phase,
-                                parent_task_id=parent_task_id,
-                                created_at=created_at,
-                            )
-                        )
-                        await db.commit()
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "task-assigned",
-                                "workerId": wid,
-                                "taskId": task_id,
-                                "name": name,
-                                "description": desc,
-                                "tool": tool,
-                                "phase": phase,
-                                "parentTaskId": parent_task_id,
-                                "issueNumber": inp.get("issue_number"),
-                                "issueRepo": inp.get("issue_repo"),
-                            },
-                        )
-                        result_text = f"Task {task_id} queued for {wid}."
+                            "parentTaskId": parent_task_id,
+                            "issueNumber": inp.get("issue_number"),
+                            "issueRepo": inp.get("issue_repo"),
+                        },
+                    )
+                    result_text = f"Task {task_id} queued for {wid}."
 
-                elif tu.name == "send_followup":
-                    task_id = inp["task_id"]
-                    instructions = inp["instructions"]
+            elif tu.name == "send_followup":
+                task_id = inp["task_id"]
+                instructions = inp["instructions"]
+                result = await db.execute(
+                    select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
+                )
+                worker_id_val = result.scalar_one_or_none()
+                if not worker_id_val:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    await db.execute(
+                        update(Task)
+                        .where(Task.id == task_id)
+                        .values(state="working", phase="followup")
+                    )
+                    await db.commit()
+                    await broadcast(
+                        guild_id,
+                        {
+                            "type": "task-followup",
+                            "workerId": worker_id_val,
+                            "taskId": task_id,
+                            "instructions": instructions,
+                        },
+                    )
+                    result_text = f"Follow-up sent to {worker_id_val} for task {task_id}."
+
+            elif tu.name == "finalize_task":
+                task_id = inp["task_id"]
+                deleted_at, err = _resolve_finalize_deleted_at(inp)
+                if err:
+                    result_text = err
+                    is_error = True
+                else:
                     result = await db.execute(
                         select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
                     )
@@ -635,379 +684,345 @@ async def exec_tools(guild_id: str, tool_uses: list) -> list:
                     if not worker_id_val:
                         result_text = f"Task {task_id} not found."
                     else:
+                        finished_at = datetime.now(UTC).isoformat()
                         await db.execute(
                             update(Task)
                             .where(Task.id == task_id)
-                            .values(state="working", phase="followup")
+                            .values(
+                                state="done",
+                                finished_at=finished_at,
+                                deleted_at=deleted_at,
+                            )
                         )
                         await db.commit()
                         await broadcast(
                             guild_id,
                             {
-                                "type": "task-followup",
+                                "type": "task-finalize",
+                                "workerId": worker_id_val,
+                                "taskId": task_id,
+                            },
+                        )
+                        await broadcast(
+                            guild_id,
+                            {
+                                "type": "task-update",
+                                "taskId": task_id,
+                                "state": "done",
+                                "finishedAt": finished_at,
+                                "deletedAt": deleted_at,
+                            },
+                        )
+                        result_text = f"Task {task_id} finalized; soft-delete at {deleted_at}."
+
+            elif tu.name == "message_worker":
+                wid = inp["worker_id"]
+                msg = inp["message"]
+                await emit_terminal_line(guild_id, wid, f"[foreman] {msg}")
+                await broadcast(
+                    guild_id,
+                    {
+                        "type": "worker-message",
+                        "workerId": wid,
+                        "message": msg,
+                    },
+                )
+                result_text = f"Message delivered to {wid}."
+
+            elif tu.name == "redirect_task":
+                task_id = inp["task_id"]
+                instructions = inp["instructions"]
+                result = await db.execute(
+                    select(Task.worker_id, Task.state).where(
+                        Task.id == task_id, Task.guild_id == guild_id
+                    )
+                )
+                row = result.one_or_none()
+                if not row:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    worker_id_val, state = row
+                    if state in ("done", "failed", "cancelled"):
+                        result_text = f"Task {task_id} is {state} — cannot redirect."
+                    else:
+                        await db.execute(
+                            update(Task).where(Task.id == task_id).values(state="working")
+                        )
+                        await db.commit()
+                        await broadcast(
+                            guild_id,
+                            {
+                                "type": "task-redirect",
                                 "workerId": worker_id_val,
                                 "taskId": task_id,
                                 "instructions": instructions,
                             },
                         )
-                        result_text = f"Follow-up sent to {worker_id_val} for task {task_id}."
-
-                elif tu.name == "finalize_task":
-                    task_id = inp["task_id"]
-                    deleted_at, err = _resolve_finalize_deleted_at(inp)
-                    if err:
-                        result_text = err
-                        is_error = True
-                    else:
-                        result = await db.execute(
-                            select(Task.worker_id).where(
-                                Task.id == task_id, Task.guild_id == guild_id
-                            )
+                        await broadcast(
+                            guild_id,
+                            {
+                                "type": "task-update",
+                                "taskId": task_id,
+                                "state": "working",
+                            },
                         )
-                        worker_id_val = result.scalar_one_or_none()
-                        if not worker_id_val:
-                            result_text = f"Task {task_id} not found."
-                        else:
-                            finished_at = datetime.now(UTC).isoformat()
-                            await db.execute(
-                                update(Task)
-                                .where(Task.id == task_id)
-                                .values(
-                                    state="done",
-                                    finished_at=finished_at,
-                                    deleted_at=deleted_at,
-                                )
-                            )
-                            await db.commit()
-                            await broadcast(
-                                guild_id,
-                                {
-                                    "type": "task-finalize",
-                                    "workerId": worker_id_val,
-                                    "taskId": task_id,
-                                },
-                            )
-                            await broadcast(
-                                guild_id,
-                                {
-                                    "type": "task-update",
-                                    "taskId": task_id,
-                                    "state": "done",
-                                    "finishedAt": finished_at,
-                                    "deletedAt": deleted_at,
-                                },
-                            )
-                            result_text = f"Task {task_id} finalized; soft-delete at {deleted_at}."
+                        result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
 
-                elif tu.name == "message_worker":
-                    wid = inp["worker_id"]
-                    msg = inp["message"]
-                    await emit_terminal_line(guild_id, wid, f"[foreman] {msg}")
-                    await broadcast(
-                        guild_id,
-                        {
-                            "type": "worker-message",
-                            "workerId": wid,
-                            "message": msg,
-                        },
+            elif tu.name == "cancel_task":
+                task_id = inp["task_id"]
+                reason = inp.get("reason", "")
+                result = await db.execute(
+                    select(Task.worker_id, Task.state).where(
+                        Task.id == task_id, Task.guild_id == guild_id
                     )
-                    result_text = f"Message delivered to {wid}."
-
-                elif tu.name == "redirect_task":
-                    task_id = inp["task_id"]
-                    instructions = inp["instructions"]
-                    result = await db.execute(
-                        select(Task.worker_id, Task.state).where(
-                            Task.id == task_id, Task.guild_id == guild_id
+                )
+                row = result.one_or_none()
+                if not row:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    worker_id_val, state = row
+                    if state in ("done", "failed", "cancelled"):
+                        result_text = f"Task {task_id} is already {state}."
+                    else:
+                        finished_at = datetime.now(UTC).isoformat()
+                        await db.execute(
+                            update(Task)
+                            .where(Task.id == task_id)
+                            .values(state="cancelled", finished_at=finished_at)
                         )
-                    )
-                    row = result.one_or_none()
-                    if not row:
-                        result_text = f"Task {task_id} not found."
-                    else:
-                        worker_id_val, state = row
-                        if state in ("done", "failed", "cancelled"):
-                            result_text = f"Task {task_id} is {state} — cannot redirect."
-                        else:
-                            await db.execute(
-                                update(Task).where(Task.id == task_id).values(state="working")
-                            )
-                            await db.commit()
-                            await broadcast(
-                                guild_id,
-                                {
-                                    "type": "task-redirect",
-                                    "workerId": worker_id_val,
-                                    "taskId": task_id,
-                                    "instructions": instructions,
-                                },
-                            )
-                            await broadcast(
-                                guild_id,
-                                {
-                                    "type": "task-update",
-                                    "taskId": task_id,
-                                    "state": "working",
-                                },
-                            )
-                            result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
-
-                elif tu.name == "cancel_task":
-                    task_id = inp["task_id"]
-                    reason = inp.get("reason", "")
-                    result = await db.execute(
-                        select(Task.worker_id, Task.state).where(
-                            Task.id == task_id, Task.guild_id == guild_id
+                        await db.commit()
+                        await broadcast(
+                            guild_id,
+                            {
+                                "type": "task-cancel",
+                                "workerId": worker_id_val,
+                                "taskId": task_id,
+                            },
                         )
-                    )
-                    row = result.one_or_none()
-                    if not row:
-                        result_text = f"Task {task_id} not found."
-                    else:
-                        worker_id_val, state = row
-                        if state in ("done", "failed", "cancelled"):
-                            result_text = f"Task {task_id} is already {state}."
-                        else:
-                            finished_at = datetime.now(UTC).isoformat()
-                            await db.execute(
-                                update(Task)
-                                .where(Task.id == task_id)
-                                .values(state="cancelled", finished_at=finished_at)
-                            )
-                            await db.commit()
-                            await broadcast(
-                                guild_id,
-                                {
-                                    "type": "task-cancel",
-                                    "workerId": worker_id_val,
-                                    "taskId": task_id,
-                                },
-                            )
-                            await broadcast(
-                                guild_id,
-                                {
-                                    "type": "task-update",
-                                    "taskId": task_id,
-                                    "state": "cancelled",
-                                    "finishedAt": finished_at,
-                                },
-                            )
-                            result_text = f"Task {task_id} cancelled." + (
-                                f" Reason: {reason}" if reason else ""
-                            )
-
-                elif tu.name == "shutdown_worker":
-                    wid = inp["worker_id"]
-                    reason = inp.get("reason", "")
-                    worker_result = await db.execute(
-                        select(Worker.id).where(Worker.id == wid, Worker.guild_id == guild_id)
-                    )
-                    if worker_result.scalar_one_or_none() is None:
-                        result_text = f"Worker {wid} not found."
-                    else:
-                        message: dict = {"type": "worker-shutdown", "workerId": wid}
-                        if reason:
-                            message["reason"] = reason
-                        await broadcast(guild_id, message)
-                        result_text = f"Shutdown signal sent to {wid}." + (
+                        await broadcast(
+                            guild_id,
+                            {
+                                "type": "task-update",
+                                "taskId": task_id,
+                                "state": "cancelled",
+                                "finishedAt": finished_at,
+                            },
+                        )
+                        result_text = f"Task {task_id} cancelled." + (
                             f" Reason: {reason}" if reason else ""
                         )
 
-                elif tu.name == "get_task_status":
-                    task_id = inp["task_id"]
-                    limit = min(int(inp.get("log_lines", 10)), 50)
-                    task_result = await db.execute(
-                        select(Task).where(Task.id == task_id, Task.guild_id == guild_id)
+            elif tu.name == "shutdown_worker":
+                wid = inp["worker_id"]
+                reason = inp.get("reason", "")
+                worker_result = await db.execute(
+                    select(Worker.id).where(Worker.id == wid, Worker.guild_id == guild_id)
+                )
+                if worker_result.scalar_one_or_none() is None:
+                    result_text = f"Worker {wid} not found."
+                else:
+                    message: dict = {"type": "worker-shutdown", "workerId": wid}
+                    if reason:
+                        message["reason"] = reason
+                    await broadcast(guild_id, message)
+                    result_text = f"Shutdown signal sent to {wid}." + (
+                        f" Reason: {reason}" if reason else ""
                     )
-                    task = task_result.scalar_one_or_none()
-                    if not task:
-                        result_text = f"Task {task_id} not found."
-                    else:
-                        agent_info = None
-                        if task.worker_id and task.worker_id != "foreman":
-                            agent_result = await db.execute(
-                                select(Agent.id, Agent.state)
-                                .where(Agent.worker_id == task.worker_id, Agent.state != "offline")
-                                .limit(1)
-                            )
-                            agent_row = agent_result.one_or_none()
-                            if agent_row:
-                                agent_info = {"agent_id": agent_row[0], "agent_state": agent_row[1]}
-                        logs_result = await db.execute(
-                            select(TaskLog.timestamp, TaskLog.line)
-                            .where(TaskLog.task_id == task_id)
-                            .order_by(TaskLog.id.desc())
-                            .limit(limit)
+
+            elif tu.name == "get_task_status":
+                task_id = inp["task_id"]
+                limit = min(int(inp.get("log_lines", 10)), 50)
+                task_result = await db.execute(
+                    select(Task).where(Task.id == task_id, Task.guild_id == guild_id)
+                )
+                task = task_result.scalar_one_or_none()
+                if not task:
+                    result_text = f"Task {task_id} not found."
+                else:
+                    agent_info = None
+                    if task.worker_id and task.worker_id != "foreman":
+                        agent_result = await db.execute(
+                            select(Agent.id, Agent.state)
+                            .where(Agent.worker_id == task.worker_id, Agent.state != "offline")
+                            .limit(1)
                         )
-                        log_rows = list(reversed(logs_result.fetchall()))
+                        agent_row = agent_result.one_or_none()
+                        if agent_row:
+                            agent_info = {"agent_id": agent_row[0], "agent_state": agent_row[1]}
+                    logs_result = await db.execute(
+                        select(TaskLog.timestamp, TaskLog.line)
+                        .where(TaskLog.task_id == task_id)
+                        .order_by(TaskLog.id.desc())
+                        .limit(limit)
+                    )
+                    log_rows = list(reversed(logs_result.fetchall()))
+                    result_text = json.dumps(
+                        {
+                            "id": task.id,
+                            "name": task.name,
+                            "state": task.state,
+                            "phase": task.phase,
+                            "worker_id": task.worker_id,
+                            "agent": agent_info,
+                            "branch": task.branch,
+                            "pr_url": task.pr_url,
+                            "created_at": task.created_at,
+                            "finished_at": task.finished_at,
+                            "recent_logs": [{"time": r[0], "line": r[1]} for r in log_rows],
+                        }
+                    )
+        finally:
+            await db.close()
+
+        # GitHub tools — use guild's OAuth token
+        if tu.name in (
+            "list_github_issues",
+            "get_github_issue",
+            "list_github_prs",
+            "claim_github_issue",
+            "create_github_issue",
+            "search_github_issues",
+        ):
+            creds = await _guild_github_token(guild_id)
+            if not creds:
+                result_text = (
+                    "No GitHub token found for this guild — user must connect GitHub first."
+                )
+                is_error = True
+            else:
+                token, username = creds
+                try:
+                    if tu.name == "list_github_issues":
+                        repo = inp["repo"]
+                        state = inp.get("state", "open")
+                        limit = min(int(inp.get("limit", 20)), 50)
+                        issues = await asyncio.to_thread(
+                            _gh_api,
+                            f"/repos/{repo}/issues?state={state}&per_page={limit}",
+                            token,
+                        )
+                        trimmed = [
+                            {
+                                "number": i["number"],
+                                "title": i["title"],
+                                "state": i["state"],
+                                "labels": [l["name"] for l in i.get("labels", [])],
+                                "assignees": [a["login"] for a in i.get("assignees", [])],
+                                "created_at": i["created_at"],
+                            }
+                            for i in issues
+                            if "pull_request" not in i
+                        ]
+                        result_text = json.dumps(trimmed)
+
+                    elif tu.name == "get_github_issue":
+                        repo = inp["repo"]
+                        num = int(inp["issue_number"])
+                        issue = await asyncio.to_thread(
+                            _gh_api, f"/repos/{repo}/issues/{num}", token
+                        )
+                        comments_raw = await asyncio.to_thread(
+                            _gh_api, f"/repos/{repo}/issues/{num}/comments?per_page=20", token
+                        )
                         result_text = json.dumps(
                             {
-                                "id": task.id,
-                                "name": task.name,
-                                "state": task.state,
-                                "phase": task.phase,
-                                "worker_id": task.worker_id,
-                                "agent": agent_info,
-                                "branch": task.branch,
-                                "pr_url": task.pr_url,
-                                "created_at": task.created_at,
-                                "finished_at": task.finished_at,
-                                "recent_logs": [{"time": r[0], "line": r[1]} for r in log_rows],
+                                "number": issue["number"],
+                                "title": issue["title"],
+                                "state": issue["state"],
+                                "body": (issue.get("body") or "")[:2000],
+                                "labels": [l["name"] for l in issue.get("labels", [])],
+                                "comments": [
+                                    {
+                                        "author": c["user"]["login"],
+                                        "body": (c.get("body") or "")[:500],
+                                    }
+                                    for c in comments_raw
+                                ],
                             }
                         )
-            finally:
-                await db.close()
 
-            # GitHub tools — use guild's OAuth token
-            if tu.name in (
-                "list_github_issues",
-                "get_github_issue",
-                "list_github_prs",
-                "claim_github_issue",
-                "create_github_issue",
-                "search_github_issues",
-            ):
-                creds = await _guild_github_token(guild_id)
-                if not creds:
-                    result_text = (
-                        "No GitHub token found for this guild — user must connect GitHub first."
-                    )
-                    is_error = True
-                else:
-                    token, username = creds
-                    try:
-                        if tu.name == "list_github_issues":
-                            repo = inp["repo"]
-                            state = inp.get("state", "open")
-                            limit = min(int(inp.get("limit", 20)), 50)
-                            issues = await asyncio.to_thread(
-                                _gh_api,
-                                f"/repos/{repo}/issues?state={state}&per_page={limit}",
-                                token,
-                            )
-                            trimmed = [
+                    elif tu.name == "list_github_prs":
+                        repo = inp["repo"]
+                        state = inp.get("state", "open")
+                        prs = await asyncio.to_thread(
+                            _gh_api, f"/repos/{repo}/pulls?state={state}&per_page=20", token
+                        )
+                        result_text = json.dumps(
+                            [
+                                {
+                                    "number": p["number"],
+                                    "title": p["title"],
+                                    "state": p["state"],
+                                    "head": p["head"]["ref"],
+                                    "draft": p.get("draft", False),
+                                }
+                                for p in prs
+                            ]
+                        )
+
+                    elif tu.name == "claim_github_issue":
+                        repo = inp["repo"]
+                        num = int(inp["issue_number"])
+                        await asyncio.to_thread(
+                            _gh_api_post,
+                            f"/repos/{repo}/issues/{num}/assignees",
+                            token,
+                            {"assignees": [username]},
+                        )
+                        result_text = f"Issue #{num} in {repo} assigned to {username}."
+
+                    elif tu.name == "create_github_issue":
+                        repo = inp["repo"]
+                        payload: dict = {"title": inp["title"], "body": inp.get("body", "")}
+                        if inp.get("labels"):
+                            payload["labels"] = inp["labels"]
+                        issue = await asyncio.to_thread(
+                            _gh_api_post, f"/repos/{repo}/issues", token, payload
+                        )
+                        result_text = json.dumps(
+                            {
+                                "number": issue["number"],
+                                "url": issue["html_url"],
+                                "title": issue["title"],
+                            }
+                        )
+
+                    elif tu.name == "search_github_issues":
+                        repo = inp["repo"]
+                        query = inp["query"]
+                        state = inp.get("state", "open")
+                        state_q = "" if state == "all" else f"+state:{state}"
+                        search_url = (
+                            f"/search/issues?q={urllib.parse.quote(query)}"
+                            f"+repo:{repo}{state_q}&per_page=10&sort=created&order=desc"
+                        )
+                        data = await asyncio.to_thread(_gh_api, search_url, token)
+                        items = data.get("items", []) if isinstance(data, dict) else data
+                        result_text = json.dumps(
+                            [
                                 {
                                     "number": i["number"],
                                     "title": i["title"],
                                     "state": i["state"],
+                                    "url": i["html_url"],
                                     "labels": [l["name"] for l in i.get("labels", [])],
-                                    "assignees": [a["login"] for a in i.get("assignees", [])],
-                                    "created_at": i["created_at"],
                                 }
-                                for i in issues
-                                if "pull_request" not in i
+                                for i in items
                             ]
-                            result_text = json.dumps(trimmed)
+                        )
 
-                        elif tu.name == "get_github_issue":
-                            repo = inp["repo"]
-                            num = int(inp["issue_number"])
-                            issue = await asyncio.to_thread(
-                                _gh_api, f"/repos/{repo}/issues/{num}", token
-                            )
-                            comments_raw = await asyncio.to_thread(
-                                _gh_api, f"/repos/{repo}/issues/{num}/comments?per_page=20", token
-                            )
-                            result_text = json.dumps(
-                                {
-                                    "number": issue["number"],
-                                    "title": issue["title"],
-                                    "state": issue["state"],
-                                    "body": (issue.get("body") or "")[:2000],
-                                    "labels": [l["name"] for l in issue.get("labels", [])],
-                                    "comments": [
-                                        {
-                                            "author": c["user"]["login"],
-                                            "body": (c.get("body") or "")[:500],
-                                        }
-                                        for c in comments_raw
-                                    ],
-                                }
-                            )
+                except urllib.error.HTTPError as exc:
+                    result_text = f"GitHub API error: {exc.code} {exc.reason}"
+                    is_error = True
+                except Exception as exc:
+                    result_text = f"GitHub error: {exc}"
+                    is_error = True
 
-                        elif tu.name == "list_github_prs":
-                            repo = inp["repo"]
-                            state = inp.get("state", "open")
-                            prs = await asyncio.to_thread(
-                                _gh_api, f"/repos/{repo}/pulls?state={state}&per_page=20", token
-                            )
-                            result_text = json.dumps(
-                                [
-                                    {
-                                        "number": p["number"],
-                                        "title": p["title"],
-                                        "state": p["state"],
-                                        "head": p["head"]["ref"],
-                                        "draft": p.get("draft", False),
-                                    }
-                                    for p in prs
-                                ]
-                            )
+    except Exception as exc:
+        result_text = f"Tool {tu.name} failed: {exc}"
+        is_error = True
 
-                        elif tu.name == "claim_github_issue":
-                            repo = inp["repo"]
-                            num = int(inp["issue_number"])
-                            await asyncio.to_thread(
-                                _gh_api_post,
-                                f"/repos/{repo}/issues/{num}/assignees",
-                                token,
-                                {"assignees": [username]},
-                            )
-                            result_text = f"Issue #{num} in {repo} assigned to {username}."
-
-                        elif tu.name == "create_github_issue":
-                            repo = inp["repo"]
-                            payload: dict = {"title": inp["title"], "body": inp.get("body", "")}
-                            if inp.get("labels"):
-                                payload["labels"] = inp["labels"]
-                            issue = await asyncio.to_thread(
-                                _gh_api_post, f"/repos/{repo}/issues", token, payload
-                            )
-                            result_text = json.dumps(
-                                {
-                                    "number": issue["number"],
-                                    "url": issue["html_url"],
-                                    "title": issue["title"],
-                                }
-                            )
-
-                        elif tu.name == "search_github_issues":
-                            repo = inp["repo"]
-                            query = inp["query"]
-                            state = inp.get("state", "open")
-                            state_q = "" if state == "all" else f"+state:{state}"
-                            search_url = (
-                                f"/search/issues?q={urllib.parse.quote(query)}"
-                                f"+repo:{repo}{state_q}&per_page=10&sort=created&order=desc"
-                            )
-                            data = await asyncio.to_thread(_gh_api, search_url, token)
-                            items = data.get("items", []) if isinstance(data, dict) else data
-                            result_text = json.dumps(
-                                [
-                                    {
-                                        "number": i["number"],
-                                        "title": i["title"],
-                                        "state": i["state"],
-                                        "url": i["html_url"],
-                                        "labels": [l["name"] for l in i.get("labels", [])],
-                                    }
-                                    for i in items
-                                ]
-                            )
-
-                    except urllib.error.HTTPError as exc:
-                        result_text = f"GitHub API error: {exc.code} {exc.reason}"
-                        is_error = True
-                    except Exception as exc:
-                        result_text = f"GitHub error: {exc}"
-                        is_error = True
-
-        except Exception as exc:
-            result_text = f"Tool {tu.name} failed: {exc}"
-            is_error = True
-
-        block: dict = {"type": "tool_result", "tool_use_id": tu.id, "content": result_text}
-        if is_error:
-            block["is_error"] = True
-        results.append(block)
-    return results
+    block: dict = {"type": "tool_result", "tool_use_id": tu.id, "content": result_text}
+    if is_error:
+        block["is_error"] = True
+    return block

--- a/backend/main.py
+++ b/backend/main.py
@@ -46,14 +46,13 @@ try:
 except ImportError:
     pass
 
+import ws_handlers
 from events import agent_owners, broadcast, connections, emit_terminal_line, pending_claude_auth
 from foreman import (
     clear_foreman_history,
     get_foreman_history,
-    maybe_post_plan_comment,
-    reset_foreman_poll,
-    run_foreman_ai,
 )
+from ws_handlers import _resolve_user_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -418,18 +417,6 @@ async def _ensure_membership(db, guild_id: str, user_id: str) -> str:
     raise HTTPException(status_code=403, detail="Not a member of this guild")
 
 
-async def _resolve_user_identifier(db, identifier: str) -> str | None:
-    """Look up a User by either id (numeric github id as text) or github_login.
-
-    Returns the canonical ``users.id`` or ``None`` if no match.
-    """
-    ident = (identifier or "").strip()
-    if not ident:
-        return None
-    res = await db.execute(select(User.id).where((User.id == ident) | (User.github_login == ident)))
-    return res.scalar_one_or_none()
-
-
 def require_member(*allowed_roles: str):
     """FastAPI dependency factory: caller must be a member (optionally with one of the given roles)."""
 
@@ -447,6 +434,49 @@ def require_member(*allowed_roles: str):
         return github_user_id
 
     return _dep
+
+
+async def _authorize_worker_or_member(guild_id: str, token: str | None) -> str:
+    """Validate *token* against worker auth_tokens or member login_tokens.
+
+    Returns ``"worker:<worker_id>"`` or ``"user:<github_user_id>"`` so callers
+    can audit-log the principal. Raises 401/403/404 (matching require_member's
+    contract) on failure.
+    """
+    if not token:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    db = await get_db()
+    try:
+        worker_res = await db.execute(
+            select(Worker.id).where(Worker.guild_id == guild_id, Worker.auth_token == token)
+        )
+        worker_id = worker_res.scalar_one_or_none()
+        if worker_id:
+            return f"worker:{worker_id}"
+
+        user_res = await db.execute(
+            select(UserSession.github_user_id).where(UserSession.token == token)
+        )
+        github_user_id = user_res.scalar_one_or_none()
+        if not github_user_id:
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+        await _ensure_membership(db, guild_id, github_user_id)
+        return f"user:{github_user_id}"
+    finally:
+        await db.close()
+
+
+async def require_worker_or_member(
+    guild_id: str = Query(...),
+    credentials: HTTPAuthorizationCredentials | None = Depends(_http_bearer),
+) -> str:
+    """Dependency for query-string endpoints that fetch guild secrets.
+
+    Accepts either a worker auth_token (issued at registration) or a member
+    login_token. Returns the principal string; see ``_authorize_worker_or_member``.
+    """
+    token = credentials.credentials if credentials else None
+    return await _authorize_worker_or_member(guild_id, token)
 
 
 # ---------------------------------------------------------------------------
@@ -583,8 +613,14 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
 
 
 @app.get("/auth/github/token")
-async def get_github_token(guild_id: str = Query(...)):
-    """Return the stored OAuth token for the guild's linked GitHub user. Used by workers."""
+async def get_github_token(
+    guild_id: str = Query(...),
+    _principal: str = Depends(require_worker_or_member),
+):
+    """Return the stored OAuth token for the guild's linked GitHub user. Used by workers.
+
+    Requires a worker auth_token (from registration) or a member login_token.
+    Without auth, anyone knowing a guild_id could exfiltrate the GitHub token."""
     db = await get_db()
     try:
         result = await db.execute(select(Guild.github_user_id).where(Guild.id == guild_id))
@@ -605,8 +641,14 @@ async def get_github_token(guild_id: str = Query(...)):
 
 
 @app.get("/auth/claude/credentials")
-async def get_claude_credentials(guild_id: str = Query(...)):
-    """Return stored Claude credentials blob for a worker. Called by workers on startup."""
+async def get_claude_credentials(
+    guild_id: str = Query(...),
+    _principal: str = Depends(require_worker_or_member),
+):
+    """Return stored Claude credentials blob for a worker. Called by workers on startup.
+
+    Requires a worker auth_token (from registration) or a member login_token —
+    these credentials are sensitive and must not be readable by guild_id alone."""
     db = await get_db()
     try:
         result = await db.execute(
@@ -623,8 +665,16 @@ async def get_claude_credentials(guild_id: str = Query(...)):
 
 
 @app.post("/auth/claude/credentials")
-async def store_claude_credentials(data: ClaudeCredentialsRequest):
-    """Store Claude credentials blob (called by worker after successful login)."""
+async def store_claude_credentials(
+    data: ClaudeCredentialsRequest,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_http_bearer),
+):
+    """Store Claude credentials blob (called by worker after successful login).
+
+    Requires a worker auth_token or member login_token for ``data.guild_id``.
+    Without this check, anyone could overwrite a guild's Claude credentials."""
+    token = credentials.credentials if credentials else None
+    await _authorize_worker_or_member(data.guild_id, token)
     now = datetime.now(UTC).isoformat()
     db = await get_db()
     try:
@@ -1042,8 +1092,6 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
     if guild_id not in connections:
         connections[guild_id] = []
     connections[guild_id].append(websocket)
-    # Agents that joined via this websocket; marked offline when it disconnects.
-    joined_agents: set[str] = set()
 
     # Identify the browser user from the optional ?token= query param.
     # Workers don't pass a token; ws_user_id stays None for them.
@@ -1062,407 +1110,20 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
             await _auth_db.close()
 
     db = await get_db()
+    ctx = ws_handlers.WSContext(
+        websocket=websocket, guild_id=guild_id, db=db, ws_user_id=ws_user_id
+    )
+    joined_agents = ctx.joined_agents  # alias for the disconnect cleanup below
     try:
         while True:
             data = await websocket.receive_json()
-            msg_type = data.get("type")
 
             # Refresh last_seen for any inbound frame so the sweeper knows
             # this worker is still alive. Cheap no-op for browser users
             # (they don't carry an agentId/workerId).
             await _touch_agent(db, guild_id, data.get("agentId"), data.get("workerId"))
 
-            if msg_type == "ping":
-                # Application-level heartbeat. Workers send this on an idle
-                # timer so quiet workers stay marked online; reply with pong
-                # so the worker can detect a half-open socket too.
-                await websocket.send_json(
-                    {"type": "pong", "timestamp": datetime.now(UTC).isoformat()}
-                )
-                continue
-
-            if msg_type == "join":
-                agent_id = data.get("agentId")
-                agent_name = data.get("agentName", "Unknown")
-                agent_type = data.get("agentType", "worker")
-                worker_id = data.get("workerId")
-                joined_at = datetime.now(UTC).isoformat()
-                stmt = sqlite_insert(Agent).values(
-                    id=agent_id,
-                    guild_id=guild_id,
-                    worker_id=worker_id,
-                    name=agent_name,
-                    type=agent_type,
-                    state="idle",
-                    joined_at=joined_at,
-                    last_seen=joined_at,
-                )
-                stmt = stmt.on_conflict_do_update(
-                    index_elements=["id"],
-                    set_={
-                        "guild_id": stmt.excluded.guild_id,
-                        "worker_id": stmt.excluded.worker_id,
-                        "name": stmt.excluded.name,
-                        "type": stmt.excluded.type,
-                        "state": stmt.excluded.state,
-                        "joined_at": stmt.excluded.joined_at,
-                        "last_seen": stmt.excluded.last_seen,
-                    },
-                )
-                await db.execute(stmt)
-                # Mark worker online when it (re)connects.
-                if agent_type == "worker" and worker_id:
-                    await db.execute(
-                        update(Worker)
-                        .where(Worker.id == worker_id, Worker.guild_id == guild_id)
-                        .values(state="online", last_seen=joined_at)
-                    )
-                await db.commit()
-                if agent_id:
-                    joined_agents.add(agent_id)
-                    agent_owners[agent_id] = websocket
-                broadcast_msg = {
-                    "type": "agent-joined",
-                    "agentId": agent_id,
-                    "agentName": agent_name,
-                    "agentType": agent_type,
-                    "workerId": worker_id,
-                    "state": "idle",
-                    "joinedAt": joined_at,
-                }
-                await broadcast(guild_id, broadcast_msg)
-                if agent_type == "worker":
-                    reset_foreman_poll(guild_id)
-
-            elif msg_type == "agent-state":
-                agent_id = data.get("agentId")
-                state = data.get("state", "idle")
-                activity = data.get("activity")  # fine-grained activity (reading/editing/etc.)
-                update_vals: dict = {"state": state}
-                if activity is not None:
-                    update_vals["activity"] = activity
-                elif state in ("idle", "offline"):
-                    update_vals["activity"] = None
-                await db.execute(
-                    update(Agent)
-                    .where(Agent.id == agent_id, Agent.guild_id == guild_id)
-                    .values(**update_vals)
-                )
-                await db.commit()
-                broadcast_msg: dict = {"type": "agent-state", "agentId": agent_id, "state": state}
-                if "activity" in update_vals:
-                    broadcast_msg["activity"] = update_vals["activity"]
-                await broadcast(guild_id, broadcast_msg)
-
-            elif msg_type == "chat":
-                from_agent = data.get("from", "user")
-                to_agent = data.get("to", "foreman")
-                content = data.get("content", "")
-                created_at = datetime.now(UTC).isoformat()
-                db.add(
-                    Message(
-                        guild_id=guild_id,
-                        from_agent=from_agent,
-                        to_agent=to_agent,
-                        content=content,
-                        message_type="chat",
-                        created_at=created_at,
-                        user_id=ws_user_id if from_agent == "user" else None,
-                    )
-                )
-                await db.commit()
-                await broadcast(
-                    guild_id,
-                    {
-                        "type": "chat",
-                        "from": from_agent,
-                        "to": to_agent,
-                        "content": content,
-                        "createdAt": created_at,
-                        **({"userId": ws_user_id} if ws_user_id and from_agent == "user" else {}),
-                    },
-                )
-                # Route human messages addressed to foreman through the AI.
-                # Each authenticated user gets their own foreman conversation thread.
-                # Exception: if a worker is waiting for a Claude auth code, treat
-                # the next user message as that code and bypass the foreman AI.
-                if from_agent == "user" and to_agent == "foreman" and content:
-                    pending_workers = pending_claude_auth.get(guild_id, {})
-                    if pending_workers:
-                        pending_worker_id = next(iter(pending_workers))
-                        pending_workers.pop(pending_worker_id)
-                        logger.info(
-                            "chat intercepted as auth code for %s in guild %s code_len=%d",
-                            pending_worker_id,
-                            guild_id,
-                            len(content),
-                        )
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "worker-auth-response",
-                                "workerId": pending_worker_id,
-                                "code": content,
-                            },
-                        )
-                    else:
-                        asyncio.create_task(run_foreman_ai(guild_id, content, user_id=ws_user_id))
-                        reset_foreman_poll(guild_id)
-
-            elif msg_type == "terminal-output":
-                msg_agent_id = data.get("agentId")
-                line = data.get("line", "")
-                task_id = data.get("taskId")
-                detail = data.get("detail")
-                created_at = datetime.now(UTC).isoformat()
-                # Look up worker_id for this agent to tag logs for cross-filter queries.
-                worker_id_for_log = None
-                if msg_agent_id:
-                    result = await db.execute(
-                        select(Agent.worker_id).where(Agent.id == msg_agent_id)
-                    )
-                    worker_id_for_log = result.scalar_one_or_none()
-                if line:
-                    db.add(
-                        TaskLog(
-                            task_id=task_id or None,
-                            timestamp=created_at,
-                            line=line,
-                            worker_id=worker_id_for_log,
-                            agent_id=msg_agent_id,
-                            data=json.dumps(detail) if detail else None,
-                        )
-                    )
-                    await db.commit()
-                await broadcast(
-                    guild_id,
-                    {
-                        "type": "terminal-output",
-                        "agentId": msg_agent_id,
-                        "workerId": worker_id_for_log,
-                        "taskId": task_id,
-                        "line": line,
-                        "timestamp": created_at,
-                        **({"detail": detail} if detail else {}),
-                    },
-                )
-
-            elif msg_type == "worker-register":
-                # A standalone worker process is announcing/refreshing its config.
-                worker_id = data.get("workerId")
-                repos = data.get("repos") or []
-                user_ident = data.get("user")
-                if worker_id:
-                    update_vals: dict = {"repos": json.dumps(repos)}
-                    if user_ident:
-                        resolved = await _resolve_user_identifier(db, user_ident)
-                        if resolved:
-                            update_vals["user_id"] = resolved
-                    await db.execute(
-                        update(Worker)
-                        .where(Worker.id == worker_id, Worker.guild_id == guild_id)
-                        .values(**update_vals)
-                    )
-                    await db.commit()
-
-            elif msg_type == "worker-disconnect":
-                # Worker is shutting down gracefully; mark agents and worker offline now
-                # rather than waiting for the WebSocket to close.
-                worker_id = data.get("workerId")
-                for agent_id in joined_agents:
-                    await db.execute(
-                        update(Agent)
-                        .where(Agent.id == agent_id, Agent.guild_id == guild_id)
-                        .values(state="offline")
-                    )
-                if worker_id:
-                    await db.execute(
-                        update(Worker)
-                        .where(Worker.id == worker_id, Worker.guild_id == guild_id)
-                        .values(state="offline")
-                    )
-                if joined_agents or worker_id:
-                    await db.commit()
-                for agent_id in joined_agents:
-                    await broadcast(
-                        guild_id,
-                        {
-                            "type": "agent-state",
-                            "agentId": agent_id,
-                            "state": "offline",
-                        },
-                    )
-                reset_foreman_poll(guild_id)
-
-            elif msg_type == "task-update":
-                # Worker is reporting a task state change; persist + rebroadcast.
-                task_id = data.get("taskId")
-                if task_id:
-                    update_values: dict = {}
-                    for src, col in (
-                        ("state", "state"),
-                        ("branch", "branch"),
-                        ("worktreePath", "worktree_path"),
-                        ("prUrl", "pr_url"),
-                        ("finishedAt", "finished_at"),
-                    ):
-                        if src in data:
-                            update_values[col] = data[src]
-                    if update_values:
-                        await db.execute(
-                            update(Task).where(Task.id == task_id).values(**update_values)
-                        )
-                        await db.commit()
-                    await broadcast(guild_id, data, exclude=websocket)
-
-            elif msg_type == "task-complete":
-                task_id = data.get("taskId")
-                worker_id_msg = data.get("workerId", "")
-                desc = data.get("description", "")
-                branch = data.get("branch", "")
-                finalized_by = data.get("finalizedBy", "")
-                last_text = data.get("lastText", "")
-                if task_id:
-                    await db.execute(
-                        update(Task)
-                        .where(Task.id == task_id, Task.state == "working")
-                        .values(state="awaiting-review")
-                    )
-                    await db.commit()
-                await broadcast(guild_id, data, exclude=websocket)
-                if task_id and not finalized_by:
-                    asyncio.create_task(maybe_post_plan_comment(guild_id, task_id, last_text))
-                if task_id:
-                    if finalized_by == "timeout":
-                        finished_at = datetime.now(UTC).isoformat()
-                        await db.execute(
-                            update(Task)
-                            .where(Task.id == task_id)
-                            .values(state="done", finished_at=finished_at)
-                        )
-                        await db.commit()
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "task-update",
-                                "taskId": task_id,
-                                "state": "done",
-                                "finishedAt": finished_at,
-                            },
-                        )
-                        asyncio.create_task(
-                            run_foreman_ai(
-                                guild_id,
-                                f"[timeout] Follow-up window expired for task {task_id} "
-                                f"(worker {worker_id_msg}). The task has been auto-finalized "
-                                "as done — no foreman action required.",
-                            )
-                        )
-                        reset_foreman_poll(guild_id)
-                    else:
-                        asyncio.create_task(
-                            run_foreman_ai(
-                                guild_id,
-                                f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
-                                f'"{desc[:80]}" — branch: {branch}. '
-                                "Review this result. Call send_followup if additional work is needed "
-                                "(e.g. update tests, add docs, fix lint errors). "
-                                "Otherwise call finalize_task to mark it complete.",
-                            )
-                        )
-                        reset_foreman_poll(guild_id)
-
-            elif msg_type == "task-followup-done":
-                task_id = data.get("taskId")
-                worker_id_msg = data.get("workerId", "")
-                if task_id:
-                    await db.execute(
-                        update(Task).where(Task.id == task_id).values(state="awaiting-review")
-                    )
-                    await db.commit()
-                await broadcast(guild_id, data, exclude=websocket)
-                if task_id:
-                    asyncio.create_task(
-                        run_foreman_ai(
-                            guild_id,
-                            f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
-                            "Decide: call send_followup for more work, or call finalize_task to mark it done.",
-                        )
-                    )
-                    reset_foreman_poll(guild_id)
-
-            elif msg_type == "needs-input":
-                # Worker escalation: broadcast to frontend and loop the foreman in.
-                await broadcast(guild_id, data, exclude=websocket)
-                wid = data.get("workerId", "a worker")
-                task_id = data.get("taskId", "")
-                description = data.get("description", "")
-                stop_reason = data.get("stopReason", "")
-                last_msg = data.get("lastMessage", "")
-                escalation = (
-                    f"Worker {wid} could not complete task {task_id} and needs your help.\n"
-                    f"Task: {description}\n"
-                    f"Stop reason: {stop_reason}"
-                    + (f"\nLast message: {last_msg}" if last_msg else "")
-                )
-                asyncio.create_task(run_foreman_ai(guild_id, escalation))
-
-            elif msg_type == "claude-auth-required":
-                # Worker needs Claude authentication; broadcast URL to UI and loop foreman in.
-                worker_id = data.get("workerId", "a worker")
-                auth_url = data.get("url", "")
-                logger.info(
-                    "claude-auth-required from %s in guild %s url=%s",
-                    worker_id,
-                    guild_id,
-                    auth_url[:80],
-                )
-                await broadcast(guild_id, data, exclude=websocket)
-                # Track so new frontend connections can restore the auth panel.
-                pending_claude_auth.setdefault(guild_id, {})[worker_id] = auth_url
-                logger.info(
-                    "pending_claude_auth now has %d entries for guild %s",
-                    len(pending_claude_auth.get(guild_id, {})),
-                    guild_id,
-                )
-                asyncio.create_task(
-                    run_foreman_ai(
-                        guild_id,
-                        f"Worker {worker_id} needs Claude authentication. "
-                        f"Auth URL: {auth_url}. "
-                        "A human must visit this URL, complete authentication, then paste the "
-                        "resulting code into the auth panel that has appeared in the chat UI "
-                        "(or type it into the Foreman Comms input). The worker is waiting.",
-                    )
-                )
-
-            elif msg_type == "worker-auth-response":
-                # Human is submitting an auth code; clear pending state and
-                # broadcast to all connections so the waiting worker receives it.
-                worker_id = data.get("workerId", "")
-                code_len = len(data.get("code", ""))
-                logger.info(
-                    "worker-auth-response for %s in guild %s code_len=%d",
-                    worker_id,
-                    guild_id,
-                    code_len,
-                )
-                pending_claude_auth.get(guild_id, {}).pop(worker_id, None)
-                peer_count = len(connections.get(guild_id, []))
-                logger.info(
-                    "broadcasting worker-auth-response to %d connections in guild %s",
-                    peer_count,
-                    guild_id,
-                )
-                await broadcast(guild_id, data)
-
-            elif msg_type in ("offer", "answer", "ice-candidate"):
-                # WebRTC signaling - forward to all
-                await broadcast(guild_id, data, exclude=websocket)
-
-            else:
-                # Generic broadcast
-                await broadcast(guild_id, data)
+            await ws_handlers.dispatch(ctx, data)
 
     except WebSocketDisconnect:
         if guild_id in connections and websocket in connections[guild_id]:
@@ -1803,10 +1464,16 @@ async def stop_agent_run(
 @app.post("/guilds/{guild_id}/workers")
 async def create_worker(guild_id: str, data: WorkerCreate):
     """Register a worker agent. The actual worker process must connect via WebSocket
-    using the returned id (see the standalone /worker package)."""
+    using the returned id (see the standalone /worker package).
+
+    The response includes an ``auth_token`` the worker must present as a Bearer
+    credential when fetching guild secrets (Claude/GitHub creds). The token is
+    only returned here — there is no read-after-create endpoint by design, so
+    losing it means re-registering."""
     worker_id = "w-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
     created_at = datetime.now(UTC).isoformat()
     worker_name = _worker_name(worker_id, data.hostname)
+    auth_token = secrets.token_urlsafe(32)
 
     db = await get_db()
     try:
@@ -1819,6 +1486,7 @@ async def create_worker(guild_id: str, data: WorkerCreate):
                 state="offline",
                 created_at=created_at,
                 user_id=resolved_user_id,
+                auth_token=auth_token,
             )
         )
         stmt = sqlite_insert(Agent).values(
@@ -1857,7 +1525,13 @@ async def create_worker(guild_id: str, data: WorkerCreate):
             "joinedAt": created_at,
         },
     )
-    return {"id": worker_id, "name": worker_name, "repos": data.repos, "created_at": created_at}
+    return {
+        "id": worker_id,
+        "name": worker_name,
+        "repos": data.repos,
+        "created_at": created_at,
+        "auth_token": auth_token,
+    }
 
 
 def _decode_claude_oauth_token(blob: str | None) -> str | None:

--- a/backend/models.py
+++ b/backend/models.py
@@ -74,6 +74,11 @@ class Worker(Base):
     # Identity of the human user this worker process runs on behalf of.
     # NULL for legacy/unattributed workers.
     user_id = Column(Text, ForeignKey("users.id"), nullable=True)
+    # Bearer token issued at registration; required for fetching guild secrets
+    # (Claude credentials, GitHub token) over REST. NULL on legacy rows that
+    # predate the auth requirement — those workers must re-register to get a
+    # token before they can fetch credentials.
+    auth_token = Column(Text, nullable=True)
 
 
 class Task(Base):
@@ -98,6 +103,10 @@ class Task(Base):
     # ISO-8601 UTC timestamp at which this task is considered soft-deleted.
     # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
     deleted_at = Column(Text, nullable=True)
+    # github_user_id of the human who initiated this task. Used to route
+    # worker-driven foreman events (task-complete, etc.) back to the originator's
+    # foreman thread in multi-user guilds. NULL on legacy/system tasks.
+    user_id = Column(Text, nullable=True)
 
 
 class GithubToken(Base):

--- a/backend/tests/test_credentials_auth.py
+++ b/backend/tests/test_credentials_auth.py
@@ -1,0 +1,184 @@
+"""Tests for the auth gates on /auth/claude/credentials and /auth/github/token.
+
+These endpoints used to be unauthenticated — anyone with a guild_id could
+exfiltrate or overwrite stored Claude OAuth credentials and the guild's
+GitHub token. The fix introduces a worker auth_token (issued at registration)
+plus a member-login fallback. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+
+sys.path.insert(0, os.path.dirname(__file__))
+from helpers import insert_guild, make_auth_token
+
+
+def _register_worker(test_client, guild_id: str) -> dict:
+    resp = test_client.post(
+        f"/guilds/{guild_id}/workers",
+        json={"repos": ["owner/repo"]},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _seed_claude_credentials(db_path: str, guild_id: str, blob: str = "BLOB") -> None:
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO claude_credentials (guild_id, credentials_blob, updated_at) "
+            "VALUES (?, ?, ?)",
+            (guild_id, blob, now),
+        )
+        conn.commit()
+
+
+def _seed_github_token(db_path: str, user_id: str = "gh-user-test") -> None:
+    """The default test user already has a github_tokens row via make_auth_token —
+    this is a no-op that just ensures it's there for clarity."""
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM github_tokens WHERE github_user_id = ?", (user_id,)
+        ).fetchone()
+        if row:
+            return
+        now = datetime.now(UTC).isoformat()
+        conn.execute(
+            "INSERT INTO github_tokens "
+            "(github_user_id, github_username, access_token, token_type, scope, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (user_id, "tester", "gh_tok", "bearer", "repo", now, now),
+        )
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# /auth/claude/credentials GET
+# ---------------------------------------------------------------------------
+
+
+def test_get_claude_credentials_requires_auth(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-claude")
+    _seed_claude_credentials(db_path, "g-claude")
+    resp = test_client.get("/auth/claude/credentials", params={"guild_id": "g-claude"})
+    assert resp.status_code == 401
+
+
+def test_get_claude_credentials_rejects_random_token(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-claude")
+    _seed_claude_credentials(db_path, "g-claude")
+    resp = test_client.get(
+        "/auth/claude/credentials",
+        params={"guild_id": "g-claude"},
+        headers={"Authorization": "Bearer not-a-real-token"},
+    )
+    assert resp.status_code == 401
+
+
+def test_get_claude_credentials_accepts_worker_token(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-claude")
+    _seed_claude_credentials(db_path, "g-claude", blob="THE_BLOB")
+    worker = _register_worker(test_client, "g-claude")
+    auth_token = worker["auth_token"]
+    assert auth_token, "registration response must include auth_token"
+    resp = test_client.get(
+        "/auth/claude/credentials",
+        params={"guild_id": "g-claude"},
+        headers={"Authorization": f"Bearer {auth_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["credentials_blob"] == "THE_BLOB"
+
+
+def test_get_claude_credentials_accepts_member_login_token(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-claude")
+    _seed_claude_credentials(db_path, "g-claude", blob="THE_BLOB")
+    login_token = make_auth_token(db_path)
+    resp = test_client.get(
+        "/auth/claude/credentials",
+        params={"guild_id": "g-claude"},
+        headers={"Authorization": f"Bearer {login_token}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_get_claude_credentials_rejects_worker_token_for_other_guild(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-mine")
+    insert_guild(db_path, "g-other")
+    _seed_claude_credentials(db_path, "g-other", blob="SECRET")
+    worker = _register_worker(test_client, "g-mine")
+    resp = test_client.get(
+        "/auth/claude/credentials",
+        params={"guild_id": "g-other"},
+        headers={"Authorization": f"Bearer {worker['auth_token']}"},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /auth/claude/credentials POST
+# ---------------------------------------------------------------------------
+
+
+def test_post_claude_credentials_requires_auth(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-write")
+    resp = test_client.post(
+        "/auth/claude/credentials",
+        json={"guild_id": "g-write", "credentials_blob": "NEW"},
+    )
+    assert resp.status_code == 401
+
+
+def test_post_claude_credentials_accepts_worker_token(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-write")
+    worker = _register_worker(test_client, "g-write")
+    resp = test_client.post(
+        "/auth/claude/credentials",
+        json={"guild_id": "g-write", "credentials_blob": "NEW"},
+        headers={"Authorization": f"Bearer {worker['auth_token']}"},
+    )
+    assert resp.status_code == 200
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT credentials_blob FROM claude_credentials WHERE guild_id = ?",
+            ("g-write",),
+        ).fetchone()
+    assert row[0] == "NEW"
+
+
+# ---------------------------------------------------------------------------
+# /auth/github/token GET
+# ---------------------------------------------------------------------------
+
+
+def test_get_github_token_requires_auth(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-gh")
+    _seed_github_token(db_path)
+    resp = test_client.get("/auth/github/token", params={"guild_id": "g-gh"})
+    assert resp.status_code == 401
+
+
+def test_get_github_token_accepts_worker_token(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g-gh")
+    _seed_github_token(db_path)
+    worker = _register_worker(test_client, "g-gh")
+    resp = test_client.get(
+        "/auth/github/token",
+        params={"guild_id": "g-gh"},
+        headers={"Authorization": f"Bearer {worker['auth_token']}"},
+    )
+    assert resp.status_code == 200
+    assert "access_token" in resp.json()

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -324,6 +324,43 @@ class TestExecToolsDispatching:
             row = conn.execute("SELECT phase FROM tasks WHERE id=?", (task_id,)).fetchone()
         assert row[0] == "execute"
 
+    async def test_create_task_stamps_user_id(self, db_session):
+        """Tasks created via the foreman remember which user initiated them so
+        worker callbacks can later route the conversation back to the right
+        user thread instead of always falling through to the guild owner."""
+        insert_guild(db_session, "g-stamp")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-stamp",
+                [_fake_tool_use("create_task", {"name": "Owned", "description": "task"})],
+                user_id="gh-user-42",
+            )
+        task_id = results[0]["content"].split()[1]
+        with sqlite3.connect(db_session) as conn:
+            row = conn.execute("SELECT user_id FROM tasks WHERE id=?", (task_id,)).fetchone()
+        assert row[0] == "gh-user-42"
+
+    async def test_assign_task_new_stamps_user_id(self, db_session):
+        insert_guild(db_session, "g-stamp-assign")
+        _insert_worker(db_session, "g-stamp-assign", "w-stamp1")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-stamp-assign",
+                [
+                    _fake_tool_use(
+                        "assign_task",
+                        {"worker_id": "w-stamp1", "description": "do it"},
+                    )
+                ],
+                user_id="gh-user-99",
+            )
+        # exec_tools returns "Task t-XXXXXX queued for w-stamp1." — extract the id.
+        content = results[0]["content"]
+        task_id = next(tok for tok in content.split() if tok.startswith("t-"))
+        with sqlite3.connect(db_session) as conn:
+            row = conn.execute("SELECT user_id FROM tasks WHERE id=?", (task_id,)).fetchone()
+        assert row[0] == "gh-user-99"
+
     async def test_create_task_custom_phase(self, db_session):
         insert_guild(db_session, "g-planphase")
         with patch("foreman.tools.broadcast", new_callable=AsyncMock):

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -1,0 +1,514 @@
+"""WebSocket message handlers for the per-guild ``/ws/{guild_id}`` endpoint.
+
+Each handler is keyed by the inbound ``type`` field. Handlers receive a
+``WSContext`` (the shared state held inside the live-connection coroutine —
+DB session, socket, identity, the per-connection ``joined_agents`` set) and
+the raw message dict.
+
+Splitting the dispatch into named handlers keeps ``main.websocket_endpoint``
+small enough to read at a glance and gives each branch a stable place to
+land tests + future logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from events import (
+    agent_owners,
+    broadcast,
+    connections,
+    pending_claude_auth,
+)
+from fastapi import WebSocket
+from foreman import maybe_post_plan_comment, reset_foreman_poll, run_foreman_ai
+from models import Agent, Message, Task, TaskLog, User, Worker
+from sqlalchemy import select, update
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure DB lookups; live here because main.py + ws_handlers both use
+# them and importing back into main.py from this module is the natural edge).
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_user_identifier(db, identifier: str) -> str | None:
+    """Look up a User by id (numeric github id as text) or github_login.
+
+    Returns the canonical ``users.id`` or ``None`` if no match.
+    """
+    ident = (identifier or "").strip()
+    if not ident:
+        return None
+    res = await db.execute(select(User.id).where((User.id == ident) | (User.github_login == ident)))
+    return res.scalar_one_or_none()
+
+
+async def _task_user_id(db, task_id: str | None) -> str | None:
+    """Return the github_user_id who initiated *task_id*, or None if unknown.
+
+    Used by worker-event handlers to route the resulting foreman conversation
+    back to the originating user instead of always falling through to the guild
+    owner. Returns None for legacy tasks (no user_id stamped) or unknown IDs;
+    ``run_foreman_ai`` handles the None fallback itself.
+    """
+    if not task_id:
+        return None
+    res = await db.execute(select(Task.user_id).where(Task.id == task_id))
+    return res.scalar_one_or_none()
+
+
+# ---------------------------------------------------------------------------
+# Context
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WSContext:
+    """Per-connection state shared across handlers.
+
+    Mutating ``joined_agents`` in the join handler is intentional — when the
+    connection closes, the endpoint walks that set to mark agents offline.
+    """
+
+    websocket: WebSocket
+    guild_id: str
+    db: object  # AsyncSession; typed as object to avoid SQLAlchemy import dance
+    joined_agents: set[str] = field(default_factory=set)
+    ws_user_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def handle_ping(ctx: WSContext, data: dict) -> None:
+    """Application-level heartbeat. Reply with pong so the worker can detect a
+    half-open socket too."""
+    await ctx.websocket.send_json({"type": "pong", "timestamp": datetime.now(UTC).isoformat()})
+
+
+async def handle_join(ctx: WSContext, data: dict) -> None:
+    agent_id = data.get("agentId")
+    agent_name = data.get("agentName", "Unknown")
+    agent_type = data.get("agentType", "worker")
+    worker_id = data.get("workerId")
+    joined_at = datetime.now(UTC).isoformat()
+    stmt = sqlite_insert(Agent).values(
+        id=agent_id,
+        guild_id=ctx.guild_id,
+        worker_id=worker_id,
+        name=agent_name,
+        type=agent_type,
+        state="idle",
+        joined_at=joined_at,
+        last_seen=joined_at,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["id"],
+        set_={
+            "guild_id": stmt.excluded.guild_id,
+            "worker_id": stmt.excluded.worker_id,
+            "name": stmt.excluded.name,
+            "type": stmt.excluded.type,
+            "state": stmt.excluded.state,
+            "joined_at": stmt.excluded.joined_at,
+            "last_seen": stmt.excluded.last_seen,
+        },
+    )
+    await ctx.db.execute(stmt)
+    if agent_type == "worker" and worker_id:
+        await ctx.db.execute(
+            update(Worker)
+            .where(Worker.id == worker_id, Worker.guild_id == ctx.guild_id)
+            .values(state="online", last_seen=joined_at)
+        )
+    await ctx.db.commit()
+    if agent_id:
+        ctx.joined_agents.add(agent_id)
+        agent_owners[agent_id] = ctx.websocket
+    await broadcast(
+        ctx.guild_id,
+        {
+            "type": "agent-joined",
+            "agentId": agent_id,
+            "agentName": agent_name,
+            "agentType": agent_type,
+            "workerId": worker_id,
+            "state": "idle",
+            "joinedAt": joined_at,
+        },
+    )
+    if agent_type == "worker":
+        reset_foreman_poll(ctx.guild_id)
+
+
+async def handle_agent_state(ctx: WSContext, data: dict) -> None:
+    agent_id = data.get("agentId")
+    state = data.get("state", "idle")
+    activity = data.get("activity")
+    update_vals: dict = {"state": state}
+    if activity is not None:
+        update_vals["activity"] = activity
+    elif state in ("idle", "offline"):
+        update_vals["activity"] = None
+    await ctx.db.execute(
+        update(Agent)
+        .where(Agent.id == agent_id, Agent.guild_id == ctx.guild_id)
+        .values(**update_vals)
+    )
+    await ctx.db.commit()
+    msg: dict = {"type": "agent-state", "agentId": agent_id, "state": state}
+    if "activity" in update_vals:
+        msg["activity"] = update_vals["activity"]
+    await broadcast(ctx.guild_id, msg)
+
+
+async def handle_chat(ctx: WSContext, data: dict) -> None:
+    """Persist the chat message + route to foreman.
+
+    Each authenticated user gets their own foreman conversation thread (keyed
+    by ``ws_user_id``). One special case: if a worker is waiting for a Claude
+    auth code, the next user message is captured as that code and bypasses
+    the foreman AI entirely.
+    """
+    from_agent = data.get("from", "user")
+    to_agent = data.get("to", "foreman")
+    content = data.get("content", "")
+    created_at = datetime.now(UTC).isoformat()
+    ctx.db.add(
+        Message(
+            guild_id=ctx.guild_id,
+            from_agent=from_agent,
+            to_agent=to_agent,
+            content=content,
+            message_type="chat",
+            created_at=created_at,
+            user_id=ctx.ws_user_id if from_agent == "user" else None,
+        )
+    )
+    await ctx.db.commit()
+    await broadcast(
+        ctx.guild_id,
+        {
+            "type": "chat",
+            "from": from_agent,
+            "to": to_agent,
+            "content": content,
+            "createdAt": created_at,
+            **({"userId": ctx.ws_user_id} if ctx.ws_user_id and from_agent == "user" else {}),
+        },
+    )
+    if not (from_agent == "user" and to_agent == "foreman" and content):
+        return
+
+    pending_workers = pending_claude_auth.get(ctx.guild_id, {})
+    if pending_workers:
+        pending_worker_id = next(iter(pending_workers))
+        pending_workers.pop(pending_worker_id)
+        logger.info(
+            "chat intercepted as auth code for %s in guild %s code_len=%d",
+            pending_worker_id,
+            ctx.guild_id,
+            len(content),
+        )
+        await broadcast(
+            ctx.guild_id,
+            {
+                "type": "worker-auth-response",
+                "workerId": pending_worker_id,
+                "code": content,
+            },
+        )
+    else:
+        asyncio.create_task(run_foreman_ai(ctx.guild_id, content, user_id=ctx.ws_user_id))
+        reset_foreman_poll(ctx.guild_id)
+
+
+async def handle_terminal_output(ctx: WSContext, data: dict) -> None:
+    msg_agent_id = data.get("agentId")
+    line = data.get("line", "")
+    task_id = data.get("taskId")
+    detail = data.get("detail")
+    created_at = datetime.now(UTC).isoformat()
+    worker_id_for_log = None
+    if msg_agent_id:
+        result = await ctx.db.execute(select(Agent.worker_id).where(Agent.id == msg_agent_id))
+        worker_id_for_log = result.scalar_one_or_none()
+    if line:
+        ctx.db.add(
+            TaskLog(
+                task_id=task_id or None,
+                timestamp=created_at,
+                line=line,
+                worker_id=worker_id_for_log,
+                agent_id=msg_agent_id,
+                data=json.dumps(detail) if detail else None,
+            )
+        )
+        await ctx.db.commit()
+    await broadcast(
+        ctx.guild_id,
+        {
+            "type": "terminal-output",
+            "agentId": msg_agent_id,
+            "workerId": worker_id_for_log,
+            "taskId": task_id,
+            "line": line,
+            "timestamp": created_at,
+            **({"detail": detail} if detail else {}),
+        },
+    )
+
+
+async def handle_worker_register(ctx: WSContext, data: dict) -> None:
+    worker_id = data.get("workerId")
+    if not worker_id:
+        return
+    repos = data.get("repos") or []
+    user_ident = data.get("user")
+    update_vals: dict = {"repos": json.dumps(repos)}
+    if user_ident:
+        resolved = await _resolve_user_identifier(ctx.db, user_ident)
+        if resolved:
+            update_vals["user_id"] = resolved
+    await ctx.db.execute(
+        update(Worker)
+        .where(Worker.id == worker_id, Worker.guild_id == ctx.guild_id)
+        .values(**update_vals)
+    )
+    await ctx.db.commit()
+
+
+async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
+    worker_id = data.get("workerId")
+    for agent_id in ctx.joined_agents:
+        await ctx.db.execute(
+            update(Agent)
+            .where(Agent.id == agent_id, Agent.guild_id == ctx.guild_id)
+            .values(state="offline")
+        )
+    if worker_id:
+        await ctx.db.execute(
+            update(Worker)
+            .where(Worker.id == worker_id, Worker.guild_id == ctx.guild_id)
+            .values(state="offline")
+        )
+    if ctx.joined_agents or worker_id:
+        await ctx.db.commit()
+    for agent_id in ctx.joined_agents:
+        await broadcast(
+            ctx.guild_id,
+            {"type": "agent-state", "agentId": agent_id, "state": "offline"},
+        )
+    reset_foreman_poll(ctx.guild_id)
+
+
+async def handle_task_update(ctx: WSContext, data: dict) -> None:
+    task_id = data.get("taskId")
+    if not task_id:
+        return
+    update_values: dict = {}
+    for src, col in (
+        ("state", "state"),
+        ("branch", "branch"),
+        ("worktreePath", "worktree_path"),
+        ("prUrl", "pr_url"),
+        ("finishedAt", "finished_at"),
+    ):
+        if src in data:
+            update_values[col] = data[src]
+    if update_values:
+        await ctx.db.execute(update(Task).where(Task.id == task_id).values(**update_values))
+        await ctx.db.commit()
+    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+
+
+async def handle_task_complete(ctx: WSContext, data: dict) -> None:
+    task_id = data.get("taskId")
+    worker_id_msg = data.get("workerId", "")
+    desc = data.get("description", "")
+    branch = data.get("branch", "")
+    finalized_by = data.get("finalizedBy", "")
+    last_text = data.get("lastText", "")
+    if task_id:
+        await ctx.db.execute(
+            update(Task)
+            .where(Task.id == task_id, Task.state == "working")
+            .values(state="awaiting-review")
+        )
+        await ctx.db.commit()
+    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    if task_id and not finalized_by:
+        asyncio.create_task(maybe_post_plan_comment(ctx.guild_id, task_id, last_text))
+    if not task_id:
+        return
+
+    task_uid = await _task_user_id(ctx.db, task_id)
+    if finalized_by == "timeout":
+        finished_at = datetime.now(UTC).isoformat()
+        await ctx.db.execute(
+            update(Task).where(Task.id == task_id).values(state="done", finished_at=finished_at)
+        )
+        await ctx.db.commit()
+        await broadcast(
+            ctx.guild_id,
+            {
+                "type": "task-update",
+                "taskId": task_id,
+                "state": "done",
+                "finishedAt": finished_at,
+            },
+        )
+        asyncio.create_task(
+            run_foreman_ai(
+                ctx.guild_id,
+                f"[timeout] Follow-up window expired for task {task_id} "
+                f"(worker {worker_id_msg}). The task has been auto-finalized "
+                "as done — no foreman action required.",
+                user_id=task_uid,
+            )
+        )
+    else:
+        asyncio.create_task(
+            run_foreman_ai(
+                ctx.guild_id,
+                f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
+                f'"{desc[:80]}" — branch: {branch}. '
+                "Review this result. Call send_followup if additional work is needed "
+                "(e.g. update tests, add docs, fix lint errors). "
+                "Otherwise call finalize_task to mark it complete.",
+                user_id=task_uid,
+            )
+        )
+    reset_foreman_poll(ctx.guild_id)
+
+
+async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
+    task_id = data.get("taskId")
+    worker_id_msg = data.get("workerId", "")
+    if task_id:
+        await ctx.db.execute(update(Task).where(Task.id == task_id).values(state="awaiting-review"))
+        await ctx.db.commit()
+    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    if not task_id:
+        return
+    task_uid = await _task_user_id(ctx.db, task_id)
+    asyncio.create_task(
+        run_foreman_ai(
+            ctx.guild_id,
+            f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
+            "Decide: call send_followup for more work, or call finalize_task to mark it done.",
+            user_id=task_uid,
+        )
+    )
+    reset_foreman_poll(ctx.guild_id)
+
+
+async def handle_needs_input(ctx: WSContext, data: dict) -> None:
+    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    wid = data.get("workerId", "a worker")
+    task_id = data.get("taskId", "")
+    description = data.get("description", "")
+    stop_reason = data.get("stopReason", "")
+    last_msg = data.get("lastMessage", "")
+    escalation = (
+        f"Worker {wid} could not complete task {task_id} and needs your help.\n"
+        f"Task: {description}\n"
+        f"Stop reason: {stop_reason}" + (f"\nLast message: {last_msg}" if last_msg else "")
+    )
+    task_uid = await _task_user_id(ctx.db, task_id) if task_id else None
+    asyncio.create_task(run_foreman_ai(ctx.guild_id, escalation, user_id=task_uid))
+
+
+async def handle_claude_auth_required(ctx: WSContext, data: dict) -> None:
+    worker_id = data.get("workerId", "a worker")
+    auth_url = data.get("url", "")
+    logger.info(
+        "claude-auth-required from %s in guild %s url=%s",
+        worker_id,
+        ctx.guild_id,
+        auth_url[:80],
+    )
+    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    pending_claude_auth.setdefault(ctx.guild_id, {})[worker_id] = auth_url
+    logger.info(
+        "pending_claude_auth now has %d entries for guild %s",
+        len(pending_claude_auth.get(ctx.guild_id, {})),
+        ctx.guild_id,
+    )
+    asyncio.create_task(
+        run_foreman_ai(
+            ctx.guild_id,
+            f"Worker {worker_id} needs Claude authentication. "
+            f"Auth URL: {auth_url}. "
+            "A human must visit this URL, complete authentication, then paste the "
+            "resulting code into the auth panel that has appeared in the chat UI "
+            "(or type it into the Foreman Comms input). The worker is waiting.",
+        )
+    )
+
+
+async def handle_worker_auth_response(ctx: WSContext, data: dict) -> None:
+    worker_id = data.get("workerId", "")
+    code_len = len(data.get("code", ""))
+    logger.info(
+        "worker-auth-response for %s in guild %s code_len=%d",
+        worker_id,
+        ctx.guild_id,
+        code_len,
+    )
+    pending_claude_auth.get(ctx.guild_id, {}).pop(worker_id, None)
+    peer_count = len(connections.get(ctx.guild_id, []))
+    logger.info(
+        "broadcasting worker-auth-response to %d connections in guild %s",
+        peer_count,
+        ctx.guild_id,
+    )
+    await broadcast(ctx.guild_id, data)
+
+
+async def handle_webrtc_signal(ctx: WSContext, data: dict) -> None:
+    """offer/answer/ice-candidate — forward to all peers in the guild."""
+    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+
+
+HANDLERS: dict[str, callable] = {
+    "ping": handle_ping,
+    "join": handle_join,
+    "agent-state": handle_agent_state,
+    "chat": handle_chat,
+    "terminal-output": handle_terminal_output,
+    "worker-register": handle_worker_register,
+    "worker-disconnect": handle_worker_disconnect,
+    "task-update": handle_task_update,
+    "task-complete": handle_task_complete,
+    "task-followup-done": handle_task_followup_done,
+    "needs-input": handle_needs_input,
+    "claude-auth-required": handle_claude_auth_required,
+    "worker-auth-response": handle_worker_auth_response,
+    "offer": handle_webrtc_signal,
+    "answer": handle_webrtc_signal,
+    "ice-candidate": handle_webrtc_signal,
+}
+
+
+async def dispatch(ctx: WSContext, data: dict) -> None:
+    """Route an inbound WS message to its handler.
+
+    Unknown types fall through to a generic broadcast (legacy behaviour).
+    """
+    msg_type = data.get("type")
+    handler = HANDLERS.get(msg_type)
+    if handler is None:
+        await broadcast(ctx.guild_id, data)
+        return
+    await handler(ctx, data)

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -21,6 +21,10 @@ class Config:
     repos: list[str] = field(default_factory=list)
     worker_id: str | None = None
     worker_name: str | None = None
+    # Bearer token issued by the backend at registration; required for fetching
+    # guild secrets (Claude credentials, GitHub token). Populated by Worker.run
+    # after _register and held in memory only.
+    auth_token: str | None = None
     github_token: str | None = None
     # Identity of the human this worker runs on behalf of.
     # Either a numeric GitHub user id (text) or a github_login.

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -75,8 +75,14 @@ class Worker:
         self._shutdown_event = asyncio.Event()
 
     # ------------------------------------------------------------------ HTTP
-    async def _http(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(base_url=self.cfg.http_url, timeout=30.0)
+    async def _http(self, *, authed: bool = False) -> httpx.AsyncClient:
+        """Return an httpx client. With ``authed=True`` the worker's bearer
+        token is attached so secret-fetching endpoints (claude creds, github
+        token) accept the request — those routes reject anonymous callers."""
+        headers = {}
+        if authed and self.cfg.auth_token:
+            headers["Authorization"] = f"Bearer {self.cfg.auth_token}"
+        return httpx.AsyncClient(base_url=self.cfg.http_url, timeout=30.0, headers=headers)
 
     async def _register(self) -> None:
         async with await self._http() as client:
@@ -90,8 +96,16 @@ class Worker:
                 },
             )
             resp.raise_for_status()
-            wid = resp.json()["id"]
+            payload = resp.json()
+            wid = payload["id"]
+            self.cfg.auth_token = payload.get("auth_token")
         self.cfg.worker_id = wid
+        if not self.cfg.auth_token:
+            logger.warning(
+                "Registration response did not include auth_token — "
+                "secret-fetching endpoints will reject this worker. "
+                "Backend may need an upgrade."
+            )
         logger.info(
             "Registered as worker %s (%d agents) user=%s",
             wid,
@@ -103,7 +117,7 @@ class Worker:
         if self.cfg.github_token:
             return
         try:
-            async with await self._http() as client:
+            async with await self._http(authed=True) as client:
                 resp = await client.get(
                     "/auth/github/token",
                     params={"guild_id": self.cfg.guild_id},
@@ -204,7 +218,7 @@ class Worker:
         # `claude setup-token`, and the legacy base64(tar.gz of ~/.claude)
         # blob produced by older versions running `claude auth login`.
         try:
-            async with await self._http() as client:
+            async with await self._http(authed=True) as client:
                 resp = await client.get(
                     "/auth/claude/credentials",
                     params={"guild_id": self.cfg.guild_id},
@@ -432,7 +446,7 @@ class Worker:
 
         try:
             blob = base64.b64encode(json.dumps({"oauth_token": token}).encode()).decode()
-            async with await self._http() as client:
+            async with await self._http(authed=True) as client:
                 await client.post(
                     "/auth/claude/credentials",
                     json={"guild_id": self.cfg.guild_id, "credentials_blob": blob},
@@ -842,9 +856,19 @@ class Worker:
     # ------------------------------------------------------------------ Listener
     async def _listen(self) -> None:
         logger.info("Listener started")
+        # Message types safe to process before _join() completes — auth-related
+        # messages flow during the pre-join window (claude setup-token), and
+        # heartbeats are protocol-level. Everything else (task assignments,
+        # follow-ups, redirects, etc.) must wait until we've actually joined,
+        # otherwise we'd start work before the backend sees us online.
+        _PRE_JOIN_ALLOWED = {"pong", "worker-message", "worker-auth-response"}
         async for msg in self.ws.messages():
             mtype = msg.get("type")
             logger.debug("WS message: type=%s keys=%s", mtype, list(msg.keys()))
+
+            if not self._joined and mtype not in _PRE_JOIN_ALLOWED:
+                logger.debug("Dropping %s message received before join", mtype)
+                continue
 
             if mtype == "pong":
                 # Heartbeat reply from the backend; nothing to do.


### PR DESCRIPTION
- auth credentials endpoints (#1): /auth/claude/credentials (GET+POST) and
  /auth/github/token now require either a worker auth_token (issued on
  registration) or a member login_token. Adds workers.auth_token column,
  threads token through worker HTTP client, and pins the contract with 9
  new tests in test_credentials_auth.py.

- per-user foreman context (#2): tasks.user_id stamps the originating user
  on create_task / assign_task; worker callbacks (task-complete,
  task-followup-done, needs-input) look it up and route the resulting
  foreman conversation to that user's thread instead of always the guild
  owner.

- ws handlers extraction (#3): pulled the 470-line message dispatch out of
  main.websocket_endpoint into ws_handlers.py — one async handler per
  message type plus a HANDLERS dispatch dict. main.py shrinks from 2521
  to ~2200 lines; the endpoint itself becomes ~50 lines.

- worker connect race (#4): _listen() now drops task/redirect/etc.
  messages received before _join() completes; auth-related messages
  (worker-message, worker-auth-response, pong) still flow through the
  pre-join window.

- parallel foreman tools (#5): exec_tools runs independent tool calls in
  the same batch via asyncio.gather instead of awaiting them serially.