### PR TITLE
backend: codebase review + main.py split + concurrency-safety pass

### DIFF
--- a/backend/tests/test_spawn_helper.py
+++ b/backend/tests/test_spawn_helper.py
@@ -7,9 +7,41 @@ import logging
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from util.tasks import pending_count, spawn  # noqa: E402
+
+
+@pytest.fixture
+def captured_util_tasks_logs():
+    """Attach a record-collecting handler directly to the ``util.tasks`` logger.
+
+    Avoids ``caplog``: pytest's logging plugin sets ``logger.disabled=True``
+    between tests in a worker session, which suppresses emit *before* the
+    record reaches caplog's root handler. We set ``disabled=False`` and
+    pin a handler at the source so test ordering can't mask the assertion.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger("util.tasks")
+    handler = _ListHandler(level=logging.ERROR)
+    prior_level = logger.level
+    prior_disabled = logger.disabled
+    logger.addHandler(handler)
+    logger.setLevel(logging.ERROR)
+    logger.disabled = False
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prior_level)
+        logger.disabled = prior_disabled
 
 
 async def test_spawn_runs_and_clears_registry():
@@ -26,37 +58,34 @@ async def test_spawn_runs_and_clears_registry():
     assert pending_count() == 0
 
 
-async def test_spawn_logs_uncaught_exception(caplog):
+async def test_spawn_logs_uncaught_exception(captured_util_tasks_logs):
     async def _job():
         raise RuntimeError("boom")
 
-    with caplog.at_level(logging.ERROR, logger="util.tasks"):
-        task = spawn(_job(), name="boomer")
-        # Wait for the task itself, then drain done-callbacks one tick later.
-        try:
-            await task
-        except RuntimeError:
-            pass
-        await asyncio.sleep(0)
+    task = spawn(_job(), name="boomer")
+    try:
+        await task
+    except RuntimeError:
+        pass
+    # Done-callbacks run on the next loop iteration.
+    await asyncio.sleep(0)
 
-    messages = [rec.getMessage() for rec in caplog.records]
+    messages = [rec.getMessage() for rec in captured_util_tasks_logs]
     assert any("boomer" in m for m in messages), messages
     assert pending_count() == 0
 
 
-async def test_spawn_silent_on_cancellation(caplog):
+async def test_spawn_silent_on_cancellation(captured_util_tasks_logs):
     async def _job():
         await asyncio.sleep(60)
 
-    with caplog.at_level(logging.ERROR, logger="util.tasks"):
-        task = spawn(_job(), name="sleeper")
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        await asyncio.sleep(0)
+    task = spawn(_job(), name="sleeper")
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    await asyncio.sleep(0)
 
     # Cancellation must not trip the error-logging done-callback.
-    error_records = [r for r in caplog.records if r.name == "util.tasks"]
-    assert error_records == []
+    assert captured_util_tasks_logs == []


### PR DESCRIPTION
## Summary

Three commits, each independently reviewable.

### 1. `CODE_REVIEW.md` — full audit (cc698fb)
Overall **B / 7.5**. 7 high-severity findings, 10 medium, 7 low, plus 5 ranked improvement projects with effort estimates. Key risks called out: CORS `*`+credentials, OAuth state in process memory, fire-and-forget `asyncio.create_task` losing foreman errors, bare `except Exception:` in WS auth/disconnect, infinite background loops without per-iteration error boundaries, and `backend/main.py` at 2195 lines (CLAUDE.md still claimed "~1700").

### 2. Concurrency-safety pass + `main.py` split (cebc3c8)
Implements Project 1 and most of Project 3 from the review.

**Concurrency safety**
- New `backend/util/tasks.py` with `spawn(coro, *, name)` — retains tasks in a registry and logs uncaught exceptions via `add_done_callback`.
- Replaces 9 fire-and-forget `asyncio.create_task` sites with `spawn` (foreman triggers from chat / task-complete / followup-done / needs-input / claude-auth-required / plan-comment, plus the foreman poll loop, lifespan sweeper, and agent-stream task).
- Wraps `foreman._poll_loop` body in try/except so a transient DB error no longer kills the loop.
- Adds `events.agent_owner_lock(guild_id)` (per-guild `asyncio.Lock`) and uses it in both `handle_join` and the WS disconnect cleanup so a fast reconnect can no longer race the previous socket's cleanup and stamp the just-joined agent offline.
- Replaces silent `except Exception: pass` in the WS endpoint with `logger.exception`.

**`backend/main.py` split: 2195 → 233 lines**
- New top-level modules: `oauth.py`, `auth_deps.py`, `agent_runner.py`, `utils.py`.
- Routes moved into `routes/{auth,guilds,agents,workers,tasks,foreman,websocket}.py` and registered via `app.include_router`.
- `main.py` keeps `app`, `lifespan`, `init_db`, the sweeper + its constants (so the existing `test_liveness` monkeypatches still work), and re-exports the names tests import directly.

### 3. Test fix (74c93c2)
`test_spawn_logs_uncaught_exception` was green in isolation but red in CI: pytest's logging plugin sets `logger.disabled=True` between tests, so when any other test ran first, `logger.exception` was suppressed at the source before any handler could see it. Fixture now sets `disabled=False` and restores prior state on teardown.

## Test plan
- [x] `python -m pytest tests/` from `backend/` → **227 passed** (was 224; +3 spawn helper tests)
- [x] `python -m pytest tests/` from `worker/` → **67 passed**
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `python -c "import main"` — all routers register; route paths unchanged
- [ ] Smoke-test the running app end-to-end (no behavior change expected; routes mount on the same `app` at the same paths)

https://claude.ai/code/session_01BcbxNP5aVN6JCL18oqrfgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcbxNP5aVN6JCL18oqrfgi)_