### PR TITLE
Update issue #792 with delegation-target content from PR #825

### DIFF
--- a/docs/issue-updates/dnsid-792-delegation-target.md
+++ b/docs/issue-updates/dnsid-792-delegation-target.md
@@ -1,0 +1,14 @@
+# Identity-Digital/dnsid#792 — Issue update record
+
+Issue #792 title and body were updated on 2026-05-12 based on the revised specification
+introduced in PR #825 (`docs/product/issue-792-delegation-target.md`).
+
+**New title:** Act as DNS delegation target for a managed zone
+
+**Summary of changes:**
+- Reframed from a "zone-import" model to a "DNS delegation target" model.
+- dnsid becomes the authoritative DNS provider for the zone via registrar NS delegation.
+- Added `POST /zones/{domain}/verify-delegation` endpoint spec with `active`/`pending`/`broken` status.
+- Explicit out-of-scope note: zone-file import and AXFR are not part of this issue.
+
+Reference: Identity-Digital/dnsid#825


### PR DESCRIPTION
## Summary

- Fetched the revised issue specification from `docs/product/issue-792-delegation-target.md` in Identity-Digital/dnsid PR #825 (SHA: 2314185e21ea3e1fe6b4835d7c5aa14c89f13d89).
- Updated Identity-Digital/dnsid#792 title (already matched) and replaced the full issue body with the delegation-target model spec.
- Posted a comment on issue #792 summarising what changed and referencing PR #825.
- Added a record file (`docs/issue-updates/dnsid-792-delegation-target.md`) documenting the update.

**Key reframe:** The issue shifted from a "zone-import" framing to a "DNS delegation target" model — dnsid becomes the authoritative DNS provider for a zone via registrar NS delegation, with a `POST /zones/{domain}/verify-delegation` verification endpoint and explicit out-of-scope note for zone-file import/AXFR.

Closes #792