### PR TITLE
feat(backend): wire GitHub webhooks into the foreman (Phase 2)

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -40,7 +40,27 @@ Pass deleted_at instead if you need an exact ISO-8601 timestamp.
 
 ## GitHub access
 You have direct GitHub access via list_github_issues, get_github_issue, list_github_prs,
-search_github_issues, create_github_issue, and claim_github_issue.
+search_github_issues, create_github_issue, claim_github_issue, and get_pr_status
+(reviews + check-runs + merged state for one PR).
+
+## Reacting to GitHub PR events
+Messages prefixed `[github-event]` are pushed by GitHub webhooks for PRs you opened.
+The header line names the event type, action, repo/PR number, and the linked task id.
+Use the body to decide:
+- **PR merged** (`pull_request/closed` with `merged=true`): call finalize_task.
+- **PR closed unmerged**: call get_pr_status to read the rejection reason, then either
+  send_followup with the fix or finalize_task with expires_in_seconds=86400 if abandoning.
+- **Review submitted, `changes_requested`**: send_followup with the requested changes.
+- **Review submitted, `approved`**: usually no action — wait for merge, or finalize if
+  the workflow auto-merges.
+- **CI failure** (`check_run`/`check_suite/completed` with `conclusion=failure`):
+  send_followup with concrete instructions to fix the failure (read the summary line).
+- **CI success**: typically no action, unless this was the last required check and you
+  want to finalize.
+- **Issue comment / review comment on a PR**: send_followup if the human is requesting
+  changes; otherwise no action.
+Foreman events from bots on non-CI surfaces are filtered out before reaching you, so
+treat every `[github-event]` you see as something a human likely cares about.
 
 ## Issue-first workflow
 **Skip issue creation entirely** for: follow-ups, CI fixes, lint fixes, test fixes, or any

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -365,6 +365,24 @@ FOREMAN_TOOLS = [
         },
     },
     {
+        "name": "get_pr_status",
+        "description": (
+            "Fetch the live status of a single pull request: merged/closed/open state, "
+            "submitted reviews, and the latest check-run conclusions for the head SHA. "
+            "Use this to interpret a `[github-event]` message that doesn't carry enough "
+            "context, or when deciding whether all required checks have completed before "
+            "finalizing a task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "pr_number": {"type": "integer", "description": "Pull request number."},
+            },
+            "required": ["repo", "pr_number"],
+        },
+    },
+    {
         "name": "search_github_issues",
         "description": (
             "Search GitHub issues and PRs by keyword within a repo. "
@@ -897,6 +915,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
             "claim_github_issue",
             "create_github_issue",
             "search_github_issues",
+            "get_pr_status",
         ):
             creds = await _guild_github_token(guild_id)
             if not creds:
@@ -999,6 +1018,56 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 "number": issue["number"],
                                 "url": issue["html_url"],
                                 "title": issue["title"],
+                            }
+                        )
+
+                    elif tu.name == "get_pr_status":
+                        repo = inp["repo"]
+                        num = int(inp["pr_number"])
+                        pr = await asyncio.to_thread(_gh_api, f"/repos/{repo}/pulls/{num}", token)
+                        reviews_raw = await asyncio.to_thread(
+                            _gh_api,
+                            f"/repos/{repo}/pulls/{num}/reviews?per_page=20",
+                            token,
+                        )
+                        head_sha = (pr.get("head") or {}).get("sha")
+                        check_runs: list = []
+                        if head_sha:
+                            crs = await asyncio.to_thread(
+                                _gh_api,
+                                f"/repos/{repo}/commits/{head_sha}/check-runs?per_page=30",
+                                token,
+                            )
+                            if isinstance(crs, dict):
+                                check_runs = crs.get("check_runs", []) or []
+                        result_text = json.dumps(
+                            {
+                                "number": pr["number"],
+                                "state": pr["state"],
+                                "merged": pr.get("merged", False),
+                                "mergeable": pr.get("mergeable"),
+                                "draft": pr.get("draft", False),
+                                "head_sha": head_sha,
+                                "reviews": [
+                                    {
+                                        "user": (r.get("user") or {}).get("login"),
+                                        "state": r.get("state"),
+                                        "body": (r.get("body") or "")[:300],
+                                        "submitted_at": r.get("submitted_at"),
+                                    }
+                                    for r in reviews_raw
+                                ],
+                                "checks": [
+                                    {
+                                        "name": cr.get("name"),
+                                        "status": cr.get("status"),
+                                        "conclusion": cr.get("conclusion"),
+                                        "summary": ((cr.get("output") or {}).get("summary") or "")[
+                                            :300
+                                        ],
+                                    }
+                                    for cr in check_runs
+                                ],
                             }
                         )
 

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -6,8 +6,10 @@ verifies the HMAC-SHA256 signature against the guild's stored secret,
 persists the event (idempotent on the X-GitHub-Delivery header), and
 broadcasts a ``github-event`` WS message to the guild.
 
