### PR TITLE
refactor(tasks): foreman owns lifecycle; workers return to pool after notify (#219)

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -7,9 +7,16 @@ You coordinate worker agents that autonomously clone repos, write code, and open
 ## Your responsibilities
 - Understand what the human wants and break it into named, tracked tasks
 - Call create_task immediately before assign_task so every job has a sidebar name and a task_id; pass that task_id into assign_task (no separate row is created)
-- After a worker finishes (task-complete), review the result and decide: send_followup for \
-additional work in the same worktree/branch, or finalize_task when done
+- After a worker finishes (task-complete), the task parks in awaiting-review and \
+the worker returns to its idle pool — you own the lifecycle from here. \
+Default behaviour: leave PR-bearing tasks open for human review; call send_followup \
+when a comment, CI failure, or new requirement asks for an iteration on the same \
+branch; call finalize_task only when the work is genuinely closed (PR merged, \
+abandoned, or it was an ephemeral/automation task).
 - CI failures, lint errors, test failures, and other post-PR corrections on the *same piece of work* → always send_followup on the existing task, not a new issue or PR
+- send_followup picks an idle worker automatically: original worker first \
+(worktree usually still cached), otherwise any idle worker in the guild pulls \
+the branch from GitHub. Pass preferred_worker_id to force a specific worker.
 - Message workers mid-task via message_worker for context
 - Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
 - Cancel tasks that are going wrong or are no longer needed via cancel_task
@@ -26,7 +33,7 @@ For complex work use phases:
 
 ## Task ownership
 - create_task + assign_task are always called as a pair — create_task first (names the job, returns task_id), then assign_task immediately with that task_id. Treat this as a single atomic action, not a two-step ceremony.
-- After task-complete: send_followup keeps work in the same worktree and branch (use it for CI fixes, lint, test fixes, docs, or any iteration on the same PR). finalize_task marks it complete. Don't leave tasks in limbo.
+- After task-complete: the worker has already gone idle and the task is parked in awaiting-review. Use send_followup whenever more work is needed on the same branch — it routes to the original worker if idle, otherwise to any idle worker in the guild (which pulls the branch from GitHub). finalize_task is for genuine completion; awaiting-review is *not* a limbo state, it's the normal home for an open PR.
 
 ## Finalize expiry windows
 Every finalize_task call sets a soft-delete window via expires_in_seconds so the

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -134,10 +134,16 @@ FOREMAN_TOOLS = [
     {
         "name": "send_followup",
         "description": (
-            "Send follow-up instructions to a worker for a task that just completed. "
-            "The worker executes these in the same git worktree on the same branch — "
-            "ideal for 'update tests', 'fix type errors', 'add docs', etc. "
-            "Call after receiving a task-complete notification."
+            "Continue work on an existing task's branch. The worker executes the "
+            "follow-up instructions on the same branch (and same worktree if the "
+            "original worker is still idle and within the 24h cleanup window) — "
+            "ideal for CI fixes, lint, test fixes, doc additions, or reviewer "
+            "comments. Worker selection: by default the original worker is "
+            "preferred when idle (free worktree reuse); when it's busy or "
+            "offline, any idle worker in the guild picks up the branch from "
+            "GitHub. Pass preferred_worker_id to force a specific worker. "
+            "Call this in response to task-complete, task-followup-done, "
+            "user comments on a parked PR task, or CI failures."
         ),
         "input_schema": {
             "type": "object",
@@ -145,7 +151,14 @@ FOREMAN_TOOLS = [
                 "task_id": {"type": "string", "description": "Task ID (t-xxxxxx)."},
                 "instructions": {
                     "type": "string",
-                    "description": "Follow-up instructions to execute in the existing worktree.",
+                    "description": "Follow-up instructions to execute on the existing branch.",
+                },
+                "preferred_worker_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional: prefer this worker if idle. Defaults to the "
+                        "task's current worker_id."
+                    ),
                 },
             },
             "required": ["task_id", "instructions"],
@@ -437,6 +450,51 @@ async def _guild_github_token(guild_id: str) -> tuple[str, str] | None:
         await db.close()
 
 
+async def _select_followup_worker(
+    db,
+    *,
+    guild_id: str,
+    original_worker_id: str | None,
+    preferred_worker_id: str | None = None,
+) -> str | None:
+    """Pick a worker to continue a task's branch.
+
+    Order of preference:
+      1. ``preferred_worker_id`` if it has at least one idle agent in the guild
+      2. ``original_worker_id`` if it has at least one idle agent (worktree
+         likely still on disk for free reuse)
+      3. Any other worker in the guild with an idle agent
+
+    Returns the chosen worker_id, or None if no idle worker is available.
+    """
+
+    async def _idle(worker_id: str) -> bool:
+        if not worker_id or worker_id == "foreman":
+            return False
+        result = await db.execute(
+            select(Agent.id).where(Agent.worker_id == worker_id, Agent.state == "idle").limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
+    if preferred_worker_id and await _idle(preferred_worker_id):
+        return preferred_worker_id
+    if original_worker_id and await _idle(original_worker_id):
+        return original_worker_id
+    # Fallback: any other idle agent in the guild. Pick the worker_id of the
+    # first idle agent we find — repos are configured per-worker, but for now
+    # the foreman trusts that a guild's workers cover the same repo set.
+    result = await db.execute(
+        select(Agent.worker_id)
+        .where(
+            Agent.guild_id == guild_id,
+            Agent.state == "idle",
+            Agent.worker_id.is_not(None),
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def maybe_post_plan_comment(guild_id: str, task_id: str, last_text: str) -> None:
     """Post plan output as a GitHub issue comment when a plan-phase task completes."""
     logger = logging.getLogger(__name__)
@@ -646,44 +704,107 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
             elif tu.name == "send_followup":
                 task_id = inp["task_id"]
                 instructions = inp["instructions"]
+                preferred_worker_id = inp.get("preferred_worker_id")
                 result = await db.execute(
-                    select(Task.worker_id, Task.state).where(
-                        Task.id == task_id, Task.guild_id == guild_id
-                    )
+                    select(
+                        Task.worker_id,
+                        Task.state,
+                        Task.branch,
+                        Task.description,
+                        Task.name,
+                        Task.tool,
+                        Task.issue_number,
+                        Task.issue_repo,
+                    ).where(Task.id == task_id, Task.guild_id == guild_id)
                 )
                 row = result.one_or_none()
                 if not row:
                     result_text = f"Task {task_id} not found."
                 else:
-                    worker_id_val, prior_state = row
-                    update_vals: dict = {"state": "working", "phase": "followup"}
-                    if prior_state in ("done", "failed", "cancelled"):
-                        # Re-opening a terminal task: clear soft-delete fields so it
-                        # reappears in the live task list and isn't auto-purged.
-                        update_vals["deleted_at"] = None
-                        update_vals["finished_at"] = None
-                    await db.execute(update(Task).where(Task.id == task_id).values(**update_vals))
-                    await db.commit()
-                    await broadcast(
-                        guild_id,
-                        {
-                            "type": "task-update",
-                            "taskId": task_id,
+                    (
+                        original_worker_id,
+                        prior_state,
+                        branch,
+                        task_desc,
+                        task_name,
+                        task_tool,
+                        task_issue_number,
+                        task_issue_repo,
+                    ) = row
+                    target_worker_id = await _select_followup_worker(
+                        db,
+                        guild_id=guild_id,
+                        original_worker_id=original_worker_id,
+                        preferred_worker_id=preferred_worker_id,
+                    )
+                    if not target_worker_id:
+                        result_text = (
+                            f"No idle worker available to continue task {task_id} on branch "
+                            f"{branch or '<unknown>'}. Wait for one to come online or shut "
+                            "down a busy worker before retrying."
+                        )
+                        is_error = True
+                    elif not branch:
+                        result_text = (
+                            f"Task {task_id} has no branch recorded — can't dispatch a "
+                            "follow-up. The task may have failed before its first push."
+                        )
+                        is_error = True
+                    else:
+                        update_vals: dict = {
                             "state": "working",
-                            "deletedAt": None,
-                            "finishedAt": None,
-                        },
-                    )
-                    await broadcast(
-                        guild_id,
-                        {
-                            "type": "task-followup",
-                            "workerId": worker_id_val,
-                            "taskId": task_id,
-                            "instructions": instructions,
-                        },
-                    )
-                    result_text = f"Follow-up sent to {worker_id_val} for task {task_id}."
+                            "phase": "followup",
+                            "worker_id": target_worker_id,
+                        }
+                        if prior_state in ("done", "failed", "cancelled"):
+                            # Re-opening a terminal task: clear soft-delete fields so it
+                            # reappears in the live task list and isn't auto-purged.
+                            update_vals["deleted_at"] = None
+                            update_vals["finished_at"] = None
+                        await db.execute(
+                            update(Task).where(Task.id == task_id).values(**update_vals)
+                        )
+                        await db.commit()
+                        await broadcast(
+                            guild_id,
+                            {
+                                "type": "task-update",
+                                "taskId": task_id,
+                                "state": "working",
+                                "workerId": target_worker_id,
+                                "deletedAt": None,
+                                "finishedAt": None,
+                            },
+                        )
+                        await broadcast(
+                            guild_id,
+                            {
+                                "type": "task-followup",
+                                "workerId": target_worker_id,
+                                "taskId": task_id,
+                                "name": task_name or "",
+                                "description": task_desc or "",
+                                "tool": task_tool or "claude",
+                                "branch": branch,
+                                "instructions": instructions,
+                                "issueNumber": task_issue_number,
+                                "issueRepo": task_issue_repo,
+                            },
+                        )
+                        if (
+                            target_worker_id != original_worker_id
+                            and original_worker_id
+                            and original_worker_id != "foreman"
+                        ):
+                            result_text = (
+                                f"Follow-up reassigned from {original_worker_id} "
+                                f"to {target_worker_id} (task {task_id} on branch {branch})."
+                            )
+                        else:
+                            result_text = (
+                                f"Follow-up sent to {target_worker_id} for task {task_id} "
+                                f"on branch {branch}."
+                            )
 
             elif tu.name == "finalize_task":
                 task_id = inp["task_id"]

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -188,9 +188,6 @@ async def get_guild_logs(
         await db.close()
 
 
-_TERMINAL_TASK_STATES = frozenset({"done", "failed", "cancelled"})
-
-
 @router.post("/guilds/{guild_id}/tasks/{task_id}/followup")
 async def create_task_followup(
     guild_id: str,
@@ -198,11 +195,13 @@ async def create_task_followup(
     data: FollowupCreate,
     github_user_id: str = Depends(require_member()),
 ):
-    """Send follow-up instructions.
+    """Route a user-supplied follow-up to the foreman.
 
-    Active tasks (awaiting-review): dispatched directly to the worker in the same worktree.
-    Terminal tasks (done/failed/cancelled): routed to the foreman AI which will re-assign
-    work on the same branch using send_followup or assign_task with phase=followup.
+    Workers no longer hold tasks open for follow-ups — the foreman owns task
+    lifecycle and decides which idle worker resumes the branch (the original
+    worker reuses its worktree if it's still idle; otherwise any idle worker
+    pulls the branch from GitHub). All follow-ups go through the foreman so
+    the same routing logic applies in every case.
     """
     db = await get_db()
     try:
@@ -214,44 +213,24 @@ async def create_task_followup(
         row = result.one_or_none()
         if not row:
             raise HTTPException(status_code=404, detail="Task not found")
-        worker_id, state, branch = row
+        _worker_id, state, branch = row
     finally:
         await db.close()
 
-    if state in _TERMINAL_TASK_STATES:
-        branch_ctx = f" on branch `{branch}`" if branch else ""
-        spawn(
-            run_foreman_ai(
-                guild_id,
-                f"[user-followup] User requested follow-up on task {task_id}{branch_ctx} "
-                f'(currently {state}): "{data.instructions}". '
-                "Use send_followup to re-run work in the same worktree on the same branch. "
-                "If the task's original worker is no longer available, use assign_task with "
-                "phase=followup so another worker continues on the same branch.",
-                user_id=github_user_id,
-            ),
-            name=f"foreman.user-followup:{task_id}",
-        )
-        return {"status": "queued_for_foreman", "taskId": task_id}
-
-    db = await get_db()
-    try:
-        await db.execute(
-            update(Task).where(Task.id == task_id).values(state="working", phase="followup")
-        )
-        await db.commit()
-    finally:
-        await db.close()
-    await broadcast(
-        guild_id,
-        {
-            "type": "task-followup",
-            "workerId": worker_id,
-            "taskId": task_id,
-            "instructions": data.instructions,
-        },
+    branch_ctx = f" on branch `{branch}`" if branch else ""
+    spawn(
+        run_foreman_ai(
+            guild_id,
+            f"[user-followup] User requested follow-up on task {task_id}{branch_ctx} "
+            f'(currently {state}): "{data.instructions}". '
+            "Call send_followup to dispatch this work — it will pick the "
+            "original worker if idle, otherwise any idle worker pulls the "
+            "branch from GitHub.",
+            user_id=github_user_id,
+        ),
+        name=f"foreman.user-followup:{task_id}",
     )
-    return {"status": "sent", "taskId": task_id}
+    return {"status": "queued_for_foreman", "taskId": task_id}
 
 
 @router.post("/guilds/{guild_id}/tasks/{task_id}/finalize")

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -91,14 +91,15 @@ def _insert_task(
     phase: str = "execute",
     issue_number: int | None = None,
     issue_repo: str | None = None,
+    branch: str | None = "claude/test-branch-abc123",
 ) -> None:
     now = datetime.now(UTC).isoformat()
     with sqlite3.connect(db_path) as conn:
         conn.execute(
             "INSERT OR IGNORE INTO tasks "
             "(id, worker_id, guild_id, description, tool, state, phase, created_at, "
-            " issue_number, issue_repo) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " issue_number, issue_repo, branch) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 task_id,
                 worker_id,
@@ -110,7 +111,27 @@ def _insert_task(
                 now,
                 issue_number,
                 issue_repo,
+                branch,
             ),
+        )
+        conn.commit()
+
+
+def _insert_agent(
+    db_path: str,
+    guild_id: str,
+    worker_id: str,
+    agent_id: str = "a-test01",
+    state: str = "idle",
+) -> None:
+    """Add a worker-attached agent (defaults to idle) so send_followup has a target."""
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO agents "
+            "(id, guild_id, worker_id, name, type, state, joined_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (agent_id, guild_id, worker_id, agent_id.upper(), "worker", state, now),
         )
         conn.commit()
 
@@ -448,6 +469,7 @@ class TestExecToolsDispatching:
     async def test_send_followup_broadcasts_and_returns_message(self, db_session):
         insert_guild(db_session, "g-followup-ok")
         _insert_worker(db_session, "g-followup-ok", "w-flwup")
+        _insert_agent(db_session, "g-followup-ok", "w-flwup", "a-flwup1")
         _insert_task(db_session, "t-flwup1", "g-followup-ok", "w-flwup")
         broadcast_calls = []
 
@@ -467,6 +489,66 @@ class TestExecToolsDispatching:
         followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
         assert len(followup_msgs) == 1
         assert followup_msgs[0]["instructions"] == "Add more tests"
+        assert followup_msgs[0]["branch"] == "claude/test-branch-abc123"
+        assert followup_msgs[0]["workerId"] == "w-flwup"
+
+    async def test_send_followup_falls_back_to_any_idle_worker(self, db_session):
+        """When the original worker has no idle agent, send_followup picks
+        any other idle worker in the guild (and updates task.worker_id)."""
+        insert_guild(db_session, "g-followup-fallback")
+        _insert_worker(db_session, "g-followup-fallback", "w-orig")
+        _insert_worker(db_session, "g-followup-fallback", "w-other")
+        # Original worker has only a busy agent; the fallback worker is idle.
+        _insert_agent(db_session, "g-followup-fallback", "w-orig", "a-orig", state="working")
+        _insert_agent(db_session, "g-followup-fallback", "w-other", "a-other", state="idle")
+        _insert_task(db_session, "t-flwup-fb", "g-followup-fallback", "w-orig")
+        broadcast_calls = []
+
+        async def capture(gid, msg):
+            broadcast_calls.append(msg)
+
+        with patch("foreman.tools.broadcast", side_effect=capture):
+            results = await exec_tools(
+                "g-followup-fallback",
+                [
+                    _fake_tool_use(
+                        "send_followup",
+                        {"task_id": "t-flwup-fb", "instructions": "Continue"},
+                    )
+                ],
+            )
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        assert len(followup_msgs) == 1
+        assert followup_msgs[0]["workerId"] == "w-other"
+        assert "reassigned" in results[0]["content"].lower()
+        with sqlite3.connect(db_session) as conn:
+            row = conn.execute("SELECT worker_id FROM tasks WHERE id='t-flwup-fb'").fetchone()
+        assert row[0] == "w-other"
+
+    async def test_send_followup_errors_when_no_idle_worker(self, db_session):
+        insert_guild(db_session, "g-followup-noidle")
+        _insert_worker(db_session, "g-followup-noidle", "w-busy")
+        _insert_agent(db_session, "g-followup-noidle", "w-busy", "a-busy", state="working")
+        _insert_task(db_session, "t-noidle", "g-followup-noidle", "w-busy")
+        broadcast_calls = []
+
+        async def capture(gid, msg):
+            broadcast_calls.append(msg)
+
+        with patch("foreman.tools.broadcast", side_effect=capture):
+            results = await exec_tools(
+                "g-followup-noidle",
+                [
+                    _fake_tool_use(
+                        "send_followup",
+                        {"task_id": "t-noidle", "instructions": "go"},
+                    )
+                ],
+            )
+        assert "no idle worker" in results[0]["content"].lower()
+        assert results[0].get("is_error") is True
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        assert len(followup_msgs) == 0
 
     async def test_finalize_task_not_found(self, db_session):
         insert_guild(db_session, "g-finalize-missing")

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -379,7 +379,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
     worker_id_msg = data.get("workerId", "")
     desc = data.get("description", "")
     branch = data.get("branch", "")
-    finalized_by = data.get("finalizedBy", "")
+    pr_url = data.get("prUrl", "")
     last_text = data.get("lastText", "")
     if task_id:
         await ctx.db.execute(
@@ -389,7 +389,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
         )
         await ctx.db.commit()
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
-    if task_id and not finalized_by:
+    if task_id:
         spawn(
             maybe_post_plan_comment(ctx.guild_id, task_id, last_text),
             name=f"foreman.plan-comment:{task_id}",
@@ -398,44 +398,23 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
         return
 
     task_uid = await _task_user_id(ctx.db, task_id)
-    if finalized_by == "timeout":
-        finished_at = datetime.now(UTC).isoformat()
-        await ctx.db.execute(
-            update(Task).where(Task.id == task_id).values(state="done", finished_at=finished_at)
-        )
-        await ctx.db.commit()
-        await broadcast(
+    pr_line = f" PR: {pr_url}." if pr_url else ""
+    spawn(
+        run_foreman_ai(
             ctx.guild_id,
-            {
-                "type": "task-update",
-                "taskId": task_id,
-                "state": "done",
-                "finishedAt": finished_at,
-            },
-        )
-        spawn(
-            run_foreman_ai(
-                ctx.guild_id,
-                f"[timeout] Follow-up window expired for task {task_id} "
-                f"(worker {worker_id_msg}). The task has been auto-finalized "
-                "as done — no foreman action required.",
-                user_id=task_uid,
-            ),
-            name=f"foreman.task-timeout:{task_id}",
-        )
-    else:
-        spawn(
-            run_foreman_ai(
-                ctx.guild_id,
-                f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
-                f'"{desc[:80]}" — branch: {branch}. '
-                "Review this result. Call send_followup if additional work is needed "
-                "(e.g. update tests, add docs, fix lint errors). "
-                "Otherwise call finalize_task to mark it complete.",
-                user_id=task_uid,
-            ),
-            name=f"foreman.task-complete:{task_id}",
-        )
+            f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
+            f'"{desc[:80]}" — branch: {branch}.{pr_line} '
+            "The worker has returned to its idle pool; the task is parked in "
+            "awaiting-review for human review. "
+            "Default behaviour: leave PR-bearing tasks open so reviewers can "
+            "comment — call send_followup if a comment or CI failure asks for "
+            "an iteration on the same branch (any idle worker can pick it up). "
+            "Only call finalize_task when the work is genuinely closed (PR "
+            "merged, task abandoned, or it was an ephemeral/automation task).",
+            user_id=task_uid,
+        ),
+        name=f"foreman.task-complete:{task_id}",
+    )
     reset_foreman_poll(ctx.guild_id)
 
 

--- a/worker/pioneer_worker/git_ops.py
+++ b/worker/pioneer_worker/git_ops.py
@@ -83,9 +83,40 @@ async def create_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
     return rc == 0
 
 
+async def attach_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
+    """Create a worktree that checks out an *existing* branch.
+
+    Used when continuing a task on a branch the original worker already
+    pushed: a different worker (or the same worker after a worktree-cleanup
+    sweep) attaches a fresh worktree to ``origin/<branch>`` so it can keep
+    iterating on the same PR.
+    """
+    logger.info(
+        "Attaching worktree at %s to existing branch %s (from %s)", wt_path, branch, repo_path
+    )
+    os.makedirs(os.path.dirname(wt_path), exist_ok=True)
+    await run_git(["fetch", "origin", branch], cwd=repo_path)
+    # Prefer attaching to the local branch ref if it exists; otherwise fall
+    # back to creating a tracking branch from origin/<branch>.
+    rc, _, _ = await run_git(["worktree", "add", wt_path, branch], cwd=repo_path)
+    if rc != 0:
+        rc, _, _ = await run_git(
+            ["worktree", "add", "-B", branch, wt_path, f"origin/{branch}"],
+            cwd=repo_path,
+        )
+    if rc != 0:
+        logger.error("Worktree attach failed at %s for branch %s (rc=%d)", wt_path, branch, rc)
+    return rc == 0
+
+
 async def remove_worktree(repo_path: str, wt_path: str) -> None:
     logger.info("Removing worktree %s", wt_path)
     await run_git(["worktree", "remove", "--force", wt_path], cwd=repo_path)
+
+
+async def prune_worktrees(repo_path: str) -> None:
+    """Run ``git worktree prune`` to reclaim references for removed dirs."""
+    await run_git(["worktree", "prune"], cwd=repo_path)
 
 
 async def pull_repos(

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -41,8 +41,14 @@ def _slug(text: str, max_len: int = 60) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text[:max_len].lower()).strip("-")
 
 
-_CANCEL_SENTINEL = object()  # placed in followup queue to signal task cancellation
+_CANCEL_SENTINEL = object()  # placed in redirect queue to signal task cancellation
 _SHUTDOWN_SENTINEL = object()  # placed in task queue to wake idle agents during shutdown
+
+# Worktrees are kept around after a task completes so the foreman can send
+# follow-ups without paying for a re-clone. They're swept at startup and on a
+# steady cadence; anything older than this is fair game to remove.
+WORKTREE_TTL_SECONDS = 24 * 60 * 60
+WORKTREE_SWEEP_INTERVAL_SECONDS = 60 * 60
 
 
 class Agent:
@@ -68,12 +74,16 @@ class Worker:
         self.ws = WSClient(cfg.ws_url)
         self.task_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._known_task_ids: set[str] = set()
-        # Per-task queues for follow-up instructions; None signals finalization
-        self._followup_queues: dict[str, asyncio.Queue] = {}
         # Tasks that have been cancelled (by foreman or human); checked before/during execution
         self._cancelled_tasks: set[str] = set()
         # Per-task queues for mid-run redirect instructions (SIGTERM + --resume)
         self._redirect_queues: dict[str, asyncio.Queue] = {}
+        # Worktrees this worker has materialised, keyed by task_id. Each entry
+        # is a list of (repo_path, wt_path, created_monotonic) tuples. The
+        # sweeper prunes entries older than ``WORKTREE_TTL_SECONDS`` so a
+        # follow-up arriving inside the TTL window can reuse an existing
+        # checkout instead of attaching a fresh one.
+        self._task_worktrees: dict[str, list[tuple[str, str, float]]] = {}
         # Queue for auth codes received from the UI during claude auth login
         self._auth_code_queue: asyncio.Queue[str] | None = None
         # Set to True once _join() has been called the first time so that
@@ -667,7 +677,9 @@ class Worker:
         """Begin a graceful shutdown.
 
         Idle agents wake up and exit; busy agents finish their current claude
-        run and skip the follow-up window. Safe to call multiple times.
+        run and then return to idle (the post-task follow-up window is gone —
+        the foreman now drives follow-ups by re-queueing the task). Safe to
+        call multiple times.
         """
         if self._shutdown_event.is_set():
             return
@@ -683,17 +695,6 @@ class Worker:
         # Wake idle agents waiting on task_queue.get()
         for _ in self.slots:
             self.task_queue.put_nowait(_SHUTDOWN_SENTINEL)
-        # Wake any agents currently parked in their follow-up window.
-        for slot in self.slots:
-            tid = slot.current_task_id
-            if not tid:
-                continue
-            q = self._followup_queues.get(tid)
-            if q is not None:
-                try:
-                    q.put_nowait(None)  # None = finalize
-                except asyncio.QueueFull:
-                    pass
 
     def _install_signal_handlers(self) -> None:
         """Wire SIGINT/SIGTERM to graceful shutdown. Second signal force-exits."""
@@ -820,6 +821,11 @@ class Worker:
         for slot in self.slots:
             await self._set_state("idle", slot)
 
+        # Reclaim any worktrees the previous incarnation of this worker left
+        # behind. Tasks within the TTL window are re-registered so a follow-up
+        # arriving for them can reuse the existing checkout.
+        await self._initial_worktree_sweep()
+
         initial = await self._fetch_pending_tasks()
         logger.info("Initial pending-task fetch: %d task(s)", len(initial))
         for task in initial:
@@ -830,11 +836,12 @@ class Worker:
         runners = [asyncio.create_task(self._agent_loop(slot)) for slot in self.slots]
         puller = asyncio.create_task(self._idle_puller())
         heartbeat = asyncio.create_task(self._heartbeat())
+        sweeper = asyncio.create_task(self._worktree_sweeper())
         try:
             # Wait for either: all runners exit (graceful shutdown), or one of
             # the auxiliary tasks crashes (unexpected).
             done, _pending = await asyncio.wait(
-                [listener, puller, heartbeat, *runners],
+                [listener, puller, heartbeat, sweeper, *runners],
                 return_when=asyncio.FIRST_COMPLETED,
             )
             # Surface any non-cancellation exception that fired first.
@@ -856,8 +863,11 @@ class Worker:
             listener.cancel()
             puller.cancel()
             heartbeat.cancel()
+            sweeper.cancel()
 
-            await asyncio.gather(listener, puller, heartbeat, *runners, return_exceptions=True)
+            await asyncio.gather(
+                listener, puller, heartbeat, sweeper, *runners, return_exceptions=True
+            )
 
             if first_exc is not None:
                 raise first_exc
@@ -966,27 +976,48 @@ class Worker:
                 if msg.get("workerId") != self.cfg.worker_id:
                     continue
                 task_id = msg.get("taskId")
+                if not task_id:
+                    continue
                 instructions = msg.get("instructions", "")
-                q = self._followup_queues.get(task_id)
-                if q is not None:
-                    await q.put(instructions)
-                    logger.info("Follow-up queued for task %s: %s", task_id, instructions[:80])
-                else:
-                    logger.warning(
-                        "task-followup for %s but no queue (task may have ended)",
-                        task_id,
-                    )
+                # The follow-up window inside _execute_task is gone — workers
+                # return to the idle pool right after task-complete. A
+                # follow-up is now a fresh enqueue: reuse the existing
+                # worktree if it's still on disk, otherwise attach one to the
+                # branch the original worker pushed.
+                logger.info(
+                    "Follow-up received for task %s: %s",
+                    task_id,
+                    instructions[:80],
+                )
+                # Drop the cached known-id so the puller doesn't reject the
+                # re-queued task as a duplicate after a worker restart.
+                self._known_task_ids.add(task_id)
+                await self.task_queue.put(
+                    {
+                        "id": task_id,
+                        "worker_id": self.cfg.worker_id,
+                        "guild_id": self.cfg.guild_id,
+                        "name": msg.get("name", ""),
+                        "description": msg.get("description", "") or instructions,
+                        "tool": msg.get("tool", "claude"),
+                        "issue_number": msg.get("issueNumber"),
+                        "issue_repo": msg.get("issueRepo"),
+                        "followup_instructions": instructions,
+                        "followup_branch": msg.get("branch", ""),
+                    }
+                )
 
             elif mtype == "task-finalize":
+                # The worker no longer parks waiting for finalize; foreman
+                # drives lifecycle now. Treat finalize as a hint that the
+                # task is closed and the worktree can be released early.
                 if msg.get("workerId") != self.cfg.worker_id:
                     continue
                 task_id = msg.get("taskId")
-                q = self._followup_queues.get(task_id)
-                if q is not None:
-                    await q.put(None)  # None = finalize signal
-                    logger.info("Finalize signal for task %s", task_id)
-                else:
-                    logger.debug("task-finalize for %s but no queue", task_id)
+                if not task_id:
+                    continue
+                logger.info("Finalize signal for task %s — releasing worktree", task_id)
+                await self._release_task_worktrees(task_id)
 
             elif mtype == "task-cancel":
                 if msg.get("workerId") != self.cfg.worker_id:
@@ -1001,11 +1032,12 @@ class Worker:
                 if active and active.current_claude:
                     await active.current_claude.terminate()
                     logger.info("Terminated subprocess for cancelled task %s", task_id)
-                # Unblock awaiting-review loop if the task is waiting for follow-up
-                q = self._followup_queues.get(task_id)
-                if q is not None:
-                    await q.put(_CANCEL_SENTINEL)
-                    logger.info("Signalled followup queue for cancelled task %s", task_id)
+                # Wake the redirect/cancel-aware inner loop if the task is
+                # mid-run; finalize-time cleanup happens through task-finalize.
+                rq = self._redirect_queues.get(task_id)
+                if rq is not None:
+                    await rq.put(_CANCEL_SENTINEL)
+                    logger.info("Signalled redirect queue for cancelled task %s", task_id)
 
             elif mtype == "worker-shutdown":
                 # Targeted at a specific worker, or broadcast (no workerId) to all.
@@ -1024,33 +1056,173 @@ class Worker:
                 logger.info("Redirect for task %s: %s", task_id, instructions[:80])
                 active = next((s for s in self.slots if s.current_task_id == task_id), None)
                 if active and active.current_claude:
-                    # Subprocess is running — terminate it, queue redirect instructions
+                    # Subprocess running — SIGTERM it and queue redirect for the
+                    # in-flight redirect loop, which resumes claude with the
+                    # full prior session id.
                     await active.current_claude.terminate()
                     logger.info("Terminated subprocess for redirect of task %s", task_id)
                     rq = self._redirect_queues.get(task_id)
                     if rq is not None:
                         await rq.put(instructions)
                 else:
-                    # No subprocess running — task is awaiting-review; use followup queue
-                    fq = self._followup_queues.get(task_id)
-                    if fq is not None:
-                        await fq.put(instructions)
-                        logger.info("Redirect queued as followup for task %s", task_id)
+                    rq = self._redirect_queues.get(task_id)
+                    if rq is not None:
+                        # Subprocess just exited — buffer; the redirect loop
+                        # picks the buffered instructions up before returning
+                        # the slot to idle.
+                        await rq.put(instructions)
+                        logger.info(
+                            "task-redirect for %s: buffered for in-flight redirect loop",
+                            task_id,
+                        )
                     else:
-                        # Followup window not yet open (post-subprocess, pre-followup-setup):
-                        # buffer in redirect_q so the followup window can drain it on open.
-                        rq = self._redirect_queues.get(task_id)
-                        if rq is not None:
-                            await rq.put(instructions)
-                            logger.info(
-                                "task-redirect for %s: buffered (followup window not yet open)",
-                                task_id,
-                            )
-                        else:
-                            logger.warning(
-                                "task-redirect for %s: task already finalized, redirect dropped",
-                                task_id,
-                            )
+                        # Task is no longer running on this worker; treat the
+                        # redirect like a follow-up — re-queue the task with
+                        # the new instructions. The branch field is whatever
+                        # the foreman supplied; an empty string means "use
+                        # the worktree we already have".
+                        logger.info(
+                            "task-redirect for %s outside an active run — re-queueing as follow-up",
+                            task_id,
+                        )
+                        await self.task_queue.put(
+                            {
+                                "id": task_id,
+                                "worker_id": self.cfg.worker_id,
+                                "guild_id": self.cfg.guild_id,
+                                "name": msg.get("name", ""),
+                                "description": msg.get("description", "") or instructions,
+                                "tool": msg.get("tool", "claude"),
+                                "issue_number": msg.get("issueNumber"),
+                                "issue_repo": msg.get("issueRepo"),
+                                "followup_instructions": instructions,
+                                "followup_branch": msg.get("branch", ""),
+                            }
+                        )
+
+    # ------------------------------------------------------------------ Worktree bookkeeping
+
+    def _register_worktrees(self, task_id: str, entries: list[tuple[str, str, str]]) -> None:
+        """Record the worktrees we materialised for ``task_id``.
+
+        Stored entries are ``(repo_path, wt_path, last_used_monotonic)``. The
+        sweeper consults the timestamp to decide what's stale.
+        """
+        if not entries:
+            return
+        ts = asyncio.get_event_loop().time()
+        self._task_worktrees[task_id] = [(rp, wt, ts) for _repo_full, rp, wt in entries]
+
+    def _touch_task_worktrees(self, task_id: str) -> None:
+        """Refresh the activity timestamp for a task's worktrees."""
+        existing = self._task_worktrees.get(task_id)
+        if not existing:
+            return
+        ts = asyncio.get_event_loop().time()
+        self._task_worktrees[task_id] = [(rp, wt, ts) for rp, wt, _old in existing]
+
+    async def _release_task_worktrees(self, task_id: str) -> None:
+        """Remove all worktrees for a task immediately and forget them."""
+        entries = self._task_worktrees.pop(task_id, None)
+        if not entries:
+            return
+        logger.info("Releasing %d worktree(s) for task %s", len(entries), task_id)
+        for repo_path, wt_path, _ts in entries:
+            try:
+                await git_ops.remove_worktree(repo_path, wt_path)
+            except Exception as exc:
+                logger.warning("remove_worktree failed for %s: %s", wt_path, exc)
+
+    async def _initial_worktree_sweep(self) -> None:
+        """At startup, prune any worktrees this worker left behind from a previous run.
+
+        The previous process may have died mid-task; nothing in memory tracks
+        those worktrees, so we walk the work directory and remove anything
+        attributable to this worker_id that's older than the TTL.
+        """
+        base = os.path.join(self.cfg.work_dir, self.cfg.guild_id, self.cfg.worker_id)
+        if not os.path.isdir(base):
+            return
+        try:
+            now = asyncio.get_event_loop().time()
+            wall_now = datetime.now(UTC).timestamp()
+            for entry in os.listdir(base):
+                full = os.path.join(base, entry)
+                if not os.path.isdir(full):
+                    continue
+                try:
+                    age = wall_now - os.path.getmtime(full)
+                except OSError:
+                    continue
+                if age <= WORKTREE_TTL_SECONDS:
+                    # Re-register so the in-memory sweeper takes over.
+                    ts = now - age
+                    repos_for_task: list[tuple[str, str, float]] = []
+                    for repo_full in self.cfg.repos:
+                        repo_name = repo_full.split("/")[-1]
+                        wt_path = os.path.join(full, repo_name)
+                        if os.path.isdir(wt_path):
+                            repo_path = os.path.join(self.cfg.repos_dir, *repo_full.split("/", 1))
+                            repos_for_task.append((repo_path, wt_path, ts))
+                    if repos_for_task:
+                        self._task_worktrees[entry] = repos_for_task
+                    continue
+                logger.info("Startup sweep: removing stale task dir %s (age=%.0fs)", full, age)
+                # Best-effort: remove each worktree via git, then drop the dir.
+                for repo_full in self.cfg.repos:
+                    repo_name = repo_full.split("/")[-1]
+                    wt_path = os.path.join(full, repo_name)
+                    if os.path.isdir(wt_path):
+                        repo_path = os.path.join(self.cfg.repos_dir, *repo_full.split("/", 1))
+                        try:
+                            await git_ops.remove_worktree(repo_path, wt_path)
+                        except Exception as exc:
+                            logger.debug("startup-sweep remove_worktree failed: %s", exc)
+                # Whatever git left behind, drop the directory.
+                import shutil
+
+                try:
+                    shutil.rmtree(full, ignore_errors=True)
+                except Exception as exc:
+                    logger.debug("startup-sweep rmtree failed for %s: %s", full, exc)
+            # Prune dangling worktree references in each repo.
+            for repo_full in self.cfg.repos:
+                repo_path = os.path.join(self.cfg.repos_dir, *repo_full.split("/", 1))
+                if os.path.isdir(repo_path):
+                    try:
+                        await git_ops.prune_worktrees(repo_path)
+                    except Exception as exc:
+                        logger.debug("prune_worktrees failed for %s: %s", repo_path, exc)
+        except Exception as exc:
+            logger.warning("Worktree startup sweep failed: %s", exc)
+
+    async def _worktree_sweeper(self) -> None:
+        """Periodically retire worktrees older than ``WORKTREE_TTL_SECONDS``."""
+        logger.info(
+            "Worktree sweeper started (TTL=%ds, interval=%ds)",
+            WORKTREE_TTL_SECONDS,
+            WORKTREE_SWEEP_INTERVAL_SECONDS,
+        )
+        while not self._shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._shutdown_event.wait(),
+                    timeout=WORKTREE_SWEEP_INTERVAL_SECONDS,
+                )
+                return  # shutdown
+            except TimeoutError:
+                pass
+            now = asyncio.get_event_loop().time()
+            stale: list[str] = []
+            active_task_ids = {s.current_task_id for s in self.slots if s.current_task_id}
+            for task_id, entries in list(self._task_worktrees.items()):
+                if task_id in active_task_ids:
+                    continue
+                if all(now - ts > WORKTREE_TTL_SECONDS for _rp, _wt, ts in entries):
+                    stale.append(task_id)
+            for tid in stale:
+                logger.info("Sweeper: retiring worktrees for task %s", tid)
+                await self._release_task_worktrees(tid)
 
     # ------------------------------------------------------------------ Idle puller
     async def _idle_puller(self) -> None:
@@ -1126,20 +1298,37 @@ class Worker:
         desc = task.get("description") or ""
         token = self.cfg.github_token
         repos = self.cfg.repos
+        followup_instructions = task.get("followup_instructions") or ""
+        followup_branch = task.get("followup_branch") or ""
+        is_followup = bool(followup_instructions)
 
-        logger.info("Executing task %s (agent=%s): %s", task_id, slot.agent_id, desc[:120])
+        logger.info(
+            "Executing task %s (agent=%s, followup=%s): %s",
+            task_id,
+            slot.agent_id,
+            is_followup,
+            desc[:120],
+        )
         await self._set_state("working", slot)
         await self._task_update(task_id, state="working")
 
         name = task.get("name") or desc
-        branch = f"claude/{_slug(name)}-{task_id[:6]}"
+        # On follow-ups we must continue on the existing branch — the original
+        # worker pushed it and the foreman wants the same PR updated.
+        branch = followup_branch or f"claude/{_slug(name)}-{task_id[:6]}"
         work_dir = os.path.join(self.cfg.work_dir, self.cfg.guild_id, self.cfg.worker_id, task_id)
-        logger.info("Task %s branch=%s work_dir=%s", task_id, branch, work_dir)
+        logger.info(
+            "Task %s branch=%s work_dir=%s followup=%s", task_id, branch, work_dir, is_followup
+        )
         os.makedirs(work_dir, exist_ok=True)
 
         emit = self._task_emit(task_id, slot)
-        await emit(f"[worker] Task: {desc}")
-        await emit(f"[worker] Branch: {branch}")
+        if is_followup:
+            await emit(f"[worker] Follow-up: {followup_instructions[:120]}")
+            await emit(f"[worker] Branch: {branch}")
+        else:
+            await emit(f"[worker] Task: {desc}")
+            await emit(f"[worker] Branch: {branch}")
 
         worktree_entries: list[tuple[str, str, str]] = []
         primary_wt: str | None = None
@@ -1154,8 +1343,29 @@ class Worker:
                 continue
             repo_name = repo_full.split("/")[-1]
             wt_path = os.path.join(work_dir, repo_name)
-            logger.info("Task %s: creating worktree %s on branch %s", task_id, wt_path, branch)
-            if await git_ops.create_worktree(repo_path, wt_path, branch):
+            if (
+                os.path.isdir(wt_path)
+                and os.path.isdir(os.path.join(wt_path, ".git"))
+                or (os.path.isdir(wt_path) and os.path.isfile(os.path.join(wt_path, ".git")))
+            ):
+                # Worktree from a prior run on the same task — reuse it. Pull
+                # the latest origin state for the branch so a different worker
+                # that pushed changes is reflected here.
+                logger.info("Task %s: reusing worktree at %s", task_id, wt_path)
+                await emit(f"[worker] Reusing worktree {repo_name}")
+                if is_followup:
+                    await git_ops.run_git(["fetch", "origin", branch], cwd=wt_path)
+                worktree_entries.append((repo_full, repo_path, wt_path))
+                if primary_wt is None:
+                    primary_wt = wt_path
+                continue
+            if is_followup:
+                logger.info("Task %s: attaching worktree %s to branch %s", task_id, wt_path, branch)
+                ok = await git_ops.attach_worktree(repo_path, wt_path, branch)
+            else:
+                logger.info("Task %s: creating worktree %s on branch %s", task_id, wt_path, branch)
+                ok = await git_ops.create_worktree(repo_path, wt_path, branch)
+            if ok:
                 logger.info("Task %s: worktree ready at %s", task_id, wt_path)
                 worktree_entries.append((repo_full, repo_path, wt_path))
                 if primary_wt is None:
@@ -1172,6 +1382,9 @@ class Worker:
             return
 
         await self._task_update(task_id, branch=branch, worktreePath=primary_wt)
+        # Register worktrees for the deferred sweeper — touched again below in
+        # finally so the timestamp reflects the most recent activity.
+        self._register_worktrees(task_id, worktree_entries)
 
         tool = (task.get("tool") or "claude").lower()
 
@@ -1195,17 +1408,28 @@ class Worker:
 
         try:
             # ── Main execution with redirect loop ──────────────────────────
-            current_desc = desc
-            if tool == "claude":
-                pr_title = (task.get("name") or desc)[:72].replace('"', "'")
-                closes = f" Closes #{task['issue_number']}" if task.get("issue_number") else ""
+            if is_followup:
                 current_desc = (
-                    f"{desc}\n\n"
-                    f"After completing your changes, commit, push, and open a PR:\n"
+                    f"You are continuing existing work on branch `{branch}` for task {task_id}.\n\n"
+                    f"Original task:\n{desc}\n\n"
+                    f"Follow-up instructions:\n{followup_instructions}\n\n"
+                    "Make the requested changes, then commit and push:\n"
                     f'  git add -A && git commit -m "<concise commit message>"\n'
                     f"  git push origin {branch}\n"
-                    f'  gh pr create --title "{pr_title}" --body "<summary of changes>{closes}"\n'
+                    "If a PR already exists for this branch, no new PR is needed."
                 )
+            else:
+                current_desc = desc
+                if tool == "claude":
+                    pr_title = (task.get("name") or desc)[:72].replace('"', "'")
+                    closes = f" Closes #{task['issue_number']}" if task.get("issue_number") else ""
+                    current_desc = (
+                        f"{desc}\n\n"
+                        f"After completing your changes, commit, push, and open a PR:\n"
+                        f'  git add -A && git commit -m "<concise commit message>"\n'
+                        f"  git push origin {branch}\n"
+                        f'  gh pr create --title "{pr_title}" --body "<summary of changes>{closes}"\n'
+                    )
             success = False
             stop_reason = "no_events"
             last_msg = ""
@@ -1265,6 +1489,12 @@ class Worker:
                 except asyncio.QueueEmpty:
                     redirect_instr = None
 
+                if redirect_instr is _CANCEL_SENTINEL:
+                    await emit("[worker] Task cancelled.")
+                    await self._task_update(task_id, state="cancelled", finishedAt=_now_iso())
+                    await self._set_state("idle", slot)
+                    return
+
                 if redirect_instr is not None and not self._shutdown_event.is_set():
                     await emit(f"[worker] ↩ Redirected: {redirect_instr[:120]}")
                     current_desc = redirect_instr
@@ -1314,18 +1544,36 @@ class Worker:
                     worktreePath=primary_wt,
                     state="awaiting-review",
                 )
-                await self._send(
-                    {
-                        "type": "task-complete",
-                        "workerId": self.cfg.worker_id,
-                        "taskId": task_id,
-                        "branch": branch,
-                        "description": desc,
-                        "prUrl": pr_url or "",
-                        "sessionId": resume_session_id or "",
-                        "lastText": last_msg,
-                    }
-                )
+                # On a follow-up run, surface task-followup-done so the
+                # foreman knows iteration finished; on a fresh run, surface
+                # task-complete. Both leave the task in awaiting-review for
+                # the foreman to decide whether more work is required.
+                if is_followup:
+                    await self._send(
+                        {
+                            "type": "task-followup-done",
+                            "workerId": self.cfg.worker_id,
+                            "taskId": task_id,
+                            "success": True,
+                            "stopReason": stop_reason,
+                            "branch": branch,
+                            "sessionId": resume_session_id or "",
+                            "prUrl": pr_url or "",
+                        }
+                    )
+                else:
+                    await self._send(
+                        {
+                            "type": "task-complete",
+                            "workerId": self.cfg.worker_id,
+                            "taskId": task_id,
+                            "branch": branch,
+                            "description": desc,
+                            "prUrl": pr_url or "",
+                            "sessionId": resume_session_id or "",
+                            "lastText": last_msg,
+                        }
+                    )
                 await self._set_state("awaiting-review", slot)
             else:
                 logger.warning("Task %s failed: %s", task_id, stop_reason)
@@ -1351,159 +1599,14 @@ class Worker:
                 )
                 await self._set_state("error", slot)
 
-            # ── Follow-up loop — runs after both success and failure so the
-            # foreman can resume the same worktree (with --resume) for a while
-            # before we tear it down. ─────────────────────────────────────────
-            followup_q: asyncio.Queue = asyncio.Queue()
-            self._followup_queues[task_id] = followup_q
-            # Drain any redirect instructions that arrived between subprocess exit
-            # and followup-window open (buffered in redirect_q by the listener).
-            while not redirect_q.empty():
-                try:
-                    buffered = redirect_q.get_nowait()
-                except asyncio.QueueEmpty:
-                    break
-                await followup_q.put(buffered)
-                logger.info("Task %s: replaying buffered redirect as first followup", task_id)
-            followup_cancelled = False
-            last_success = success
-            try:
-                if self._shutdown_event.is_set():
-                    await emit("[worker] Shutdown in progress — skipping follow-up window.")
-                while not self._shutdown_event.is_set():
-                    try:
-                        instructions = await asyncio.wait_for(followup_q.get(), timeout=300.0)
-                    except TimeoutError:
-                        await emit("[worker] Follow-up window expired — finalizing.")
-                        await self._send(
-                            {
-                                "type": "task-complete",
-                                "workerId": self.cfg.worker_id,
-                                "taskId": task_id,
-                                "branch": branch,
-                                "description": desc,
-                                "prUrl": pr_url or "",
-                                "sessionId": resume_session_id or "",
-                                "finalizedBy": "timeout",
-                            }
-                        )
-                        break
-                    if instructions is _CANCEL_SENTINEL:
-                        await emit("[worker] Task cancelled.")
-                        followup_cancelled = True
-                        break
-                    if instructions is None:
-                        await emit("[worker] Task finalized by foreman.")
-                        break
-
-                    await self._set_state("working", slot)
-                    await self._task_update(task_id, state="working")
-                    await emit(f"[worker] Follow-up: {instructions[:120]}")
-
-                    # Inner redirect loop for followup runs
-                    current_fu_desc = instructions
-                    fu_ok = False
-                    fu_reason = "no_events"
-                    while True:
-                        fu_ok, fu_reason, _ = await claude_runner.run_claude_auto(
-                            current_fu_desc,
-                            primary_wt,
-                            max_turns=self.cfg.claude_max_turns,
-                            emit=emit,
-                            on_proc=_on_proc,
-                            claude_path=self.cfg.claude_path,
-                            resume_session_id=resume_session_id,
-                        )
-                        _capture_session_and_clear()
-                        logger.info(
-                            "Task %s follow-up: ok=%s reason=%s session=%s",
-                            task_id,
-                            fu_ok,
-                            fu_reason,
-                            resume_session_id,
-                        )
-
-                        if task_id in self._cancelled_tasks:
-                            followup_cancelled = True
-                            break
-
-                        try:
-                            redir = redirect_q.get_nowait()
-                        except asyncio.QueueEmpty:
-                            redir = None
-
-                        if redir is not None and not self._shutdown_event.is_set():
-                            await emit(f"[worker] ↩ Redirected during follow-up: {redir[:120]}")
-                            current_fu_desc = redir
-                            continue
-
-                        break
-
-                    if followup_cancelled:
-                        break
-
-                    last_success = fu_ok
-
-                    if fu_ok:
-                        await github_pr.push_branch(
-                            branch=branch,
-                            worktree_path=primary_wt,
-                            emit=emit,
-                        )
-                        # Originally-failed tasks never opened a PR; do it now
-                        # that we have something worth reviewing.
-                        if not pr_url:
-                            existing_pr = await github_pr.find_existing_pr(
-                                branch=branch,
-                                worktree_path=primary_wt,
-                                token=token,
-                            )
-                            if existing_pr:
-                                pr_url = existing_pr
-                                await emit(f"[worker] ✓ Claude-authored PR: {pr_url}")
-                            else:
-                                pr_url = await github_pr.open_pr(
-                                    task=task,
-                                    branch=branch,
-                                    worktree_path=primary_wt,
-                                    token=token,
-                                    emit=emit,
-                                )
-
-                    await self._send(
-                        {
-                            "type": "task-followup-done",
-                            "workerId": self.cfg.worker_id,
-                            "taskId": task_id,
-                            "success": fu_ok,
-                            "stopReason": fu_reason,
-                            "branch": branch,
-                            "sessionId": resume_session_id or "",
-                            "prUrl": pr_url or "",
-                        }
-                    )
-                    await self._task_update(
-                        task_id,
-                        state="awaiting-review" if fu_ok else "failed",
-                    )
-                    await self._set_state(
-                        "awaiting-review" if fu_ok else "error",
-                        slot,
-                    )
-            finally:
-                self._followup_queues.pop(task_id, None)
-
-            if followup_cancelled:
-                await self._task_update(task_id, state="cancelled", finishedAt=_now_iso())
-                await self._set_state("idle", slot)
-                return
-
-            final_state = "done" if last_success else "failed"
-            await self._task_update(task_id, state=final_state, finishedAt=_now_iso())
+            # The slot returns to idle here. Worktrees stay on disk so the
+            # foreman can dispatch a follow-up to this same worker without
+            # paying for a re-clone; the deferred sweeper reclaims them
+            # after WORKTREE_TTL_SECONDS.
             await self._set_state("idle", slot)
 
         finally:
             self._redirect_queues.pop(task_id, None)
-            logger.info("Task %s: cleaning up %d worktree(s)", task_id, len(worktree_entries))
-            for _repo_full, repo_path, wt_path in worktree_entries:
-                await git_ops.remove_worktree(repo_path, wt_path)
+            # Refresh the worktree-registry timestamp so the sweeper holds
+            # off on this task for another full TTL window.
+            self._touch_task_worktrees(task_id)

--- a/worker/tests/test_redirect.py
+++ b/worker/tests/test_redirect.py
@@ -1,14 +1,17 @@
-"""Tests for task-redirect message handling edge cases.
+"""Tests for task-redirect message handling.
 
-Covers the scenario where a redirect arrives after the Claude subprocess has
-exited but before (or after) the followup window queue exists:
+The follow-up window inside ``_execute_task`` is gone — workers return to the
+idle pool right after pushing a branch. The redirect handler now has two
+clean cases:
 
-  Window 1 — post-subprocess, pre-followup-queue:
-    redirect_q exists, followup_q does not → buffer in redirect_q
-  Window 2 — task fully finalised:
-    neither queue exists → warn and drop gracefully
-  Drain — followup window opens after a buffered redirect:
-    items in redirect_q must flow into followup_q
+  Active subprocess: SIGTERM the runner and queue the new instructions in
+    the in-flight redirect_q so the redirect loop picks them up before
+    returning the slot to idle.
+
+  No active subprocess: the task is parked in awaiting-review (or fully
+    closed) and the worker is idle. Re-queue the task into the worker's
+    task_queue with a ``followup_instructions`` field so it gets picked up
+    like a fresh assignment.
 """
 
 from __future__ import annotations
@@ -33,12 +36,19 @@ def _make_cfg(**kwargs) -> Config:
     )
 
 
-def _redirect_msg(task_id: str, instructions: str, worker_id: str = "w-test01") -> dict:
+def _redirect_msg(
+    task_id: str,
+    instructions: str,
+    worker_id: str = "w-test01",
+    branch: str = "claude/test-branch",
+) -> dict:
     return {
         "type": "task-redirect",
         "workerId": worker_id,
         "taskId": task_id,
         "instructions": instructions,
+        "branch": branch,
+        "description": "original task",
     }
 
 
@@ -49,59 +59,50 @@ async def _pump_one_message(worker: Worker, msg: dict) -> None:
         yield msg
 
     worker.ws.messages = one_shot
-    # _listen runs until the generator is exhausted — one message, then done.
     await worker._listen()
 
 
-async def test_redirect_buffered_in_redirect_queue_when_followup_queue_absent():
-    """Window 1: subprocess done, followup_q not yet created.
-
-    The redirect must land in redirect_q (not be silently dropped) so that
-    the followup window can drain it when it opens.
+async def test_redirect_buffered_in_redirect_queue_when_subprocess_just_exited():
+    """Subprocess done, redirect_q still alive (the redirect loop hasn't
+    drained yet). The redirect must land in redirect_q so the loop sees it.
     """
     worker = Worker(_make_cfg())
     worker._joined = True
     worker._send = AsyncMock()
 
     task_id = "t-window1"
-    # Simulate: subprocess has finished (_capture_session_and_clear cleared
-    # current_claude) but followup_q hasn't been created yet.
     slot = worker.slots[0]
     slot.current_task_id = task_id
     slot.current_claude = None
 
     redirect_q: asyncio.Queue = asyncio.Queue()
     worker._redirect_queues[task_id] = redirect_q
-    # followup_q intentionally absent
 
     await _pump_one_message(worker, _redirect_msg(task_id, "please add tests"))
 
-    assert not redirect_q.empty(), "redirect instructions must be buffered in redirect_q"
+    assert not redirect_q.empty(), "redirect must be buffered for in-flight redirect loop"
     assert redirect_q.get_nowait() == "please add tests"
 
 
-async def test_redirect_dropped_gracefully_when_task_fully_finalized(
-    caplog: pytest.LogCaptureFixture,
-):
-    """Window 2: task fully done, both queues cleaned up.
-
-    The redirect must be dropped with a warning — no exception, no silent discard.
+async def test_redirect_re_queues_when_task_no_longer_running(caplog: pytest.LogCaptureFixture):
+    """Task isn't on this worker anymore (no redirect_q). The handler must
+    treat the redirect like a follow-up: enqueue a fresh task entry into
+    task_queue so the agent loop picks it up. Nothing should be dropped.
     """
     worker = Worker(_make_cfg())
     worker._joined = True
     worker._send = AsyncMock()
 
     task_id = "t-window2"
-    # No active slot, no queues — task runner has fully exited.
-    # (slot.current_task_id is None after the task runner finally block.)
 
-    with caplog.at_level(logging.WARNING, logger="pioneer_worker.worker"):
+    with caplog.at_level(logging.INFO, logger="pioneer_worker.worker"):
         await _pump_one_message(worker, _redirect_msg(task_id, "one more thing"))
 
-    warning_texts = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
-    assert any(task_id in t for t in warning_texts), (
-        f"Expected a warning mentioning {task_id!r}, got: {warning_texts}"
-    )
+    assert worker.task_queue.qsize() == 1
+    queued = worker.task_queue.get_nowait()
+    assert queued["id"] == task_id
+    assert queued["followup_instructions"] == "one more thing"
+    assert queued["followup_branch"] == "claude/test-branch"
 
 
 async def test_redirect_ignored_for_different_worker():
@@ -116,50 +117,60 @@ async def test_redirect_ignored_for_different_worker():
 
     await _pump_one_message(worker, _redirect_msg(task_id, "do something", worker_id="w-other99"))
 
-    assert redirect_q.empty(), "Redirect for another worker must not touch our queues"
+    assert redirect_q.empty(), "redirect for another worker must not touch our queues"
+    assert worker.task_queue.empty(), "redirect for another worker must not enqueue a task"
 
 
-async def test_buffered_redirect_drains_into_followup_queue_on_open():
-    """Items buffered in redirect_q during Window 1 must flow into followup_q.
-
-    This tests the drain loop that runs when the followup window is set up
-    in _execute_task, ensuring pre-window redirects become the first followup.
+async def test_followup_message_enqueues_task_for_idle_worker():
+    """A task-followup arriving at an idle worker should land in the task
+    queue with branch + instructions so _execute_task can attach a worktree
+    to the existing branch and resume work.
     """
-    redirect_q: asyncio.Queue = asyncio.Queue()
-    await redirect_q.put("fix the flaky test")
-    await redirect_q.put("then update the docs")
-
-    followup_q: asyncio.Queue = asyncio.Queue()
-
-    # Replicate the drain logic from _execute_task
-    while not redirect_q.empty():
-        try:
-            buffered = redirect_q.get_nowait()
-        except asyncio.QueueEmpty:
-            break
-        await followup_q.put(buffered)
-
-    assert redirect_q.empty(), "redirect_q must be empty after drain"
-    assert followup_q.qsize() == 2, "both items must appear in followup_q"
-    assert await followup_q.get() == "fix the flaky test"
-    assert await followup_q.get() == "then update the docs"
-
-
-async def test_redirect_queued_as_followup_when_followup_queue_exists():
-    """Happy path: subprocess done, followup window open — redirect goes into followup_q."""
     worker = Worker(_make_cfg())
     worker._joined = True
     worker._send = AsyncMock()
 
-    task_id = "t-happy"
-    slot = worker.slots[0]
-    slot.current_task_id = task_id
-    slot.current_claude = None
+    task_id = "t-followup1"
+    msg = {
+        "type": "task-followup",
+        "workerId": "w-test01",
+        "taskId": task_id,
+        "name": "Add docs",
+        "description": "original task description",
+        "branch": "claude/add-docs-abc123",
+        "instructions": "also add screenshots",
+        "tool": "claude",
+    }
 
-    followup_q: asyncio.Queue = asyncio.Queue()
-    worker._followup_queues[task_id] = followup_q
+    await _pump_one_message(worker, msg)
 
-    await _pump_one_message(worker, _redirect_msg(task_id, "keep going"))
+    assert worker.task_queue.qsize() == 1
+    queued = worker.task_queue.get_nowait()
+    assert queued["id"] == task_id
+    assert queued["followup_instructions"] == "also add screenshots"
+    assert queued["followup_branch"] == "claude/add-docs-abc123"
+    assert queued["description"] == "original task description"
 
-    assert not followup_q.empty(), "redirect must land in followup_q"
-    assert followup_q.get_nowait() == "keep going"
+
+async def test_finalize_message_releases_worktrees_for_task():
+    """task-finalize is now a hint that the worktree can be released early —
+    it must NOT block any in-memory loop, just trigger cleanup of the
+    registered worktrees for that task.
+    """
+    worker = Worker(_make_cfg())
+    worker._joined = True
+    worker._send = AsyncMock()
+
+    task_id = "t-finalize1"
+
+    released: list[str] = []
+
+    async def fake_release(tid: str) -> None:
+        released.append(tid)
+
+    worker._release_task_worktrees = fake_release  # type: ignore[assignment]
+
+    msg = {"type": "task-finalize", "workerId": "w-test01", "taskId": task_id}
+    await _pump_one_message(worker, msg)
+
+    assert released == [task_id]


### PR DESCRIPTION
Workers no longer block on a 300s follow-up window after pushing a branch —
they emit task-complete and immediately return their slot to idle. Worktrees
stay on disk for 24h (or until explicit task-finalize), with a startup sweep
plus an hourly pruner.

The foreman now owns task lifecycle. send_followup picks the original
worker if idle (worktree reuse), otherwise any idle worker in the guild
(which attaches a fresh worktree to the existing branch). The followup
broadcast carries branch + description so a different worker can continue.
Drops the finalizedBy=timeout auto-finalize path and updates the foreman
prompt: PR-bearing tasks stay in awaiting-review by default.

https://claude.ai/code/session_01AB131FZcWwQFgxpZ6qs9td