### PR TITLE
Webhook: backend logging + foreman chat events (#270)

### DIFF
--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -24,7 +24,7 @@ from database import get_db
 from events import broadcast
 from fastapi import APIRouter, HTTPException, Request, Response
 from foreman import reset_foreman_poll, run_foreman_ai
-from models import GithubEvent, Guild, Task
+from models import GithubEvent, Guild, Message, Task
 from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
@@ -230,6 +230,44 @@ def _build_foreman_summary(
     return f"{header}{sender_line}\n{detail}".strip() if detail else f"{header}{sender_line}"
 
 
+def _build_chat_line(
+    event_type: str,
+    action: str | None,
+    repo: str | None,
+    pr_number: int | None,
+    payload: dict,
+    task_id: str | None,
+) -> str:
+    """Build a compact ``[github-event]`` chat line for the foreman stream.
+
+    Format: ``[github-event] pull_request/closed — repo#42 (merged=true) — task: t-abc``
+    """
+    event_action = f"{event_type}/{action}" if action else event_type
+    pr_part = f" — {repo}#{pr_number}" if repo and pr_number else (f" — {repo}" if repo else "")
+
+    extra = ""
+    if event_type == "pull_request" and action == "closed":
+        pr = payload.get("pull_request") or {}
+        merged = pr.get("merged")
+        if merged is not None:
+            extra = f"merged={str(merged).lower()}"
+    elif event_type in {"check_run", "check_suite"}:
+        node = payload.get(event_type) or {}
+        conclusion = node.get("conclusion") if isinstance(node, dict) else None
+        if conclusion:
+            extra = f"conclusion={conclusion}"
+    elif event_type == "pull_request_review" and action == "submitted":
+        review = payload.get("review") or {}
+        state = review.get("state") if isinstance(review, dict) else None
+        if state:
+            extra = f"state={state}"
+
+    extra_part = f" ({extra})" if extra else ""
+    task_part = f" — task: {task_id}" if task_id else ""
+
+    return f"[github-event] {event_action}{pr_part}{extra_part}{task_part}"
+
+
 @router.post("/webhooks/github/{guild_id}")
 async def github_webhook(guild_id: str, request: Request) -> Response:
     body = await request.body()
@@ -243,6 +281,13 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
     signature = request.headers.get("x-hub-signature-256")
     if not delivery_id or not event_type:
         raise HTTPException(status_code=400, detail="Missing GitHub headers")
+
+    logger.info(
+        "github webhook received guild=%s delivery=%s event=%s",
+        guild_id,
+        delivery_id,
+        event_type,
+    )
 
     db = await get_db()
     try:
@@ -264,13 +309,31 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
         # GitHub sends ping deliveries on webhook setup; accept them but skip
         # the rest of the pipeline (no PR context, no foreman action).
         if event_type == "ping":
+            logger.info(
+                "github webhook ping guild=%s delivery=%s",
+                guild_id,
+                delivery_id,
+            )
             return Response(status_code=204)
 
         try:
             payload = json.loads(body)
         except json.JSONDecodeError:
+            logger.warning(
+                "github webhook invalid JSON guild=%s delivery=%s event=%s excerpt=%r",
+                guild_id,
+                delivery_id,
+                event_type,
+                body[:200].decode("utf-8", errors="replace"),
+            )
             raise HTTPException(status_code=400, detail="Invalid JSON body") from None
         if not isinstance(payload, dict):
+            logger.warning(
+                "github webhook non-object payload guild=%s delivery=%s event=%s",
+                guild_id,
+                delivery_id,
+                event_type,
+            )
             raise HTTPException(status_code=400, detail="Payload must be a JSON object")
 
         action = payload.get("action") if isinstance(payload.get("action"), str) else None
@@ -352,6 +415,34 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
             "sender": sender_login,
         },
     )
