### PR TITLE
Integrate code-review-agent as Foreman MCP client (#258)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,17 @@ CLAUDE_CODE_OAUTH_TOKEN=
 # Worker-only: GitHub token for cloning private repos and opening PRs.
 # Optional — if empty, worker fetches the OAuth token from the backend DB.
 GITHUB_TOKEN=
+
+# --- Code-review-agent MCP integration (optional) ---
+# To enable automated PR reviews, run the code-review-agent harness and the
+# crv-mcp stdio MCP server (https://github.com/Identity-Digital/code-review-agent).
+#
+# REVIEWER_MCP_CMD: shell command to launch the crv-mcp stdio MCP server.
+#   Example: REVIEWER_MCP_CMD=/opt/code-review-agent/bin/crv-mcp
+# REVIEWER_MCP_URL: alternative — HTTP endpoint of an MCP-over-HTTP server.
+#   Example: REVIEWER_MCP_URL=http://localhost:9000/mcp
+# REVIEWER_AGENT_URL: URL of the code-review-agent harness (service side).
+#   Example: REVIEWER_AGENT_URL=https://crv.example.com
+REVIEWER_MCP_CMD=
+REVIEWER_MCP_URL=
+REVIEWER_AGENT_URL=

--- a/.env.example
+++ b/.env.example
@@ -30,16 +30,13 @@ CLAUDE_CODE_OAUTH_TOKEN=
 # Optional — if empty, worker fetches the OAuth token from the backend DB.
 GITHUB_TOKEN=
 
-# --- Code-review-agent MCP integration (optional) ---
-# To enable automated PR reviews, run the code-review-agent harness and the
-# crv-mcp stdio MCP server (https://github.com/Identity-Digital/code-review-agent).
+# --- Code-review-agent MCP integration ---
+# Automated PR reviews use the shared MCP server at https://agent.meyers.life.
+# Per-guild agent URLs are derived automatically as {guild_id}.pioneer-square.melloy.life.
 #
-# REVIEWER_MCP_CMD: shell command to launch the crv-mcp stdio MCP server.
+# REVIEWER_MCP_URL: HTTP endpoint of the MCP server.
+#   Default: https://agent.meyers.life — override only if running a private instance.
+# REVIEWER_MCP_CMD: alternative — shell command to launch a local stdio MCP server.
 #   Example: REVIEWER_MCP_CMD=/opt/code-review-agent/bin/crv-mcp
-# REVIEWER_MCP_URL: alternative — HTTP endpoint of an MCP-over-HTTP server.
-#   Example: REVIEWER_MCP_URL=http://localhost:9000/mcp
-# REVIEWER_AGENT_URL: URL of the code-review-agent harness (service side).
-#   Example: REVIEWER_AGENT_URL=https://crv.example.com
-REVIEWER_MCP_CMD=
-REVIEWER_MCP_URL=
-REVIEWER_AGENT_URL=
+REVIEWER_MCP_URL=https://agent.meyers.life
+# REVIEWER_MCP_CMD=

--- a/backend/foreman/mcp_client.py
+++ b/backend/foreman/mcp_client.py
@@ -1,12 +1,12 @@
 """Lightweight async MCP client for the Foreman.
 
 Supports two transports:
+- **HTTP**: POSTs JSON-RPC 2.0 to an HTTP endpoint.
+  Configure via ``REVIEWER_MCP_URL`` env var (default: ``https://agent.meyers.life``).
 - **stdio**: launches a subprocess and speaks JSON-RPC 2.0 over stdin/stdout.
   Configure via ``REVIEWER_MCP_CMD`` env var (e.g. ``"crv-mcp"``).
-- **HTTP**: POSTs JSON-RPC 2.0 to an HTTP endpoint.
-  Configure via ``REVIEWER_MCP_URL`` env var.
 
-When both are set, HTTP takes precedence.
+HTTP takes precedence when both are configured.
 """
 
 import asyncio
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 _JSONRPC_VERSION = "2.0"
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 _DEFAULT_TIMEOUT_SECS = 180.0  # code-review-agent reviews can take ~2 min
+_DEFAULT_MCP_URL = "https://agent.meyers.life"
 
 
 class MCPError(Exception):
@@ -42,12 +43,10 @@ class MCPClient:
         timeout: float = _DEFAULT_TIMEOUT_SECS,
     ):
         self._cmd = cmd if cmd is not None else os.environ.get("REVIEWER_MCP_CMD")
-        self._url = url if url is not None else os.environ.get("REVIEWER_MCP_URL")
+        _explicit_url = url if url is not None else os.environ.get("REVIEWER_MCP_URL")
+        # Default to the shared MCP server only when no transport is explicitly configured.
+        self._url = _explicit_url if _explicit_url else (None if self._cmd else _DEFAULT_MCP_URL)
         self._timeout = timeout
-        if not self._cmd and not self._url:
-            raise ValueError(
-                "MCPClient requires REVIEWER_MCP_CMD (stdio) or REVIEWER_MCP_URL (HTTP)."
-            )
 
     async def list_tools(self) -> list[dict]:
         """Return the tools exposed by the MCP server."""

