### PR TITLE
feat(worker): auto-register GitHub webhooks after open_pr (Phase 3)

### DIFF
--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -38,6 +38,12 @@ class Config:
     pull_interval: float = 300.0
     claude_max_turns: int = 50
     max_agents: int = 4
+    # Optional public-facing backend URL used when registering GitHub webhooks.
+    # ``backend_url`` may point at an internal address GitHub can't reach
+    # (e.g. ``http://backend:8000`` in Docker); set ``public_backend_url`` to
+    # the externally-reachable URL (e.g. an ngrok / Cloudflare tunnel) and
+    # webhook registration will target it. Defaults to ``backend_url``.
+    public_backend_url: str | None = None
 
     config_path: Path = field(default_factory=Path)
 
@@ -47,6 +53,12 @@ class Config:
         parsed = urlparse(self.backend_url)
         scheme = {"ws": "http", "wss": "https"}.get(parsed.scheme, parsed.scheme or "http")
         return urlunparse((scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+
+    @property
+    def webhook_target_url(self) -> str:
+        """Public URL GitHub should POST webhook deliveries to for this guild."""
+        base = (self.public_backend_url or self.http_url).rstrip("/")
+        return f"{base}/webhooks/github/{self.guild_id}"
 
     @property
     def ws_url(self) -> str:
@@ -167,5 +179,8 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             if overrides.get("max_agents") is not None
             else raw.get("max_agents", 4)
         ),
+        public_backend_url=overrides.get("public_backend_url")
+        or raw.get("public_backend_url")
+        or os.environ.get("PIONEER_PUBLIC_BACKEND_URL"),
         config_path=cfg_path,
     )

--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import urllib.error
 import urllib.request
@@ -12,6 +13,21 @@ from collections.abc import Awaitable, Callable
 from . import git_ops
 
 EmitFn = Callable[[str], Awaitable[None]]
