### PR TITLE
Fix work floor min-width on mobile (#277)

### DIFF
--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -111,8 +111,10 @@ const floorH = ref(600)
 
 function updateFloorSize() {
   if (floorEl.value) {
-    floorW.value = floorEl.value.clientWidth || 900
-    floorH.value = floorEl.value.clientHeight || 600
+    const w = floorEl.value.clientWidth
+    const h = floorEl.value.clientHeight
+    if (w > 0) floorW.value = w
+    if (h > 0) floorH.value = h
   }
 }
 
@@ -124,7 +126,7 @@ const floorSize = computed<'sm' | 'md' | 'lg'>(() => {
 
 const tableWidth = computed(() => {
   const reservedRight = floorSize.value === 'sm' ? 0 : CHAT_PANE_W
-  return Math.max(floorW.value - reservedRight - TABLE_LEFT * 2, 360)
+  return Math.max(floorW.value - reservedRight - TABLE_LEFT * 2, 50)
 })
 
 const visibleRowCount = computed(() => {
@@ -200,14 +202,20 @@ const choreography = useAgentChoreography({
   stations: STATIONS,
 })
 
+let resizeObserver: ResizeObserver | null = null
+
 onMounted(() => {
+  if (floorEl.value) {
+    resizeObserver = new ResizeObserver(updateFloorSize)
+    resizeObserver.observe(floorEl.value)
+  }
   updateFloorSize()
-  window.addEventListener('resize', updateFloorSize)
   choreography.syncAll()
 })
 
 onUnmounted(() => {
-  window.removeEventListener('resize', updateFloorSize)
+  resizeObserver?.disconnect()
+  resizeObserver = null
 })
 
 // ── Ticker ─────────────────────────────────────────────────

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -187,7 +187,7 @@ watch(
   display: flex;
   flex-direction: column;
   height: 100vh;
-  width: 100vw;
+  width: 100%;
   overflow: hidden;
   background: var(--color-bg);
 }
@@ -264,9 +264,9 @@ watch(
     left: 0;
     right: 0;
     bottom: 52px;
-    width: 100vw !important;
+    width: 100% !important;
     min-width: 0 !important;
-    max-width: 100vw !important;
+    max-width: 100% !important;
     height: calc(100dvh - 96px) !important;
     max-height: calc(100dvh - 96px) !important;
     display: none !important;


### PR DESCRIPTION
## Summary

- **Root cause 1 (main bug)**: `FactoryFloor.vue` measured the floor width with a `window` resize listener. On mobile, the Work pane starts hidden (`display: none`) when another tab is active, so `clientWidth` is `0` at mount and falls back to the `900` default. The floor never re-measured when the tab became visible, causing a `844px` task table inside a `390px` viewport.

  **Fix**: Replaced `window.addEventListener('resize', ...)` with a `ResizeObserver` on the floor element. `ResizeObserver` fires whenever the element's box changes — including when it transitions from `display: none` to visible — so `floorW` always reflects the real rendered width.

- **Root cause 2**: `tableWidth` enforced a `Math.max(..., 360)` minimum, which exceeds the content area on sub-400 px phones (e.g. 320 px iPhone SE). Reduced minimum to `50px`.

- **Root cause 3**: `.app-layout` and the mobile pane rules used `width: 100vw`, which includes scrollbar width on desktop and can push content past the visible edge. Changed to `width: 100%` (the `left: 0; right: 0` already pins fixed-positioned panes to full viewport width).

## Files changed
- `frontend/src/components/FactoryFloor.vue` — ResizeObserver, lower tableWidth min
- `frontend/src/views/AppView.vue` — `100vw` → `100%` on layout root and mobile pane rules

Closes #277