### PR TITLE
Worker org config + lazy clone repos

### DIFF
--- a/backend/alembic/versions/20260506_000002_add_org_to_workers.py
+++ b/backend/alembic/versions/20260506_000002_add_org_to_workers.py
@@ -1,0 +1,34 @@
+"""add_org_to_workers
+
+Adds an ``org`` column to the ``workers`` table so a worker can be configured
+with a GitHub org name instead of (or alongside) an explicit ``repos`` list.
+When set, the worker is eligible for any task targeting ``<org>/*`` and clones
+repos lazily on first use.
+
+Existing rows are left with NULL (behaves as before: explicit repos list only).
+
+Revision ID: 20260506_000002_add_org_to_workers
+Revises: 20260506_000001_add_custom_jwks_to_guild_keys
+Create Date: 2026-05-06 00:02:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260506_000002_add_org_to_workers"
+down_revision: str | Sequence[str] | None = "20260506_000001_add_custom_jwks_to_guild_keys"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("workers") as batch_op:
+        batch_op.add_column(sa.Column("org", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workers") as batch_op:
+        batch_op.drop_column("org")

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -429,7 +429,7 @@ async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
 
     result = await db.execute(
         text(
-            "SELECT w.id, w.repos, w.state as worker_state,"
+            "SELECT w.id, w.repos, w.org, w.state as worker_state,"
             " COUNT(a.id) as agent_count,"
             " GROUP_CONCAT(a.id || ':' || a.state) as agents"
             " FROM workers w"
@@ -437,7 +437,7 @@ async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
             " WHERE w.guild_id = :guild_id AND w.state = 'online'"
             " GROUP BY w.id"
             " UNION ALL"
-            " SELECT a.id, '[]', a.state, 1, a.id || ':' || a.state"
+            " SELECT a.id, '[]', NULL, a.state, 1, a.id || ':' || a.state"
             " FROM agents a"
             " WHERE a.guild_id = :guild_id AND a.type = 'worker'"
             " AND a.worker_id IS NULL AND a.state != 'offline'"
@@ -511,6 +511,7 @@ async def run_foreman_ai(
                 "id": r["id"],
                 "state": r["worker_state"] or "idle",
                 "repos": json.loads(r["repos"] or "[]"),
+                **({"org": r["org"]} if r.get("org") else {}),
                 "agent_count": r["agent_count"] or 0,
             }
             for r in worker_rows

--- a/backend/models.py
+++ b/backend/models.py
@@ -72,6 +72,9 @@ class Worker(Base):
     id = Column(Text, primary_key=True)
     guild_id = Column(Text, ForeignKey("guilds.id"), nullable=False)
     repos = Column(Text, nullable=False, server_default="[]")
+    # Optional GitHub org; when set the worker accepts any task targeting <org>/*
+    # and clones repos lazily. NULL for workers that use an explicit repos list only.
+    org = Column(Text, nullable=True)
     state = Column(Text, nullable=False, server_default="idle")
     created_at = Column(Text, nullable=False)
     last_seen = Column(Text, nullable=True)

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -35,7 +35,10 @@ router = APIRouter()
 
 
 class WorkerCreate(BaseModel):
-    repos: list[str]  # ["owner/repo", ...]
+    repos: list[str] = []  # ["owner/repo", ...]
+    # Optional GitHub org. When set the worker accepts any task for <org>/* and
+    # clones repos lazily. May be used alongside or instead of repos.
+    org: str | None = None
     github_token: str | None = None
     hostname: str | None = None
     # Either a users.id (numeric GitHub id as text) or a github_login. The
@@ -85,6 +88,7 @@ async def create_worker(guild_id: str, data: WorkerCreate):
                 id=worker_id,
                 guild_id=guild_id,
                 repos=json.dumps(data.repos),
+                org=data.org,
                 state="offline",
                 created_at=created_at,
                 user_id=resolved_user_id,
@@ -131,6 +135,7 @@ async def create_worker(guild_id: str, data: WorkerCreate):
         "id": worker_id,
         "name": worker_name,
         "repos": data.repos,
+        "org": data.org,
         "created_at": created_at,
         "auth_token": auth_token,
     }

--- a/worker/README.md
+++ b/worker/README.md
@@ -78,6 +78,10 @@ Required keys:
   WebSocket URL automatically.
 - `session_id` — the 6-char session id from the Pioneer Square UI.
 - `[github] repos` — list of `owner/repo` strings the worker may operate on.
+- `[github] org` — GitHub organisation name (e.g. `"jmelloy"`). When set, the
+  worker accepts tasks targeting *any* repo under that org and clones repos
+  lazily the first time a task arrives. Can be used alongside `repos` (union)
+  or instead of it.
 
 Optional:
 

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -22,8 +22,12 @@ pull_interval = 300
 # max_agents = 4
 
 [github]
-# Repos this worker will clone and operate on.
+# Repos this worker will clone and operate on (static list).
 repos = ["owner/repo"]
+
+# Alternatively (or additionally), specify a GitHub org. When set, the worker
+# accepts tasks for any repo under that org and clones them lazily on first use.
+# org = "myorg"
 
 # GitHub token for cloning private repos and opening pull requests.
 # Use "env:VAR_NAME" to read from an environment variable instead of inlining.

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -19,6 +19,10 @@ class Config:
     backend_url: str
     guild_id: str
     repos: list[str] = field(default_factory=list)
+    # GitHub org name (e.g. "jmelloy"). When set, the worker is eligible for
+    # any task targeting <org>/* and will clone repos lazily on first use.
+    # Can be used alongside repos (static list) or instead of it.
+    org: str | None = None
     worker_id: str | None = None
     worker_name: str | None = None
     # Bearer token issued by the backend at registration; required for fetching
@@ -147,6 +151,10 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             or raw.get("repos")
             or _repos_from_env
         ),
+        org=overrides.get("org")
+        or github_block.get("org")
+        or os.environ.get("PIONEER_ORG")
+        or None,
         worker_name=overrides.get("worker_name")
         or raw.get("worker_name")
         or os.environ.get("PIONEER_WORKER_NAME"),

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -112,6 +112,7 @@ class Worker:
                 f"/guilds/{self.cfg.guild_id}/workers",
                 json={
                     "repos": self.cfg.repos,
+                    "org": self.cfg.org,
                     "github_token": None,
                     "hostname": socket.gethostname(),
                     "user": self.cfg.user,
@@ -1193,6 +1194,20 @@ class Worker:
             except Exception as exc:
                 logger.warning("remove_worktree failed for %s: %s", wt_path, exc)
 
+    def _known_repos(self) -> list[str]:
+        """All repos this worker may have cloned: static list + org repos already on disk."""
+        repos = list(self.cfg.repos)
+        if self.cfg.org:
+            org_dir = os.path.join(self.cfg.repos_dir, self.cfg.org)
+            if os.path.isdir(org_dir):
+                for entry in os.listdir(org_dir):
+                    repo_full = f"{self.cfg.org}/{entry}"
+                    if repo_full not in repos and os.path.isdir(
+                        os.path.join(org_dir, entry, ".git")
+                    ):
+                        repos.append(repo_full)
+        return repos
+
     async def _initial_worktree_sweep(self) -> None:
         """At startup, prune any worktrees this worker left behind from a previous run.
 
