### PR TITLE
Switch auto-generated guild keys from EC P-256 to Ed25519

### DIFF
--- a/backend/routes/wellknown.py
+++ b/backend/routes/wellknown.py
@@ -1,8 +1,8 @@
 """Serves /.well-known/jwks.json for guild subdomains and manages guild keys.
 
-Each guild gets one EC P-256 key pair, generated lazily on first request.
-The public key is returned as a JWK so external consumers can verify
-guild-issued tokens.
+Each guild gets one Ed25519 key pair, generated lazily on first request.
+The public key is returned as a JWK (OKP / Ed25519) with a kid equal to its
+RFC 7638 thumbprint so external consumers can verify guild-issued tokens.
 
 Custom keys can be uploaded via PUT /guilds/{guild_id}/jwks — when set they
 replace the auto-generated key in the .well-known response. A private key JWK
@@ -12,13 +12,14 @@ can also be stored (never served) for backend signing.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import secrets
 from datetime import UTC, datetime
 
 from auth_deps import require_member
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 from database import get_db
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -38,21 +39,36 @@ def _extract_guild_from_host(host: str) -> str | None:
     return None
 
 
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
 def _public_key_to_jwk(guild_key: GuildKey) -> dict:
     pub = serialization.load_pem_public_key(guild_key.public_key_pem.encode())
-    nums = pub.public_numbers()  # type: ignore[union-attr]
+    raw = pub.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    x = _b64url(raw)
+    # RFC 7638: SHA-256 of canonical JSON of required members in lex order.
+    canonical = json.dumps(
+        {"crv": "Ed25519", "kty": "OKP", "x": x}, separators=(",", ":"), sort_keys=True
+    )
+    kid = _b64url(hashlib.sha256(canonical.encode()).digest())
+    return {"kty": "OKP", "crv": "Ed25519", "x": x, "kid": kid, "use": "sig"}
 
-    def _b64url(n: int) -> str:
-        return base64.urlsafe_b64encode(n.to_bytes(32, "big")).rstrip(b"=").decode()
 
-    return {
-        "kty": "EC",
-        "crv": "P-256",
-        "kid": guild_key.key_id,
-        "use": "sig",
-        "x": _b64url(nums.x),
-        "y": _b64url(nums.y),
-    }
+def _generate_ed25519_pems() -> tuple[str, str]:
+    """Return (public_pem, private_pem) for a fresh Ed25519 key pair."""
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = (
+        priv.public_key()
+        .public_bytes(serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo)
+        .decode()
+    )
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    return pub_pem, priv_pem
 
 
 async def _get_or_create_guild_key(guild_id: str) -> GuildKey | None:
@@ -61,27 +77,21 @@ async def _get_or_create_guild_key(guild_id: str) -> GuildKey | None:
         row = (
             await db.execute(select(GuildKey).where(GuildKey.guild_id == guild_id))
         ).scalar_one_or_none()
+
         if row:
+            # Migrate any existing P-256 key to Ed25519.
+            pub = serialization.load_pem_public_key(row.public_key_pem.encode())
+            if not isinstance(pub, Ed25519PublicKey):
+                row.public_key_pem, row.private_key_pem = _generate_ed25519_pems()
+                await db.commit()
+                await db.refresh(row)
             return row
 
         guild = (await db.execute(select(Guild).where(Guild.id == guild_id))).scalar_one_or_none()
         if not guild:
             return None
 
-        private_key = ec.generate_private_key(ec.SECP256R1())
-        pub_pem = (
-            private_key.public_key()
-            .public_bytes(
-                serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
-            )
-            .decode()
-        )
-        priv_pem = private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        ).decode()
-
+        pub_pem, priv_pem = _generate_ed25519_pems()
         row = GuildKey(
             guild_id=guild_id,
             key_id=secrets.token_urlsafe(16),
@@ -168,28 +178,18 @@ async def set_jwks_config(
         ).scalar_one_or_none()
 
         if not row:
-            # Ensure guild exists before creating a key row
             guild = (
                 await db.execute(select(Guild).where(Guild.id == guild_id))
             ).scalar_one_or_none()
             if not guild:
                 raise HTTPException(404, detail="Guild not found")
 
-            # Placeholder auto-generated key so NOT NULL columns are satisfied
-            private_key = ec.generate_private_key(ec.SECP256R1())
+            pub_pem, priv_pem = _generate_ed25519_pems()
             row = GuildKey(
                 guild_id=guild_id,
                 key_id=secrets.token_urlsafe(16),
-                public_key_pem=private_key.public_key()
-                .public_bytes(
-                    serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
-                )
-                .decode(),
-                private_key_pem=private_key.private_bytes(
-                    serialization.Encoding.PEM,
-                    serialization.PrivateFormat.PKCS8,
-                    serialization.NoEncryption(),
-                ).decode(),
+                public_key_pem=pub_pem,
+                private_key_pem=priv_pem,
                 created_at=datetime.now(UTC).isoformat(),
             )
             db.add(row)


### PR DESCRIPTION
## Summary

- Replaces EC P-256 auto-generated guild keys with Ed25519 (`kty: "OKP"`)
- `kid` is now the RFC 7638 thumbprint (SHA-256 of canonical `{"crv","kty","x"}` JSON)
- JWK fields: `kty`, `crv`, `x`, `kid`, `use` — matches the required format for the challenge workflow
- Any guild with an existing P-256 key in the DB is silently migrated to Ed25519 on the next `/.well-known/jwks.json` request

## Test plan

- [ ] `curl https://{guild}.pioneer-square.melloy.life/.well-known/jwks.json` returns `kty: "OKP"`, `crv: "Ed25519"`, and a `kid` matching the RFC 7638 thumbprint of `x`
- [ ] Second request returns identical `kid` (key stable across requests)
- [ ] Guild with old P-256 key gets a new Ed25519 key on next request

🤖 Generated with [Claude Code](https://claude.com/claude-code)