### PR TITLE
Enable uvicorn access logs via programmatic startup (#248)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,4 +35,4 @@ RUN mkdir -p /data
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "main.py"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -271,3 +271,8 @@ class _SPAStaticFiles(StaticFiles):
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
 if _STATIC_DIR.is_dir():
     app.mount("/", _SPAStaticFiles(directory=_STATIC_DIR, html=True), name="spa")
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, access_log=True, log_level="info")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - backend-data:/data
       - /var/run/docker.sock:/var/run/docker.sock
-    command: sh -c "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000"
+    command: sh -c "alembic upgrade head && python main.py"
     restart: unless-stopped
 
   worker:


### PR DESCRIPTION
## Summary

- Added a `__main__` block to `backend/main.py` that launches uvicorn programmatically with `access_log=True` and `log_level="info"`
- Updated `backend/Dockerfile` CMD from `uvicorn main:app --host 0.0.0.0 --port 8000` to `python main.py`
- Updated `docker-compose.yml` backend command from `uvicorn main:app ...` to `python main.py` (preserving the `alembic upgrade head` prefix)
- `uvicorn[standard]` was already present in `backend/requirements.txt` — no dependency changes needed

## Test plan

- [ ] Build and run the Docker image; confirm HTTP access logs appear in container stdout
- [ ] Run `docker compose up` and verify the backend starts and access logs are visible
- [ ] Confirm `python main.py` works locally in `backend/` with the venv activated

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)