@@ -1206,6 +1221,7 @@ class Worker:
         try:
             now = asyncio.get_event_loop().time()
             wall_now = datetime.now(UTC).timestamp()
+            known_repos = self._known_repos()
             for entry in os.listdir(base):
                 full = os.path.join(base, entry)
                 if not os.path.isdir(full):
@@ -1218,7 +1234,7 @@ class Worker:
                     # Re-register so the in-memory sweeper takes over.
                     ts = now - age
                     repos_for_task: list[tuple[str, str, float]] = []
-                    for repo_full in self.cfg.repos:
+                    for repo_full in known_repos:
                         repo_name = repo_full.split("/")[-1]
                         wt_path = os.path.join(full, repo_name)
                         if os.path.isdir(wt_path):
@@ -1229,7 +1245,7 @@ class Worker:
                     continue
                 logger.info("Startup sweep: removing stale task dir %s (age=%.0fs)", full, age)
                 # Best-effort: remove each worktree via git, then drop the dir.
-                for repo_full in self.cfg.repos:
+                for repo_full in known_repos:
                     repo_name = repo_full.split("/")[-1]
                     wt_path = os.path.join(full, repo_name)
                     if os.path.isdir(wt_path):
@@ -1246,7 +1262,7 @@ class Worker:
                 except Exception as exc:
                     logger.debug("startup-sweep rmtree failed for %s: %s", full, exc)
             # Prune dangling worktree references in each repo.
