### PR TITLE
Don't insert agent row on create_worker (#264)

### DIFF
--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -1,9 +1,8 @@
 """Worker registration, container spawn, task assignment, and worker messaging.
 
 Note: a ``Worker`` row is the persistent identity for one running worker
-process; an ``Agent`` row is its live WebSocket presence (mirrored 1:1 by
-``id``). Creating a worker also writes the matching Agent so the foreman can
-list it immediately, even before the worker process connects.
+process; an ``Agent`` row is its live WebSocket presence, created only when
+the worker process connects via WebSocket (``join`` message in ws_handlers.py).
 """
 
 from __future__ import annotations
@@ -19,10 +18,9 @@ from auth_deps import require_member
 from database import get_db
 from events import broadcast, emit_terminal_line, pending_claude_auth
 from fastapi import APIRouter, Depends, HTTPException
-from models import Agent, ClaudeCredentials, Task, Worker, live_tasks_filter
+from models import ClaudeCredentials, Task, Worker, live_tasks_filter
 from pydantic import BaseModel
 from sqlalchemy import select
-from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from utils import (
     build_spawn_worker_env,
     decode_claude_oauth_token,
@@ -95,42 +93,10 @@ async def create_worker(guild_id: str, data: WorkerCreate):
                 auth_token=auth_token,
             )
         )
-        stmt = sqlite_insert(Agent).values(
-            id=worker_id,
-            guild_id=guild_id,
-            worker_id=worker_id,
-            name=worker_name,
-            type="worker",
-            state="offline",
-            joined_at=created_at,
-        )
-        stmt = stmt.on_conflict_do_update(
-            index_elements=["id"],
-            set_={
-                "guild_id": stmt.excluded.guild_id,
-                "worker_id": stmt.excluded.worker_id,
-                "name": stmt.excluded.name,
-                "type": stmt.excluded.type,
-                "state": stmt.excluded.state,
-                "joined_at": stmt.excluded.joined_at,
-            },
-        )
-        await db.execute(stmt)
         await db.commit()
     finally:
         await db.close()
 
-    await broadcast(
-        guild_id,
-        {
-            "type": "agent-joined",
-            "agentId": worker_id,
-            "agentName": worker_name,
-            "agentType": "worker",
-            "state": "offline",
-            "joinedAt": created_at,
-        },
-    )
     return {
         "id": worker_id,
         "name": worker_name,

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -52,6 +52,25 @@ def test_create_worker_appears_in_list(client):
     assert workers[0]["guild_id"] == "guild03"
 
 
+def test_create_worker_does_not_insert_agent_row(client):
+    """Worker registration must not create a phantom agent row (issue #264).
+
+    Agent rows are created only when the worker process sends a ``join``
+    message over WebSocket, not during REST-based registration.
+    """
+    import sqlite3
+
+    test_client, db_path = client
+    insert_guild(db_path, "guild03b")
+    resp = test_client.post("/guilds/guild03b/workers", json={"repos": []})
+    assert resp.status_code == 200
+    worker_id = resp.json()["id"]
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT id FROM agents WHERE id = ?", (worker_id,)).fetchone()
+    assert row is None, f"create_worker must not insert an agent row, but found: {row}"
+
+
 def test_create_multiple_workers(client):
     test_client, db_path = client
     insert_guild(db_path, "guild04")


### PR DESCRIPTION
## Summary

- Removed the `Agent` table insert from `create_worker` in `backend/routes/workers.py`
- Removed the premature `agent-joined` broadcast that fired on worker REST registration
- Agent rows are now only created when the worker process actually connects via WebSocket and sends a `join` message (handled in `ws_handlers.py`), which was always the correct place
- Added `test_create_worker_does_not_insert_agent_row` to verify no phantom agent row is written at registration time

## Test plan
- [x] All 343 backend tests pass
- [x] New test `test_create_worker_does_not_insert_agent_row` explicitly asserts no agent row exists after worker registration
- [x] Existing disconnect and liveness tests (which create agents via WebSocket `join`) continue to pass

Closes #264