### PR TITLE
Fix first agent slot showing worker name (#283)

### DIFF
--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -30,6 +30,7 @@ from models import Agent, Message, Task, TaskLog, User, Worker
 from sqlalchemy import select, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from util.tasks import spawn
+from utils import worker_display_name
 
 logger = logging.getLogger(__name__)
 
@@ -206,18 +207,18 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
                         "issueRepo": pt.issue_repo,
                     }
                 )
-    await broadcast(
-        ctx.guild_id,
-        {
-            "type": "agent-joined",
-            "agentId": agent_id,
-            "agentName": agent_name,
-            "agentType": agent_type,
-            "workerId": worker_id,
-            "state": "idle",
-            "joinedAt": joined_at,
-        },
-    )
+    broadcast_payload: dict = {
+        "type": "agent-joined",
+        "agentId": agent_id,
+        "agentName": agent_name,
+        "agentType": agent_type,
+        "workerId": worker_id,
+        "state": "idle",
+        "joinedAt": joined_at,
+    }
+    if worker_id:
+        broadcast_payload["workerName"] = worker_display_name(worker_id)
+    await broadcast(ctx.guild_id, broadcast_payload)
 
 
 async def handle_agent_state(ctx: WSContext, data: dict) -> None:

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -36,6 +36,16 @@ interface AssignTaskOpts {
   issueRepo?: string | null
 }
 
+// Mirrors backend/utils.py worker_display_name() (without hostname).
+// Deriving the worker label from workerId rather than the first agent's name
+// prevents slot 0's droid name from appearing identical to the worker name (#283).
+function _workerDroidName(workerId: string): string {
+  const raw = workerId.slice(2).toUpperCase()
+  const charSum = raw.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0)
+  const split = 2 + (charSum % 3)
+  return `${raw.slice(0, split)}-${raw.slice(split)}`
+}
+
 export const useAgentsStore = defineStore('agents', () => {
   const agents = ref<Agent[]>([])
   const workerLogs = ref<Record<string, LogEntry[]>>({})
@@ -52,7 +62,7 @@ export const useAgentsStore = defineStore('agents', () => {
       if (!map.has(agent.workerId)) {
         map.set(agent.workerId, {
           id: agent.workerId,
-          name: agent.name.replace(/\/\d+$/, ''),
+          name: _workerDroidName(agent.workerId),
           state: agent.state,
         })
       } else {

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -19,6 +19,7 @@ interface RegisterAgentData {
   agentName?: string
   agentType?: string
   workerId?: string | null
+  workerName?: string
   state?: AgentState
   joinedAt?: string
 }
@@ -62,7 +63,9 @@ export const useAgentsStore = defineStore('agents', () => {
       if (!map.has(agent.workerId)) {
         map.set(agent.workerId, {
           id: agent.workerId,
-          name: _workerDroidName(agent.workerId),
+          // Prefer the backend-supplied workerName from the agent-joined payload;
+          // fall back to local derivation for agents from older backends or REST init.
+          name: agent.workerName || _workerDroidName(agent.workerId),
           state: agent.state,
         })
       } else {
@@ -82,12 +85,14 @@ export const useAgentsStore = defineStore('agents', () => {
       existing.state = agentData.state || 'idle'
       existing.name = agentData.agentName || existing.name
       if (agentData.workerId) existing.workerId = agentData.workerId
+      if (agentData.workerName) existing.workerName = agentData.workerName
     } else {
       agents.value.push({
         id: agentData.agentId,
         name: agentData.agentName || 'Unknown',
         type: agentData.agentType || 'worker',
         workerId: agentData.workerId || null,
+        workerName: agentData.workerName,
         state: agentData.state || 'idle',
         logs: [],
         joinedAt: agentData.joinedAt || new Date().toISOString(),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,6 +37,7 @@ export interface Agent {
   name: string
   type: AgentType
   workerId: string | null
+  workerName?: string
   state: AgentState
   activity?: AgentActivity | null
   logs: LogEntry[]
@@ -164,6 +165,7 @@ export interface AgentJoinedWS {
   agentName?: string
   agentType?: string
   workerId?: string | null
+  workerName?: string
   state?: AgentState
   joinedAt?: string
 }


### PR DESCRIPTION
## Summary

- The `workers` computed in `agents.ts` derived the worker's display name from the **first registered agent** (slot 0) using `agent.name.replace(/\/\d+$/, '')`. Since the worker sends plain droid names without a slot-index suffix, the regex was a no-op — leaving the worker name identical to slot 0's agent name.
- In the sidebar and on the factory floor, slot 0's avatar/label showed the same name as the worker row, making it look like slot 0 was "showing the worker name" while slots 1+ had unique names.
- Fix: added `_workerDroidName(workerId)` that mirrors `backend/utils.py worker_display_name()` (without hostname), computing the worker's label from its `workerId` directly. The worker label is now always distinct from any individual agent slot's droid name.

## Test plan

- [ ] Start a worker with `max_agents > 1`; confirm the worker row label in the sidebar is different from all agent slot labels (including slot 0)
- [ ] Confirm slot 0's avatar on the factory floor shows its own unique droid name, not the worker's name
- [ ] Confirm slots 1+ are unaffected

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)