-            for repo_full in self.cfg.repos:
+            for repo_full in known_repos:
                 repo_path = os.path.join(self.cfg.repos_dir, *repo_full.split("/", 1))
                 if os.path.isdir(repo_path):
                     try:
@@ -1310,13 +1326,15 @@ class Worker:
             except Exception as exc:
                 logger.warning("Pending-task poll failed: %s", exc)
             all_idle = all(s.current_claude is None for s in self.slots)
-            if self.task_queue.empty() and all_idle and self.cfg.repos:
-                await git_ops.pull_repos(
-                    self.cfg.repos_dir,
-                    self.cfg.repos,
-                    self.cfg.github_token,
-                    self._emit,
-                )
+            if self.task_queue.empty() and all_idle:
+                known = self._known_repos()
+                if known:
+                    await git_ops.pull_repos(
+                        self.cfg.repos_dir,
+                        known,
+                        self.cfg.github_token,
+                        self._emit,
+                    )
 
     # ------------------------------------------------------------------ Agent loop
     async def _agent_loop(self, slot: Agent) -> None:
@@ -1357,7 +1375,12 @@ class Worker:
         task_id = task["id"]
         desc = task.get("description") or ""
         token = self.cfg.github_token
-        repos = self.cfg.repos
+        # Build effective repo list: static config repos + lazy org repo if applicable.
+        repos = list(self.cfg.repos)
+        issue_repo = task.get("issue_repo") or ""
+        if self.cfg.org and issue_repo.startswith(f"{self.cfg.org}/"):
+            if issue_repo not in repos:
+                repos.insert(0, issue_repo)
         followup_instructions = task.get("followup_instructions") or ""
         followup_branch = task.get("followup_branch") or ""
         is_followup = bool(followup_instructions)

--- a/worker/tests/test_config.py
+++ b/worker/tests/test_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from pioneer_worker.config import Config, load
 
@@ -56,12 +58,14 @@ def test_ws_url_converts_https_to_wss():
 
 
 def test_load_missing_file_raises(tmp_path):
-    with pytest.raises(FileNotFoundError):
+    env = {"PIONEER_BACKEND_URL": "", "PIONEER_GUILD_ID": ""}
+    with patch.dict("os.environ", env, clear=False), pytest.raises(FileNotFoundError):
         load(str(tmp_path / "missing.toml"))
 
 
 def test_load_missing_file_no_overrides_raises():
-    with pytest.raises(FileNotFoundError):
+    env = {"PIONEER_BACKEND_URL": "", "PIONEER_GUILD_ID": ""}
+    with patch.dict("os.environ", env, clear=False), pytest.raises(FileNotFoundError):
         load("/nonexistent/pioneer-worker.toml")
 
 
@@ -215,9 +219,7 @@ def test_org_defaults_to_none():
 
 def test_load_org_from_toml(tmp_path):
     toml_path = tmp_path / "pioneer-worker.toml"
-    toml_path.write_text(
-        'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\norg = "myorg"\n'
-    )
+    toml_path.write_text('backend_url = "ws://x:1"\nguild_id = "g"\n[github]\norg = "myorg"\n')
     cfg = load(str(toml_path))
     assert cfg.org == "myorg"
 
