### PR TITLE
Fix JWKS 403 and subdomain auth via token bridge

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from database import AsyncSessionLocal
 from events import agent_owners, broadcast
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from models import Agent, Worker
@@ -198,6 +198,17 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def _wellknown_middleware(request: Request, call_next):
+    # Starlette's StaticFiles returns 403 for dotfile paths, intercepting
+    # /.well-known/ before the route handler fires. Handle it here first.
+    if request.url.path.startswith("/.well-known/"):
+        from routes.wellknown import jwks
+
+        return await jwks(request)
+    return await call_next(request)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/oauth.py
+++ b/backend/oauth.py
@@ -35,7 +35,36 @@ FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
 
 # Short-lived state tokens for OAuth CSRF protection. In-memory only; will be
 # lost on backend restart. See CODE_REVIEW.md H2 for the planned DB persistence.
-oauth_states: set[str] = set()
+# Maps state token → return_to origin (None = default FRONTEND_URL).
+oauth_states: dict[str, str | None] = {}
+
+
+def _is_allowed_return_to(url: str) -> bool:
+    """Validate that return_to is one of our own origins."""
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+        hostname = parsed.hostname or ""
+        if not hostname:
+            return False
+        frontend_parsed = urllib.parse.urlparse(FRONTEND_URL)
+        frontend_host = frontend_parsed.hostname or ""
+        if hostname == frontend_host:
+            return True
+        if frontend_host and hostname.endswith("." + frontend_host):
+            return True
+        # Always allow localhost and its subdomains (local dev).
+        if hostname == "localhost" or hostname.endswith(".localhost"):
+            return True
+        return False
+    except Exception:
+        return False
+
+
+def get_return_to(state: str) -> str | None:
+    """Peek at the return_to origin stored with a state token (without removing it)."""
+    return oauth_states.get(state)
 
 
 # ---------------------------------------------------------------------------
