### PR TITLE
Route Send Follow-up through foreman on finalized tasks (#201)

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -647,18 +647,33 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 task_id = inp["task_id"]
                 instructions = inp["instructions"]
                 result = await db.execute(
-                    select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
+                    select(Task.worker_id, Task.state).where(
+                        Task.id == task_id, Task.guild_id == guild_id
+                    )
                 )
-                worker_id_val = result.scalar_one_or_none()
-                if not worker_id_val:
+                row = result.one_or_none()
+                if not row:
                     result_text = f"Task {task_id} not found."
                 else:
-                    await db.execute(
-                        update(Task)
-                        .where(Task.id == task_id)
-                        .values(state="working", phase="followup")
-                    )
+                    worker_id_val, prior_state = row
+                    update_vals: dict = {"state": "working", "phase": "followup"}
+                    if prior_state in ("done", "failed", "cancelled"):
+                        # Re-opening a terminal task: clear soft-delete fields so it
+                        # reappears in the live task list and isn't auto-purged.
+                        update_vals["deleted_at"] = None
+                        update_vals["finished_at"] = None
+                    await db.execute(update(Task).where(Task.id == task_id).values(**update_vals))
                     await db.commit()
+                    await broadcast(
+                        guild_id,
+                        {
+                            "type": "task-update",
+                            "taskId": task_id,
+                            "state": "working",
+                            "deletedAt": None,
+                            "finishedAt": None,
+                        },
+                    )
                     await broadcast(
                         guild_id,
                         {

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -14,9 +14,11 @@ from auth_deps import require_member
 from database import get_db
 from events import broadcast
 from fastapi import APIRouter, Depends, HTTPException
+from foreman import run_foreman_ai
 from models import Guild, Task, TaskLog, live_tasks_filter
 from pydantic import BaseModel
 from sqlalchemy import select, update
+from util.tasks import spawn
 
 router = APIRouter()
 
@@ -186,6 +188,9 @@ async def get_guild_logs(
         await db.close()
 
 
+_TERMINAL_TASK_STATES = frozenset({"done", "failed", "cancelled"})
+
+
 @router.post("/guilds/{guild_id}/tasks/{task_id}/followup")
 async def create_task_followup(
     guild_id: str,
@@ -193,15 +198,44 @@ async def create_task_followup(
     data: FollowupCreate,
     github_user_id: str = Depends(require_member()),
 ):
-    """Send follow-up instructions to a worker — executed in the same worktree/branch."""
+    """Send follow-up instructions.
+
+    Active tasks (awaiting-review): dispatched directly to the worker in the same worktree.
+    Terminal tasks (done/failed/cancelled): routed to the foreman AI which will re-assign
+    work on the same branch using send_followup or assign_task with phase=followup.
+    """
     db = await get_db()
     try:
         result = await db.execute(
-            select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_id)
+            select(Task.worker_id, Task.state, Task.branch).where(
+                Task.id == task_id, Task.guild_id == guild_id
+            )
         )
-        worker_id = result.scalar_one_or_none()
-        if not worker_id:
+        row = result.one_or_none()
+        if not row:
             raise HTTPException(status_code=404, detail="Task not found")
+        worker_id, state, branch = row
+    finally:
+        await db.close()
+
+    if state in _TERMINAL_TASK_STATES:
+        branch_ctx = f" on branch `{branch}`" if branch else ""
+        spawn(
+            run_foreman_ai(
+                guild_id,
+                f"[user-followup] User requested follow-up on task {task_id}{branch_ctx} "
+                f'(currently {state}): "{data.instructions}". '
+                "Use send_followup to re-run work in the same worktree on the same branch. "
+                "If the task's original worker is no longer available, use assign_task with "
+                "phase=followup so another worker continues on the same branch.",
+                user_id=github_user_id,
+            ),
+            name=f"foreman.user-followup:{task_id}",
+        )
+        return {"status": "queued_for_foreman", "taskId": task_id}
+
+    db = await get_db()
+    try:
         await db.execute(
             update(Task).where(Task.id == task_id).values(state="working", phase="followup")
         )

--- a/frontend/src/components/log-pane/TaskActions.vue
+++ b/frontend/src/components/log-pane/TaskActions.vue
@@ -32,14 +32,14 @@
     </button>
   </div>
 
-  <!-- Task: follow-up panel -->
-  <div v-if="taskState === 'awaiting-review'" class="followup-panel">
-    <div class="followup-header">FOREMAN FOLLOW-UP</div>
+  <!-- Task: follow-up panel — visible for awaiting-review and terminal states -->
+  <div v-if="showFollowupPanel" class="followup-panel">
+    <div class="followup-header">{{ followupPanelHeader }}</div>
     <div class="followup-row">
       <textarea
         v-model="followupText"
         class="followup-input"
-        placeholder="Additional instructions (e.g. 'update tests', 'add docstrings')…"
+        :placeholder="followupPlaceholder"
         rows="2"
         @keydown.ctrl.enter="sendFollowupAction"
       />
@@ -52,7 +52,13 @@
       >
         ↺ Follow-up
       </button>
-      <button class="pixel-btn finalize-btn" @click="finalizeTaskAction">✓ Finalize</button>
+      <button
+        v-if="taskState === 'awaiting-review'"
+        class="pixel-btn finalize-btn"
+        @click="finalizeTaskAction"
+      >
+        ✓ Finalize
+      </button>
     </div>
   </div>
 </template>
@@ -72,6 +78,26 @@ const guildStore = useGuildStore()
 const tasksStore = useTasksStore()
 
 const isWorkerTask = computed(() => props.workerId && props.workerId !== 'foreman')
+
+const _TERMINAL_STATES = new Set(['done', 'failed', 'cancelled'])
+
+const isTerminalState = computed(() => _TERMINAL_STATES.has(props.taskState || ''))
+
+const showFollowupPanel = computed(
+  () =>
+    isWorkerTask.value &&
+    (props.taskState === 'awaiting-review' || isTerminalState.value),
+)
+
+const followupPanelHeader = computed(() =>
+  isTerminalState.value ? 'SEND TO FOREMAN' : 'FOREMAN FOLLOW-UP',
+)
+
+const followupPlaceholder = computed(() =>
+  isTerminalState.value
+    ? 'Request additional work on this branch — foreman will re-assign it…'
+    : "Additional instructions (e.g. 'update tests', 'add docstrings')…",
+)
 
 const canCancel = computed(() => {
   const s = props.taskState


### PR DESCRIPTION
## Summary

- **UI**: Follow-up input/button is now always visible for worker tasks in terminal states (`done`, `failed`, `cancelled`), not just `awaiting-review`. The header changes to "SEND TO FOREMAN" and the placeholder updates to indicate the foreman will handle re-assignment. The "Finalize" button only appears in `awaiting-review`.
- **Routing**: `POST /guilds/{guild_id}/tasks/{task_id}/followup` checks the task state — terminal tasks dispatch a `[user-followup]` message to `run_foreman_ai` (with task_id, branch, and instructions) instead of broadcasting directly to the worker.
- **Foreman**: The `send_followup` tool now clears `deleted_at` and `finished_at` when re-opening a terminal task (and broadcasts a `task-update` so the frontend removes the soft-delete countdown). The foreman can also fall back to `assign_task` with `phase=followup` on the same branch if the original worker is gone.

## Test plan

- [ ] Open a finalized (`done`) task in the task pane — confirm follow-up input is visible with "SEND TO FOREMAN" header
- [ ] Submit a follow-up on a `done` task — confirm the foreman receives a `[user-followup]` message in chat and calls `send_followup`
- [ ] Confirm the task transitions back to `working` and soft-delete timer is cleared
- [ ] Confirm follow-up on an `awaiting-review` task still routes directly to the worker (unchanged behavior)
- [ ] `ruff check . && ruff format .` — passes clean
- [ ] `npm run type-check` — passes clean

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)