@@ -232,9 +234,7 @@ def test_load_org_from_env(tmp_path, monkeypatch):
 
 def test_load_org_override_beats_toml(tmp_path):
     toml_path = tmp_path / "pioneer-worker.toml"
-    toml_path.write_text(
-        'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\norg = "tomlorg"\n'
-    )
+    toml_path.write_text('backend_url = "ws://x:1"\nguild_id = "g"\n[github]\norg = "tomlorg"\n')
     cfg = load(str(toml_path), overrides={"org": "overrideorg"})
     assert cfg.org == "overrideorg"
 

--- a/worker/tests/test_config.py
+++ b/worker/tests/test_config.py
@@ -201,3 +201,60 @@ def test_load_github_token_empty_pioneer_falls_through(tmp_path, monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_github")
     cfg = load(str(tmp_path / "missing.toml"))
     assert cfg.github_token == "ghp_github"
+
+
+# ---------------------------------------------------------------------------
+# load() — org field
+# ---------------------------------------------------------------------------
+
+
+def test_org_defaults_to_none():
+    cfg = Config(backend_url="ws://x:1", guild_id="g")
+    assert cfg.org is None
+
+
+def test_load_org_from_toml(tmp_path):
+    toml_path = tmp_path / "pioneer-worker.toml"
+    toml_path.write_text(
+        'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\norg = "myorg"\n'
+    )
+    cfg = load(str(toml_path))
+    assert cfg.org == "myorg"
+
+
+def test_load_org_from_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("PIONEER_BACKEND_URL", "ws://x:1")
+    monkeypatch.setenv("PIONEER_GUILD_ID", "g")
+    monkeypatch.setenv("PIONEER_ORG", "envorg")
+    cfg = load(str(tmp_path / "missing.toml"))
+    assert cfg.org == "envorg"
+
+
+def test_load_org_override_beats_toml(tmp_path):
+    toml_path = tmp_path / "pioneer-worker.toml"
+    toml_path.write_text(
+        'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\norg = "tomlorg"\n'
+    )
+    cfg = load(str(toml_path), overrides={"org": "overrideorg"})
+    assert cfg.org == "overrideorg"
+
+
+def test_load_org_and_repos_can_coexist(tmp_path):
+    toml_path = tmp_path / "pioneer-worker.toml"
+    toml_path.write_text(
+        'backend_url = "ws://x:1"\nguild_id = "g"\n'
+        '[github]\norg = "myorg"\nrepos = ["myorg/extra"]\n'
+    )
+    cfg = load(str(toml_path))
+    assert cfg.org == "myorg"
+    assert "myorg/extra" in cfg.repos
+
+
+def test_load_repos_only_org_none(tmp_path):
+    toml_path = tmp_path / "pioneer-worker.toml"
+    toml_path.write_text(
+        'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\nrepos = ["owner/repo"]\n'
+    )
+    cfg = load(str(toml_path))
+    assert cfg.org is None
+    assert "owner/repo" in cfg.repos

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -70,6 +70,7 @@ async def test_run_sends_disconnect_before_ws_close():
     worker._send = capture_send
     worker._register = AsyncMock()
     worker._fetch_github_token_if_needed = AsyncMock()
+    worker._check_gh_auth = AsyncMock()
     worker._check_claude_auth = AsyncMock()
     worker._fetch_pending_tasks = AsyncMock(return_value=[])
     worker.ws.connect = AsyncMock()

--- a/worker/tests/test_org_clone.py
+++ b/worker/tests/test_org_clone.py
@@ -1,0 +1,280 @@
+"""Tests for org-based lazy clone logic.
+
+Covers:
+  - Task for an uncloned org repo triggers ensure_repo (clone)
+  - Task for an already-cloned repo skips ensure_repo
+  - Worker with repos list only still works (no org set)
+  - _known_repos() includes lazily-cloned repos from the org dir
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_cfg(**kwargs) -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="test-guild",
+        worker_id="w-test01",
+        max_agents=1,
+        pull_interval=3600.0,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal task dict
+# ---------------------------------------------------------------------------
+
+
+def _task(task_id: str, issue_repo: str | None = None, tool: str = "claude") -> dict:
+    return {
+        "id": task_id,
+        "name": "test task",
+        "description": "do something",
+        "tool": tool,
+        "issue_repo": issue_repo,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lazy clone: org repo is cloned when task arrives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_org_repo_cloned_on_first_task(tmp_path):
+    """When a task targets an org repo not yet on disk, ensure_repo is called."""
+    worker = Worker(
+        _make_cfg(
+            org="myorg",
+            repos=[],
+            repos_dir=str(tmp_path / "repos"),
+            work_dir=str(tmp_path / "work"),
+        )
+    )
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+
+    slot = worker.slots[0]
+    task = _task("t-org001", issue_repo="myorg/newrepo")
+
+    cloned: list[str] = []
+
+    async def fake_ensure_repo(repos_dir, repo_full, token):
+        cloned.append(repo_full)
+        repo_path = os.path.join(repos_dir, *repo_full.split("/", 1))
+        os.makedirs(os.path.join(repo_path, ".git"), exist_ok=True)
+        return repo_path
+
+    with (
+        patch("pioneer_worker.worker.git_ops.ensure_repo", side_effect=fake_ensure_repo),
+        patch("pioneer_worker.worker.git_ops.create_worktree", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.claude_runner.run_claude_auto",
+            new=AsyncMock(return_value=(True, "end_turn", "done")),
+        ),
+        patch("pioneer_worker.worker.github_pr.push_branch", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.github_pr.ensure_pr",
+            new=AsyncMock(return_value="https://github.com/myorg/newrepo/pull/1"),
+        ),
+        patch("pioneer_worker.worker.git_ops.ensure_webhook", new=AsyncMock()),
+    ):
+        await worker._execute_task(task, slot)
+
+    assert "myorg/newrepo" in cloned, "ensure_repo must be called for the org repo"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: already-cloned repo skips the clone step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_already_cloned_repo_skips_clone(tmp_path):
+    """ensure_repo is still called (it handles fetch internally), but the
+    worktree is reused when the wt_path already exists."""
+    repos_dir = tmp_path / "repos"
+    work_dir = tmp_path / "work"
+
+    worker = Worker(
+        _make_cfg(
+            org="myorg",
+            repos=[],
+            repos_dir=str(repos_dir),
+            work_dir=str(work_dir),
+        )
+    )
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+
+    slot = worker.slots[0]
+    task_id = "t-org002"
+    task = _task(task_id, issue_repo="myorg/existingrepo")
+
+    # Pre-create the repo mirror and the worktree path to simulate an
+    # already-cloned repo with an existing worktree.
+    repo_path = repos_dir / "myorg" / "existingrepo"
+    (repo_path / ".git").mkdir(parents=True)
+
+    wt_path = work_dir / "test-guild" / "w-test01" / task_id / "existingrepo"
+    (wt_path / ".git").mkdir(parents=True)
+
+    ensure_repo_calls: list[str] = []
+
+    async def fake_ensure_repo(repos_dir_, repo_full, token):
+        ensure_repo_calls.append(repo_full)
+        parts = repo_full.split("/", 1)
+        return str(repos_dir / parts[0] / parts[1])
+
+    with (
+        patch("pioneer_worker.worker.git_ops.ensure_repo", side_effect=fake_ensure_repo),
+        patch("pioneer_worker.worker.git_ops.create_worktree", new=AsyncMock(return_value=True)),
+        patch("pioneer_worker.worker.git_ops.run_git", new=AsyncMock(return_value=(0, "", ""))),
+        patch(
+            "pioneer_worker.worker.claude_runner.run_claude_auto",
+            new=AsyncMock(return_value=(True, "end_turn", "done")),
+        ),
+        patch("pioneer_worker.worker.github_pr.push_branch", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.github_pr.ensure_pr",
+            new=AsyncMock(return_value="https://github.com/myorg/existingrepo/pull/1"),
+        ),
+        patch("pioneer_worker.worker.git_ops.ensure_webhook", new=AsyncMock()),
+    ):
+        await worker._execute_task(task, slot)
+
+    # ensure_repo was called (it updates the mirror), but no new clone needed
+    assert "myorg/existingrepo" in ensure_repo_calls
+
+
+# ---------------------------------------------------------------------------
+# Backwards compat: repos-list-only worker still works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repos_only_worker_no_org(tmp_path):
+    """A worker with repos=["owner/repo"] and no org works as before."""
+    worker = Worker(
+        _make_cfg(
+            org=None,
+            repos=["owner/myrepo"],
+            repos_dir=str(tmp_path / "repos"),
+            work_dir=str(tmp_path / "work"),
+        )
+    )
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+
+    slot = worker.slots[0]
+    task = _task("t-norg01")  # no issue_repo
+
+    cloned: list[str] = []
+
+    async def fake_ensure_repo(repos_dir, repo_full, token):
+        cloned.append(repo_full)
+        repo_path = os.path.join(repos_dir, *repo_full.split("/", 1))
+        os.makedirs(os.path.join(repo_path, ".git"), exist_ok=True)
+        return repo_path
+
+    with (
+        patch("pioneer_worker.worker.git_ops.ensure_repo", side_effect=fake_ensure_repo),
+        patch("pioneer_worker.worker.git_ops.create_worktree", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.claude_runner.run_claude_auto",
+            new=AsyncMock(return_value=(True, "end_turn", "done")),
+        ),
+        patch("pioneer_worker.worker.github_pr.push_branch", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.github_pr.ensure_pr",
+            new=AsyncMock(return_value="https://github.com/owner/myrepo/pull/1"),
+        ),
+        patch("pioneer_worker.worker.git_ops.ensure_webhook", new=AsyncMock()),
+    ):
+        await worker._execute_task(task, slot)
+
+    assert "owner/myrepo" in cloned
+    assert len(cloned) == 1
+
+
+# ---------------------------------------------------------------------------
+# _known_repos: includes lazily-cloned repos from org dir
+# ---------------------------------------------------------------------------
+
+
+def test_known_repos_includes_org_repos_on_disk(tmp_path):
+    """_known_repos() discovers repos already cloned under <repos_dir>/<org>/."""
+    repos_dir = tmp_path / "repos"
+    org_dir = repos_dir / "myorg"
+    (org_dir / "repo1" / ".git").mkdir(parents=True)
+    (org_dir / "repo2" / ".git").mkdir(parents=True)
+    # A non-repo directory (no .git) should be excluded
+    (org_dir / "notarepo").mkdir(parents=True)
+
+    worker = Worker(
+        _make_cfg(
+            org="myorg",
+            repos=[],
+            repos_dir=str(repos_dir),
+        )
+    )
+    known = worker._known_repos()
+    assert "myorg/repo1" in known
+    assert "myorg/repo2" in known
+    assert "myorg/notarepo" not in known
+
+
+def test_known_repos_with_static_repos_no_org(tmp_path):
+    """Without org, _known_repos() returns only the static repos list."""
+    worker = Worker(
+        _make_cfg(
+            org=None,
+            repos=["owner/repo"],
+            repos_dir=str(tmp_path / "repos"),
+        )
+    )
+    known = worker._known_repos()
+    assert known == ["owner/repo"]
+
+
+def test_known_repos_combines_static_and_org(tmp_path):
+    """With both repos and org, _known_repos() returns the union."""
+    repos_dir = tmp_path / "repos"
+    (repos_dir / "myorg" / "lazyrepo" / ".git").mkdir(parents=True)
+
+    worker = Worker(
+        _make_cfg(
+            org="myorg",
+            repos=["myorg/staticrepo"],
+            repos_dir=str(repos_dir),
+        )
+    )
+    known = worker._known_repos()
+    assert "myorg/staticrepo" in known
+    assert "myorg/lazyrepo" in known
+    # No duplicates
+    assert known.count("myorg/staticrepo") == 1
+
+
+def test_known_repos_deduplicates_org_repos(tmp_path):
+    """A repo already in the static list is not duplicated even if on disk."""
+    repos_dir = tmp_path / "repos"
+    (repos_dir / "myorg" / "myrepo" / ".git").mkdir(parents=True)
+
+    worker = Worker(
+        _make_cfg(
+            org="myorg",
+            repos=["myorg/myrepo"],
+            repos_dir=str(repos_dir),
+        )
+    )
+    known = worker._known_repos()
+    assert known.count("myorg/myrepo") == 1

--- a/worker/tests/test_org_clone.py
+++ b/worker/tests/test_org_clone.py
@@ -82,10 +82,14 @@ async def test_org_repo_cloned_on_first_task(tmp_path):
         ),
         patch("pioneer_worker.worker.github_pr.push_branch", new=AsyncMock(return_value=True)),
         patch(
-            "pioneer_worker.worker.github_pr.ensure_pr",
+            "pioneer_worker.worker.github_pr.find_existing_pr",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "pioneer_worker.worker.github_pr.open_pr",
             new=AsyncMock(return_value="https://github.com/myorg/newrepo/pull/1"),
         ),
-        patch("pioneer_worker.worker.git_ops.ensure_webhook", new=AsyncMock()),
+        patch("pioneer_worker.worker.github_pr.ensure_webhook", new=AsyncMock()),
     ):
         await worker._execute_task(task, slot)
 
@@ -144,10 +148,14 @@ async def test_already_cloned_repo_skips_clone(tmp_path):
         ),
         patch("pioneer_worker.worker.github_pr.push_branch", new=AsyncMock(return_value=True)),
         patch(
-            "pioneer_worker.worker.github_pr.ensure_pr",
+            "pioneer_worker.worker.github_pr.find_existing_pr",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "pioneer_worker.worker.github_pr.open_pr",
             new=AsyncMock(return_value="https://github.com/myorg/existingrepo/pull/1"),
         ),
-        patch("pioneer_worker.worker.git_ops.ensure_webhook", new=AsyncMock()),
+        patch("pioneer_worker.worker.github_pr.ensure_webhook", new=AsyncMock()),
     ):
         await worker._execute_task(task, slot)
 
@@ -194,10 +202,14 @@ async def test_repos_only_worker_no_org(tmp_path):
         ),
         patch("pioneer_worker.worker.github_pr.push_branch", new=AsyncMock(return_value=True)),
         patch(
-            "pioneer_worker.worker.github_pr.ensure_pr",
+            "pioneer_worker.worker.github_pr.find_existing_pr",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "pioneer_worker.worker.github_pr.open_pr",
             new=AsyncMock(return_value="https://github.com/owner/myrepo/pull/1"),
         ),
-        patch("pioneer_worker.worker.git_ops.ensure_webhook", new=AsyncMock()),
+        patch("pioneer_worker.worker.github_pr.ensure_webhook", new=AsyncMock()),
     ):
         await worker._execute_task(task, slot)
 


### PR DESCRIPTION
## Summary

- Add `org` field to worker config alongside existing `repos` list (backwards compatible)
- Implement lazy clone logic: when a task arrives for an uncloned repo under the configured org, clone it automatically before creating the worktree
- Update worker-matching/dispatcher logic so `org: "foo"` workers are eligible for any `foo/*` repo task
- Add unit/integration tests covering lazy clone, already-cloned idempotency, and legacy `repos`-only config

## Test plan

- [ ] `cd worker && python -m pytest` — all 35 tests pass
- [ ] Configure worker with `org: "yourorg"` and no `repos` list; assign a task targeting a repo in that org; verify it's cloned and the task runs
- [ ] Assign a second task to the same repo; verify clone is skipped
- [ ] Worker with only `repos` list still works as before

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)