### PR TITLE
feat(backend): GitHub webhook receiver (Phase 1)

### DIFF
--- a/backend/alembic/versions/e7f8a9b0c1d2_add_github_webhooks.py
+++ b/backend/alembic/versions/e7f8a9b0c1d2_add_github_webhooks.py
@@ -1,0 +1,66 @@
+"""add_github_webhooks
+
+Adds the plumbing for receiving GitHub webhook deliveries:
+
+- ``guilds.webhook_secret``: HMAC-SHA256 shared secret used to verify
+  incoming webhook bodies. Generated lazily when an owner first requests it.
+- ``tasks.pr_number`` / ``tasks.pr_repo``: explicit PR coordinates extracted
+  at PR-creation time so events can be linked back to the originating task
+  without fragile URL string matching.
+- ``github_events``: append-only log of accepted webhook deliveries. The
+  ``delivery_id`` unique constraint short-circuits GitHub's redelivery on
+  non-2xx responses so the foreman is never invoked twice for the same event.
+
+Revision ID: e7f8a9b0c1d2
+Revises: c7d8e9f0a1b2
+Create Date: 2026-05-06 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e7f8a9b0c1d2"
+down_revision: Union[str, Sequence[str], None] = "c7d8e9f0a1b2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("guilds") as batch_op:
+        batch_op.add_column(sa.Column("webhook_secret", sa.Text(), nullable=True))
+
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.add_column(sa.Column("pr_number", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("pr_repo", sa.Text(), nullable=True))
+
+    op.create_table(
+        "github_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("guild_id", sa.Text(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("task_id", sa.Text(), sa.ForeignKey("tasks.id"), nullable=True),
+        sa.Column("delivery_id", sa.Text(), nullable=False, unique=True),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("action", sa.Text(), nullable=True),
+        sa.Column("repo", sa.Text(), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=True),
+        sa.Column("pr_url", sa.Text(), nullable=True),
+        sa.Column("sender_login", sa.Text(), nullable=True),
+        sa.Column("payload_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+    )
+    op.create_index("ix_github_events_task_id", "github_events", ["task_id"])
+    op.create_index("ix_github_events_guild_id", "github_events", ["guild_id", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_github_events_guild_id", table_name="github_events")
+    op.drop_index("ix_github_events_task_id", table_name="github_events")
+    op.drop_table("github_events")
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.drop_column("pr_repo")
+        batch_op.drop_column("pr_number")
+    with op.batch_alter_table("guilds") as batch_op:
+        batch_op.drop_column("webhook_secret")

--- a/backend/auth_deps.py
+++ b/backend/auth_deps.py
@@ -131,3 +131,18 @@ async def require_worker_or_member(
     """
     token = credentials.credentials if credentials else None
     return await authorize_worker_or_member(guild_id, token)
+
+
+async def require_worker_or_member_path(
+    guild_id: str,
+    credentials: HTTPAuthorizationCredentials | None = Depends(http_bearer),
+) -> str:
+    """Dependency for path-string endpoints (``/guilds/{guild_id}/...``).
+
+    Same contract as ``require_worker_or_member`` but reads ``guild_id`` from
+    the path instead of the query string. Useful when the canonical URL
+    already carries the guild id and adding a duplicate query param would be
+    redundant.
+    """
+    token = credentials.credentials if credentials else None
+    return await authorize_worker_or_member(guild_id, token)

--- a/backend/main.py
+++ b/backend/main.py
@@ -207,6 +207,7 @@ from routes import auth as _auth_routes  # noqa: E402
 from routes import foreman as _foreman_routes  # noqa: E402
 from routes import guilds as _guilds_routes  # noqa: E402
 from routes import tasks as _tasks_routes  # noqa: E402
+from routes import webhooks as _webhooks_routes  # noqa: E402
 from routes import websocket as _ws_routes  # noqa: E402
 from routes import workers as _workers_routes  # noqa: E402
 
@@ -216,6 +217,7 @@ app.include_router(_agents_routes.router)
 app.include_router(_workers_routes.router)
 app.include_router(_tasks_routes.router)
 app.include_router(_foreman_routes.router)
+app.include_router(_webhooks_routes.router)
 app.include_router(_ws_routes.router)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -28,6 +28,10 @@ class Guild(Base):
     name = Column(Text)
     github_user_id = Column(Text)
     primary_repo = Column(Text, nullable=True)
