### PR TITLE
Guild ID: slugify + remove vowels + uniqueness check (#250)

### DIFF
--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -15,7 +15,7 @@ from events import broadcast
 from fastapi import APIRouter, Depends, HTTPException
 from models import Agent, Guild, GuildMember, Message, User
 from pydantic import BaseModel
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 from utils import generate_guild_id, row_to_dict
@@ -56,36 +56,35 @@ async def create_guild(
     created_at = datetime.now(UTC).isoformat()
     db = await get_db()
     try:
-        for _ in range(5):
-            guild_id = generate_guild_id()
-            try:
-                db.add(
-                    Guild(
-                        id=guild_id,
-                        created_at=created_at,
-                        name=data.name or f"Guild {guild_id}",
-                        github_user_id=github_user_id,
-                    )
+        result = await db.execute(text("SELECT id FROM guilds"))
+        existing_ids = {row[0] for row in result.fetchall()}
+        guild_id = generate_guild_id(name=data.name or "", existing_ids=existing_ids)
+        guild_name = data.name or f"Guild {guild_id}"
+        try:
+            db.add(
+                Guild(
+                    id=guild_id,
+                    created_at=created_at,
+                    name=guild_name,
+                    github_user_id=github_user_id,
                 )
-                await db.flush()
-                db.add(
-                    GuildMember(
-                        guild_id=guild_id,
-                        user_id=github_user_id,
-                        role="owner",
-                        created_at=created_at,
-                    )
+            )
+            await db.flush()
+            db.add(
+                GuildMember(
+                    guild_id=guild_id,
+                    user_id=github_user_id,
+                    role="owner",
+                    created_at=created_at,
                 )
-                await db.commit()
-                break
-            except IntegrityError:
-                await db.rollback()
-                continue
-        else:
+            )
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
             raise HTTPException(status_code=500, detail="Could not generate unique guild ID")
     finally:
         await db.close()
-    return {"id": guild_id, "created_at": created_at, "name": data.name or f"Guild {guild_id}"}
+    return {"id": guild_id, "created_at": created_at, "name": guild_name}
 
 
 @router.get("/guilds")

--- a/backend/tests/test_generate_guild_id.py
+++ b/backend/tests/test_generate_guild_id.py
@@ -1,0 +1,129 @@
+"""Unit tests for the generate_guild_id() helper."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from utils import _candidate_from_name, generate_guild_id
+
+# ---------------------------------------------------------------------------
+# _candidate_from_name unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_pioneer_square():
+    # "Pioneer Square" → slug "pioneer-square" → devowel "pnr-sqr" (7 chars, ≤8, ≥5)
+    assert _candidate_from_name("Pioneer Square") == "pnr-sqr"
+
+
+def test_all_consonants_already_short():
+    # "Sqr" → slug "sqr" → devowel "sqr" (3 chars < 5) → fall back to slug "sqr"
+    assert _candidate_from_name("Sqr") == "sqr"
+
+
+def test_name_with_special_chars():
+    # Non-alphanumeric becomes hyphens; accented chars are stripped via NFKD
+    result = _candidate_from_name("Héllo Wörld!")
+    # "héllo wörld!" → ascii normalize → "hello world!" → slug "hello-world"
+    # devowel "hll-wrld" (8 chars exactly, within target)
+    assert result == "hll-wrld"
+
+
+def test_name_with_only_vowels():
+    # "aeiou" → slug "aeiou" → devowel "" → too short → fall back to slug "aeiou"
+    assert _candidate_from_name("aeiou") == "aeiou"
+
+
+def test_long_name_trimmed_to_target():
+    # A slug longer than 8 chars after devoweling should be trimmed to ≤8 without going below 5.
+    result = _candidate_from_name("Steampunk Factory Floor")
+    # slug: "steampunk-factory-floor"
+    # devowel: "stmpnk-fctr-flr" (15 chars) → trim from end to 8
+    assert len(result) <= 8
+    assert len(result) >= 5
+
+
+def test_empty_name_falls_back_to_random():
+    result = generate_guild_id(name="", existing_ids=set())
+    assert len(result) == 6
+    assert result.isalnum()
+
+
+def test_no_name_falls_back_to_random():
+    result = generate_guild_id()
+    assert len(result) == 6
+    assert result.isalnum()
+
+
+# ---------------------------------------------------------------------------
+# generate_guild_id integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_normal_case_unique_on_first_try():
+    result = generate_guild_id(name="Pioneer Square", existing_ids=set())
+    assert result == "pnr-sqr"
+
+
+def test_collision_appends_random_suffix():
+    existing = {"pnr-sqr"}
+    result = generate_guild_id(name="Pioneer Square", existing_ids=existing)
+    assert result.startswith("pnr-sqr-")
+    suffix = result[len("pnr-sqr-") :]
+    assert len(suffix) == 4
+    assert result not in existing
+
+
+def test_collision_suffix_also_collides():
+    # Force a collision on the first suffix by pre-populating many suffixes.
+    import random as _random
+
+    _random.seed(42)
+    first_suffix = "".join(_random.choices("abcdefghijklmnopqrstuvwxyz0123456789", k=4))
+    _random.seed(42)
+    existing = {"pnr-sqr", f"pnr-sqr-{first_suffix}"}
+    result = generate_guild_id(name="Pioneer Square", existing_ids=existing)
+    assert result.startswith("pnr-sqr-")
+    assert result not in existing
+
+
+def test_short_name_below_min():
+    # "AI" → slug "ai" → devowel "" → too short → fall back to slug "ai" (2 chars < 5)
+    # The candidate is "ai"; it's returned as-is since it doesn't collide.
+    result = generate_guild_id(name="AI", existing_ids=set())
+    assert result == "ai"
+
+
+def test_short_name_collision_gets_suffix():
+    result = generate_guild_id(name="AI", existing_ids={"ai"})
+    assert result.startswith("ai-")
+    assert result not in {"ai"}
+
+
+def test_special_characters_in_name():
+    # Unicode + punctuation should produce a valid slug
+    result = generate_guild_id(name="Héllo Wörld! @2024", existing_ids=set())
+    assert result == "hll-wrld"
+
+
+def test_name_with_consecutive_special_chars():
+    result = generate_guild_id(name="foo  ---  bar", existing_ids=set())
+    # slug: "foo-bar" → devowel "f-br" (4 chars < 5) → fall back to "foo-bar"
+    assert result == "foo-bar"
+
+
+def test_unique_id_not_in_existing():
+    existing = {"pnr-sqr"}
+    result = generate_guild_id(name="Pioneer Square", existing_ids=existing)
+    assert result not in existing
+
+
+def test_result_is_deterministic_without_collision():
+    # Same name + empty existing always gives the same result.
+    r1 = generate_guild_id(name="My Workspace", existing_ids=set())
+    r2 = generate_guild_id(name="My Workspace", existing_ids=set())
+    assert r1 == r2

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -70,7 +70,7 @@ def test_create_guild_returns_id(client):
     data = resp.json()
     assert "id" in data
     assert data["name"] == "Test Guild"
-    assert len(data["id"]) == 6
+    assert len(data["id"]) >= 2
 
 
 def test_create_guild_default_name(client):

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -9,7 +9,14 @@ from __future__ import annotations
 import base64
 import json
 import random
+import re
 import string
+import unicodedata
+
+_VOWELS = frozenset("aeiou")
+_MIN_LEN = 5
+_TARGET_LEN = 8
+_SUFFIX_LEN = 4
 
 
 def row_to_dict(obj) -> dict:
@@ -17,9 +24,75 @@ def row_to_dict(obj) -> dict:
     return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
 
 
-def generate_guild_id() -> str:
-    """Random 6-char lowercase id used in guild URLs."""
-    return "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+def _slugify(name: str) -> str:
+    """Lowercase, normalize unicode, replace non-alphanumeric runs with '-'."""
+    normalized = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+    lowered = normalized.lower()
+    slugged = re.sub(r"[^a-z0-9]+", "-", lowered)
+    return slugged.strip("-")
+
+
+def _strip_vowels(s: str) -> str:
+    """Remove vowels, keeping consonants and digits and hyphens."""
+    return "".join(c for c in s if c not in _VOWELS)
+
+
+def _candidate_from_name(name: str) -> str:
+    """Derive a deterministic slug from a guild name."""
+    slug = _slugify(name)
+    if not slug:
+        return ""
+
+    devoweled = _strip_vowels(slug)
+
+    # If devoweling left nothing or below minimum, fall back to the slug.
+    if len(devoweled) < _MIN_LEN:
+        base = slug
+    else:
+        base = devoweled
+
+    # Trim from end until we're at or below the target length.
+    while len(base) > _TARGET_LEN:
+        # Don't trim past the minimum.
+        if len(base) <= _MIN_LEN:
+            break
+        base = base[:-1].rstrip("-")
+
+    return base or slug
+
+
+def generate_guild_id(name: str = "", existing_ids: set[str] | None = None) -> str:
+    """Return a slug-based guild ID derived from *name*, unique among *existing_ids*.
+
+    Algorithm:
+    1. Slugify the name (lowercase, replace non-alphanum with '-').
+    2. Remove vowels from the slug.
+    3. If the result is < _MIN_LEN chars, fall back to the full slug.
+    4. Trim from the end to _TARGET_LEN, never below _MIN_LEN.
+    5. If the candidate collides with an existing ID, append a random suffix.
+    6. If no name is given, generate a fully random ID (legacy fallback).
+    """
+    if existing_ids is None:
+        existing_ids = set()
+
+    candidate = _candidate_from_name(name) if name else ""
+
+    if not candidate:
+        # No usable name — generate a random ID.
+        while True:
+            rid = "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+            if rid not in existing_ids:
+                return rid
+
+    if candidate not in existing_ids:
+        return candidate
+
+    # Collision: append a random suffix.
+    while True:
+        suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=_SUFFIX_LEN))
+        unique = f"{candidate}-{suffix}"
+        if unique not in existing_ids:
+            return unique
 
 
 def worker_display_name(worker_id: str, hostname: str | None = None) -> str:


### PR DESCRIPTION
## Summary

- Replaces random 6-char guild IDs with deterministic slug-based IDs derived from the guild name
- Algorithm: slugify (lowercase, non-alphanum → `-`) → strip vowels → trim to ≤8 chars, never below 5 → check uniqueness → append 4-char random suffix only on collision
- Falls back to a random 6-char ID when no name is given (backward-compatible with existing tooling)
- `"Pioneer Square"` → `pnr-sqr`; collision → `pnr-sqr-x7f2`
- Unicode names normalized via NFKD before slugifying

## Changes

- **`backend/utils.py`**: new `generate_guild_id(name, existing_ids)` with `_slugify`, `_strip_vowels`, `_candidate_from_name` helpers; old random-only signature still works (no-arg call)
- **`backend/routes/guilds.py`**: `create_guild` now fetches all existing IDs and passes the guild name to `generate_guild_id`; simplified to single insert (no retry loop needed)
- **`backend/tests/test_generate_guild_id.py`**: 16 new unit tests covering normal case, collision, double-collision, short/vowel-only names, unicode, and special characters
- **`backend/tests/test_guild_api.py`**: relaxed `len(id) == 6` assertion (IDs are now variable-length slugs)

## Test plan

- [x] `python -m pytest tests/test_generate_guild_id.py tests/test_guild_api.py` — 30 tests pass
- [x] `ruff check . --fix && ruff format .` — clean

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)