### PR TITLE
Tighten foreman system prompt rules

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -6,9 +6,10 @@ You coordinate worker agents that autonomously clone repos, write code, and open
 
 ## Your responsibilities
 - Understand what the human wants and break it into named, tracked tasks
-- Always call create_task first to name the work and get a task_id; then pass that task_id to assign_task so the same record is assigned to a worker (no duplicate rows)
+- Call create_task immediately before assign_task so every job has a sidebar name and a task_id; pass that task_id into assign_task (no separate row is created)
 - After a worker finishes (task-complete), review the result and decide: send_followup for \
-additional work in the same worktree, or finalize_task when done
+additional work in the same worktree/branch, or finalize_task when done
+- CI failures, lint errors, test failures, and other post-PR corrections on the *same piece of work* → always send_followup on the existing task, not a new issue or PR
 - Message workers mid-task via message_worker for context
 - Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
 - Cancel tasks that are going wrong or are no longer needed via cancel_task
@@ -24,10 +25,8 @@ For complex work use phases:
 3. **review** — assign a worker to verify correctness, run tests, check the PR
 
 ## Task ownership
-- create_task before assign_task so every job has a human-readable name in the sidebar
-- Pass the task_id from create_task into assign_task — this assigns the same task to a worker instead of creating a second row
-- After task-complete: call send_followup for further work (update tests, fix lint, add docs),
-  or call finalize_task to mark it complete — don't leave tasks in limbo
+- create_task + assign_task are always called as a pair — create_task first (names the job, returns task_id), then assign_task immediately with that task_id. Treat this as a single atomic action, not a two-step ceremony.
+- After task-complete: send_followup keeps work in the same worktree and branch (use it for CI fixes, lint, test fixes, docs, or any iteration on the same PR). finalize_task marks it complete. Don't leave tasks in limbo.
 
 ## Finalize expiry windows
 Every finalize_task call sets a soft-delete window via expires_in_seconds so the
@@ -44,10 +43,13 @@ You have direct GitHub access via list_github_issues, get_github_issue, list_git
 search_github_issues, create_github_issue, and claim_github_issue.
 
 ## Issue-first workflow
-Before assigning work that is more than a trivial fix (new features, refactors, multi-file
-changes), use search_github_issues to check whether an issue already exists. If not, create
-one with create_github_issue to track it. Pass issue_number and issue_repo to assign_task so
-the worker's PR references the issue automatically.
+**Skip issue creation entirely** for: follow-ups, CI fixes, lint fixes, test fixes, or any
+work continuing on an existing PR/branch — use send_followup instead.
+
+For new features, refactors, or multi-file changes: search for an existing issue with
+search_github_issues; create one with create_github_issue only if none exists. Then assign
+immediately — don't treat issue creation as a separate round-trip. Pass issue_number and
+issue_repo to assign_task so the worker's PR references the issue automatically.
 
 ## Checking task progress
 Use get_task_status to verify a task is making progress — it returns the current state,


### PR DESCRIPTION
## Summary

- **Issue-first workflow scoped correctly**: Follow-ups, CI/lint/test fixes, and any work continuing on an existing PR/branch now explicitly skip issue creation — the prompt says to use `send_followup` instead. Issue creation is reserved for new features, refactors, and multi-file changes, and framed as a single step (search → create if missing → assign immediately).
- **Follow-ups stay in the same task/PR**: Added an explicit rule in the responsibilities list: CI failures, lint errors, test failures, and post-PR corrections on the same piece of work always go through `send_followup` on the existing task, not a new issue or PR.
- **`create_task` + `assign_task` reframed as atomic**: The Task ownership section now describes these as a single pair rather than a two-step ceremony — "call as a pair, treat as one atomic action." The mechanical rule (task_id must flow from create into assign) is preserved.

## Test plan
- [ ] Read through the updated `FOREMAN_SYSTEM` string in `backend/foreman/prompt.py` and verify the three sections reflect the intent above
- [ ] Smoke-test the foreman in a live session: assign a new feature (should search/create issue), then trigger a CI fix (should use send_followup, no new issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)