### PR TITLE
Fix CI and backend test failures (#193)

### DIFF
--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 
+import anyio
 import ws_handlers
 from database import get_db
 from events import agent_owner_lock, agent_owners, broadcast, connections
@@ -106,36 +107,45 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
         if guild_id in connections and websocket in connections[guild_id]:
             connections[guild_id].remove(websocket)
     finally:
-        try:
-            # Only mark agents offline if this WS is still the current owner.
-            # The per-guild lock pairs with handle_join's ownership write so a
-            # reconnect's just-installed agent can't be stamped offline by the
-            # previous socket's cleanup running concurrently.
-            async with agent_owner_lock(guild_id):
-                stale_agents = [aid for aid in joined_agents if agent_owners.get(aid) is websocket]
+        # Shield the cleanup from anyio cancel-scope cancellation so that
+        # db operations and db.close() always run to completion.  Without
+        # the shield, a cancelled cancel scope (e.g. TestClient teardown)
+        # raises Cancelled inside the aiosqlite layer, which then propagates
+        # as an unhandled exception from this task and causes the anyio task
+        # group to cancel sibling connections.
+        with anyio.CancelScope(shield=True):
+            try:
+                # Only mark agents offline if this WS is still the current owner.
+                # The per-guild lock pairs with handle_join's ownership write so a
+                # reconnect's just-installed agent can't be stamped offline by the
+                # previous socket's cleanup running concurrently.
+                async with agent_owner_lock(guild_id):
+                    stale_agents = [
+                        aid for aid in joined_agents if agent_owners.get(aid) is websocket
+                    ]
+                    for agent_id in stale_agents:
+                        agent_owners.pop(agent_id, None)
+                        await db.execute(
+                            update(Agent)
+                            .where(Agent.id == agent_id, Agent.guild_id == guild_id)
+                            .values(state="offline")
+                        )
+                        # Mirror into workers table so foreman sees the worker as offline.
+                        await db.execute(
+                            update(Worker)
+                            .where(Worker.id == agent_id, Worker.guild_id == guild_id)
+                            .values(state="offline")
+                        )
+                    if stale_agents:
+                        await db.commit()
                 for agent_id in stale_agents:
-                    agent_owners.pop(agent_id, None)
-                    await db.execute(
-                        update(Agent)
-                        .where(Agent.id == agent_id, Agent.guild_id == guild_id)
-                        .values(state="offline")
+                    await broadcast(
+                        guild_id,
+                        {
+                            "type": "agent-state",
+                            "agentId": agent_id,
+                            "state": "offline",
+                        },
                     )
-                    # Mirror into workers table so foreman sees the worker as offline.
-                    await db.execute(
-                        update(Worker)
-                        .where(Worker.id == agent_id, Worker.guild_id == guild_id)
-                        .values(state="offline")
-                    )
-                if stale_agents:
-                    await db.commit()
-            for agent_id in stale_agents:
-                await broadcast(
-                    guild_id,
-                    {
-                        "type": "agent-state",
-                        "agentId": agent_id,
-                        "state": "offline",
-                    },
-                )
-        finally:
-            await db.close()
+            finally:
+                await db.close()

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -140,24 +140,15 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         # decide it owns the agent, and stamp the just-joined agent offline.
         async with agent_owner_lock(ctx.guild_id):
             agent_owners[agent_id] = ctx.websocket
-    await broadcast(
-        ctx.guild_id,
-        {
-            "type": "agent-joined",
-            "agentId": agent_id,
-            "agentName": agent_name,
-            "agentType": agent_type,
-            "workerId": worker_id,
-            "state": "idle",
-            "joinedAt": joined_at,
-        },
-    )
     if agent_type == "worker":
         reset_foreman_poll(ctx.guild_id)
         # Replay any pending tasks already assigned to this worker so they
         # aren't lost if the backend sent task-assigned while the socket was
         # down. The worker's HTTP _fetch_pending_tasks() covers the same gap,
         # but this server-push path is faster (no polling interval required).
+        # Done before the agent-joined broadcast so all DB work finishes before
+        # observers see the join event; this prevents anyio cancel-scope races
+        # in tests where a peer WS closes on receiving the broadcast.
         if worker_id:
             result = await ctx.db.execute(
                 select(Task).where(
@@ -185,6 +176,18 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
                         "issueRepo": pt.issue_repo,
                     }
                 )
+    await broadcast(
+        ctx.guild_id,
+        {
+            "type": "agent-joined",
+            "agentId": agent_id,
+            "agentName": agent_name,
+            "agentType": agent_type,
+            "workerId": worker_id,
+            "state": "idle",
+            "joinedAt": joined_at,
+        },
+    )
 
 
 async def handle_agent_state(ctx: WSContext, data: dict) -> None:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -586,15 +586,8 @@ class Worker:
         )
 
     async def _join(self) -> None:
-        hostname = socket.gethostname()
-        host_prefix = hostname[:3].upper()
-        raw = (self.cfg.worker_id or "")[2:].upper()
-        split = 2 + sum(ord(c) for c in raw) % 3
-        droid = f"{raw[:split]}-{raw[split:]}"
-        worker_name = self.cfg.worker_name or f"{host_prefix}/{droid}"
-        
-        for idx, slot in enumerate(self.slots, start=1):
-            agent_split = split = 2 + sum(ord(c) for c in slot.agent_id) % 3
+        for _idx, slot in enumerate(self.slots, start=1):
+            agent_split = 2 + sum(ord(c) for c in slot.agent_id) % 3
             await self._send(
                 {
                     "type": "join",


### PR DESCRIPTION
## Summary

- **`routes/websocket.py`**: Wrap the WS endpoint's disconnect-cleanup `finally` block in `anyio.CancelScope(shield=True)`. When Starlette's TestClient cancels a WebSocket task (on context-manager exit), aiosqlite would raise `ValueError: Connection closed` inside the cleanup, which propagated as an unhandled task exception and caused anyio's task group to **cancel sibling connections**. The shield ensures `db.close()` and DB state writes always run to completion, preventing the cascade.

- **`ws_handlers.py`**: Move the pending-task replay block in `handle_join` to run **before** the `agent-joined` broadcast instead of after. This ensures all server-side work finishes before observers receive the sync-point message, eliminating a secondary cancel-scope race in the reconnect test.

- **`worker/pioneer_worker/worker.py`**: Fix three ruff lint errors — `F841` unused `worker_name` variable (and its dead computation chain), `W293` blank line with trailing whitespace, and `B007` unused `idx` loop variable.

## Test plan

- [x] `python -m pytest` in `backend/` → 227 passed, 0 failed
- [x] `ruff check . && ruff format . --check` → all clean

Closes #193