### PR TITLE
fix(tasks): persist pr_url when worker reports task complete

### DIFF
--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -419,10 +419,14 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
     pr_url = data.get("prUrl", "")
     last_text = data.get("lastText", "")
     if task_id:
+        update_values: dict = {"state": "awaiting-review"}
+        if pr_url:
+            update_values["pr_url"] = pr_url
+            pr_number, pr_repo = _parse_pr_url(pr_url)
+            update_values["pr_number"] = pr_number
+            update_values["pr_repo"] = pr_repo
         await ctx.db.execute(
-            update(Task)
-            .where(Task.id == task_id, Task.state == "working")
-            .values(state="awaiting-review")
+            update(Task).where(Task.id == task_id, Task.state == "working").values(**update_values)
         )
         await ctx.db.commit()
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1629,6 +1629,7 @@ class Worker:
                     task_id,
                     branch=branch,
                     worktreePath=primary_wt,
+                    prUrl=pr_url or "",
                     state="awaiting-review",
                 )
                 # On a follow-up run, surface task-followup-done so the


### PR DESCRIPTION
## Summary

- **Root cause 1 — worker.py**: The `_task_update()` call on the success path (line 1628) was missing `prUrl=pr_url`. The backend `handle_task_update()` only persists `pr_url` when `prUrl` is present in the `task-update` message, so the URL was silently dropped on every task completion.
- **Root cause 2 — ws_handlers.py**: `handle_task_complete()` received `prUrl` in the message and passed it to the foreman AI narrative, but its DB update only wrote `state="awaiting-review"` — never `pr_url`, `pr_number`, or `pr_repo`.

Both bugs together meant `pr_url` was always `NULL` in the DB even when the worker successfully opened a PR.

**Fixes:**
1. `worker/pioneer_worker/worker.py`: add `prUrl=pr_url or ""` to the `_task_update()` call so the `task-update` message carries the URL (processed by `handle_task_update()` which already correctly persists it).
2. `backend/ws_handlers.py`: make `handle_task_complete()` also persist `pr_url`/`pr_number`/`pr_repo` via `_parse_pr_url()` — provides defence-in-depth if the `task-update` message ever arrives without the field.

## Test plan
- [ ] Run a worker task end-to-end; confirm `pr_url` column is non-null in `pioneer_square.db` after task reaches `awaiting-review`
- [ ] Verify `pr_number` and `pr_repo` are also populated (needed for webhook event matching)
- [ ] Confirm frontend task sidebar and log pane display the PR link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)