-Foreman dispatch (Phase 2) will be wired on top of the persisted row — the
-goal of this file is just to land the receiver and its persistence story.
+When the event is linked to a known task and clears the noise filters
+(see ``_should_dispatch_to_foreman``), the receiver also schedules a
+``run_foreman_ai`` invocation with a structured summary so the foreman
+can decide whether to send_followup, finalize, or no-op.
 """
 
 from __future__ import annotations
@@ -21,10 +23,12 @@ from datetime import UTC, datetime
 from database import get_db
 from events import broadcast
 from fastapi import APIRouter, HTTPException, Request, Response
+from foreman import reset_foreman_poll, run_foreman_ai
 from models import GithubEvent, Guild, Task
 from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
+from util.tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +39,12 @@ router = APIRouter()
 # review-comment diff hunks can balloon — 64 KB is a safe upper bound that
 # keeps the row size manageable while preserving enough for foreman context.
 _MAX_PAYLOAD_BYTES = 64 * 1024
+
+# Event types that are *expected* to come from bots (``[bot]`` suffix in
+# sender.login). For these the bot filter is bypassed because bots drive
+# most CI/automation traffic — filtering them out would silence the very
+# events we want to react to.
+_BOT_OK_EVENTS = frozenset({"check_run", "check_suite", "status"})
 
 
 def _verify_signature(secret: str, body: bytes, signature_header: str | None) -> bool:
@@ -78,12 +88,16 @@ def _extract_pr_info(payload: dict) -> tuple[int | None, str | None, str | None]
     return None, None, repo
 
 
-async def _find_task_id(db, guild_id: str, repo: str | None, pr_number: int | None) -> str | None:
-    """Match a webhook to one of this guild's tasks by (repo, pr_number)."""
+async def _find_task(db, guild_id: str, repo: str | None, pr_number: int | None):
+    """Match a webhook to one of this guild's tasks by (repo, pr_number).
+
+    Returns the task row (id + user_id) or ``None``. The user_id is needed so
+    foreman dispatch routes back to the user who originally created the task.
+    """
     if not repo or pr_number is None:
         return None
     res = await db.execute(
-        select(Task.id)
+        select(Task.id, Task.user_id)
         .where(
             Task.guild_id == guild_id,
             Task.pr_repo == repo,
@@ -92,7 +106,128 @@ async def _find_task_id(db, guild_id: str, repo: str | None, pr_number: int | No
         .order_by(Task.created_at.desc())
         .limit(1)
     )
-    return res.scalar_one_or_none()
+    return res.first()
+
+
+def _should_dispatch_to_foreman(
+    event_type: str,
+    action: str | None,
+    payload: dict,
+    sender_login: str | None,
+    task_id: str | None,
+) -> tuple[bool, str]:
+    """Decide whether this webhook should wake the foreman.
+
+    Returns ``(dispatch, reason)``. *reason* is the skip reason when
+    ``dispatch`` is False, or an empty string otherwise — useful for
+    log lines and tests.
+
+    Filtering rules (see docs/github-pr-subscriptions.md §4):
+    - No matching task ⇒ skip (foreman has no context)
+    - ``[bot]`` senders on non-CI events ⇒ skip (Dependabot opening PRs etc)
+    - ``check_run`` events with ``status != "completed"`` ⇒ skip (pending runs are noisy)
+    """
+    if not task_id:
+        return False, "no-matching-task"
+    if sender_login and sender_login.endswith("[bot]") and event_type not in _BOT_OK_EVENTS:
+        return False, "bot-non-ci-sender"
+    if event_type in {"check_run", "check_suite"}:
+        node = payload.get(event_type) or {}
+        status = node.get("status") if isinstance(node, dict) else None
+        if status and status != "completed":
+            return False, f"check-status-{status}"
+        # Skip neutral / skipped conclusions — only success/failure/cancelled
+        # are actionable signals for the foreman.
+        conclusion = node.get("conclusion") if isinstance(node, dict) else None
+        if conclusion in {"neutral", "skipped"}:
+            return False, f"check-conclusion-{conclusion}"
+    return True, ""
+
+
+def _build_foreman_summary(
+    event_type: str,
+    action: str | None,
+    payload: dict,
+    repo: str | None,
+    pr_number: int | None,
+    task_id: str,
+    sender_login: str | None,
+) -> str:
+    """Render a structured ``[github-event]`` message for the foreman.
+
+    The format is intentionally compact and includes the task id + PR
+    coordinates first so the foreman can immediately route to send_followup
+    / finalize_task without a get_task_status round-trip for trivial cases.
+    """
+    header = (
+        f"[github-event] {event_type}"
+        + (f"/{action}" if action else "")
+        + f" on {repo}#{pr_number} (task {task_id})"
+    )
+    sender_line = f" by @{sender_login}" if sender_login else ""
+
+    detail = ""
+    if event_type == "pull_request" and action in {"closed", "reopened"}:
+        pr = payload.get("pull_request") or {}
+        merged = pr.get("merged")
+        if action == "closed" and merged:
+            detail = (
+                "PR was merged. Call finalize_task — "
+                "the work has landed and no follow-up is needed."
+            )
+        elif action == "closed":
+            detail = (
+                "PR was closed without merging. Investigate why "
+                "(check_pr_status, get_task_status), then either send_followup "
+                "to address the rejection or finalize_task if the work is being abandoned."
+            )
+        else:
+            detail = (
+                "PR was reopened — no immediate action required unless prior work needs revisiting."
+            )
+    elif event_type == "pull_request_review" and action == "submitted":
+        review = payload.get("review") or {}
+        state = review.get("state")
+        body = (review.get("body") or "")[:400]
+        detail = f"Review state: {state}." + (f"\nReview body:\n{body}" if body else "")
+        if state == "changes_requested":
+            detail += "\nCall send_followup with the requested changes."
+        elif state == "approved":
+            detail += (
+                "\nReview is approved — wait for merge before finalizing, "
+                "or finalize now if the workflow auto-merges."
+            )
+    elif event_type == "pull_request_review_comment" and action == "created":
+        comment = payload.get("comment") or {}
+        path = comment.get("path", "")
+        body = (comment.get("body") or "")[:400]
+        detail = f"Inline comment on `{path}`:\n{body}\nDecide whether send_followup is warranted."
+    elif event_type == "issue_comment" and action == "created":
+        comment = payload.get("comment") or {}
+        body = (comment.get("body") or "")[:400]
+        detail = (
+            f"PR comment:\n{body}\n"
+            "If this is a request for changes, send_followup; otherwise no action."
+        )
+    elif event_type in {"check_run", "check_suite"}:
+        node = payload.get(event_type) or {}
+        name = node.get("name") or node.get("app", {}).get("slug") or "check"
+        conclusion = node.get("conclusion")
+        summary = (node.get("output") or {}).get("summary") or ""
+        detail = f"{name}: {conclusion}." + (f"\nSummary: {summary[:400]}" if summary else "")
+        if conclusion == "failure":
+            detail += (
+                "\nCI failed — call send_followup with concrete instructions to fix the failure."
+            )
+        elif conclusion == "success":
+            detail += "\nCI passed — if all required checks have completed, you can finalize_task."
+    elif event_type == "status":
+        state = payload.get("state")
+        context = payload.get("context") or "status"
+        description = payload.get("description") or ""
+        detail = f"{context}: {state}.{(' ' + description) if description else ''}"
+
+    return f"{header}{sender_line}\n{detail}".strip() if detail else f"{header}{sender_line}"
 
 
 @router.post("/webhooks/github/{guild_id}")
@@ -143,7 +278,9 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
         sender = payload.get("sender") or {}
         sender_login = sender.get("login") if isinstance(sender, dict) else None
 
-        task_id = await _find_task_id(db, guild_id, repo, pr_number)
+        task_row = await _find_task(db, guild_id, repo, pr_number)
+        task_id = task_row.id if task_row else None
+        task_user_id = task_row.user_id if task_row else None
 
         # Trim the persisted payload so a runaway diff hunk can't balloon the DB.
         body_text = body.decode("utf-8", errors="replace")
@@ -215,4 +352,26 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
             "sender": sender_login,
         },
     )
