### PR TITLE
Render result messages as markdown in agent tab (#268)

### DIFF
--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -77,7 +77,13 @@ function linkify(text: string): string {
 }
 
 function isMarkdownLine(line: string): boolean {
-  return line.startsWith('[thinking]') || line.startsWith('[claude]')
+  if (!line) return false
+  // Tool/metadata prefixes are plain text; everything else (including Claude's output) is markdown
+  if (line.startsWith('▶') || line.startsWith('✓') || line.startsWith('✗') || line.startsWith('  →'))
+    return false
+  if (line.startsWith('[') && !line.startsWith('[thinking]') && !line.startsWith('[claude]'))
+    return false
+  return true
 }
 
 


### PR DESCRIPTION
## Summary

- `isMarkdownLine` in `LogList.vue` previously only returned `true` for `[thinking]` and `[claude]` prefixed lines
- Claude's actual text output (assistant content blocks with no prefix) was rendered as plain linkified text, even though it contains markdown
- Flipped the logic: now all lines are treated as markdown **except** known tool/metadata prefixes:
  - `▶` — tool invocations
  - `✓` / `✗` — success/error outcomes  
  - `  →` — tool result summaries
  - `[...]` bracketed metadata (worker, stderr, pi, etc.) — excluding `[thinking]` and `[claude]` which were already markdown

Other message types (tool lines, success/error, metadata) are unaffected — they still use `linkify`.

## Test plan

- [ ] Run an agent from the UI's Run button and verify the response text renders with markdown formatting (headers, bold, code blocks, lists)
- [ ] Confirm `▶ tool-use`, `✓ Done`, `✗ error`, `  → result`, and `[worker]` lines are still plain text
- [ ] `[thinking]` and `[claude]` lines still render as markdown (existing behaviour preserved)
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (49 tests)
- [ ] `npm run lint` passes

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)