+
+    chat_line = _build_chat_line(event_type, action, repo, pr_number, payload, task_id)
+    chat_now = datetime.now(UTC).isoformat()
+    await broadcast(
+        guild_id,
+        {
+            "type": "chat",
+            "from": "github",
+            "to": "foreman",
+            "content": chat_line,
+            "createdAt": chat_now,
+        },
+    )
+    msg_db = await get_db()
+    try:
+        msg_db.add(
+            Message(
+                guild_id=guild_id,
+                from_agent="github",
+                to_agent="foreman",
+                content=chat_line,
+                message_type="chat",
+                created_at=chat_now,
+            )
+        )
+        await msg_db.commit()
+    finally:
+        await msg_db.close()
 
     dispatch, skip_reason = _should_dispatch_to_foreman(
         event_type, action, payload, sender_login, task_id

--- a/backend/tests/test_github_webhooks.py
+++ b/backend/tests/test_github_webhooks.py
@@ -292,6 +292,77 @@ def test_webhook_missing_github_headers(client):
     assert resp.status_code == 400
 
 
+def test_webhook_emits_foreman_chat_message(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gchat1")
+    _set_webhook_secret(db_path, "gchat1", "schat1")
+    _insert_task(
+        db_path,
+        task_id="t-chat1",
+        guild_id="gchat1",
+        pr_url="https://github.com/owner/repo/pull/10",
+        pr_number=10,
+        pr_repo="owner/repo",
+    )
+    payload = _pr_payload(action="opened", repo="owner/repo", number=10)
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("schat1", body, event="pull_request", delivery="d-chat-1")
+    resp = test_client.post("/webhooks/github/gchat1", content=body, headers=headers)
+    assert resp.status_code == 202
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT from_agent, to_agent, content, message_type FROM messages"
+        ).fetchone()
+    assert row is not None
+    from_agent, to_agent, content, message_type = row
+    assert from_agent == "github"
+    assert to_agent == "foreman"
+    assert content.startswith("[github-event]")
+    assert "pull_request/opened" in content
+    assert "owner/repo#10" in content
+    assert "task: t-chat1" in content
+    assert message_type == "chat"
+
+
+def test_webhook_chat_line_includes_merged_status(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gchat2")
+    _set_webhook_secret(db_path, "gchat2", "schat2")
+    payload = {
+        "action": "closed",
+        "repository": {"full_name": "owner/repo"},
+        "pull_request": {
+            "number": 5,
+            "html_url": "https://github.com/owner/repo/pull/5",
+            "merged": True,
+        },
+        "sender": {"login": "octocat"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("schat2", body, event="pull_request", delivery="d-chat-2")
+    resp = test_client.post("/webhooks/github/gchat2", content=body, headers=headers)
+    assert resp.status_code == 202
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT content FROM messages").fetchone()
+    assert row is not None
+    assert "merged=true" in row[0]
+    assert "task:" not in row[0]  # no task linked
+
+
+def test_webhook_chat_line_not_emitted_for_duplicate(client):
+    test_client, db_path = client
+    insert_guild(db_path, "gchat3")
+    _set_webhook_secret(db_path, "gchat3", "schat3")
+    payload = _pr_payload(action="opened", repo="owner/repo", number=1)
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("schat3", body, event="pull_request", delivery="d-chat-dup")
+    test_client.post("/webhooks/github/gchat3", content=body, headers=headers)
+    test_client.post("/webhooks/github/gchat3", content=body, headers=headers)
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    assert count == 1  # second delivery is a duplicate; no second message
+
+
 # ---------------------------------------------------------------------------
 # Webhook-secret REST endpoints
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Initial INFO log** on every delivery (delivery ID + event type) logged before validation; ping events get their own INFO line; existing accepted/duplicate logs already carry action, repo, and task fields
- **WARNING logs** with a payload excerpt on JSON parse failure or non-object body
- **Foreman chat message**: after persisting each unique event, a `type: "chat"` WebSocket message is broadcast from `"github"` to `"foreman"` and persisted to the `messages` table so it appears in the chat UI. Format:
  ```
  [github-event] pull_request/closed — repo#42 (merged=true) — task: t-abc123
  ```
  Contextual extras are included per event type: `merged=` for PR closes, `conclusion=` for check runs, `state=` for reviews. Duplicate deliveries do **not** emit a second message.
- New `_build_chat_line()` helper in `backend/routes/webhooks.py`
- Three new tests: chat message emission, `merged=true` detail, no-emit-on-duplicate

## Test plan

- [x] All 44 webhook tests pass (`pytest tests/test_github_webhooks.py tests/test_github_webhooks_phase2.py`)
- [x] `ruff check . --fix && ruff format .` clean

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)