+
+    dispatch, skip_reason = _should_dispatch_to_foreman(
+        event_type, action, payload, sender_login, task_id
+    )
+    if dispatch:
+        summary = _build_foreman_summary(
+            event_type, action, payload, repo, pr_number, task_id, sender_login
+        )
+        spawn(
+            run_foreman_ai(guild_id, summary, user_id=task_user_id),
+            name=f"foreman.github-event:{delivery_id}",
+        )
+        reset_foreman_poll(guild_id)
+    else:
+        logger.info(
+            "github webhook skip-foreman guild=%s delivery=%s event=%s reason=%s",
+            guild_id,
+            delivery_id,
+            event_type,
+            skip_reason,
+        )
+
     return Response(status_code=202)

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -1,0 +1,464 @@
+"""Tests for Phase 2 GitHub webhook plumbing.
+
+Covers:
+- Foreman dispatch + filtering rules (``_should_dispatch_to_foreman``,
+  ``_build_foreman_summary``)
+- The end-to-end receiver-to-foreman path (verifying ``run_foreman_ai``
+  is invoked when a webhook arrives that matches a known task)
+- The new ``get_pr_status`` foreman tool
+- The system prompt section that teaches the foreman how to react
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module  # noqa: E402
+from foreman.tools import exec_tools  # noqa: E402
+from helpers import create_db, insert_guild, make_auth_token  # noqa: E402
+from routes.webhooks import (  # noqa: E402
+    _build_foreman_summary,
+    _should_dispatch_to_foreman,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror test_github_webhooks.py to keep these focused on Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def _set_webhook_secret(db_path: str, guild_id: str, secret: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE guilds SET webhook_secret = ? WHERE id = ?",
+            (secret, guild_id),
+        )
+        conn.commit()
+
+
+def _insert_task(
+    db_path: str,
+    *,
+    task_id: str,
+    guild_id: str,
+    pr_url: str | None = None,
+    pr_number: int | None = None,
+    pr_repo: str | None = None,
+    user_id: str | None = None,
+) -> None:
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO workers (id, guild_id, repos, state, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (f"w-{task_id}", guild_id, "[]", "online", now),
+        )
+        conn.execute(
+            "INSERT INTO tasks (id, worker_id, guild_id, description, tool, state, "
+            "pr_url, pr_number, pr_repo, user_id, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                task_id,
+                f"w-{task_id}",
+                guild_id,
+                "test task",
+                "claude",
+                "awaiting-review",
+                pr_url,
+                pr_number,
+                pr_repo,
+                user_id,
+                now,
+            ),
+        )
+        conn.commit()
+
+
+def _signed_headers(secret: str, body: bytes, *, event: str, delivery: str) -> dict[str, str]:
+    sig = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return {
+        "X-GitHub-Event": event,
+        "X-GitHub-Delivery": delivery,
+        "X-Hub-Signature-256": f"sha256={sig}",
+        "Content-Type": "application/json",
+    }
+
+
+def _pr_payload(*, action: str, repo: str, number: int, **extra) -> dict:
+    pr = {
+        "number": number,
+        "html_url": f"https://github.com/{repo}/pull/{number}",
+        **extra.pop("pull_request_extra", {}),
+    }
+    return {
+        "action": action,
+        "repository": {"full_name": repo},
+        "pull_request": pr,
+        "sender": {"login": extra.pop("sender_login", "octocat")},
+        **extra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filter
+# ---------------------------------------------------------------------------
+
+
+class TestShouldDispatch:
+    def test_no_task_skips(self):
+        ok, reason = _should_dispatch_to_foreman("pull_request", "opened", {}, "alice", None)
+        assert not ok
+        assert reason == "no-matching-task"
+
+    def test_bot_sender_on_non_ci_skips(self):
+        ok, reason = _should_dispatch_to_foreman(
+            "issue_comment", "created", {}, "dependabot[bot]", "t-1"
+        )
+        assert not ok
+        assert reason == "bot-non-ci-sender"
+
+    def test_bot_sender_on_check_run_dispatches(self):
+        payload = {"check_run": {"status": "completed", "conclusion": "failure"}}
+        ok, _ = _should_dispatch_to_foreman(
+            "check_run", "completed", payload, "github-actions[bot]", "t-1"
+        )
+        assert ok
+
+    def test_pending_check_run_skips(self):
+        payload = {"check_run": {"status": "in_progress"}}
+        ok, reason = _should_dispatch_to_foreman("check_run", "created", payload, "ci[bot]", "t-1")
+        assert not ok
+        assert reason == "check-status-in_progress"
+
+    def test_neutral_check_conclusion_skips(self):
+        payload = {"check_run": {"status": "completed", "conclusion": "neutral"}}
+        ok, reason = _should_dispatch_to_foreman(
+            "check_run", "completed", payload, "ci[bot]", "t-1"
+        )
+        assert not ok
+        assert reason == "check-conclusion-neutral"
+
+    def test_skipped_check_conclusion_skips(self):
+        payload = {"check_suite": {"status": "completed", "conclusion": "skipped"}}
+        ok, _ = _should_dispatch_to_foreman("check_suite", "completed", payload, "ci[bot]", "t-1")
+        assert not ok
+
+    def test_human_review_dispatches(self):
+        ok, _ = _should_dispatch_to_foreman(
+            "pull_request_review", "submitted", {}, "human-reviewer", "t-1"
+        )
+        assert ok
+
+
+# ---------------------------------------------------------------------------
+# Summary builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSummary:
+    def test_pr_merged(self):
+        payload = {"pull_request": {"merged": True}}
+        s = _build_foreman_summary(
+            "pull_request", "closed", payload, "owner/repo", 42, "t-1", "human"
+        )
+        assert "[github-event] pull_request/closed on owner/repo#42 (task t-1)" in s
+        assert "merged" in s.lower()
+        assert "finalize_task" in s
+
+    def test_pr_closed_unmerged(self):
+        payload = {"pull_request": {"merged": False}}
+        s = _build_foreman_summary(
+            "pull_request", "closed", payload, "owner/repo", 42, "t-1", "human"
+        )
+        assert "without merging" in s.lower()
+        assert "send_followup" in s
+
+    def test_review_changes_requested(self):
+        payload = {"review": {"state": "changes_requested", "body": "needs work"}}
+        s = _build_foreman_summary(
+            "pull_request_review", "submitted", payload, "o/r", 1, "t-1", "alice"
+        )
+        assert "changes_requested" in s
+        assert "needs work" in s
+        assert "send_followup" in s
+
+    def test_review_approved(self):
+        payload = {"review": {"state": "approved", "body": ""}}
+        s = _build_foreman_summary(
+            "pull_request_review", "submitted", payload, "o/r", 1, "t-1", "alice"
+        )
+        assert "approved" in s
+
+    def test_check_run_failure(self):
+        payload = {
+            "check_run": {
+                "name": "rspec",
+                "conclusion": "failure",
+                "output": {"summary": "3 tests failed in spec/auth_spec.rb"},
+            }
+        }
+        s = _build_foreman_summary("check_run", "completed", payload, "o/r", 9, "t-2", "ci[bot]")
+        assert "rspec" in s
+        assert "failure" in s
+        assert "3 tests failed" in s
+        assert "send_followup" in s
+
+    def test_check_run_success(self):
+        payload = {"check_run": {"name": "rspec", "conclusion": "success"}}
+        s = _build_foreman_summary("check_run", "completed", payload, "o/r", 9, "t-2", "ci[bot]")
+        assert "success" in s
+        assert "finalize_task" in s
+
+    def test_issue_comment(self):
+        payload = {"comment": {"body": "please rebase"}}
+        s = _build_foreman_summary("issue_comment", "created", payload, "o/r", 9, "t-2", "alice")
+        assert "please rebase" in s
+
+    def test_review_comment_includes_path(self):
+        payload = {"comment": {"path": "src/app.py", "body": "this is wrong"}}
+        s = _build_foreman_summary(
+            "pull_request_review_comment", "created", payload, "o/r", 9, "t-2", "alice"
+        )
+        assert "src/app.py" in s
+        assert "this is wrong" in s
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: webhook → foreman dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_dispatches_to_foreman_when_task_matches(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gd1")
+    _set_webhook_secret(db_path, "gd1", "ssecret")
+    _insert_task(
+        db_path,
+        task_id="t-dispatch-1",
+        guild_id="gd1",
+        pr_url="https://github.com/o/r/pull/3",
+        pr_number=3,
+        pr_repo="o/r",
+        user_id="user-42",
+    )
+    payload = _pr_payload(
+        action="closed", repo="o/r", number=3, pull_request_extra={"merged": True}
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("ssecret", body, event="pull_request", delivery="d-disp-1")
+    with (
+        patch("routes.webhooks.spawn") as mock_spawn,
+        patch("routes.webhooks.reset_foreman_poll") as mock_reset,
+    ):
+        resp = test_client.post("/webhooks/github/gd1", content=body, headers=headers)
+    assert resp.status_code == 202
+    # spawn() called once, with run_foreman_ai coroutine
+    assert mock_spawn.call_count == 1
+    call_kwargs = mock_spawn.call_args
+    coro = call_kwargs.args[0]
+    assert hasattr(coro, "send")  # it's a coroutine
+    coro.close()  # so asyncio doesn't whine about a never-awaited coroutine
+    assert mock_reset.call_count == 1
+
+
+def test_webhook_skips_foreman_when_no_task_match(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gd2")
+    _set_webhook_secret(db_path, "gd2", "ssecret")
+    payload = _pr_payload(action="opened", repo="o/r", number=99)
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("ssecret", body, event="pull_request", delivery="d-disp-2")
+    with patch("routes.webhooks.spawn") as mock_spawn:
+        resp = test_client.post("/webhooks/github/gd2", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_spawn.call_count == 0
+
+
+def test_webhook_skips_foreman_for_bot_on_non_ci(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gd3")
+    _set_webhook_secret(db_path, "gd3", "ssecret")
+    _insert_task(
+        db_path,
+        task_id="t-bot",
+        guild_id="gd3",
+        pr_url="https://github.com/o/r/pull/5",
+        pr_number=5,
+        pr_repo="o/r",
+    )
+    payload = {
+        "action": "created",
+        "repository": {"full_name": "o/r"},
+        "issue": {
+            "number": 5,
+            "html_url": "https://github.com/o/r/pull/5",
+            "pull_request": {},
+        },
+        "comment": {"body": "Automated comment"},
+        "sender": {"login": "dependabot[bot]"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("ssecret", body, event="issue_comment", delivery="d-bot")
+    with patch("routes.webhooks.spawn") as mock_spawn:
+        resp = test_client.post("/webhooks/github/gd3", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_spawn.call_count == 0
+
+
+def test_webhook_dispatches_for_ci_bot_check_run(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gd4")
+    _set_webhook_secret(db_path, "gd4", "ssecret")
+    _insert_task(
+        db_path,
+        task_id="t-ci",
+        guild_id="gd4",
+        pr_url="https://github.com/o/r/pull/7",
+        pr_number=7,
+        pr_repo="o/r",
+    )
+    payload = {
+        "action": "completed",
+        "repository": {"full_name": "o/r"},
+        "check_run": {
+            "name": "rspec",
+            "status": "completed",
+            "conclusion": "failure",
+            "output": {"summary": "boom"},
+            "pull_requests": [{"number": 7, "html_url": "https://github.com/o/r/pull/7"}],
+        },
+        "sender": {"login": "github-actions[bot]"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("ssecret", body, event="check_run", delivery="d-ci-1")
+    with (
+        patch("routes.webhooks.spawn") as mock_spawn,
+        patch("routes.webhooks.reset_foreman_poll"),
+    ):
+        resp = test_client.post("/webhooks/github/gd4", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_spawn.call_count == 1
+    coro = mock_spawn.call_args.args[0]
+    coro.close()
+
+
+# ---------------------------------------------------------------------------
+# get_pr_status tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test_phase2.db")
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DB_PATH", db_path)
+    create_db(db_path)
+    engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    monkeypatch.setattr(database_module, "AsyncSessionLocal", session_factory)
+    yield db_path
+
+
+def _fake_tool_use(name: str, inputs: dict, tool_id: str = "tool-1"):
+    return SimpleNamespace(name=name, input=inputs, id=tool_id)
+
+
+@pytest.mark.asyncio
+async def test_get_pr_status_returns_reviews_and_checks(db_session):
+    insert_guild(db_session, "g-prs")
+    fake_pr = {
+        "number": 42,
+        "state": "open",
+        "merged": False,
+        "mergeable": True,
+        "draft": False,
+        "head": {"sha": "deadbeef"},
+    }
+    fake_reviews = [
+        {
+            "user": {"login": "alice"},
+            "state": "approved",
+            "body": "lgtm",
+            "submitted_at": "2026-05-06T00:00:00Z",
+        }
+    ]
+    fake_checks = {
+        "check_runs": [
+            {
+                "name": "rspec",
+                "status": "completed",
+                "conclusion": "success",
+                "output": {"summary": "100/100 passed"},
+            }
+        ]
+    }
+    responses = iter([fake_pr, fake_reviews, fake_checks])
+    with (
+        patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+        patch("foreman.tools._gh_api", side_effect=lambda *a, **kw: next(responses)),
+    ):
+        results = await exec_tools(
+            "g-prs", [_fake_tool_use("get_pr_status", {"repo": "o/r", "pr_number": 42})]
+        )
+    parsed = json.loads(results[0]["content"])
+    assert parsed["number"] == 42
+    assert parsed["merged"] is False
+    assert parsed["head_sha"] == "deadbeef"
+    assert parsed["reviews"][0]["user"] == "alice"
+    assert parsed["reviews"][0]["state"] == "approved"
+    assert parsed["checks"][0]["name"] == "rspec"
+    assert parsed["checks"][0]["conclusion"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_get_pr_status_skips_check_runs_when_no_head_sha(db_session):
+    """If the PR has no head.sha (rare, but possible for ghost branches) the
+    check-runs API call must be skipped, not retried with a None SHA."""
+    insert_guild(db_session, "g-prs2")
+    fake_pr = {"number": 1, "state": "closed", "merged": False, "head": {}}
+    fake_reviews: list = []
+    responses = iter([fake_pr, fake_reviews])
+    with (
+        patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+        patch("foreman.tools._gh_api", side_effect=lambda *a, **kw: next(responses)),
+    ):
+        results = await exec_tools(
+            "g-prs2", [_fake_tool_use("get_pr_status", {"repo": "o/r", "pr_number": 1})]
+        )
+    parsed = json.loads(results[0]["content"])
+    assert parsed["checks"] == []
+
+
+def test_get_pr_status_in_tool_definitions():
+    """Sanity check: tool is registered so the foreman can call it."""
+    from foreman.tools import FOREMAN_TOOLS
+
+    names = [t["name"] for t in FOREMAN_TOOLS]
+    assert "get_pr_status" in names
+
+
+def test_prompt_describes_github_events():
+    """The system prompt should teach the foreman about [github-event] triggers."""
+    from foreman.prompt import FOREMAN_SYSTEM, build_system_prompt
+
+    assert "[github-event]" in FOREMAN_SYSTEM
+    assert "get_pr_status" in FOREMAN_SYSTEM
+    rendered = build_system_prompt("[]", "[]")
+    assert "github-event" in rendered


### PR DESCRIPTION
## Summary

Stacked on #224 (Phase 1: webhook receiver). Phase 2 of the GitHub PR
event subscription design — when a webhook arrives that matches a known
task, dispatch a structured `[github-event]` message to the foreman so
it can decide whether to send_followup, finalize_task, or no-op.

> **Review only the most recent commit** — this PR builds on #224.
> GitHub will auto-rebase/retarget once #224 merges to `main`.

### Filter (`_should_dispatch_to_foreman`)
Skips foreman invocation when:
- The event has no matching task (foreman has no context to act on)
- Sender is `*[bot]` and the event is not a CI surface
  (`check_run`/`check_suite`/`status`) — keeps Dependabot etc. quiet
- `check_run` is still `status=in_progress` (pending runs are noisy)
- `check_run` conclusion is `neutral` or `skipped` (not actionable)

### Summary builder (`_build_foreman_summary`)
Per-event-type templates: header → context body → action hint. The
foreman gets a decision-ready prompt instead of a raw payload dump.
Examples:
- `pull_request/closed` (merged) → "Call finalize_task"
- `pull_request_review/submitted` (changes_requested) → "Call send_followup with the requested changes"
- `check_run/completed` (failure) → "Call send_followup with concrete instructions to fix the failure"

### Foreman additions
- New `get_pr_status` tool wraps `GET /pulls/{n}` + `/reviews` +
  `/commits/{sha}/check-runs` into one call so the foreman can fill in
  context the webhook summary doesn't carry (e.g. "are *all* required
  checks passing yet?").
- `## Reacting to GitHub PR events` section in `FOREMAN_SYSTEM` teaches
  the foreman how to interpret each event flavour.

## Test plan
- [x] 23 new tests in `tests/test_github_webhooks_phase2.py`
- [x] Filter rules: no-task, bot-on-non-CI, bot-on-CI (dispatches),
  pending check, neutral/skipped conclusion, human review
- [x] Summary builder for: PR merged, PR closed unmerged, review
  changes_requested, review approved, check_run failure/success,
  issue_comment, review_comment with file path
- [x] End-to-end: webhook → spawn(run_foreman_ai) called when expected,
  skipped when filter rejects (Dependabot non-CI; no matching task)
- [x] `get_pr_status` returns reviews + check-runs; gracefully skips
  the check-runs call when head SHA is missing
- [x] System prompt mentions `[github-event]` and `get_pr_status`
- [x] Full backend suite: 268/268 passing
- [x] `ruff check . && ruff format .` clean

https://claude.ai/code/session_01Ud1EgSZHda2NMAxwUMvtC3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud1EgSZHda2NMAxwUMvtC3)_