--- a/backend/foreman/mcp_client.py
+++ b/backend/foreman/mcp_client.py
@@ -1,0 +1,211 @@
+"""Lightweight async MCP client for the Foreman.
+
+Supports two transports:
+- **stdio**: launches a subprocess and speaks JSON-RPC 2.0 over stdin/stdout.
+  Configure via ``REVIEWER_MCP_CMD`` env var (e.g. ``"crv-mcp"``).
+- **HTTP**: POSTs JSON-RPC 2.0 to an HTTP endpoint.
+  Configure via ``REVIEWER_MCP_URL`` env var.
+
+When both are set, HTTP takes precedence.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+
+logger = logging.getLogger(__name__)
+
+_JSONRPC_VERSION = "2.0"
+_MCP_PROTOCOL_VERSION = "2024-11-05"
+_DEFAULT_TIMEOUT_SECS = 180.0  # code-review-agent reviews can take ~2 min
+
+
+class MCPError(Exception):
+    """Raised when an MCP server returns a JSON-RPC error response."""
+
+    def __init__(self, code: int, message: str, data=None):
+        self.code = code
+        self.message = message
+        self.data = data
+        super().__init__(f"MCP error {code}: {message}")
+
+
+class MCPClient:
+    """Minimal async MCP client that the Foreman uses to call external agents."""
+
+    def __init__(
+        self,
+        cmd: str | list[str] | None = None,
+        url: str | None = None,
+        timeout: float = _DEFAULT_TIMEOUT_SECS,
+    ):
+        self._cmd = cmd if cmd is not None else os.environ.get("REVIEWER_MCP_CMD")
+        self._url = url if url is not None else os.environ.get("REVIEWER_MCP_URL")
+        self._timeout = timeout
+        if not self._cmd and not self._url:
+            raise ValueError(
+                "MCPClient requires REVIEWER_MCP_CMD (stdio) or REVIEWER_MCP_URL (HTTP)."
+            )
+
+    async def list_tools(self) -> list[dict]:
+        """Return the tools exposed by the MCP server."""
+        result = await self._request("tools/list", {})
+        return result.get("tools", [])
+
+    async def call_tool(self, name: str, arguments: dict) -> dict:
+        """Call a named MCP tool and return the result dict."""
+        return await self._request("tools/call", {"name": name, "arguments": arguments})
+
+    # ------------------------------------------------------------------
+    # Transport helpers
+    # ------------------------------------------------------------------
+
+    async def _request(self, method: str, params: dict) -> dict:
+        if self._url:
+            return await self._http_request(method, params)
+        return await self._stdio_request(method, params)
+
+    async def _http_request(self, method: str, params: dict) -> dict:
+        """JSON-RPC 2.0 over HTTP (streamable-HTTP MCP transport)."""
+        import urllib.error
+        import urllib.request
+
+        req_id = str(uuid.uuid4())
+        payload = json.dumps(
+            {"jsonrpc": _JSONRPC_VERSION, "id": req_id, "method": method, "params": params}
+        ).encode()
+
+        def _do_post():
+            req = urllib.request.Request(
+                self._url,
+                data=payload,
+                headers={"Content-Type": "application/json", "Accept": "application/json"},
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as exc:
+                raise MCPError(-32000, f"HTTP {exc.code}: {exc.reason}") from exc
+
+        data = await asyncio.to_thread(_do_post)
+        if "error" in data:
+            err = data["error"]
+            raise MCPError(err.get("code", -1), err.get("message", "unknown"), err.get("data"))
+        return data.get("result", {})
+
+    async def _stdio_request(self, method: str, params: dict) -> dict:
+        """JSON-RPC 2.0 over a stdio subprocess (MCP stdio transport).
+
+        Performs the full MCP handshake (initialize → notifications/initialized)
+        before sending the actual request, then reads stdout until the matching
+        response arrives.  Progress notifications are logged and skipped.
+        """
+        cmd = self._cmd
+        if isinstance(cmd, str):
+            cmd = cmd.split()
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        req_id = str(uuid.uuid4())
+        try:
+            # Write the full MCP session in one shot:
+            # 1. initialize request
+            # 2. notifications/initialized notification
+            # 3. actual request
+            messages = (
+                json.dumps(
+                    {
+                        "jsonrpc": _JSONRPC_VERSION,
+                        "id": "mcp-init",
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": _MCP_PROTOCOL_VERSION,
+                            "clientInfo": {
+                                "name": "pioneer-square-foreman",
+                                "version": "1.0",
+                            },
+                            "capabilities": {},
+                        },
+                    }
+                )
+                + "\n"
+                + json.dumps({"jsonrpc": _JSONRPC_VERSION, "method": "notifications/initialized"})
+                + "\n"
+                + json.dumps(
+                    {
+                        "jsonrpc": _JSONRPC_VERSION,
+                        "id": req_id,
+                        "method": method,
+                        "params": params,
+                    }
+                )
+                + "\n"
+            )
+            proc.stdin.write(messages.encode())
+            await proc.stdin.drain()
+            proc.stdin.close()
+
+            deadline = asyncio.get_event_loop().time() + self._timeout
+            while True:
+                remaining = max(0.5, deadline - asyncio.get_event_loop().time())
+                try:
+                    line = await asyncio.wait_for(proc.stdout.readline(), timeout=remaining)
+                except TimeoutError:
+                    raise TimeoutError(
+                        f"MCP {method!r} timed out after {self._timeout:.0f}s"
+                    ) from None
+
+                if not line:
+                    stderr_out = b""
+                    try:
+                        stderr_out = await asyncio.wait_for(proc.stderr.read(), timeout=2.0)
+                    except TimeoutError:
+                        pass
+                    raise RuntimeError(
+                        "MCP server closed stdout unexpectedly. "
+                        f"stderr: {stderr_out.decode(errors='replace')[:400]}"
+                    )
+
+                try:
+                    data = json.loads(line.decode(errors="replace"))
+                except json.JSONDecodeError:
+                    logger.debug("MCP non-JSON line: %s", line[:120])
+                    continue
+
+                msg_id = data.get("id")
+                if msg_id == req_id:
+                    if "error" in data:
+                        err = data["error"]
+                        raise MCPError(
+                            err.get("code", -1),
+                            err.get("message", "unknown"),
+                            err.get("data"),
+                        )
+                    return data.get("result", {})
+
+                # Skip the init handshake response and all notifications
+                if "method" in data:
+                    logger.debug("MCP notification: %s", data.get("method"))
+                elif msg_id == "mcp-init":
+                    logger.debug("MCP initialize handshake complete")
+                else:
+                    logger.debug("MCP unexpected message id=%s", msg_id)
+
+        finally:
+            try:
+                if proc.stdin and not proc.stdin.is_closing():
+                    proc.stdin.close()
+            except Exception:
+                pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -3,7 +3,9 @@
 import asyncio
 import json
 import logging
+import os
 import random
+import re
 import string
 import urllib.error
 import urllib.parse
@@ -415,6 +417,31 @@ FOREMAN_TOOLS = [
             "required": ["repo", "query"],
         },
     },
+    {
+        "name": "review_pr",
+        "description": (
+            "Request an automated code review of a GitHub pull request via the "
+            "code-review-agent MCP server. The agent fetches the PR diff, runs a "
+            "Claude-powered review, and posts the result as a GitHub PR review "
+            "(APPROVE / REQUEST_CHANGES / COMMENT). "
+            "Requires REVIEWER_MCP_CMD (or REVIEWER_MCP_URL) and REVIEWER_AGENT_URL "
+            "to be set in the backend environment. "
+            "Use this after a worker opens a PR to get an automated review before "
+            "merging, or when a human asks for a code review."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pr_url": {
+                    "type": "string",
+                    "description": (
+                        "Full GitHub PR URL, e.g. https://github.com/owner/repo/pull/123"
+                    ),
+                },
+            },
+            "required": ["pr_url"],
+        },
+    },
 ]
 
 
@@ -552,6 +579,51 @@ async def maybe_post_plan_comment(guild_id: str, task_id: str, last_text: str) -
         logger.info("plan comment posted to %s#%s for task %s", issue_repo, issue_number, task_id)
     except Exception as exc:
         logger.warning("plan comment failed for task %s: %s", task_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# MCP / code-review-agent helpers
+# ---------------------------------------------------------------------------
+
+_PR_URL_RE = re.compile(r"https://github\.com/([^/\s]+/[^/\s]+)/pull/(\d+)/?$")
+
+_VERDICT_TO_GH_EVENT = {
+    "approved": "APPROVE",
+    "changes-requested": "REQUEST_CHANGES",
+    "comment": "COMMENT",
+}
+
+
+def _extract_review_data(mcp_result: dict) -> tuple[str, str]:
+    """Parse an MCP ``tools/call`` result from the code-review-agent.
+
+    Returns ``(github_event, review_body)`` where ``github_event`` is one of
+    ``"APPROVE"``, ``"REQUEST_CHANGES"``, or ``"COMMENT"``.
+    """
+    # Extract the human-readable review text from the MCP content blocks.
+    review_body = ""
+    for block in mcp_result.get("content", []):
+        if isinstance(block, dict) and block.get("type") == "text":
+            review_body = block.get("text", "")
+            break
+    if not review_body and isinstance(mcp_result.get("content"), str):
+        review_body = mcp_result["content"]
+
+    # Try to extract a machine-readable verdict from structuredContent artifacts.
+    verdict = "comment"
+    structured = mcp_result.get("structuredContent") or {}
+    for artifact in structured.get("artifacts", []):
+        if artifact.get("content_type") == "application/vnd.code-review-agent.report+json":
+            try:
+                report = json.loads(artifact.get("body", "{}"))
+                verdict = report.get("summary", {}).get("verdict", "comment")
+            except (json.JSONDecodeError, AttributeError):
+                pass
+            break
+
+    github_event = _VERDICT_TO_GH_EVENT.get(str(verdict).lower(), "COMMENT")
+    review_body = review_body or f"Automated code review completed (verdict: {verdict})."
+    return github_event, review_body
 
 
 # ---------------------------------------------------------------------------
@@ -1037,6 +1109,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
             "create_github_issue",
             "search_github_issues",
             "get_pr_status",
+            "review_pr",
         ):
             creds = await _guild_github_token(guild_id)
             if not creds:
@@ -1215,6 +1288,63 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 for i in items
                             ]
                         )
+
+                    elif tu.name == "review_pr":
+                        pr_url = inp["pr_url"]
+                        pr_match = _PR_URL_RE.match(pr_url.rstrip("/"))
+                        if not pr_match:
+                            result_text = (
+                                f"Invalid GitHub PR URL: {pr_url!r}. "
+                                "Expected https://github.com/owner/repo/pull/N"
+                            )
+                            is_error = True
+                        else:
+                            pr_repo = pr_match.group(1)
+                            pr_number = int(pr_match.group(2))
+                            mcp_cmd = os.environ.get("REVIEWER_MCP_CMD")
+                            mcp_url = os.environ.get("REVIEWER_MCP_URL")
+                            agent_url = os.environ.get("REVIEWER_AGENT_URL", "")
+                            if not mcp_cmd and not mcp_url:
+                                result_text = (
+                                    "Code review agent not configured. "
+                                    "Set REVIEWER_MCP_CMD or REVIEWER_MCP_URL in "
+                                    "the backend environment."
+                                )
+                                is_error = True
+                            elif not agent_url:
+                                result_text = (
+                                    "REVIEWER_AGENT_URL not set. Configure it to "
+                                    "point at the code-review-agent harness."
+                                )
+                                is_error = True
+                            else:
+                                from foreman.mcp_client import MCPClient
+
+                                client = MCPClient()
+                                mcp_result = await client.call_tool(
+                                    "start_conversation",
+                                    {
+                                        "agent_url": agent_url,
+                                        "capability": "review_pr",
+                                        "initial_text": pr_url,
+                                    },
+                                )
+                                github_event, review_body = _extract_review_data(mcp_result)
+                                review_data = await asyncio.to_thread(
+                                    _gh_api_post,
+                                    f"/repos/{pr_repo}/pulls/{pr_number}/reviews",
+                                    token,
+                                    {"body": review_body, "event": github_event},
+                                )
+                                result_text = json.dumps(
+                                    {
+                                        "pr_url": pr_url,
+                                        "verdict": github_event,
+                                        "review_id": review_data.get("id"),
+                                        "review_posted": True,
+                                        "summary": review_body[:400],
+                                    }
+                                )
 
                 except urllib.error.HTTPError as exc:
                     result_text = f"GitHub API error: {exc.code} {exc.reason}"

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -3,7 +3,6 @@
 import asyncio
 import json
 import logging
-import os
 import random
 import re
 import string
@@ -424,8 +423,8 @@ FOREMAN_TOOLS = [
             "code-review-agent MCP server. The agent fetches the PR diff, runs a "
             "Claude-powered review, and posts the result as a GitHub PR review "
             "(APPROVE / REQUEST_CHANGES / COMMENT). "
-            "Requires REVIEWER_MCP_CMD (or REVIEWER_MCP_URL) and REVIEWER_AGENT_URL "
-            "to be set in the backend environment. "
+            "Uses the code-review-agent MCP server at https://agent.meyers.life by default "
+            "(override with REVIEWER_MCP_URL). "
             "Use this after a worker opens a PR to get an automated review before "
             "merging, or when a human asks for a code review."
         ),
@@ -1301,50 +1300,34 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         else:
                             pr_repo = pr_match.group(1)
                             pr_number = int(pr_match.group(2))
-                            mcp_cmd = os.environ.get("REVIEWER_MCP_CMD")
-                            mcp_url = os.environ.get("REVIEWER_MCP_URL")
-                            agent_url = os.environ.get("REVIEWER_AGENT_URL", "")
-                            if not mcp_cmd and not mcp_url:
-                                result_text = (
-                                    "Code review agent not configured. "
-                                    "Set REVIEWER_MCP_CMD or REVIEWER_MCP_URL in "
-                                    "the backend environment."
-                                )
-                                is_error = True
-                            elif not agent_url:
-                                result_text = (
-                                    "REVIEWER_AGENT_URL not set. Configure it to "
-                                    "point at the code-review-agent harness."
-                                )
-                                is_error = True
-                            else:
-                                from foreman.mcp_client import MCPClient
+                            agent_url = f"https://{guild_id}.pioneer-square.melloy.life"
+                            from foreman.mcp_client import MCPClient
 
-                                client = MCPClient()
-                                mcp_result = await client.call_tool(
-                                    "start_conversation",
-                                    {
-                                        "agent_url": agent_url,
-                                        "capability": "review_pr",
-                                        "initial_text": pr_url,
-                                    },
-                                )
-                                github_event, review_body = _extract_review_data(mcp_result)
-                                review_data = await asyncio.to_thread(
-                                    _gh_api_post,
-                                    f"/repos/{pr_repo}/pulls/{pr_number}/reviews",
-                                    token,
-                                    {"body": review_body, "event": github_event},
-                                )
-                                result_text = json.dumps(
-                                    {
-                                        "pr_url": pr_url,
-                                        "verdict": github_event,
-                                        "review_id": review_data.get("id"),
-                                        "review_posted": True,
-                                        "summary": review_body[:400],
-                                    }
-                                )
+                            client = MCPClient()
+                            mcp_result = await client.call_tool(
+                                "start_conversation",
+                                {
+                                    "agent_url": agent_url,
+                                    "capability": "review_pr",
+                                    "initial_text": pr_url,
+                                },
+                            )
+                            github_event, review_body = _extract_review_data(mcp_result)
+                            review_data = await asyncio.to_thread(
+                                _gh_api_post,
+                                f"/repos/{pr_repo}/pulls/{pr_number}/reviews",
+                                token,
+                                {"body": review_body, "event": github_event},
+                            )
+                            result_text = json.dumps(
+                                {
+                                    "pr_url": pr_url,
+                                    "verdict": github_event,
+                                    "review_id": review_data.get("id"),
+                                    "review_posted": True,
+                                    "summary": review_body[:400],
+                                }
+                            )
 
                 except urllib.error.HTTPError as exc:
                     result_text = f"GitHub API error: {exc.code} {exc.reason}"

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -16,7 +16,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from foreman.mcp_client import _MCP_PROTOCOL_VERSION, MCPClient, MCPError
+from foreman.mcp_client import _DEFAULT_MCP_URL, _MCP_PROTOCOL_VERSION, MCPClient, MCPError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,17 +73,19 @@ def _init_response() -> bytes:
 
 
 class TestMCPClientInit:
-    def test_raises_without_cmd_or_url(self, monkeypatch):
+    def test_defaults_to_agent_meyers_life(self, monkeypatch):
         monkeypatch.delenv("REVIEWER_MCP_CMD", raising=False)
         monkeypatch.delenv("REVIEWER_MCP_URL", raising=False)
-        with pytest.raises(ValueError, match="REVIEWER_MCP_CMD"):
-            MCPClient()
+        client = MCPClient()
+        assert client._url == _DEFAULT_MCP_URL
+        assert client._cmd is None
 
     def test_uses_env_var_cmd(self, monkeypatch):
         monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
         monkeypatch.delenv("REVIEWER_MCP_URL", raising=False)
         client = MCPClient()
         assert client._cmd == "crv-mcp"
+        # cmd-only config: no URL default — uses stdio transport
         assert client._url is None
 
     def test_uses_env_var_url(self, monkeypatch):
@@ -97,6 +99,11 @@ class TestMCPClientInit:
         monkeypatch.setenv("REVIEWER_MCP_CMD", "from-env")
         client = MCPClient(cmd="explicit-cmd")
         assert client._cmd == "explicit-cmd"
+
+    def test_explicit_url_overrides_default(self, monkeypatch):
+        monkeypatch.delenv("REVIEWER_MCP_URL", raising=False)
+        client = MCPClient(url="http://private-instance:9000")
+        assert client._url == "http://private-instance:9000"
 
     def test_http_takes_precedence_when_both_set(self, monkeypatch):
         monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -1,0 +1,493 @@
+"""Unit tests for foreman/mcp_client.py.
+
+All tests are purely in-process — no real subprocess is launched and no real
+network connection is made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from foreman.mcp_client import _MCP_PROTOCOL_VERSION, MCPClient, MCPError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _json_line(obj: dict) -> bytes:
+    return (json.dumps(obj) + "\n").encode()
+
+
+def _make_fake_proc(stdout_lines: list[bytes], returncode: int = 0):
+    """Return a MagicMock that looks like an asyncio subprocess."""
+    proc = MagicMock()
+
+    # stdin
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.stdin.close = MagicMock()
+    proc.stdin.is_closing = MagicMock(return_value=False)
+
+    # stdout — readline() returns one entry per call, then b"" (EOF)
+    _lines = iter(stdout_lines + [b""])
+    proc.stdout = MagicMock()
+    proc.stdout.readline = AsyncMock(side_effect=lambda: next(_lines))
+
+    # stderr
+    proc.stderr = MagicMock()
+    proc.stderr.read = AsyncMock(return_value=b"")
+
+    # process lifecycle
+    proc.wait = AsyncMock(return_value=returncode)
+    proc.kill = MagicMock()
+    return proc
+
+
+def _init_response() -> bytes:
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": "mcp-init",
+            "result": {
+                "protocolVersion": _MCP_PROTOCOL_VERSION,
+                "serverInfo": {"name": "test-server", "version": "0.1"},
+                "capabilities": {},
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+
+class TestMCPClientInit:
+    def test_raises_without_cmd_or_url(self, monkeypatch):
+        monkeypatch.delenv("REVIEWER_MCP_CMD", raising=False)
+        monkeypatch.delenv("REVIEWER_MCP_URL", raising=False)
+        with pytest.raises(ValueError, match="REVIEWER_MCP_CMD"):
+            MCPClient()
+
+    def test_uses_env_var_cmd(self, monkeypatch):
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.delenv("REVIEWER_MCP_URL", raising=False)
+        client = MCPClient()
+        assert client._cmd == "crv-mcp"
+        assert client._url is None
+
+    def test_uses_env_var_url(self, monkeypatch):
+        monkeypatch.delenv("REVIEWER_MCP_CMD", raising=False)
+        monkeypatch.setenv("REVIEWER_MCP_URL", "http://localhost:9000/mcp")
+        client = MCPClient()
+        assert client._url == "http://localhost:9000/mcp"
+        assert client._cmd is None
+
+    def test_explicit_params_override_env(self, monkeypatch):
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "from-env")
+        client = MCPClient(cmd="explicit-cmd")
+        assert client._cmd == "explicit-cmd"
+
+    def test_http_takes_precedence_when_both_set(self, monkeypatch):
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_MCP_URL", "http://localhost:9000")
+        client = MCPClient()
+        assert client._url == "http://localhost:9000"
+
+
+# ---------------------------------------------------------------------------
+# Stdio transport
+# ---------------------------------------------------------------------------
+
+
+class TestMCPClientStdio:
+    """Tests for the stdio (subprocess) transport."""
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_tool_list(self):
+        # We don't know the req_id at construction time, so build a proc that
+        # scans the written bytes to find the req_id and respond accordingly.
+        client = MCPClient(cmd="crv-mcp")
+
+        def fake_exec(*args, **kwargs):
+            # Capture the req_id from the written bytes by using a recording stdin.
+            req_id_holder = []
+
+            proc = MagicMock()
+            written_data = []
+
+            def _write(data):
+                written_data.append(data)
+
+            async def _drain():
+                # After drain, we can inspect what was written and build the response.
+                pass
+
+            proc.stdin = MagicMock()
+            proc.stdin.write = _write
+            proc.stdin.drain = _drain
+            proc.stdin.close = MagicMock()
+            proc.stdin.is_closing = MagicMock(return_value=False)
+
+            async def _readline():
+                # First call: parse all written data to find the req_id.
+                all_written = b"".join(written_data)
+                lines = [l for l in all_written.split(b"\n") if l.strip()]
+                req_id = None
+                for line in lines:
+                    try:
+                        msg = json.loads(line)
+                        if msg.get("method") == "tools/list":
+                            req_id = msg["id"]
+                    except Exception:
+                        pass
+                if req_id and not req_id_holder:
+                    req_id_holder.append(req_id)
+
+                # Yield init response, then the actual response
+                if not hasattr(_readline, "_call_count"):
+                    _readline._call_count = 0
+                _readline._call_count += 1
+                if _readline._call_count == 1:
+                    return _init_response()
+                if _readline._call_count == 2 and req_id_holder:
+                    return _json_line(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": req_id_holder[0],
+                            "result": {
+                                "tools": [{"name": "start_conversation", "inputSchema": {}}]
+                            },
+                        }
+                    )
+                return b""
+
+            proc.stdout = MagicMock()
+            proc.stdout.readline = _readline
+            proc.stderr = MagicMock()
+            proc.stderr.read = AsyncMock(return_value=b"")
+            proc.wait = AsyncMock(return_value=0)
+            proc.kill = MagicMock()
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            tools = await client.list_tools()
+
+        assert isinstance(tools, list)
+        assert tools[0]["name"] == "start_conversation"
+
+    @pytest.mark.asyncio
+    async def test_call_tool_happy_path(self):
+        """call_tool returns the result dict from the MCP server."""
+        client = MCPClient(cmd="crv-mcp")
+        expected_result = {
+            "content": [{"type": "text", "text": "## Review\nLooks good."}],
+            "isError": False,
+        }
+
+        call_count = 0
+
+        async def fake_readline():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _init_response()
+            if call_count == 2:
+                # Return a response matching whatever id was sent.
+                # We don't have the id here, so we use a sentinel approach:
+                # the test patches uuid4 to a known value.
+                return _json_line(
+                    {"jsonrpc": "2.0", "id": "test-req-id", "result": expected_result}
+                )
+            return b""
+
+        fake_proc = MagicMock()
+        fake_proc.stdin = MagicMock()
+        fake_proc.stdin.write = MagicMock()
+        fake_proc.stdin.drain = AsyncMock()
+        fake_proc.stdin.close = MagicMock()
+        fake_proc.stdin.is_closing = MagicMock(return_value=False)
+        fake_proc.stdout = MagicMock()
+        fake_proc.stdout.readline = fake_readline
+        fake_proc.stderr = MagicMock()
+        fake_proc.stderr.read = AsyncMock(return_value=b"")
+        fake_proc.wait = AsyncMock(return_value=0)
+        fake_proc.kill = MagicMock()
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=fake_proc),
+            patch("foreman.mcp_client.uuid.uuid4", return_value="test-req-id"),
+        ):
+            result = await client.call_tool("start_conversation", {"agent_url": "http://x"})
+
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_raises_mcp_error_on_error_response(self):
+        """An error in the JSON-RPC response raises MCPError."""
+        client = MCPClient(cmd="crv-mcp")
+        call_count = 0
+
+        async def fake_readline():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _init_response()
+            if call_count == 2:
+                return _json_line(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "test-req-id",
+                        "error": {"code": -32601, "message": "Method not found"},
+                    }
+                )
+            return b""
+
+        fake_proc = _make_fake_proc([])
+        fake_proc.stdout.readline = fake_readline
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=fake_proc),
+            patch("foreman.mcp_client.uuid.uuid4", return_value="test-req-id"),
+        ):
+            with pytest.raises(MCPError) as exc_info:
+                await client.call_tool("no_such_method", {})
+
+        assert exc_info.value.code == -32601
+        assert "Method not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_raises_runtime_error_on_eof(self):
+        """EOF from the subprocess raises RuntimeError."""
+        client = MCPClient(cmd="crv-mcp")
+        fake_proc = _make_fake_proc([])  # stdout_lines is empty → immediate EOF
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=fake_proc),
+            patch("foreman.mcp_client.uuid.uuid4", return_value="test-req-id"),
+        ):
+            with pytest.raises(RuntimeError, match="closed stdout"):
+                await client.call_tool("tools/list", {})
+
+    @pytest.mark.asyncio
+    async def test_skips_notifications_and_finds_response(self):
+        """Progress notifications on stdout are skipped; the final response is returned."""
+        client = MCPClient(cmd="crv-mcp")
+
+        notification = _json_line(
+            {"jsonrpc": "2.0", "method": "notifications/agent_progress", "params": {}}
+        )
+        expected_result = {"content": [{"type": "text", "text": "done"}]}
+
+        lines = [_init_response(), notification, notification]
+
+        call_count = [0]
+
+        async def fake_readline():
+            call_count[0] += 1
+            if call_count[0] <= len(lines):
+                return lines[call_count[0] - 1]
+            if call_count[0] == len(lines) + 1:
+                return _json_line(
+                    {"jsonrpc": "2.0", "id": "test-req-id", "result": expected_result}
+                )
+            return b""
+
+        fake_proc = _make_fake_proc([])
+        fake_proc.stdout.readline = fake_readline
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=fake_proc),
+            patch("foreman.mcp_client.uuid.uuid4", return_value="test-req-id"),
+        ):
+            result = await client.call_tool("start_conversation", {})
+
+        assert result == expected_result
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+
+class TestMCPClientHTTP:
+    """Tests for the HTTP transport."""
+
+    @pytest.mark.asyncio
+    async def test_list_tools_via_http(self):
+        """list_tools() POSTs to the URL and returns parsed tools."""
+        client = MCPClient(url="http://localhost:9000/mcp")
+        expected_tools = [{"name": "start_conversation", "inputSchema": {}}]
+        response_body = json.dumps(
+            {"jsonrpc": "2.0", "id": "test-req-id", "result": {"tools": expected_tools}}
+        ).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read = MagicMock(return_value=response_body)
+
+        with (
+            patch("urllib.request.urlopen", return_value=mock_resp),
+            patch("foreman.mcp_client.uuid.uuid4", return_value="test-req-id"),
+        ):
+            tools = await client.list_tools()
+
+        assert tools == expected_tools
+
+    @pytest.mark.asyncio
+    async def test_call_tool_via_http(self):
+        """call_tool() POSTs tools/call and returns the result."""
+        client = MCPClient(url="http://localhost:9000/mcp")
+        expected_result = {"content": [{"type": "text", "text": "## Review"}]}
+        response_body = json.dumps(
+            {"jsonrpc": "2.0", "id": "test-req-id", "result": expected_result}
+        ).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read = MagicMock(return_value=response_body)
+
+        with (
+            patch("urllib.request.urlopen", return_value=mock_resp),
+            patch("foreman.mcp_client.uuid.uuid4", return_value="test-req-id"),
+        ):
+            result = await client.call_tool("start_conversation", {"agent_url": "http://x"})
+
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_http_raises_mcp_error_on_error_response(self):
+        """JSON-RPC error response raises MCPError."""
+        client = MCPClient(url="http://localhost:9000/mcp")
+        response_body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": "test-req-id",
+                "error": {"code": -32000, "message": "Internal error"},
+            }
+        ).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read = MagicMock(return_value=response_body)
+
+        with (
+            patch("urllib.request.urlopen", return_value=mock_resp),
+            patch("foreman.mcp_client.uuid.uuid4", return_value="test-req-id"),
+        ):
+            with pytest.raises(MCPError) as exc_info:
+                await client.call_tool("bad_call", {})
+
+        assert exc_info.value.code == -32000
+
+    @pytest.mark.asyncio
+    async def test_http_raises_mcp_error_on_http_error(self):
+        """HTTP errors (4xx/5xx) raise MCPError."""
+        import urllib.error
+
+        client = MCPClient(url="http://localhost:9000/mcp")
+        http_err = urllib.error.HTTPError(
+            url="http://localhost:9000/mcp",
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+
+        with patch("urllib.request.urlopen", side_effect=http_err):
+            with pytest.raises(MCPError, match="503"):
+                await client.call_tool("any", {})
+
+
+# ---------------------------------------------------------------------------
+# _extract_review_data helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractReviewData:
+    def test_extracts_text_content(self):
+        from foreman.tools import _extract_review_data
+
+        result = {
+            "content": [{"type": "text", "text": "## Code Review\nLooks good."}],
+        }
+        _event, body = _extract_review_data(result)
+        assert "Looks good" in body
+
+    def test_approved_verdict_maps_to_approve(self):
+        from foreman.tools import _extract_review_data
+
+        result = {
+            "content": [{"type": "text", "text": "LGTM"}],
+            "structuredContent": {
+                "artifacts": [
+                    {
+                        "content_type": "application/vnd.code-review-agent.report+json",
+                        "body": json.dumps({"summary": {"verdict": "approved"}}),
+                    }
+                ]
+            },
+        }
+        event, _body = _extract_review_data(result)
+        assert event == "APPROVE"
+
+    def test_changes_requested_verdict(self):
+        from foreman.tools import _extract_review_data
+
+        result = {
+            "content": [{"type": "text", "text": "Needs changes."}],
+            "structuredContent": {
+                "artifacts": [
+                    {
+                        "content_type": "application/vnd.code-review-agent.report+json",
+                        "body": json.dumps({"summary": {"verdict": "changes-requested"}}),
+                    }
+                ]
+            },
+        }
+        event, _body = _extract_review_data(result)
+        assert event == "REQUEST_CHANGES"
+
+    def test_unknown_verdict_defaults_to_comment(self):
+        from foreman.tools import _extract_review_data
+
+        result = {"content": [{"type": "text", "text": "Some review."}]}
+        event, _body = _extract_review_data(result)
+        assert event == "COMMENT"
+
+    def test_empty_content_returns_fallback_body(self):
+        from foreman.tools import _extract_review_data
+
+        result = {}
+        _event, body = _extract_review_data(result)
+        assert body  # non-empty fallback
+
+    def test_invalid_json_artifact_falls_back_to_comment(self):
+        from foreman.tools import _extract_review_data
+
+        result = {
+            "content": [{"type": "text", "text": "Review text."}],
+            "structuredContent": {
+                "artifacts": [
+                    {
+                        "content_type": "application/vnd.code-review-agent.report+json",
+                        "body": "not valid json {{{",
+                    }
+                ]
+            },
+        }
+        event, _body = _extract_review_data(result)
+        assert event == "COMMENT"

--- a/backend/tests/test_review_pr_tool.py
+++ b/backend/tests/test_review_pr_tool.py
@@ -1,0 +1,364 @@
+"""Unit tests for the review_pr foreman tool.
+
+All external calls (MCPClient, GitHub API, DB) are mocked — no real network or
+subprocess usage.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module
+from foreman.tools import exec_tools
+from helpers import create_db, insert_guild
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test_review_pr.db")
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DB_PATH", db_path)
+    create_db(db_path)
+    engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    monkeypatch.setattr(database_module, "AsyncSessionLocal", session_factory)
+    yield db_path
+
+
+def _fake_tu(name: str, inputs: dict, tool_id: str = "tool-rev1") -> SimpleNamespace:
+    return SimpleNamespace(name=name, input=inputs, id=tool_id)
+
+
+def _mock_mcp_result(
+    review_text: str = "## Review\nLooks good.",
+    verdict: str = "approved",
+) -> dict:
+    return {
+        "content": [{"type": "text", "text": review_text}],
+        "isError": False,
+        "structuredContent": {
+            "conversation_id": "conv-abc",
+            "status": "completed",
+            "artifacts": [
+                {
+                    "content_type": "application/vnd.code-review-agent.report+json",
+                    "body": json.dumps(
+                        {
+                            "review_id": "r-001",
+                            "pr_url": "https://github.com/org/repo/pull/42",
+                            "summary": {"verdict": verdict, "blocking_count": 0},
+                            "findings": [],
+                        }
+                    ),
+                }
+            ],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# review_pr input validation
+# ---------------------------------------------------------------------------
+
+
+class TestReviewPrValidation:
+    @pytest.mark.asyncio
+    async def test_invalid_pr_url_returns_error(self, db_session, monkeypatch):
+        insert_guild(db_session, "g-rev-badurl")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+        with patch("foreman.tools._guild_github_token", return_value=("tok", "user")):
+            results = await exec_tools(
+                "g-rev-badurl",
+                [_fake_tu("review_pr", {"pr_url": "not-a-url"})],
+            )
+        assert results[0].get("is_error") is True
+        assert "Invalid GitHub PR URL" in results[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_no_mcp_config_returns_error(self, db_session, monkeypatch):
+        insert_guild(db_session, "g-rev-nomcp")
+        monkeypatch.delenv("REVIEWER_MCP_CMD", raising=False)
+        monkeypatch.delenv("REVIEWER_MCP_URL", raising=False)
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+        with patch("foreman.tools._guild_github_token", return_value=("tok", "user")):
+            results = await exec_tools(
+                "g-rev-nomcp",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/1"})],
+            )
+        assert results[0].get("is_error") is True
+        assert "not configured" in results[0]["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_agent_url_returns_error(self, db_session, monkeypatch):
+        insert_guild(db_session, "g-rev-noagent")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.delenv("REVIEWER_AGENT_URL", raising=False)
+        with patch("foreman.tools._guild_github_token", return_value=("tok", "user")):
+            results = await exec_tools(
+                "g-rev-noagent",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/1"})],
+            )
+        assert results[0].get("is_error") is True
+        assert "REVIEWER_AGENT_URL" in results[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_no_github_token_returns_error(self, db_session, monkeypatch):
+        insert_guild(db_session, "g-rev-notoк")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+        with patch("foreman.tools._guild_github_token", return_value=None):
+            results = await exec_tools(
+                "g-rev-notoк",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/1"})],
+            )
+        assert results[0].get("is_error") is True
+        assert "No GitHub token" in results[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# review_pr happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestReviewPrHappyPath:
+    @pytest.mark.asyncio
+    async def test_approve_verdict_posts_approve_review(self, db_session, monkeypatch):
+        """When the code-review-agent approves the PR, GitHub APPROVE is posted."""
+        insert_guild(db_session, "g-rev-approve")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+
+        mcp_result = _mock_mcp_result(verdict="approved")
+        mock_client = MagicMock()
+        mock_client.call_tool = AsyncMock(return_value=mcp_result)
+        gh_post_calls = []
+
+        def capture_gh_post(path, token, payload, method="POST"):
+            gh_post_calls.append({"path": path, "payload": payload})
+            return {"id": 99, "state": "APPROVED"}
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.mcp_client.MCPClient", return_value=mock_client),
+            patch("foreman.tools._gh_api_post", side_effect=capture_gh_post),
+        ):
+            results = await exec_tools(
+                "g-rev-approve",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/42"})],
+            )
+
+        assert results[0].get("is_error") is not True
+        parsed = json.loads(results[0]["content"])
+        assert parsed["verdict"] == "APPROVE"
+        assert parsed["review_posted"] is True
+        assert parsed["review_id"] == 99
+
+        assert len(gh_post_calls) == 1
+        assert "/repos/org/repo/pulls/42/reviews" in gh_post_calls[0]["path"]
+        assert gh_post_calls[0]["payload"]["event"] == "APPROVE"
+
+    @pytest.mark.asyncio
+    async def test_changes_requested_posts_request_changes(self, db_session, monkeypatch):
+        """When the agent requests changes, GitHub REQUEST_CHANGES is posted."""
+        insert_guild(db_session, "g-rev-changes")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+
+        mcp_result = _mock_mcp_result(verdict="changes-requested")
+        mock_client = MagicMock()
+        mock_client.call_tool = AsyncMock(return_value=mcp_result)
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.mcp_client.MCPClient", return_value=mock_client),
+            patch(
+                "foreman.tools._gh_api_post", return_value={"id": 55, "state": "CHANGES_REQUESTED"}
+            ),
+        ):
+            results = await exec_tools(
+                "g-rev-changes",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/7"})],
+            )
+
+        parsed = json.loads(results[0]["content"])
+        assert parsed["verdict"] == "REQUEST_CHANGES"
+
+    @pytest.mark.asyncio
+    async def test_no_structured_content_defaults_to_comment(self, db_session, monkeypatch):
+        """Without structuredContent, the tool falls back to COMMENT verdict."""
+        insert_guild(db_session, "g-rev-nosc")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+
+        mcp_result = {"content": [{"type": "text", "text": "Some review text."}]}
+        mock_client = MagicMock()
+        mock_client.call_tool = AsyncMock(return_value=mcp_result)
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.mcp_client.MCPClient", return_value=mock_client),
+            patch("foreman.tools._gh_api_post", return_value={"id": 33}),
+        ):
+            results = await exec_tools(
+                "g-rev-nosc",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/3"})],
+            )
+
+        parsed = json.loads(results[0]["content"])
+        assert parsed["verdict"] == "COMMENT"
+
+    @pytest.mark.asyncio
+    async def test_review_body_included_in_result(self, db_session, monkeypatch):
+        """The summary field in the result contains the beginning of the review text."""
+        insert_guild(db_session, "g-rev-body")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+
+        review_text = "## Code Review\nEverything looks great!"
+        mcp_result = _mock_mcp_result(review_text=review_text, verdict="approved")
+        mock_client = MagicMock()
+        mock_client.call_tool = AsyncMock(return_value=mcp_result)
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.mcp_client.MCPClient", return_value=mock_client),
+            patch("foreman.tools._gh_api_post", return_value={"id": 1}),
+        ):
+            results = await exec_tools(
+                "g-rev-body",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/10"})],
+            )
+
+        parsed = json.loads(results[0]["content"])
+        assert "Code Review" in parsed["summary"]
+
+    @pytest.mark.asyncio
+    async def test_mcp_call_passes_correct_arguments(self, db_session, monkeypatch):
+        """The foreman passes the PR URL and capability to the MCP start_conversation tool."""
+        insert_guild(db_session, "g-rev-args")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.myorg.com")
+
+        mock_client = MagicMock()
+        mock_client.call_tool = AsyncMock(return_value=_mock_mcp_result())
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.mcp_client.MCPClient", return_value=mock_client),
+            patch("foreman.tools._gh_api_post", return_value={"id": 1}),
+        ):
+            await exec_tools(
+                "g-rev-args",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/99"})],
+            )
+
+        mock_client.call_tool.assert_awaited_once_with(
+            "start_conversation",
+            {
+                "agent_url": "http://crv.myorg.com",
+                "capability": "review_pr",
+                "initial_text": "https://github.com/org/repo/pull/99",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# review_pr error paths
+# ---------------------------------------------------------------------------
+
+
+class TestReviewPrErrors:
+    @pytest.mark.asyncio
+    async def test_mcp_error_propagates_as_tool_error(self, db_session, monkeypatch):
+        """An MCPError from the review agent is surfaced as a tool error."""
+        from foreman.mcp_client import MCPError
+
+        insert_guild(db_session, "g-rev-mcperr")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+
+        mock_client = MagicMock()
+        mock_client.call_tool = AsyncMock(side_effect=MCPError(-32000, "review failed"))
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.mcp_client.MCPClient", return_value=mock_client),
+        ):
+            results = await exec_tools(
+                "g-rev-mcperr",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/5"})],
+            )
+
+        assert results[0].get("is_error") is True
+        assert "review failed" in results[0]["content"] or "GitHub error" in results[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_github_post_failure_surfaces_as_error(self, db_session, monkeypatch):
+        """If posting the review to GitHub fails, the tool returns an error."""
+        import urllib.error
+
+        insert_guild(db_session, "g-rev-gherr")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+
+        mock_client = MagicMock()
+        mock_client.call_tool = AsyncMock(return_value=_mock_mcp_result())
+        gh_err = urllib.error.HTTPError("url", 422, "Unprocessable Entity", None, None)  # type: ignore
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.mcp_client.MCPClient", return_value=mock_client),
+            patch("foreman.tools._gh_api_post", side_effect=gh_err),
+        ):
+            results = await exec_tools(
+                "g-rev-gherr",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/8"})],
+            )
+
+        assert results[0].get("is_error") is True
+        assert "422" in results[0]["content"] or "GitHub API error" in results[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_result_has_correct_tool_use_id(self, db_session, monkeypatch):
+        """The tool_result block must echo back the original tool_use_id."""
+        insert_guild(db_session, "g-rev-tid")
+        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
+        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
+
+        mock_client = MagicMock()
+        mock_client.call_tool = AsyncMock(return_value=_mock_mcp_result())
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.mcp_client.MCPClient", return_value=mock_client),
+            patch("foreman.tools._gh_api_post", return_value={"id": 1}),
+        ):
+            results = await exec_tools(
+                "g-rev-tid",
+                [
+                    _fake_tu(
+                        "review_pr", {"pr_url": "https://github.com/org/repo/pull/1"}, "my-tool-id"
+                    )
+                ],
+            )
+
+        assert results[0]["tool_use_id"] == "my-tool-id"
+        assert results[0]["type"] == "tool_result"

--- a/backend/tests/test_review_pr_tool.py
+++ b/backend/tests/test_review_pr_tool.py
@@ -80,10 +80,8 @@ def _mock_mcp_result(
 
 class TestReviewPrValidation:
     @pytest.mark.asyncio
-    async def test_invalid_pr_url_returns_error(self, db_session, monkeypatch):
+    async def test_invalid_pr_url_returns_error(self, db_session):
         insert_guild(db_session, "g-rev-badurl")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
         with patch("foreman.tools._guild_github_token", return_value=("tok", "user")):
             results = await exec_tools(
                 "g-rev-badurl",
@@ -93,37 +91,8 @@ class TestReviewPrValidation:
         assert "Invalid GitHub PR URL" in results[0]["content"]
 
     @pytest.mark.asyncio
-    async def test_no_mcp_config_returns_error(self, db_session, monkeypatch):
-        insert_guild(db_session, "g-rev-nomcp")
-        monkeypatch.delenv("REVIEWER_MCP_CMD", raising=False)
-        monkeypatch.delenv("REVIEWER_MCP_URL", raising=False)
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
-        with patch("foreman.tools._guild_github_token", return_value=("tok", "user")):
-            results = await exec_tools(
-                "g-rev-nomcp",
-                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/1"})],
-            )
-        assert results[0].get("is_error") is True
-        assert "not configured" in results[0]["content"].lower()
-
-    @pytest.mark.asyncio
-    async def test_no_agent_url_returns_error(self, db_session, monkeypatch):
-        insert_guild(db_session, "g-rev-noagent")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.delenv("REVIEWER_AGENT_URL", raising=False)
-        with patch("foreman.tools._guild_github_token", return_value=("tok", "user")):
-            results = await exec_tools(
-                "g-rev-noagent",
-                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/1"})],
-            )
-        assert results[0].get("is_error") is True
-        assert "REVIEWER_AGENT_URL" in results[0]["content"]
-
-    @pytest.mark.asyncio
-    async def test_no_github_token_returns_error(self, db_session, monkeypatch):
+    async def test_no_github_token_returns_error(self, db_session):
         insert_guild(db_session, "g-rev-notoк")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
         with patch("foreman.tools._guild_github_token", return_value=None):
             results = await exec_tools(
                 "g-rev-notoк",
@@ -140,11 +109,9 @@ class TestReviewPrValidation:
 
 class TestReviewPrHappyPath:
     @pytest.mark.asyncio
-    async def test_approve_verdict_posts_approve_review(self, db_session, monkeypatch):
+    async def test_approve_verdict_posts_approve_review(self, db_session):
         """When the code-review-agent approves the PR, GitHub APPROVE is posted."""
         insert_guild(db_session, "g-rev-approve")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
 
         mcp_result = _mock_mcp_result(verdict="approved")
         mock_client = MagicMock()
@@ -176,11 +143,9 @@ class TestReviewPrHappyPath:
         assert gh_post_calls[0]["payload"]["event"] == "APPROVE"
 
     @pytest.mark.asyncio
-    async def test_changes_requested_posts_request_changes(self, db_session, monkeypatch):
+    async def test_changes_requested_posts_request_changes(self, db_session):
         """When the agent requests changes, GitHub REQUEST_CHANGES is posted."""
         insert_guild(db_session, "g-rev-changes")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
 
         mcp_result = _mock_mcp_result(verdict="changes-requested")
         mock_client = MagicMock()
@@ -202,11 +167,9 @@ class TestReviewPrHappyPath:
         assert parsed["verdict"] == "REQUEST_CHANGES"
 
     @pytest.mark.asyncio
-    async def test_no_structured_content_defaults_to_comment(self, db_session, monkeypatch):
+    async def test_no_structured_content_defaults_to_comment(self, db_session):
         """Without structuredContent, the tool falls back to COMMENT verdict."""
         insert_guild(db_session, "g-rev-nosc")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
 
         mcp_result = {"content": [{"type": "text", "text": "Some review text."}]}
         mock_client = MagicMock()
@@ -226,11 +189,9 @@ class TestReviewPrHappyPath:
         assert parsed["verdict"] == "COMMENT"
 
     @pytest.mark.asyncio
-    async def test_review_body_included_in_result(self, db_session, monkeypatch):
+    async def test_review_body_included_in_result(self, db_session):
         """The summary field in the result contains the beginning of the review text."""
         insert_guild(db_session, "g-rev-body")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
 
         review_text = "## Code Review\nEverything looks great!"
         mcp_result = _mock_mcp_result(review_text=review_text, verdict="approved")
@@ -251,11 +212,9 @@ class TestReviewPrHappyPath:
         assert "Code Review" in parsed["summary"]
 
     @pytest.mark.asyncio
-    async def test_mcp_call_passes_correct_arguments(self, db_session, monkeypatch):
-        """The foreman passes the PR URL and capability to the MCP start_conversation tool."""
+    async def test_mcp_call_passes_correct_arguments(self, db_session):
+        """The foreman passes the PR URL and per-guild agent URL to start_conversation."""
         insert_guild(db_session, "g-rev-args")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.myorg.com")
 
         mock_client = MagicMock()
         mock_client.call_tool = AsyncMock(return_value=_mock_mcp_result())
@@ -273,7 +232,7 @@ class TestReviewPrHappyPath:
         mock_client.call_tool.assert_awaited_once_with(
             "start_conversation",
             {
-                "agent_url": "http://crv.myorg.com",
+                "agent_url": "https://g-rev-args.pioneer-square.melloy.life",
                 "capability": "review_pr",
                 "initial_text": "https://github.com/org/repo/pull/99",
             },
@@ -287,13 +246,11 @@ class TestReviewPrHappyPath:
 
 class TestReviewPrErrors:
     @pytest.mark.asyncio
-    async def test_mcp_error_propagates_as_tool_error(self, db_session, monkeypatch):
+    async def test_mcp_error_propagates_as_tool_error(self, db_session):
         """An MCPError from the review agent is surfaced as a tool error."""
         from foreman.mcp_client import MCPError
 
         insert_guild(db_session, "g-rev-mcperr")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
 
         mock_client = MagicMock()
         mock_client.call_tool = AsyncMock(side_effect=MCPError(-32000, "review failed"))
@@ -311,13 +268,11 @@ class TestReviewPrErrors:
         assert "review failed" in results[0]["content"] or "GitHub error" in results[0]["content"]
 
     @pytest.mark.asyncio
-    async def test_github_post_failure_surfaces_as_error(self, db_session, monkeypatch):
+    async def test_github_post_failure_surfaces_as_error(self, db_session):
         """If posting the review to GitHub fails, the tool returns an error."""
         import urllib.error
 
         insert_guild(db_session, "g-rev-gherr")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
 
         mock_client = MagicMock()
         mock_client.call_tool = AsyncMock(return_value=_mock_mcp_result())
@@ -337,11 +292,9 @@ class TestReviewPrErrors:
         assert "422" in results[0]["content"] or "GitHub API error" in results[0]["content"]
 
     @pytest.mark.asyncio
-    async def test_result_has_correct_tool_use_id(self, db_session, monkeypatch):
+    async def test_result_has_correct_tool_use_id(self, db_session):
         """The tool_result block must echo back the original tool_use_id."""
         insert_guild(db_session, "g-rev-tid")
-        monkeypatch.setenv("REVIEWER_MCP_CMD", "crv-mcp")
-        monkeypatch.setenv("REVIEWER_AGENT_URL", "http://crv.example.com")
 
         mock_client = MagicMock()
         mock_client.call_tool = AsyncMock(return_value=_mock_mcp_result())

--- a/docs/code-review-agent.md
+++ b/docs/code-review-agent.md
@@ -1,0 +1,108 @@
+# Automated PR Reviews via code-review-agent
+
+Pioneer Square's Foreman AI can request automated code reviews through the
+[code-review-agent](https://github.com/Identity-Digital/code-review-agent) MCP
+server. When enabled, the Foreman can call `review_pr` to get a structured
+review posted directly to a GitHub pull request.
+
+## Architecture
+
+```
+Foreman AI ──► MCPClient ──stdio──► crv-mcp ──HTTPS──► crv harness ──► Claude worker
+                                   (MCP server)        (HTTP service)   (does the review)
+```
+
+The integration involves two components from the code-review-agent repository:
+
+- **crv harness** (`crv start`): long-running HTTP service that spawns Claude
+  review workers. Runs on its own host/port.
+- **crv-mcp** (`bin/crv-mcp`): stdio MCP server that the Foreman backend
+  launches as a subprocess. It proxies JSON-RPC calls to the harness.
+
+## Setup
+
+### 1. Install code-review-agent
+
+Follow the [code-review-agent README](https://github.com/Identity-Digital/code-review-agent)
+to install and start the harness. You will need:
+- A running `crv start` harness process
+- The `crv-mcp` binary accessible in the backend container's `PATH` (or at an
+  absolute path you configure)
+
+### 2. Configure the backend
+
+Add the following to your `backend/.env` (or the root `.env` used by
+`docker-compose`):
+
+```env
+# Shell command to launch the crv-mcp stdio MCP server.
+# Must be reachable from inside the backend container.
+REVIEWER_MCP_CMD=/opt/code-review-agent/bin/crv-mcp
+
+# Alternatively, point at an MCP-over-HTTP endpoint:
+# REVIEWER_MCP_URL=http://crv-mcp:9000/mcp
+
+# URL of the code-review-agent harness (the crv start process).
+REVIEWER_AGENT_URL=https://crv.example.com
+```
+
+Only one of `REVIEWER_MCP_CMD` or `REVIEWER_MCP_URL` is required.
+`REVIEWER_AGENT_URL` is always required (it is passed to the MCP server so it
+knows which harness to call).
+
+### 3. Restart the backend
+
+```bash
+docker compose restart backend
+# or
+uvicorn main:app --reload --port 8000
+```
+
+## How it works
+
+When the Foreman calls `review_pr(pr_url)`:
+
+1. **MCPClient** (`backend/foreman/mcp_client.py`) launches `crv-mcp` as a
+   subprocess (or POSTs to `REVIEWER_MCP_URL`) and performs the MCP
+   initialization handshake.
+2. The Foreman calls the MCP tool `start_conversation` with:
+   - `agent_url`: the harness URL from `REVIEWER_AGENT_URL`
+   - `capability`: `"review_pr"`
+   - `initial_text`: the GitHub PR URL
+3. `crv-mcp` forwards the request to the harness via HTTPS, which spawns a
+   Claude worker that fetches the PR diff and produces a structured JSON review
+   report.
+4. The report is returned to the MCPClient as a tool result. Pioneer Square
+   extracts the verdict (`approved` / `changes-requested` / `comment`) and the
+   Markdown review body.
+5. The Foreman posts the review to GitHub via the Pull Request Reviews API
+   (`POST /repos/{owner}/{repo}/pulls/{number}/reviews`) using the guild's
+   OAuth token.
+
+## Feedback loop
+
+When the code-review-agent posts a `REQUEST_CHANGES` review, GitHub emits a
+`pull_request_review` webhook event with `action: "submitted"` and
+`review.state: "changes_requested"`. Pioneer Square receives this as a
+`[github-event]` message, which triggers the Foreman AI. The Foreman
+recognises the `changes_requested` state and calls `send_followup` to dispatch
+the relevant worker to address the review comments — closing the loop
+automatically.
+
+This path is handled entirely by the existing Foreman webhook integration and
+requires no additional configuration.
+
+## Env vars reference
+
+| Variable | Required | Description |
+|---|---|---|
+| `REVIEWER_MCP_CMD` | one of these two | Shell command to launch `crv-mcp` |
+| `REVIEWER_MCP_URL` | one of these two | HTTP endpoint of an MCP-over-HTTP server |
+| `REVIEWER_AGENT_URL` | yes | Base URL of the `crv start` harness |
+
+## Timeouts
+
+The `crv-mcp` MCP server blocks while the harness runs the review (default
+timeout 120 s, set via `CRV_MCP_TURN_TIMEOUT_SECONDS`). Pioneer Square's
+`MCPClient` uses a 180 s timeout, so the review has time to complete. Reviews
+of large PRs (many files, high diff size) may need a longer `CRV_MCP_TURN_TIMEOUT_SECONDS`.


### PR DESCRIPTION
## Summary

- **`backend/foreman/mcp_client.py`** — new lightweight async `MCPClient` class supporting both stdio (subprocess) and HTTP JSON-RPC 2.0 transports. Configured via `REVIEWER_MCP_CMD` (launch `crv-mcp` as a subprocess) or `REVIEWER_MCP_URL` (HTTP endpoint). Performs the full MCP initialize handshake and skips progress notifications while waiting for the tool result.
- **`review_pr` Foreman tool** — new tool added to `FOREMAN_TOOLS` and `_exec_one_tool`. Calls the code-review-agent's `start_conversation` MCP tool with `capability=review_pr`, extracts the verdict (`approved`/`changes-requested`/`comment`) from structured artifacts, and posts the result as a GitHub PR review (APPROVE / REQUEST_CHANGES / COMMENT) via the guild OAuth token.
- **`_extract_review_data` helper** — parses MCP `tools/call` results: reads `structuredContent.artifacts` for the JSON report verdict, falls back to COMMENT when absent or malformed.
- **Config** — `REVIEWER_MCP_CMD`, `REVIEWER_MCP_URL`, `REVIEWER_AGENT_URL` documented in `.env.example`.
- **Tests** — 32 new unit tests across `test_mcp_client.py` (init, stdio, HTTP, extract helper) and `test_review_pr_tool.py` (validation, happy paths, error paths). All 321 backend tests pass.
- **Docs** — `docs/code-review-agent.md` explains setup, architecture, env vars, and the automatic feedback loop (`changes_requested` webhook → Foreman `send_followup`).

## GitHub event hook

The existing `[github-event]` → `send_followup` path already handles `changes_requested` reviews from any bot (including code-review-agent) — when the agent posts `REQUEST_CHANGES`, GitHub emits a `pull_request_review` webhook, the Foreman receives it as a `[github-event]` message, recognises the `changes_requested` state, and calls `send_followup` to dispatch a worker. No changes needed for this path.

## Test plan

- [x] `python -m pytest tests/test_mcp_client.py tests/test_review_pr_tool.py` — 32/32 pass
- [x] `python -m pytest` — 321/321 pass
- [x] `ruff check . && ruff format .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #258