### PR TITLE
Foreman: default design docs to issue repo (#286)

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -86,7 +86,7 @@ land in a repo), determine the target repo using this priority order:
    in its configured repo list. Prefer workers whose repos cover `issue_repo`.
 2. **issue_repo is set but no worker covers it** — fall back to the guild default repo.
    Include this note in the task description so the worker adds it to the PR body:
-   `⚠️ This artifact belongs in \`{issue_repo}\` but no worker has access to that repo; committed here as a fallback.`
+   `⚠️ This artifact belongs in \\`{issue_repo}\\` but no worker has access to that repo; committed here as a fallback.`
 3. **No issue_repo** — use the guild default repo, same as today.
 
 Always include an explicit line in the worker's task description:

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -78,6 +78,26 @@ search_github_issues; create one with create_github_issue only if none exists. T
 immediately — don't treat issue creation as a separate round-trip. Pass issue_number and
 issue_repo to assign_task so the worker's PR references the issue automatically.
 
+## Artifact repo selection
+When a task produces a committed artifact (design doc, spec, ADR, or any file that must
+land in a repo), determine the target repo using this priority order:
+
+1. **issue_repo is set** — use it, *provided* at least one online worker has that repo
+   in its configured repo list. Prefer workers whose repos cover `issue_repo`.
+2. **issue_repo is set but no worker covers it** — fall back to the guild default repo.
+   Include this note in the task description so the worker adds it to the PR body:
+   `⚠️ This artifact belongs in \`{issue_repo}\` but no worker has access to that repo; committed here as a fallback.`
+3. **No issue_repo** — use the guild default repo, same as today.
+
+Always include an explicit line in the worker's task description:
+```
+**Target repo for this artifact:** `{repo}` (derived from the linked issue / guild default)
+```
+This removes ambiguity — the worker must never have to guess which repo to commit to.
+
+Tasks with no artifact (e.g. pure code changes in a worker's own checkout) are unaffected
+by this rule; only apply it when the task explicitly produces a file to be committed.
+
 ## Checking task progress
 Use get_task_status to verify a task is making progress — it returns the current state,
 the active agent and its state, and the last log lines. If a task looks stalled, use

--- a/docs/foreman-guidelines.md
+++ b/docs/foreman-guidelines.md
@@ -1,0 +1,43 @@
+# Foreman Guidelines
+
+Operational rules that shape how the Foreman AI creates and assigns tasks.
+
+---
+
+## Artifact repo selection (added 2026-05-12)
+
+When a task produces a committed artifact — a design doc, spec, ADR, or any file
+that must land in a repository — the foreman selects the target repo using this
+priority order:
+
+| Priority | Condition | Action |
+|----------|-----------|--------|
+| 1 | `issue_repo` is set **and** a worker covers it | Commit artifact to `issue_repo`; prefer that worker |
+| 2 | `issue_repo` is set but **no worker covers it** | Fall back to guild default repo; worker adds a fallback note to the PR body |
+| 3 | No `issue_repo` | Use guild default repo (unchanged behaviour) |
+
+### Worker instruction requirement
+
+Whenever a task involves committing an artifact, the foreman must include this line
+in the task description it sends to the worker:
+
+```
+**Target repo for this artifact:** `{repo}` (derived from the linked issue / guild default)
+```
+
+This ensures the worker never has to guess which repo to commit to.
+
+### Fallback note template
+
+When falling back to the guild default because no worker covers `issue_repo`, the
+worker should add this note to the PR description:
+
+```
+⚠️ This artifact belongs in `{issue_repo}` but no worker has access to that repo;
+committed here as a fallback.
+```
+
+### Scope
+
+This rule applies only to artifact-producing tasks. Pure code-change tasks (editing
+files already in a worker's checkout) are unaffected.


### PR DESCRIPTION
## Summary

- Adds an **Artifact repo selection** section to the foreman system prompt (`backend/foreman/prompt.py`) with a three-priority rule:
  1. Use `issue_repo` if set and a worker covers it (prefer that worker)
  2. Fall back to guild default repo when no worker covers `issue_repo`, with a `⚠️` note in the PR body
  3. No `issue_repo` → guild default (unchanged behaviour)
- Requires the foreman to always include a `**Target repo for this artifact:**` line in every artifact-task description so workers never have to guess.
- Creates `docs/foreman-guidelines.md` documenting the repo-selection rule and fallback note template.

## Test plan

- [ ] Confirm existing tasks with no linked issue continue to use the guild default repo (no regression)
- [ ] Create a design-doc task linked to an issue in an external repo; verify foreman instructs the worker to commit to that repo
- [ ] Create a design-doc task linked to an issue in a repo no worker covers; verify foreman falls back to guild repo and includes the fallback warning note

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)