+    # HMAC-SHA256 shared secret used to verify GitHub webhook deliveries for
+    # this guild. NULL until an owner first requests one via the
+    # webhook-secret endpoint.
+    webhook_secret = Column(Text, nullable=True)
 
 
 class Agent(Base):
@@ -95,6 +99,11 @@ class Task(Base):
     branch = Column(Text)
     worktree_path = Column(Text)
     pr_url = Column(Text)
+    # Explicit PR coordinates extracted from pr_url at PR-creation time, so
+    # github webhook events can be linked back to the task without fragile
+    # URL substring matching. Both NULL until the worker reports a PR.
+    pr_number = Column(Integer, nullable=True)
+    pr_repo = Column(Text, nullable=True)
     created_at = Column(Text, nullable=False)
     finished_at = Column(Text)
     name = Column(Text)
@@ -188,4 +197,24 @@ class ForemanTurn(Base):
     is_tool_response = Column(Integer, nullable=False, server_default="0")
     # For tool_result turns: id of the assistant turn whose tool_use blocks this answers
     parent_id = Column(Integer, ForeignKey("foreman_turns.id"), nullable=True)
+    created_at = Column(Text, nullable=False)
+
+
+class GithubEvent(Base):
+    __tablename__ = "github_events"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    guild_id = Column(Text, ForeignKey("guilds.id"), nullable=False)
+    # task_id is nullable because an event may arrive before we've linked the
+    # PR to a task (e.g. webhook fires for a manually-opened PR).
+    task_id = Column(Text, ForeignKey("tasks.id"), nullable=True)
+    # X-GitHub-Delivery header value; UNIQUE so GitHub redelivery is a no-op.
+    delivery_id = Column(Text, nullable=False, unique=True)
+    event_type = Column(Text, nullable=False)
+    action = Column(Text, nullable=True)
+    repo = Column(Text, nullable=False)  # owner/repo
+    pr_number = Column(Integer, nullable=True)
+    pr_url = Column(Text, nullable=True)
+    sender_login = Column(Text, nullable=True)
+    payload_json = Column(Text, nullable=False)
     created_at = Column(Text, nullable=False)

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -6,9 +6,10 @@ Owns ``/guilds`` (create/list) and ``/guilds/{id}`` (read/update), plus the
 
 from __future__ import annotations
 
+import secrets
 from datetime import UTC, datetime
 
-from auth_deps import require_member, require_user
+from auth_deps import require_member, require_user, require_worker_or_member_path
 from database import get_db
 from events import broadcast
 from fastapi import APIRouter, Depends, HTTPException
@@ -287,6 +288,59 @@ async def update_guild_member(
         member.role = data.role
         await db.commit()
         return {"guild_id": guild_id, "user_id": user_id, "role": data.role}
+    finally:
+        await db.close()
+
+
+async def _ensure_webhook_secret(db, guild_id: str) -> str:
+    """Return the guild's webhook secret, generating one on first access."""
+    res = await db.execute(select(Guild).where(Guild.id == guild_id))
+    guild = res.scalar_one_or_none()
+    if not guild:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    if not guild.webhook_secret:
+        guild.webhook_secret = secrets.token_hex(32)
+        await db.commit()
+    return guild.webhook_secret
+
+
+@router.post("/guilds/{guild_id}/webhook-secret")
+async def rotate_webhook_secret(
+    guild_id: str,
+    github_user_id: str = Depends(require_member("owner")),
+):
+    """Generate a fresh webhook secret for the guild (owner only).
+
+    Rotating invalidates webhooks already configured against the previous
+    secret — callers must update each repo's webhook config to match.
+    """
+    db = await get_db()
+    try:
+        res = await db.execute(select(Guild).where(Guild.id == guild_id))
+        guild = res.scalar_one_or_none()
+        if not guild:
+            raise HTTPException(status_code=404, detail="Guild not found")
+        guild.webhook_secret = secrets.token_hex(32)
+        await db.commit()
+        return {"guild_id": guild_id, "webhook_secret": guild.webhook_secret}
+    finally:
+        await db.close()
+
+
+@router.get("/guilds/{guild_id}/webhook-secret")
+async def get_webhook_secret(
+    guild_id: str,
+    principal: str = Depends(require_worker_or_member_path),
+):
+    """Return the guild's webhook secret, generating one on first access.
+
+    Accessible by guild members (any role) or registered workers — workers
+    need it to configure ``POST /repos/{repo}/hooks`` on the user's behalf.
+    """
+    db = await get_db()
+    try:
+        secret = await _ensure_webhook_secret(db, guild_id)
+        return {"guild_id": guild_id, "webhook_secret": secret}
     finally:
         await db.close()
 

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -1,0 +1,218 @@
+"""GitHub webhook receiver.
+
+GitHub posts here for every subscribed event on a repo whose webhook is
+configured against ``{backend_url}/webhooks/github/{guild_id}``. The handler
+verifies the HMAC-SHA256 signature against the guild's stored secret,
+persists the event (idempotent on the X-GitHub-Delivery header), and
+broadcasts a ``github-event`` WS message to the guild.
+
+Foreman dispatch (Phase 2) will be wired on top of the persisted row — the
+goal of this file is just to land the receiver and its persistence story.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from datetime import UTC, datetime
+
+from database import get_db
+from events import broadcast
+from fastapi import APIRouter, HTTPException, Request, Response
+from models import GithubEvent, Guild, Task
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import IntegrityError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# Cap on stored payloads. GitHub webhook payloads are typically <50 KB but
+# review-comment diff hunks can balloon — 64 KB is a safe upper bound that
+# keeps the row size manageable while preserving enough for foreman context.
+_MAX_PAYLOAD_BYTES = 64 * 1024
+
+
+def _verify_signature(secret: str, body: bytes, signature_header: str | None) -> bool:
+    """Constant-time HMAC-SHA256 check against GitHub's ``sha256=...`` header."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    provided = signature_header[len("sha256=") :]
+    return hmac.compare_digest(expected, provided)
+
+
+def _extract_pr_info(payload: dict) -> tuple[int | None, str | None, str | None]:
+    """Pull (pr_number, pr_url, repo) out of a webhook payload.
+
+    The fields live in different places per event type. ``pull_request``,
+    ``pull_request_review``, ``pull_request_review_comment`` and
+    ``issue_comment`` (on PRs) each carry a ``pull_request`` object;
+    ``check_run`` / ``check_suite`` carry it under
+    ``check_run.pull_requests[0]`` (an array because a head SHA could be in
+    multiple PRs); ``status`` doesn't carry one at all and must be looked
+    up separately.
+    """
+    pr = payload.get("pull_request")
+    if isinstance(pr, dict):
+        repo = (payload.get("repository") or {}).get("full_name")
+        return pr.get("number"), pr.get("html_url"), repo
+
+    issue = payload.get("issue")
+    if isinstance(issue, dict) and "pull_request" in issue:
+        repo = (payload.get("repository") or {}).get("full_name")
+        return issue.get("number"), issue.get("html_url"), repo
+
+    check_run = payload.get("check_run") or payload.get("check_suite")
+    if isinstance(check_run, dict):
+        prs = check_run.get("pull_requests") or []
+        if prs and isinstance(prs[0], dict):
+            repo = (payload.get("repository") or {}).get("full_name")
+            return prs[0].get("number"), prs[0].get("html_url"), repo
+
+    repo = (payload.get("repository") or {}).get("full_name")
+    return None, None, repo
+
+
+async def _find_task_id(db, guild_id: str, repo: str | None, pr_number: int | None) -> str | None:
+    """Match a webhook to one of this guild's tasks by (repo, pr_number)."""
+    if not repo or pr_number is None:
+        return None
+    res = await db.execute(
+        select(Task.id)
+        .where(
+            Task.guild_id == guild_id,
+            Task.pr_repo == repo,
+            Task.pr_number == pr_number,
+        )
+        .order_by(Task.created_at.desc())
+        .limit(1)
+    )
+    return res.scalar_one_or_none()
+
+
+@router.post("/webhooks/github/{guild_id}")
+async def github_webhook(guild_id: str, request: Request) -> Response:
+    body = await request.body()
+    if len(body) > _MAX_PAYLOAD_BYTES * 4:
+        # Hard upper bound on accept size; 4× the persisted cap so we still
+        # accept large but plausible deliveries (e.g. very long PR bodies).
+        raise HTTPException(status_code=413, detail="Payload too large")
+
+    delivery_id = request.headers.get("x-github-delivery")
+    event_type = request.headers.get("x-github-event")
+    signature = request.headers.get("x-hub-signature-256")
+    if not delivery_id or not event_type:
+        raise HTTPException(status_code=400, detail="Missing GitHub headers")
+
+    db = await get_db()
+    try:
+        secret_res = await db.execute(select(Guild.webhook_secret).where(Guild.id == guild_id))
+        secret = secret_res.scalar_one_or_none()
+        if not secret:
+            # Guild missing or no secret configured. Don't leak which is which.
+            raise HTTPException(status_code=404, detail="Webhook not configured")
+
+        if not _verify_signature(secret, body, signature):
+            logger.warning(
+                "github webhook signature mismatch guild=%s delivery=%s event=%s",
+                guild_id,
+                delivery_id,
+                event_type,
+            )
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
+        # GitHub sends ping deliveries on webhook setup; accept them but skip
+        # the rest of the pipeline (no PR context, no foreman action).
+        if event_type == "ping":
+            return Response(status_code=204)
+
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="Invalid JSON body") from None
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="Payload must be a JSON object")
+
+        action = payload.get("action") if isinstance(payload.get("action"), str) else None
+        pr_number, pr_url, repo = _extract_pr_info(payload)
+        sender = payload.get("sender") or {}
+        sender_login = sender.get("login") if isinstance(sender, dict) else None
+
+        task_id = await _find_task_id(db, guild_id, repo, pr_number)
+
+        # Trim the persisted payload so a runaway diff hunk can't balloon the DB.
+        body_text = body.decode("utf-8", errors="replace")
+        if len(body_text) > _MAX_PAYLOAD_BYTES:
+            body_text = body_text[:_MAX_PAYLOAD_BYTES] + "\n…[truncated]"
+
+        created_at = datetime.now(UTC).isoformat()
+        stmt = (
+            sqlite_insert(GithubEvent)
+            .values(
+                guild_id=guild_id,
+                task_id=task_id,
+                delivery_id=delivery_id,
+                event_type=event_type,
+                action=action,
+                repo=repo or "",
+                pr_number=pr_number,
+                pr_url=pr_url,
+                sender_login=sender_login,
+                payload_json=body_text,
+                created_at=created_at,
+            )
+            .on_conflict_do_nothing(index_elements=["delivery_id"])
+        )
+        try:
+            result = await db.execute(stmt)
+        except IntegrityError:
+            await db.rollback()
+            result = None
+        await db.commit()
+
+        # ``rowcount`` is 0 when ON CONFLICT DO NOTHING fired — i.e. GitHub
+        # redelivered an event we already accepted. Return 202 so GitHub stops
+        # retrying without re-triggering downstream side effects.
+        is_duplicate = result is None or (result.rowcount or 0) == 0
+        if is_duplicate:
+            logger.info(
+                "github webhook duplicate delivery guild=%s delivery=%s event=%s",
+                guild_id,
+                delivery_id,
+                event_type,
+            )
+            return Response(status_code=202)
+
+        logger.info(
+            "github webhook accepted guild=%s delivery=%s event=%s action=%s repo=%s pr=%s task=%s",
+            guild_id,
+            delivery_id,
+            event_type,
+            action,
+            repo,
+            pr_number,
+            task_id,
+        )
+    finally:
+        await db.close()
+
+    await broadcast(
+        guild_id,
+        {
+            "type": "github-event",
+            "deliveryId": delivery_id,
+            "event": event_type,
+            "action": action,
+            "repo": repo,
+            "prNumber": pr_number,
+            "prUrl": pr_url,
+            "taskId": task_id,
+            "sender": sender_login,
+        },
+    )
+    return Response(status_code=202)

--- a/backend/tests/test_github_webhooks.py
+++ b/backend/tests/test_github_webhooks.py
@@ -1,0 +1,373 @@
+"""Tests for the GitHub webhook receiver and webhook-secret endpoints."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+
+sys.path.insert(0, os.path.dirname(__file__))
+from helpers import insert_guild, make_auth_token
+
+
+def _set_webhook_secret(db_path: str, guild_id: str, secret: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE guilds SET webhook_secret = ? WHERE id = ?",
+            (secret, guild_id),
+        )
+        conn.commit()
+
+
+def _insert_task(
+    db_path: str,
+    *,
+    task_id: str,
+    guild_id: str,
+    pr_url: str | None = None,
+    pr_number: int | None = None,
+    pr_repo: str | None = None,
+) -> None:
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        # Workers FK is NOT NULL; insert a placeholder worker row first.
+        conn.execute(
+            "INSERT OR IGNORE INTO workers (id, guild_id, repos, state, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (f"w-{task_id}", guild_id, "[]", "online", now),
+        )
+        conn.execute(
+            "INSERT INTO tasks (id, worker_id, guild_id, description, tool, state, "
+            "pr_url, pr_number, pr_repo, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                task_id,
+                f"w-{task_id}",
+                guild_id,
+                "test task",
+                "claude",
+                "awaiting-review",
+                pr_url,
+                pr_number,
+                pr_repo,
+                now,
+            ),
+        )
+        conn.commit()
+
+
+def _signed_headers(secret: str, body: bytes, *, event: str, delivery: str) -> dict[str, str]:
+    sig = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return {
+        "X-GitHub-Event": event,
+        "X-GitHub-Delivery": delivery,
+        "X-Hub-Signature-256": f"sha256={sig}",
+        "Content-Type": "application/json",
+    }
+
+
+def _pr_payload(*, action: str, repo: str, number: int) -> dict:
+    return {
+        "action": action,
+        "repository": {"full_name": repo},
+        "pull_request": {
+            "number": number,
+            "html_url": f"https://github.com/{repo}/pull/{number}",
+        },
+        "sender": {"login": "octocat"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Webhook receiver
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_rejects_unknown_guild(client):
+    test_client, _ = client
+    body = json.dumps({}).encode()
+    resp = test_client.post(
+        "/webhooks/github/nosuch",
+        content=body,
+        headers={
+            "X-GitHub-Event": "ping",
+            "X-GitHub-Delivery": "abc",
+            "X-Hub-Signature-256": "sha256=00",
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 404
+
+
+def test_webhook_rejects_guild_without_secret(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g1")
+    body = json.dumps({}).encode()
+    resp = test_client.post(
+        "/webhooks/github/g1",
+        content=body,
+        headers={
+            "X-GitHub-Event": "ping",
+            "X-GitHub-Delivery": "abc",
+            "X-Hub-Signature-256": "sha256=00",
+            "Content-Type": "application/json",
+        },
+    )
+    # Webhook secret never generated for this guild
+    assert resp.status_code == 404
+
+
+def test_webhook_rejects_bad_signature(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g2")
+    _set_webhook_secret(db_path, "g2", "topsecret")
+    body = json.dumps({"action": "opened"}).encode()
+    resp = test_client.post(
+        "/webhooks/github/g2",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "d-1",
+            "X-Hub-Signature-256": "sha256=" + "0" * 64,
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_webhook_rejects_missing_signature(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g3")
+    _set_webhook_secret(db_path, "g3", "topsecret")
+    body = json.dumps({"action": "opened"}).encode()
+    resp = test_client.post(
+        "/webhooks/github/g3",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "d-1",
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_webhook_accepts_ping(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g4")
+    secret = "topsecret"
+    _set_webhook_secret(db_path, "g4", secret)
+    body = json.dumps({"zen": "Mind your words"}).encode()
+    headers = _signed_headers(secret, body, event="ping", delivery="d-ping")
+    resp = test_client.post("/webhooks/github/g4", content=body, headers=headers)
+    assert resp.status_code == 204
+    # Ping deliveries are not persisted
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT COUNT(*) FROM github_events").fetchone()
+    assert rows[0] == 0
+
+
+def test_webhook_persists_event_and_links_task(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g5")
+    _set_webhook_secret(db_path, "g5", "s5")
+    _insert_task(
+        db_path,
+        task_id="t-1",
+        guild_id="g5",
+        pr_url="https://github.com/owner/repo/pull/42",
+        pr_number=42,
+        pr_repo="owner/repo",
+    )
+    payload = _pr_payload(action="opened", repo="owner/repo", number=42)
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("s5", body, event="pull_request", delivery="d-evt-1")
+    resp = test_client.post("/webhooks/github/g5", content=body, headers=headers)
+    assert resp.status_code == 202
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT guild_id, task_id, delivery_id, event_type, action, repo, "
+            "pr_number, pr_url, sender_login FROM github_events"
+        ).fetchone()
+    assert row == (
+        "g5",
+        "t-1",
+        "d-evt-1",
+        "pull_request",
+        "opened",
+        "owner/repo",
+        42,
+        "https://github.com/owner/repo/pull/42",
+        "octocat",
+    )
+
+
+def test_webhook_event_without_matching_task(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g6")
+    _set_webhook_secret(db_path, "g6", "s6")
+    payload = _pr_payload(action="opened", repo="owner/repo", number=7)
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("s6", body, event="pull_request", delivery="d-evt-2")
+    resp = test_client.post("/webhooks/github/g6", content=body, headers=headers)
+    assert resp.status_code == 202
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT task_id, pr_number FROM github_events").fetchone()
+    assert row == (None, 7)
+
+
+def test_webhook_dedupes_redelivery(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g7")
+    _set_webhook_secret(db_path, "g7", "s7")
+    payload = _pr_payload(action="opened", repo="owner/repo", number=1)
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("s7", body, event="pull_request", delivery="dup-1")
+    r1 = test_client.post("/webhooks/github/g7", content=body, headers=headers)
+    r2 = test_client.post("/webhooks/github/g7", content=body, headers=headers)
+    assert r1.status_code == 202
+    assert r2.status_code == 202
+    with sqlite3.connect(db_path) as conn:
+        n = conn.execute("SELECT COUNT(*) FROM github_events").fetchone()[0]
+    assert n == 1
+
+
+def test_webhook_check_run_extracts_pr_from_pull_requests_array(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g8")
+    _set_webhook_secret(db_path, "g8", "s8")
+    _insert_task(
+        db_path,
+        task_id="t-2",
+        guild_id="g8",
+        pr_url="https://github.com/o/r/pull/9",
+        pr_number=9,
+        pr_repo="o/r",
+    )
+    payload = {
+        "action": "completed",
+        "repository": {"full_name": "o/r"},
+        "check_run": {
+            "name": "rspec",
+            "conclusion": "failure",
+            "pull_requests": [{"number": 9, "html_url": "https://github.com/o/r/pull/9"}],
+        },
+        "sender": {"login": "ci-bot[bot]"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("s8", body, event="check_run", delivery="cr-1")
+    resp = test_client.post("/webhooks/github/g8", content=body, headers=headers)
+    assert resp.status_code == 202
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT task_id, event_type, action, pr_number FROM github_events"
+        ).fetchone()
+    assert row == ("t-2", "check_run", "completed", 9)
+
+
+def test_webhook_rejects_invalid_json(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g9")
+    _set_webhook_secret(db_path, "g9", "s9")
+    body = b"not-json"
+    headers = _signed_headers("s9", body, event="pull_request", delivery="bad-1")
+    resp = test_client.post("/webhooks/github/g9", content=body, headers=headers)
+    assert resp.status_code == 400
+
+
+def test_webhook_missing_github_headers(client):
+    test_client, db_path = client
+    insert_guild(db_path, "g10")
+    _set_webhook_secret(db_path, "g10", "s10")
+    body = json.dumps({}).encode()
+    resp = test_client.post(
+        "/webhooks/github/g10",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Webhook-secret REST endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_get_webhook_secret_requires_auth(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gs1")
+    resp = test_client.get("/guilds/gs1/webhook-secret")
+    assert resp.status_code == 401
+
+
+def test_get_webhook_secret_generates_on_first_access(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gs2")
+    token = make_auth_token(db_path)
+    resp = test_client.get(
+        "/guilds/gs2/webhook-secret",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    secret = resp.json()["webhook_secret"]
+    assert secret and len(secret) == 64  # 32 bytes hex
+
+    # Same secret on second access (no rotation)
+    resp2 = test_client.get(
+        "/guilds/gs2/webhook-secret",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp2.json()["webhook_secret"] == secret
+
+
+def test_rotate_webhook_secret_owner_only(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gs3")
+    other = make_auth_token(db_path, user_id="someone-else", username="other")
+    resp = test_client.post(
+        "/guilds/gs3/webhook-secret",
+        headers={"Authorization": f"Bearer {other}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_rotate_webhook_secret_changes_value(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gs4")
+    token = make_auth_token(db_path)
+    headers = {"Authorization": f"Bearer {token}"}
+    first = test_client.get("/guilds/gs4/webhook-secret", headers=headers).json()["webhook_secret"]
+    rotated = test_client.post("/guilds/gs4/webhook-secret", headers=headers).json()[
+        "webhook_secret"
+    ]
+    assert rotated != first
+
+
+# ---------------------------------------------------------------------------
+# pr_url -> (number, repo) backfill
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pr_url_web():
+    from ws_handlers import _parse_pr_url
+
+    assert _parse_pr_url("https://github.com/owner/repo/pull/42") == (42, "owner/repo")
+
+
+def test_parse_pr_url_api():
+    from ws_handlers import _parse_pr_url
+
+    assert _parse_pr_url("https://api.github.com/repos/o/r/pulls/9") == (9, "o/r")
+
+
+def test_parse_pr_url_handles_garbage():
+    from ws_handlers import _parse_pr_url
+
+    assert _parse_pr_url(None) == (None, None)
+    assert _parse_pr_url("") == (None, None)
+    assert _parse_pr_url("not-a-url") == (None, None)
+    assert _parse_pr_url("https://github.com/owner/repo/issues/1") == (None, None)

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -40,6 +40,36 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _parse_pr_url(pr_url: str | None) -> tuple[int | None, str | None]:
+    """Extract ``(pr_number, "owner/repo")`` from a GitHub PR URL.
+
+    Accepts both web URLs (``https://github.com/o/r/pull/42``) and API URLs
+    (``https://api.github.com/repos/o/r/pulls/42``). Returns ``(None, None)``
+    on anything that doesn't look like a PR URL — the caller stamps both
+    columns to NULL in that case so we don't link a stale (number, repo) to
+    a task whose PR was retracted.
+    """
+    if not pr_url or not isinstance(pr_url, str):
+        return None, None
+    parts = pr_url.rstrip("/").split("/")
+    try:
+        # ``…/{owner}/{repo}/pull/{n}`` or ``…/repos/{owner}/{repo}/pulls/{n}``
+        if "pull" in parts:
+            idx = parts.index("pull")
+        elif "pulls" in parts:
+            idx = parts.index("pulls")
+        else:
+            return None, None
+        owner = parts[idx - 2]
+        repo = parts[idx - 1]
+        number = int(parts[idx + 1])
+    except (ValueError, IndexError):
+        return None, None
+    if not owner or not repo:
+        return None, None
+    return number, f"{owner}/{repo}"
+
+
 async def _resolve_user_identifier(db, identifier: str) -> str | None:
     """Look up a User by id (numeric github id as text) or github_login.
 
@@ -368,6 +398,13 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
     ):
         if src in data:
             update_values[col] = data[src]
+    # When the worker reports a PR URL, derive pr_number + pr_repo so github
+    # webhook deliveries can be linked back to this task without fragile URL
+    # substring matching at receive time.
+    if "prUrl" in data:
+        pr_number, pr_repo = _parse_pr_url(data.get("prUrl"))
+        update_values["pr_number"] = pr_number
+        update_values["pr_repo"] = pr_repo
     if update_values:
         await ctx.db.execute(update(Task).where(Task.id == task_id).values(**update_values))
         await ctx.db.commit()


### PR DESCRIPTION
Lands the receiver half of the GitHub PR event subscription design
(docs/github-pr-subscriptions.md, branch claude/investigate-…-t-zqug):

- Alembic migration adds guilds.webhook_secret, tasks.pr_number/pr_repo,
  and the github_events table (with a UNIQUE delivery_id for dedup).
- POST /webhooks/github/{guild_id} verifies the X-Hub-Signature-256
  HMAC, persists the event idempotently, and broadcasts a github-event
  WS message. Ping deliveries return 204; redelivered events return
  202 without firing side effects.
- GET/POST /guilds/{guild_id}/webhook-secret lets owners read or
  rotate the per-guild secret; workers can fetch it via worker-token
  auth so they can self-register hooks at PR-creation time.
- handle_task_update extracts (pr_number, pr_repo) from prUrl when a
  worker reports it, so events can be linked back to the originating
  task without fragile string matching.

Foreman dispatch (Phase 2) will be wired on top of the persisted row
in a follow-up.

https://claude.ai/code/session_01Ud1EgSZHda2NMAxwUMvtC3