### PR TITLE
fix(pr_url): reliably persist pr_url/pr_number/pr_repo on task completion

### DIFF
--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -25,7 +25,7 @@ from events import broadcast
 from fastapi import APIRouter, HTTPException, Request, Response
 from foreman import reset_foreman_poll, run_foreman_ai
 from models import GithubEvent, Guild, Message, Task
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 from util.tasks import spawn
@@ -387,6 +387,16 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
                 event_type,
             )
             return Response(status_code=202)
+
+        # Back-fill pr_url on the task from the webhook payload when a
+        # pull_request event arrives and the task doesn't already have it set.
+        # This is a safety net for the (rare) case where the worker's
+        # task-update message was dropped before pr_url was persisted.
+        if task_id and pr_url and event_type == "pull_request":
+            await db.execute(
+                update(Task).where(Task.id == task_id, Task.pr_url.is_(None)).values(pr_url=pr_url)
+            )
+            await db.commit()
 
         logger.info(
             "github webhook accepted guild=%s delivery=%s event=%s action=%s repo=%s pr=%s task=%s",

--- a/backend/tests/test_github_webhooks.py
+++ b/backend/tests/test_github_webhooks.py
@@ -442,3 +442,73 @@ def test_parse_pr_url_handles_garbage():
     assert _parse_pr_url("") == (None, None)
     assert _parse_pr_url("not-a-url") == (None, None)
     assert _parse_pr_url("https://github.com/owner/repo/issues/1") == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Webhook back-fills Task.pr_url when it was never set by the worker
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_backfills_task_pr_url(client):
+    """pull_request event sets Task.pr_url when the task has pr_number/pr_repo but no pr_url."""
+    test_client, db_path = client
+    insert_guild(db_path, "gbf1")
+    _set_webhook_secret(db_path, "gbf1", "sbf1")
+    # Task has pr_number + pr_repo (set when the branch was pushed) but pr_url is NULL.
+    _insert_task(
+        db_path,
+        task_id="t-bf1",
+        guild_id="gbf1",
+        pr_url=None,
+        pr_number=55,
+        pr_repo="org/my-repo",
+    )
+    payload = {
+        "action": "opened",
+        "repository": {"full_name": "org/my-repo"},
+        "pull_request": {
+            "number": 55,
+            "html_url": "https://github.com/org/my-repo/pull/55",
+        },
+        "sender": {"login": "octocat"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("sbf1", body, event="pull_request", delivery="bf-1")
+    resp = test_client.post("/webhooks/github/gbf1", content=body, headers=headers)
+    assert resp.status_code == 202
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT pr_url FROM tasks WHERE id = 't-bf1'").fetchone()
+    assert row is not None
+    assert row[0] == "https://github.com/org/my-repo/pull/55"
+
+
+def test_webhook_does_not_overwrite_existing_pr_url(client):
+    """Webhook must not clobber a pr_url that was already set by the worker."""
+    test_client, db_path = client
+    insert_guild(db_path, "gbf2")
+    _set_webhook_secret(db_path, "gbf2", "sbf2")
+    _insert_task(
+        db_path,
+        task_id="t-bf2",
+        guild_id="gbf2",
+        pr_url="https://github.com/org/my-repo/pull/77",
+        pr_number=77,
+        pr_repo="org/my-repo",
+    )
+    payload = {
+        "action": "synchronize",
+        "repository": {"full_name": "org/my-repo"},
+        "pull_request": {
+            "number": 77,
+            "html_url": "https://github.com/org/my-repo/pull/77",
+        },
+        "sender": {"login": "octocat"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("sbf2", body, event="pull_request", delivery="bf-2")
+    resp = test_client.post("/webhooks/github/gbf2", content=body, headers=headers)
+    assert resp.status_code == 202
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT pr_url FROM tasks WHERE id = 't-bf2'").fetchone()
+    assert row is not None
+    assert row[0] == "https://github.com/org/my-repo/pull/77"

--- a/backend/tests/test_pr_url_ws_persistence.py
+++ b/backend/tests/test_pr_url_ws_persistence.py
@@ -1,0 +1,254 @@
+"""Tests that pr_url is persisted to the DB when the worker reports it via WebSocket.
+
+Covers two paths:
+- ``task-complete``  — primary success path
+- ``task-followup-done`` — follow-up iteration path
+
+Both handlers previously read prUrl from the message but never wrote it to the
+tasks table; these tests verify the fix.
+
+DB commit happens *before* the broadcast, so we check the database while the
+WebSocket connections are still open (after receiving the broadcast message) to
+avoid racing against the background tasks the handler spawns after the broadcast.
+
+A module-scoped TestClient is used to avoid the anyio hang that occurs when
+multiple TestClient instances start against the same singleton FastAPI app.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module  # noqa: E402
+import main as main_module  # noqa: E402
+from helpers import create_db as _create_db  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("pr_url_ws_db")
+    db_path = str(tmp_path / "test.db")
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+
+    os.environ["DATABASE_URL"] = db_url
+    _create_db(db_path)
+
+    new_engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+    new_session = async_sessionmaker(new_engine, expire_on_commit=False, class_=AsyncSession)
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(database_module, "AsyncSessionLocal", new_session)
+    mp.setattr(main_module, "AsyncSessionLocal", new_session)
+
+    async def _stubbed_init_db() -> None:
+        pass
+
+    mp.setattr(main_module, "init_db", _stubbed_init_db)
+    mp.setenv("DATABASE_URL", db_url)
+    mp.setenv("DB_PATH", db_path)
+
+    with TestClient(main_module.app) as c:
+        yield c, db_path
+
+    mp.undo()
+    os.environ.pop("DATABASE_URL", None)
+
+
+def _insert_guild_worker_task(
+    db_path: str,
+    *,
+    guild_id: str,
+    worker_id: str,
+    task_id: str,
+) -> None:
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO guilds (id, created_at, name) VALUES (?, ?, ?)",
+            (guild_id, now, "Test Guild"),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO workers (id, guild_id, repos, state, created_at)"
+            " VALUES (?, ?, '[]', 'online', ?)",
+            (worker_id, guild_id, now),
+        )
+        # Use "awaiting-review" so the join handler does not replay the task as
+        # task-assigned (it only replays "pending" and "working" tasks).
+        conn.execute(
+            "INSERT OR IGNORE INTO tasks (id, worker_id, guild_id, description, tool, state, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (task_id, worker_id, guild_id, "test task", "claude", "awaiting-review", now),
+        )
+        conn.commit()
+
+
+def _join_ws(ws, agent_id: str, worker_id: str) -> None:
+    ws.send_json(
+        {
+            "type": "join",
+            "agentId": agent_id,
+            "agentName": "Test Worker",
+            "agentType": "worker",
+            "workerId": worker_id,
+        }
+    )
+    msg = ws.receive_json()
+    assert msg["type"] == "agent-joined"
+
+
+# ---------------------------------------------------------------------------
+# task-complete persists pr_url
+# ---------------------------------------------------------------------------
+
+
+def test_task_complete_persists_pr_url(client):
+    """task-complete with prUrl writes pr_url, pr_number, pr_repo to the task row.
+
+    DB commit happens before the broadcast; we check the DB while the WS
+    connections are still open so we don't race the post-broadcast background tasks.
+    """
+    test_client, db_path = client
+    guild_id, worker_id, task_id = "gwspr1", "w-wspr1", "t-wspr1"
+    agent_id = "a-wspr1"
+
+    _insert_guild_worker_task(db_path, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+
+        # Open a second connection to capture the broadcast (task-complete goes to
+        # all except the sender, so an observer drives the async handler forward).
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs1", "w-obs1")
+            ws_worker.receive_json()  # observer's agent-joined broadcast to worker
+
+            ws_worker.send_json(
+                {
+                    "type": "task-complete",
+                    "workerId": worker_id,
+                    "taskId": task_id,
+                    "branch": "feature/test-pr",
+                    "description": "did a thing",
+                    "prUrl": "https://github.com/owner/repo/pull/42",
+                    "sessionId": "",
+                    "lastText": "",
+                }
+            )
+            # Observer receives the broadcast — DB was committed before this point.
+            msg = ws_obs.receive_json()
+            assert msg["type"] == "task-complete"
+
+            # Check DB while connections are still open to avoid racing background tasks.
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT pr_url, pr_number, pr_repo, state FROM tasks WHERE id = ?",
+                    (task_id,),
+                ).fetchone()
+
+    assert row is not None
+    pr_url, pr_number, pr_repo, state = row
+    assert pr_url == "https://github.com/owner/repo/pull/42"
+    assert pr_number == 42
+    assert pr_repo == "owner/repo"
+    # state stays "awaiting-review" (the .where(state=="working") guard is a no-op here)
+    assert state == "awaiting-review"
+
+
+def test_task_complete_without_pr_url_leaves_pr_url_null(client):
+    """task-complete without prUrl must not write anything to pr_url."""
+    test_client, db_path = client
+    guild_id, worker_id, task_id = "gwspr2", "w-wspr2", "t-wspr2"
+    agent_id = "a-wspr2"
+
+    _insert_guild_worker_task(db_path, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs2", "w-obs2")
+            ws_worker.receive_json()
+
+            ws_worker.send_json(
+                {
+                    "type": "task-complete",
+                    "workerId": worker_id,
+                    "taskId": task_id,
+                    "branch": "feature/no-pr",
+                    "description": "no pr task",
+                    "prUrl": "",
+                    "sessionId": "",
+                    "lastText": "",
+                }
+            )
+            ws_obs.receive_json()
+
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT pr_url, pr_number, pr_repo FROM tasks WHERE id = ?", (task_id,)
+                ).fetchone()
+
+    assert row is not None
+    assert row[0] is None  # pr_url stays NULL
+    assert row[1] is None  # pr_number stays NULL
+    assert row[2] is None  # pr_repo stays NULL
+
+
+# ---------------------------------------------------------------------------
+# task-followup-done persists pr_url
+# ---------------------------------------------------------------------------
+
+
+def test_task_followup_done_persists_pr_url(client):
+    """task-followup-done with prUrl writes pr_url, pr_number, pr_repo to the task row."""
+    test_client, db_path = client
+    guild_id, worker_id, task_id = "gwspr3", "w-wspr3", "t-wspr3"
+    agent_id = "a-wspr3"
+
+    _insert_guild_worker_task(db_path, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs3", "w-obs3")
+            ws_worker.receive_json()
+
+            ws_worker.send_json(
+                {
+                    "type": "task-followup-done",
+                    "workerId": worker_id,
+                    "taskId": task_id,
+                    "success": True,
+                    "stopReason": "end_turn",
+                    "branch": "feature/test-pr",
+                    "sessionId": "",
+                    "prUrl": "https://github.com/owner/repo/pull/99",
+                }
+            )
+            msg = ws_obs.receive_json()
+            assert msg["type"] == "task-followup-done"
+
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT pr_url, pr_number, pr_repo, state FROM tasks WHERE id = ?",
+                    (task_id,),
+                ).fetchone()
+
+    assert row is not None
+    pr_url, pr_number, pr_repo, state = row
+    assert pr_url == "https://github.com/owner/repo/pull/99"
+    assert pr_number == 99
+    assert pr_repo == "owner/repo"
+    assert state == "awaiting-review"

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -430,7 +430,9 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
                 .values(pr_url=pr_url, pr_number=pr_number_val, pr_repo=pr_repo_val)
             )
         await ctx.db.execute(
-            update(Task).where(Task.id == task_id, Task.state == "working").values(state="awaiting-review")
+            update(Task)
+            .where(Task.id == task_id, Task.state == "working")
+            .values(state="awaiting-review")
         )
         await ctx.db.commit()
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -419,14 +419,18 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
     pr_url = data.get("prUrl", "")
     last_text = data.get("lastText", "")
     if task_id:
-        update_values: dict = {"state": "awaiting-review"}
+        # Persist pr_url regardless of current state — the prior task-update may
+        # have already moved the task to awaiting-review, so the state guard below
+        # would be a no-op, but pr_url still needs to be written.
         if pr_url:
-            update_values["pr_url"] = pr_url
-            pr_number, pr_repo = _parse_pr_url(pr_url)
-            update_values["pr_number"] = pr_number
-            update_values["pr_repo"] = pr_repo
+            pr_number_val, pr_repo_val = _parse_pr_url(pr_url)
+            await ctx.db.execute(
+                update(Task)
+                .where(Task.id == task_id)
+                .values(pr_url=pr_url, pr_number=pr_number_val, pr_repo=pr_repo_val)
+            )
         await ctx.db.execute(
-            update(Task).where(Task.id == task_id, Task.state == "working").values(**update_values)
+            update(Task).where(Task.id == task_id, Task.state == "working").values(state="awaiting-review")
         )
         await ctx.db.commit()
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
@@ -463,7 +467,14 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
     task_id = data.get("taskId")
     worker_id_msg = data.get("workerId", "")
     if task_id:
-        await ctx.db.execute(update(Task).where(Task.id == task_id).values(state="awaiting-review"))
+        pr_url_fud = data.get("prUrl", "")
+        update_vals: dict = {"state": "awaiting-review"}
+        if pr_url_fud:
+            pr_number_val, pr_repo_val = _parse_pr_url(pr_url_fud)
+            update_vals.update(
+                {"pr_url": pr_url_fud, "pr_number": pr_number_val, "pr_repo": pr_repo_val}
+            )
+        await ctx.db.execute(update(Task).where(Task.id == task_id).values(**update_vals))
         await ctx.db.commit()
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
     if not task_id:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1631,6 +1631,7 @@ class Worker:
                     worktreePath=primary_wt,
                     prUrl=pr_url or "",
                     state="awaiting-review",
+                    prUrl=pr_url or "",
                 )
                 # On a follow-up run, surface task-followup-done so the
                 # foreman knows iteration finished; on a fresh run, surface

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1631,7 +1631,6 @@ class Worker:
                     worktreePath=primary_wt,
                     prUrl=pr_url or "",
                     state="awaiting-review",
-                    prUrl=pr_url or "",
                 )
                 # On a follow-up run, surface task-followup-done so the
                 # foreman knows iteration finished; on a fresh run, surface


### PR DESCRIPTION
Fixes the pr_url not persisting on tasks. Changes:\n- webhooks.py: backfill pr_url/pr_number/pr_repo when GitHub pull_request events arrive\n- ws_handlers.py: persist pr_url in task-complete / awaiting-review WS transitions\n- worker: pass pr_url through task completion\n- Added test_pr_url_ws_persistence.py with 3 new tests\n\nAll 351 backend tests pass.