### PR TITLE
Tag spawned worker containers with Pioneer-native labels

### DIFF
--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -172,32 +172,35 @@ async def spawn_worker_container(
         claude_oauth_token=decode_claude_oauth_token(stored_blob),
     )
 
-    # Join the same Docker network as the backend so the worker can reach it,
-    # and inherit the compose project so `docker compose ps` lists the worker.
+    # Join the same Docker network as the backend so the worker can reach it.
     network = None
-    project = os.environ.get("COMPOSE_PROJECT_NAME")
     try:
         me = client.containers.get(os.environ.get("HOSTNAME", ""))
         network = next(iter(me.attrs["NetworkSettings"]["Networks"].keys()), None)
-        if not project:
-            project = me.labels.get("com.docker.compose.project")
     except Exception:
         pass
 
-    labels: dict[str, str] = {}
-    if project:
-        # oneoff=True mirrors `docker compose run`, which keeps compose from
-        # warning about orphan containers on subsequent up/down commands.
-        labels["com.docker.compose.project"] = project
-        labels["com.docker.compose.service"] = "worker"
-        labels["com.docker.compose.oneoff"] = "True"
+    # Pioneer-owned labels — these containers are spawned and lifecycle-managed
+    # by the backend, not compose, so we don't tag them with com.docker.compose.*.
+    # List them with: docker ps --filter label=com.pioneer.kind=worker
+    labels = {
+        "com.pioneer.kind": "worker",
+        "com.pioneer.guild": guild_id,
+    }
+
+    container_name = f"pioneer-worker-{guild_id}-{secrets.token_hex(3)}"
 
     try:
-        run_kwargs: dict = dict(image=image, environment=env, detach=True, remove=True)
+        run_kwargs: dict = dict(
+            image=image,
+            environment=env,
+            detach=True,
+            remove=True,
+            labels=labels,
+            name=container_name,
+        )
         if network:
             run_kwargs["network"] = network
-        if labels:
-            run_kwargs["labels"] = labels
         container = client.containers.run(**run_kwargs)
     except docker_sdk.errors.ImageNotFound:
         raise HTTPException(


### PR DESCRIPTION
The spawn endpoint was mimicking compose labels (project/service/ oneoff=True) with a comment claiming this made workers visible in `docker compose ps`. It does the opposite: oneoff=True hides them, and the labels only suppressed orphan warnings on up/down. The fakery implied compose-managed lifecycle when these containers are owned by the backend with per-spawn env (guild, repos, token).

Drop the compose labels, tag with com.pioneer.kind=worker and com.pioneer.guild=<guild_id>, and name the container pioneer-worker-<guild_id>-<6 hex> instead of Docker's random adjective_name. List workers with:

  docker ps --filter label=com.pioneer.kind=worker