### PR TITLE
Filter GitHub webhook events from foreman chat (#279)

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,44 @@
+# GitHub Webhook Integration
+
+## Overview
+
+Pioneer Square receives GitHub webhook events at `POST /webhooks/github/{guild_id}`. Each delivery is validated with HMAC-SHA256 against the guild's stored webhook secret.
+
+## Event flow
+
+```
+GitHub → POST /webhooks/github/{guild_id}
+    ↓
+Signature verification + deduplication (X-GitHub-Delivery)
+    ↓
+_build_foreman_summary()  ──→  run_foreman_ai(summary)   [internal, not shown in chat]
+_build_chat_line()        ──→  DB persist + WS broadcast  [filtered from chat UI]
+```
+
+Two parallel paths are created for each actionable event:
+
+1. **Foreman summary** (`_build_foreman_summary`) — a structured message fed directly to the Foreman AI via `run_foreman_ai()`. This contains event-specific guidance (e.g. "PR merged — call `finalize_task`") and is part of the AI's internal reasoning context.
+
+2. **Chat line** (`_build_chat_line`) — a human-readable `[github-event]` line stored in the `messages` table and broadcast as `type: "chat"` with `from: "github"`.
+
+## Filtering from the chat UI
+
+Raw `[github-event]` lines are **not displayed** in the foreman chat panel. The frontend store (`guild.ts`) drops any incoming or historically loaded chat message where `from === "github"` before adding it to the visible `messages` array.
+
+This means:
+- The Foreman AI still receives all webhook events through its internal summary channel and acts on them normally.
+- Foreman *responses* triggered by a webhook event (e.g. a `finalize_task` or `send_followup` decision) appear in chat as normal foreman messages.
+- No raw `[github-event]` lines are ever shown to the human operator.
+
+## Actionable events
+
+Only events that pass `_should_dispatch_to_foreman()` wake the Foreman AI:
+
+| Event | Condition |
+|-------|-----------|
+| `pull_request` | Matching task found; skip bot senders unless CI-related |
+| `pull_request_review` | Review submitted with `changes_requested` or `approved` |
+| `check_run` / `check_suite` | `completed` conclusion (failure, success, etc.) |
+| `status` | Terminal state (failure, error, success) |
+
+Pending, neutral, or skipped check states are silently ignored.

--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -63,7 +63,9 @@ export const useGuildStore = defineStore('guild', () => {
     try {
       const guild = await api<Guild>(`/guilds/${guildId}`)
       currentGuild.value = guild
-      messages.value = guild.messages || []
+      messages.value = (guild.messages || []).filter(
+        (m: ChatMessage) => (m.from || m.from_agent) !== 'github',
+      )
       return guild
     } catch (e) {
       console.error('Failed to join guild', e)
@@ -115,7 +117,10 @@ export const useGuildStore = defineStore('guild', () => {
       }
       try {
         if (data.type === 'chat') {
-          messages.value.push(data as ChatMessage)
+          const chatMsg = data as ChatMessage
+          if ((chatMsg.from || chatMsg.from_agent) !== 'github') {
+            messages.value.push(chatMsg)
+          }
         }
         if (data.type === 'guild-updated') {
           if (currentGuild.value && currentGuild.value.id === data.id) {


### PR DESCRIPTION
## Summary

- Drop `[github-event]` chat messages from the visible foreman chat panel by filtering them in `guild.ts` before they reach the `messages` array
- Filter applied in two places: on initial guild load (`joinGuild`) and on incoming WebSocket frames
- The Foreman AI continues to receive webhook events through its existing internal `run_foreman_ai()` channel — no backend changes needed
- Adds `docs/webhooks.md` describing the webhook flow and filtering behaviour

## How it works

`backend/routes/webhooks.py` already routes webhook events on two independent paths:
1. `_build_foreman_summary()` → `run_foreman_ai()` — the AI's internal channel (unchanged)
2. `_build_chat_line()` → DB persist + WS broadcast as `type: "chat", from: "github"` — the human-facing channel

The fix drops path 2 in the frontend store before it reaches the Vue component. Foreman responses *triggered by* webhook events still appear normally because they originate from `from: "foreman"`.

## Test plan

- [ ] Trigger a GitHub webhook (PR open/close, CI check) and verify no `[github-event]` line appears in the chat panel
- [ ] Verify the Foreman still acts on webhook events (e.g. calls `finalize_task` on PR merge)
- [ ] Verify normal human↔foreman messages are unaffected
- [ ] Reload the page with existing `github` messages in the DB — confirm they are absent from chat history

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)