@@ -79,10 +108,10 @@ def _gh_get_user(token: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def make_authorize_url() -> str:
+def make_authorize_url(return_to: str | None = None) -> str:
     """Return the GitHub authorize URL with a fresh state token registered."""
     state = secrets.token_urlsafe(16)
-    oauth_states.add(state)
+    oauth_states[state] = return_to if return_to and _is_allowed_return_to(return_to) else None
     params = urllib.parse.urlencode(
         {
             "client_id": GITHUB_CLIENT_ID,
@@ -103,7 +132,7 @@ async def create_session(code: str, state: str) -> dict:
     """
     if state not in oauth_states:
         raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
-    oauth_states.discard(state)
+    oauth_states.pop(state)
 
     try:
         token_data = await asyncio.to_thread(_gh_exchange_code, code)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -27,7 +27,7 @@ from models import (
     User,
     UserSession,
 )
-from oauth import FRONTEND_URL, GITHUB_CLIENT_ID, create_session, make_authorize_url
+from oauth import FRONTEND_URL, GITHUB_CLIENT_ID, create_session, get_return_to, make_authorize_url
 from pydantic import BaseModel
 from sqlalchemy import delete, select
 
@@ -45,13 +45,17 @@ class ClaudeCredentialsRequest(BaseModel):
 
 
 @router.get("/auth/github/login")
-async def github_login():
-    """Start the GitHub OAuth flow. Returns the authorization URL."""
+async def github_login(return_to: str | None = Query(None)):
+    """Start the GitHub OAuth flow. Returns the authorization URL.
+
+    ``return_to`` is an optional origin URL (e.g. a guild subdomain) to redirect
+    back to after the OAuth callback, instead of the default FRONTEND_URL.
+    """
     if not GITHUB_CLIENT_ID:
         raise HTTPException(
             status_code=500, detail="GitHub OAuth not configured (missing GITHUB_CLIENT_ID)"
         )
-    return {"url": make_authorize_url()}
+    return {"url": make_authorize_url(return_to)}
 
 
 @router.post("/auth/github/exchange")
@@ -63,9 +67,11 @@ async def github_exchange(body: CodeExchangeRequest):
 @router.get("/auth/github/callback")
 async def github_callback(code: str = Query(...), state: str = Query(...)):
     """Legacy backend OAuth callback — redirects to the frontend with session params in the query string."""
+    return_to = get_return_to(state)  # peek before create_session pops the state
     payload = await create_session(code, state)
     qs = urllib.parse.urlencode(payload)
-    return RedirectResponse(url=f"{FRONTEND_URL}/?{qs}")
+    base = (return_to or FRONTEND_URL).rstrip("/")
+    return RedirectResponse(url=f"{base}/?{qs}")
 
 
 @router.get("/auth/github/token")

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,6 +2,19 @@ import { createRouter, createWebHistory } from 'vue-router'
 import LandingView from '../views/LandingView.vue'
 import AppView from '../views/AppView.vue'
 
+export function getRootOrigin(): string | null {
+  const hostname = window.location.hostname
+  const port = window.location.port
+  const scheme = window.location.protocol
+  if (hostname.endsWith('.pioneer-square.melloy.life')) {
+    return `${scheme}//pioneer-square.melloy.life`
+  }
+  if (hostname !== 'localhost' && hostname.endsWith('.localhost')) {
+    return `${scheme}//localhost${port ? ':' + port : ''}`
+  }
+  return null
+}
+
 function getSubdomainGuild(): string | null {
   const hostname = window.location.hostname
   for (const base of ['pioneer-square.melloy.life', 'localhost']) {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -24,8 +24,9 @@ export const useAuthStore = defineStore('auth', () => {
     return loginToken.value ? { Authorization: `Bearer ${loginToken.value}` } : {}
   }
 
-  async function loginWithGitHub() {
-    const res = await fetch(`${API_BASE}/auth/github/login`)
+  async function loginWithGitHub(returnTo: string = window.location.origin) {
+    const qs = new URLSearchParams({ return_to: returnTo })
+    const res = await fetch(`${API_BASE}/auth/github/login?${qs}`)
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
       throw new Error(body.detail || `Server error ${res.status}`)

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -33,6 +33,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, watch, ref, provide } from 'vue'
 import { useRouter } from 'vue-router'
+import { getRootOrigin } from '../router'
 import { useGuildStore } from '../stores/guild'
 import { useAgentsStore } from '../stores/agents'
 import { useAuthStore } from '../stores/auth'
@@ -75,7 +76,14 @@ function getClientId() {
 
 async function initGuild(guildId: string) {
   if (!authStore.isLoggedIn) {
-    router.replace('/')
+    // On a subdomain, redirect to the root domain bridge so it can pass
+    // the session token back via ?login_token= query param.
+    const rootOrigin = getRootOrigin()
+    if (rootOrigin) {
+      window.location.href = `${rootOrigin}/?to=${encodeURIComponent(window.location.origin)}`
+    } else {
+      router.replace('/')
+    }
     return
   }
   if (!guildId) {
@@ -131,6 +139,17 @@ async function initGuild(guildId: string) {
     if (reposToFetch || ghStore.selectedRepos.length > 0) {
       ghStore.fetchIssues(reposToFetch)
     }
+  }
+}
+
+// Restore session from OAuth callback params synchronously — must happen before
+// the immediate watch below so initGuild's isLoggedIn check sees the token.
+{
+  const _p = new URLSearchParams(window.location.search)
+  if (_p.has('login_token')) {
+    authStore.restoreFromCallback(_p)
+    ghStore.restoreGitHubToken(_p)
+    window.history.replaceState({}, '', window.location.pathname)
   }
 }
 

--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -102,6 +102,32 @@ onMounted(async () => {
     authStore.restoreFromCallback(params)
     ghStore.restoreGitHubToken(params)
     window.history.replaceState({}, '', '/')
+  } else if (params.has('to')) {
+    // Subdomain bridge: a guild subdomain redirected here to get the session token.
+    const targetOrigin = params.get('to')!
+    window.history.replaceState({}, '', '/')
+    if (authStore.isLoggedIn && authStore.loginToken) {
+      const bp = new URLSearchParams()
+      bp.set('login_token', authStore.loginToken)
+      if (authStore.user) {
+        bp.set('gh_login', authStore.user.login)
+        if (authStore.user.name) bp.set('gh_name', authStore.user.name)
+        if (authStore.user.avatar_url) bp.set('gh_avatar', authStore.user.avatar_url)
+        if (authStore.user.id) bp.set('gh_user_id', String(authStore.user.id))
+      }
+      window.location.href = `${targetOrigin}/?${bp}`
+      return
+    } else {
+      // Not logged in — kick off OAuth and come back to the target subdomain.
+      loggingIn.value = true
+      try {
+        await authStore.loginWithGitHub(targetOrigin)
+      } catch (e: unknown) {
+        loginError.value = e instanceof Error ? e.message : String(e)
+        loggingIn.value = false
+      }
+      return
+    }
   }
 
   if (authStore.isLoggedIn) {


### PR DESCRIPTION
JWKS 403: Starlette's StaticFiles blocks dotfile paths (/.well-known/) before route handlers fire. Add HTTP middleware that intercepts all /.well-known/ requests and calls the jwks handler directly.

Subdomain auth: localStorage is per-origin so the root-domain session token is invisible on guild subdomains. Fix with a token bridge:
- AppView on subdomain redirects to root/?to={subdomain-origin} when not logged in
- LandingView on root domain checks ?to=, passes token back via redirect if already logged in, or kicks off OAuth with return_to={subdomain} if not
- OAuth callback now uses return_to stored in state to redirect back to the originating subdomain instead of always FRONTEND_URL
- AppView restores the token synchronously at script setup (before the immediate watch fires initGuild) so the auth check sees it