+
+logger = logging.getLogger(__name__)
+
+
+# GitHub webhook events the foreman cares about — kept narrow so a single
+# repo's hook doesn't fan out the firehose. ``status`` is the legacy
+# pre-checks API; we subscribe so older repos still surface CI signals.
+_WEBHOOK_EVENTS = [
+    "pull_request",
+    "pull_request_review",
+    "pull_request_review_comment",
+    "issue_comment",
+    "check_run",
+    "status",
+]
 
 
 async def push_branch(
@@ -148,3 +164,174 @@ async def open_pr(
     except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
         await emit(f"[worker] PR failed: {exc}")
         return None
+
+
+async def _fetch_webhook_secret(*, http_url: str, guild_id: str, auth_token: str) -> str | None:
+    """GET the guild's webhook secret from the backend, returning None on failure.
+
+    The backend lazily generates the secret on first read (see
+    ``backend/routes/guilds.py``), so the first PR ever opened against a guild
+    transparently provisions one.
+    """
+
+    def _get() -> dict:
+        req = urllib.request.Request(
+            f"{http_url.rstrip('/')}/guilds/{guild_id}/webhook-secret",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+
+    try:
+        data = await asyncio.to_thread(_get)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
+        logger.warning("webhook secret fetch failed: %s", exc)
+        return None
+    secret = data.get("webhook_secret") if isinstance(data, dict) else None
+    return secret if isinstance(secret, str) and secret else None
+
+
+def _repo_from_pr_url(pr_url: str) -> str | None:
+    """Extract ``owner/repo`` from a PR HTML URL like
+    ``https://github.com/owner/repo/pull/42``."""
+    if not pr_url:
+        return None
+    m = re.search(r"github\.com/([^/]+/[^/]+)/pull/\d+", pr_url)
+    return m.group(1) if m else None
+
+
+async def ensure_webhook(
+    *,
+    repo: str,
+    target_url: str,
+    http_url: str,
+    guild_id: str,
+    auth_token: str | None,
+    github_token: str | None,
+    emit: EmitFn,
+) -> bool:
+    """Idempotently configure a Pioneer Square webhook on *repo*.
+
+    Best-effort: returns True when the hook is in place after this call,
+    False on any failure. Failures emit a single warning and are otherwise
+    swallowed — the PR has already been opened, so missing webhook coverage
+    shouldn't block the task.
+
+    Idempotency: looks up existing hooks first. If one already targets
+    *target_url* it's reused (and updated only when the active flag, secret,
+    or events list drift). Otherwise a new hook is created.
+    """
+    if not auth_token:
+        await emit("[worker] webhook setup skipped — no worker auth_token")
+        return False
+    if not github_token:
+        await emit("[worker] webhook setup skipped — no GitHub token")
+        return False
+
+    secret = await _fetch_webhook_secret(
+        http_url=http_url, guild_id=guild_id, auth_token=auth_token
+    )
+    if not secret:
+        await emit("[worker] webhook setup skipped — backend did not return a secret")
+        return False
+
+    def _list_hooks() -> list:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/hooks?per_page=100",
+            headers={
+                "Authorization": f"Bearer {github_token}",
+                "Accept": "application/vnd.github.v3+json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+
+    def _create_hook() -> dict:
+        body = json.dumps(
+            {
+                "name": "web",
+                "active": True,
+                "events": _WEBHOOK_EVENTS,
+                "config": {
+                    "url": target_url,
+                    "secret": secret,
+                    "content_type": "json",
+                    "insecure_ssl": "0",
+                },
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/hooks",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {github_token}",
+                "Accept": "application/vnd.github.v3+json",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+
+    def _patch_hook(hook_id: int) -> dict:
+        body = json.dumps(
+            {
+                "active": True,
+                "events": _WEBHOOK_EVENTS,
+                "config": {
+                    "url": target_url,
+                    "secret": secret,
+                    "content_type": "json",
+                    "insecure_ssl": "0",
+                },
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/hooks/{hook_id}",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {github_token}",
+                "Accept": "application/vnd.github.v3+json",
+                "Content-Type": "application/json",
+            },
+            method="PATCH",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+
+    try:
+        hooks = await asyncio.to_thread(_list_hooks)
+    except urllib.error.HTTPError as exc:
+        # 403 => token lacks admin:repo_hook (or admin access on the repo).
+        # Treat as a non-fatal warning; the operator can configure manually.
+        await emit(f"[worker] webhook list failed ({exc.code}): {exc.reason}")
+        return False
+    except (urllib.error.URLError, OSError) as exc:
+        await emit(f"[worker] webhook list failed: {exc}")
+        return False
+
+    existing = next(
+        (
+            h
+            for h in hooks
+            if isinstance(h, dict) and (h.get("config") or {}).get("url") == target_url
+        ),
+        None,
+    )
+
+    try:
+        if existing:
+            # Always re-PATCH: the secret may have been rotated, the events
+            # list may have grown, or the hook may have been deactivated.
+            await asyncio.to_thread(_patch_hook, int(existing["id"]))
+            await emit(f"[worker] ✓ Webhook refreshed on {repo}")
+        else:
+            await asyncio.to_thread(_create_hook)
+            await emit(f"[worker] ✓ Webhook installed on {repo} → {target_url}")
+        return True
+    except urllib.error.HTTPError as exc:
+        await emit(f"[worker] webhook setup failed ({exc.code}): {exc.reason}")
+        return False
+    except (urllib.error.URLError, OSError) as exc:
+        await emit(f"[worker] webhook setup failed: {exc}")
+        return False

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -673,6 +673,28 @@ class Worker:
             }
         )
 
+    async def _ensure_pr_webhook(self, pr_url: str, emit) -> None:
+        """Best-effort: install/refresh a Pioneer Square webhook on the PR's repo.
+
+        Failures are logged via *emit* and swallowed — the PR is already
+        open, so missing webhook coverage shouldn't block the task.
+        """
+        repo = github_pr._repo_from_pr_url(pr_url)
+        if not repo:
+            return
+        try:
+            await github_pr.ensure_webhook(
+                repo=repo,
+                target_url=self.cfg.webhook_target_url,
+                http_url=self.cfg.http_url,
+                guild_id=self.cfg.guild_id,
+                auth_token=self.cfg.auth_token,
+                github_token=self.cfg.github_token,
+                emit=emit,
+            )
+        except Exception as exc:
+            logger.warning("ensure_webhook raised for %s: %s", repo, exc)
+
     async def _initiate_shutdown(self, reason: str) -> None:
         """Begin a graceful shutdown.
 
@@ -1536,6 +1558,8 @@ class Worker:
                         token=token,
                         emit=emit,
                     )
+                if pr_url:
+                    await self._ensure_pr_webhook(pr_url, emit)
                 logger.info("Task %s: pr_url=%s", task_id, pr_url)
 
                 await self._task_update(

--- a/worker/tests/test_ensure_webhook.py
+++ b/worker/tests/test_ensure_webhook.py
@@ -1,0 +1,289 @@
+"""Tests for ensure_webhook (Phase 3 worker-side webhook auto-registration)."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pioneer_worker import github_pr
+from pioneer_worker.config import Config
+
+
+def _make_cfg(public_backend_url: str | None = None) -> Config:
+    return Config(
+        backend_url="http://backend:8000",
+        guild_id="g-test",
+        worker_id="w-test01",
+        auth_token="tok-worker",
+        github_token="gh-tok",
+        public_backend_url=public_backend_url,
+    )
+
+
+def _fake_response(payload, status=200):
+    """Return a context-manager-mimicking object urlopen would yield."""
+    body = json.dumps(payload).encode() if not isinstance(payload, bytes) else payload
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    resp.status = status
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_target_url_uses_http_when_no_override():
+    cfg = _make_cfg()
+    assert cfg.webhook_target_url == "http://backend:8000/webhooks/github/g-test"
+
+
+def test_webhook_target_url_prefers_public_url():
+    cfg = _make_cfg(public_backend_url="https://tunnel.example.com")
+    assert cfg.webhook_target_url == "https://tunnel.example.com/webhooks/github/g-test"
+
+
+def test_webhook_target_url_strips_trailing_slash():
+    cfg = _make_cfg(public_backend_url="https://tunnel.example.com/")
+    assert cfg.webhook_target_url == "https://tunnel.example.com/webhooks/github/g-test"
+
+
+def test_repo_from_pr_url():
+    assert github_pr._repo_from_pr_url("https://github.com/owner/repo/pull/42") == "owner/repo"
+    assert github_pr._repo_from_pr_url("https://github.com/o/r/pull/1?foo=bar") == "o/r"
+    assert github_pr._repo_from_pr_url("") is None
+    assert github_pr._repo_from_pr_url("not-a-url") is None
+    assert github_pr._repo_from_pr_url("https://github.com/o/r/issues/1") is None
+
+
+# ---------------------------------------------------------------------------
+# ensure_webhook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_skips_without_auth_token():
+    emit = AsyncMock()
+    ok = await github_pr.ensure_webhook(
+        repo="o/r",
+        target_url="https://example/webhooks/github/g",
+        http_url="http://b",
+        guild_id="g",
+        auth_token=None,
+        github_token="gh",
+        emit=emit,
+    )
+    assert ok is False
+    emit.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_skips_without_github_token():
+    emit = AsyncMock()
+    ok = await github_pr.ensure_webhook(
+        repo="o/r",
+        target_url="https://example/webhooks/github/g",
+        http_url="http://b",
+        guild_id="g",
+        auth_token="tok",
+        github_token=None,
+        emit=emit,
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_skips_when_secret_fetch_fails():
+    emit = AsyncMock()
+    # secret-fetch raises -> _fetch_webhook_secret returns None -> skip
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("backend down"),
+    ):
+        ok = await github_pr.ensure_webhook(
+            repo="o/r",
+            target_url="https://example/webhooks/github/g",
+            http_url="http://b",
+            guild_id="g",
+            auth_token="tok",
+            github_token="gh",
+            emit=emit,
+        )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_creates_when_no_existing_hook():
+    emit = AsyncMock()
+    secret_resp = _fake_response({"webhook_secret": "supersecret"})
+    list_resp = _fake_response([])
+    create_resp = _fake_response({"id": 99})
+    responses = iter([secret_resp, list_resp, create_resp])
+    captured: list = []
+
+    def _fake_urlopen(req, timeout=None):
+        captured.append(req)
+        return next(responses)
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        ok = await github_pr.ensure_webhook(
+            repo="owner/repo",
+            target_url="https://example/webhooks/github/g",
+            http_url="http://b",
+            guild_id="g",
+            auth_token="tok",
+            github_token="gh",
+            emit=emit,
+        )
+    assert ok is True
+    # 3 calls: secret, list, create
+    assert len(captured) == 3
+    # The create body must include the events list and the secret
+    create_req = captured[2]
+    create_body = json.loads(create_req.data.decode())
+    assert create_body["config"]["url"] == "https://example/webhooks/github/g"
+    assert create_body["config"]["secret"] == "supersecret"
+    assert create_body["config"]["content_type"] == "json"
+    assert "pull_request" in create_body["events"]
+    assert "check_run" in create_body["events"]
+    assert create_body["active"] is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_patches_existing_hook():
+    emit = AsyncMock()
+    secret_resp = _fake_response({"webhook_secret": "newsecret"})
+    list_resp = _fake_response(
+        [
+            {"id": 7, "config": {"url": "https://example/webhooks/github/g"}},
+            {"id": 8, "config": {"url": "https://other.example/webhook"}},
+        ]
+    )
+    patch_resp = _fake_response({"id": 7})
+    responses = iter([secret_resp, list_resp, patch_resp])
+    captured: list = []
+
+    def _fake_urlopen(req, timeout=None):
+        captured.append(req)
+        return next(responses)
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        ok = await github_pr.ensure_webhook(
+            repo="owner/repo",
+            target_url="https://example/webhooks/github/g",
+            http_url="http://b",
+            guild_id="g",
+            auth_token="tok",
+            github_token="gh",
+            emit=emit,
+        )
+    assert ok is True
+    # PATCH targets hook 7 (the matching one), not hook 8
+    patch_req = captured[2]
+    assert patch_req.full_url.endswith("/repos/owner/repo/hooks/7")
+    assert patch_req.get_method() == "PATCH"
+    body = json.loads(patch_req.data.decode())
+    assert body["config"]["secret"] == "newsecret"
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_handles_403_on_list():
+    """No admin:repo_hook scope ⇒ 403 Forbidden. Treat as a soft failure."""
+    emit = AsyncMock()
+    secret_resp = _fake_response({"webhook_secret": "x"})
+    forbidden = urllib.error.HTTPError(
+        url="https://api.github.com/repos/o/r/hooks",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=BytesIO(b""),
+    )
+
+    call_count = {"n": 0}
+
+    def _fake_urlopen(req, timeout=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return secret_resp
+        raise forbidden
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        ok = await github_pr.ensure_webhook(
+            repo="o/r",
+            target_url="https://example/webhooks/github/g",
+            http_url="http://b",
+            guild_id="g",
+            auth_token="tok",
+            github_token="gh",
+            emit=emit,
+        )
+    assert ok is False
+    # The 403 must surface in an emit message but never raise.
+    last_emit = emit.call_args_list[-1].args[0]
+    assert "403" in last_emit
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_idempotent_when_create_409():
+    """If list_hooks returns no match but create_hook fails (e.g. race), don't crash."""
+    emit = AsyncMock()
+    secret_resp = _fake_response({"webhook_secret": "x"})
+    list_resp = _fake_response([])
+    err = urllib.error.HTTPError(
+        url="https://api.github.com/repos/o/r/hooks",
+        code=422,
+        msg="Validation Failed",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=BytesIO(b""),
+    )
+
+    call_count = {"n": 0}
+
+    def _fake_urlopen(req, timeout=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return secret_resp
+        if call_count["n"] == 2:
+            return list_resp
+        raise err
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        ok = await github_pr.ensure_webhook(
+            repo="o/r",
+            target_url="https://example/webhooks/github/g",
+            http_url="http://b",
+            guild_id="g",
+            auth_token="tok",
+            github_token="gh",
+            emit=emit,
+        )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_webhook_secret_returns_none_on_empty_response():
+    with patch("urllib.request.urlopen", return_value=_fake_response({})):
+        secret = await github_pr._fetch_webhook_secret(
+            http_url="http://b", guild_id="g", auth_token="tok"
+        )
+    assert secret is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_webhook_secret_strips_trailing_slash():
+    captured: list = []
+
+    def _fake_urlopen(req, timeout=None):
+        captured.append(req.full_url)
+        return _fake_response({"webhook_secret": "ok"})
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        await github_pr._fetch_webhook_secret(http_url="http://b/", guild_id="g", auth_token="tok")
+    # No double slash in the constructed URL
+    assert captured[0] == "http://b/guilds/g/webhook-secret"


### PR DESCRIPTION
## Summary

Stacked on #225 (Phase 2: foreman dispatch). When a worker opens a PR
it now also installs (or refreshes) a Pioneer Square webhook on the
repo so future PR events flow back to the foreman without any manual
"Settings → Webhooks" step.

> **Review only the most recent commit** — this PR builds on #225,
> which builds on #224. GitHub will auto-rebase/retarget as the
> stack merges down.

### Flow

1. `open_pr()` returns the PR URL (unchanged).
2. New `Worker._ensure_pr_webhook()` parses `owner/repo` out of the
   URL and calls `github_pr.ensure_webhook(...)`.
3. `ensure_webhook` fetches the guild's secret from
   `GET /guilds/{id}/webhook-secret` (lazily generated on first read
   in Phase 1) using the worker's `auth_token`.
4. Lists existing hooks. If one already targets our URL we `PATCH`
   it — covers both secret rotation and events-list drift. Otherwise
   `POST`s a new hook. Subscribed events: `pull_request`,
   `pull_request_review`, `pull_request_review_comment`,
   `issue_comment`, `check_run`, `status`.

### OAuth scope

The existing `repo` scope already covers webhook management, so
**no re-authorization is needed** for existing users. The design doc
flagged a potential `admin:repo_hook` scope bump; in practice `repo`
is sufficient.

### Failure modes — all best-effort

The PR is already open by the time `ensure_webhook` runs, so webhook
setup must never block the task. Each of these emits one warning line
and returns `False`:
- 403 on the hooks API (token lacks admin access on the repo)
- 422 / other HTTPErrors (race with a prior install, etc.)
- Backend secret-fetch fails (network, expired worker token)
- Missing `auth_token` or `github_token`

### New config

`public_backend_url` (TOML / env `PIONEER_PUBLIC_BACKEND_URL`) lets
operators point GitHub at an external tunnel URL when
`backend_url` is an internal Docker address (e.g. `http://backend:8000`).
Defaults to `backend_url` so the common case stays zero-config.

## Test plan

- [x] 13 new worker tests in `worker/tests/test_ensure_webhook.py`
- [x] Secret fetch: happy path, empty response, network error, URL
  trailing-slash normalization
- [x] `target_url` construction: defaults to `http_url`,
  `public_backend_url` overrides, trailing-slash stripped
- [x] `_repo_from_pr_url` parses web URLs, query-string variants,
  rejects garbage and non-PR paths
- [x] `ensure_webhook` skip paths: no auth_token, no github_token,
  no secret returned
- [x] Create-when-no-existing: POST body has correct URL, secret,
  events, `active=true`
- [x] Patch-when-existing: targets the matching hook id (not other
  hooks on the repo), secret + events refreshed
- [x] 403 on list: surfaces in emit, returns False, never raises
- [x] 422 on create: returns False, never raises
- [x] Worker suite: 96/96 passing
- [x] Backend suite: 268/268 (no regressions)
- [x] `ruff check . && ruff format .` clean

## Open items (not in this PR)

- **Webhook deregistration on task finalize/cancel** — Phase 1
  install is per-PR-creation, but we don't tear down hooks when work
  on a repo finishes. The risk is multi-guild/multi-worker installs
  accumulating in heavy use. Worth a follow-up.
- **GitHub App migration** — Phase 5 in the design doc; deferred.

https://claude.ai/code/session_01Ud1EgSZHda2NMAxwUMvtC3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud1EgSZHda2NMAxwUMvtC3)_