### PR TITLE
Make _droid_name() deterministic from slot id (#204)

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -26,6 +26,24 @@ def _gen_id(prefix: str) -> str:
     return prefix + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
 
 
+def _droid_name(id: str) -> str:
+    """Generate a droid-style designation like R2-D2 or BB-8, seeded from id."""
+    rng = random.Random(id)
+    L = string.ascii_uppercase
+    D = string.digits
+    p1 = rng.choice(
+        [lambda: rng.choice(L) + rng.choice(D), lambda: rng.choice(L) + rng.choice(L)]
+    )()
+    p2 = rng.choice(
+        [
+            lambda: rng.choice(L) + rng.choice(D),
+            lambda: rng.choice(L) + rng.choice(L),
+            lambda: rng.choice(D),
+        ]
+    )()
+    return f"{p1}-{p2}"
+
+
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
@@ -39,8 +57,9 @@ _SHUTDOWN_SENTINEL = object()  # placed in task queue to wake idle agents during
 
 
 class _AgentSlot:
-    def __init__(self, agent_id: str) -> None:
-        self.agent_id = agent_id
+    def __init__(self, *, id: str | None = None, name: str | None = None) -> None:
+        self.id: str = id if id is not None else _gen_id("a-")
+        self.name: str = name if name is not None else _droid_name(self.id)
         self.current_claude: claude_runner.ClaudeProcess | None = None
         self.current_task_id: str | None = None
         # Last state we told the backend about; resent on WS reconnect so the
@@ -48,6 +67,10 @@ class _AgentSlot:
         self.state: str = "idle"
         # Fine-grained activity within the "working" state (reading/editing/etc.)
         self.activity: str | None = None
+
+    @property
+    def agent_id(self) -> str:
+        return self.id
 
 
 class Worker:
@@ -67,8 +90,16 @@ class Worker:
         # Set to True once _join() has been called the first time so that
         # _on_ws_reconnect doesn't prematurely join before auth completes.
         self._joined = False
-        # One slot per concurrent agent; each gets a stable ID for the guild.
-        self.slots: list[_AgentSlot] = [_AgentSlot(_gen_id("a-")) for _ in range(cfg.max_agents)]
+
+        # One slot per concurrent agent; each gets a stable ID and name for the guild.
+        def _slot_name(idx: int) -> str | None:
+            if not cfg.worker_name:
+                return None
+            return cfg.worker_name if cfg.max_agents == 1 else f"{cfg.worker_name}/{idx}"
+
+        self.slots: list[_AgentSlot] = [
+            _AgentSlot(name=_slot_name(i)) for i in range(1, cfg.max_agents + 1)
+        ]
         # Set when graceful shutdown is requested (via WS or signal). Idle
         # agents stop immediately; busy agents finish their current task and
         # skip the follow-up window.
@@ -586,13 +617,12 @@ class Worker:
         )
 
     async def _join(self) -> None:
-        for _idx, slot in enumerate(self.slots, start=1):
-            agent_split = 2 + sum(ord(c) for c in slot.agent_id) % 3
+        for slot in self.slots:
             await self._send(
                 {
                     "type": "join",
-                    "agentId": slot.agent_id,
-                    "agentName": f"{slot.agent_id[2:][:agent_split]}-{slot.agent_id[2:][agent_split:]}",
+                    "agentId": slot.id,
+                    "agentName": slot.name,
                     "agentType": "worker",
                     "workerId": self.cfg.worker_id,
                 }

--- a/worker/tests/test_agent_slot.py
+++ b/worker/tests/test_agent_slot.py
@@ -1,0 +1,92 @@
+"""Unit tests for _AgentSlot auto-generation of id and name."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from pioneer_worker.worker import _AgentSlot
+
+
+def test_default_id_is_auto_generated():
+    """When no id is supplied, _AgentSlot must generate a non-None string id."""
+    slot = _AgentSlot()
+    assert slot.id is not None
+    assert isinstance(slot.id, str)
+    assert len(slot.id) > 0
+
+
+def test_default_id_has_agent_prefix():
+    """Auto-generated ids should carry the 'a-' prefix from _gen_id."""
+    slot = _AgentSlot()
+    assert slot.id.startswith("a-")
+
+
+def test_agent_id_property_matches_id():
+    """agent_id property must return the same value as id for back-compat."""
+    slot = _AgentSlot()
+    assert slot.agent_id == slot.id
+
+
+def test_explicit_id_is_preserved():
+    """An explicitly provided id must not be overwritten."""
+    slot = _AgentSlot(id="a-custom")
+    assert slot.id == "a-custom"
+    assert slot.agent_id == "a-custom"
+
+
+def test_default_name_is_auto_generated():
+    """When no name is supplied, _AgentSlot must generate a non-None string name."""
+    slot = _AgentSlot()
+    assert slot.name is not None
+    assert isinstance(slot.name, str)
+    assert len(slot.name) > 0
+
+
+def test_default_name_is_droid_style():
+    """Auto-generated name must look like a droid designation (XX-YY uppercase)."""
+    slot = _AgentSlot()
+    assert re.match(r"^[A-Z0-9]+-[A-Z0-9]+$", slot.name), f"Unexpected name: {slot.name!r}"
+
+
+def test_explicit_name_is_preserved():
+    """An explicitly provided name must not be overwritten."""
+    slot = _AgentSlot(name="mybot/1")
+    assert slot.name == "mybot/1"
+
+
+def test_two_default_slots_get_distinct_ids():
+    """Each slot must get a distinct auto-generated id."""
+    slot_a = _AgentSlot()
+    slot_b = _AgentSlot()
+    assert slot_a.id != slot_b.id
+
+
+def test_id_and_name_both_explicit():
+    """Both id and name can be set explicitly at the same time."""
+    slot = _AgentSlot(id="a-xyz123", name="R2-D2")
+    assert slot.id == "a-xyz123"
+    assert slot.name == "R2-D2"
+    assert slot.agent_id == "a-xyz123"
+
+
+def test_default_state_is_idle():
+    """Slot must start in idle state regardless of auto-generation."""
+    slot = _AgentSlot()
+    assert slot.state == "idle"
+    assert slot.current_task_id is None
+    assert slot.activity is None
+
+
+def test_droid_name_is_deterministic_for_same_id():
+    """The same id must always produce the same droid name."""
+    slot_a = _AgentSlot(id="a-abc123")
+    slot_b = _AgentSlot(id="a-abc123")
+    assert slot_a.name == slot_b.name
+
+
+def test_droid_name_differs_for_different_ids():
+    """Two distinct ids must produce different droid names (with overwhelming probability)."""
+    slot_a = _AgentSlot(id="a-abc123")
+    slot_b = _AgentSlot(id="a-xyz999")
+    assert slot_a.name != slot_b.name


### PR DESCRIPTION
## Summary
- `_droid_name(id)` now accepts an `id: str` parameter and uses `random.Random(id)` as its RNG, making the output deterministic for a given slot id
- `_AgentSlot.__init__` upgraded to accept optional keyword-only `id` and `name` params (with auto-generation when omitted), plus an `agent_id` property for back-compat
- `Worker._join()` updated to send `slot.name` as `agentName`
- New `test_agent_slot.py` with full coverage including determinism assertions

## Test plan
- [x] `python -m pytest tests/` — 4 pre-existing env failures only, all others pass (75 passed)
- [x] `ruff check . --fix && ruff format .` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)