### PR TITLE
Replace guilds.github_user_id with guild_members (#291)

### DIFF
--- a/backend/auth_deps.py
+++ b/backend/auth_deps.py
@@ -46,17 +46,9 @@ async def require_user(
 
 
 async def ensure_membership(db, guild_id: str, user_id: str) -> str:
-    """Return the role of *user_id* in *guild_id* or raise HTTP 403/404.
-
-    Legacy guilds created before guild_members existed have a ``github_user_id``
-    on the guild row and no member rows; treat that owner as a member so the
-    pre-migration UI keeps working without a manual repair step.
-    """
-    g_res = await db.execute(
-        select(Guild.guild_id, Guild.github_user_id).where(Guild.guild_id == guild_id)
-    )
-    grow = g_res.first()
-    if not grow:
+    """Return the role of *user_id* in *guild_id* or raise HTTP 403/404."""
+    g_res = await db.execute(select(Guild.guild_id).where(Guild.guild_id == guild_id))
+    if not g_res.first():
         raise HTTPException(status_code=404, detail="Guild not found")
 
     res = await db.execute(
@@ -67,8 +59,6 @@ async def ensure_membership(db, guild_id: str, user_id: str) -> str:
     role = res.scalar_one_or_none()
     if role:
         return role
-    if grow.github_user_id and grow.github_user_id == user_id:
-        return "owner"
     raise HTTPException(status_code=403, detail="Not a member of this guild")
 
 

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from database import get_db
 from events import broadcast
-from models import ForemanTurn, Guild, Message, Task, live_tasks_filter
+from models import ForemanTurn, Guild, GuildMember, Message, Task, live_tasks_filter
 from sqlalchemy import delete, select
 from util.tasks import spawn
 
@@ -247,7 +247,11 @@ def _serialize_content(content) -> str:
 async def _get_guild_user_id(guild_id: str) -> str | None:
     db = await get_db()
     try:
-        result = await db.execute(select(Guild.github_user_id).where(Guild.guild_id == guild_id))
+        result = await db.execute(
+            select(GuildMember.user_id)
+            .where(GuildMember.guild_id == guild_id, GuildMember.role == "owner")
+            .limit(1)
+        )
         return result.scalar_one_or_none()
     finally:
         await db.close()

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime, timedelta
 
 from database import get_db
 from events import broadcast, emit_terminal_line
-from models import Agent, GithubToken, Guild, GuildKey, Task, TaskLog, Worker
+from models import Agent, GithubToken, GuildKey, GuildMember, Task, TaskLog, Worker
 from sqlalchemy import select, update
 
 # Default soft-delete window (seconds) when finalize_task is called without
@@ -561,8 +561,9 @@ async def _guild_github_token(guild_id: str) -> tuple[str, str] | None:
     try:
         result = await db.execute(
             select(GithubToken.access_token, GithubToken.github_username)
-            .join(Guild, Guild.github_user_id == GithubToken.github_user_id)
-            .where(Guild.guild_id == guild_id)
+            .join(GuildMember, GuildMember.user_id == GithubToken.github_user_id)
+            .where(GuildMember.guild_id == guild_id, GuildMember.role == "owner")
+            .limit(1)
         )
         row = result.first()
         return (row.access_token, row.github_username) if row else None

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -85,13 +85,17 @@ async def get_github_token(
     Without auth, anyone knowing a guild_id could exfiltrate the GitHub token."""
     db = await get_db()
     try:
-        result = await db.execute(select(Guild.github_user_id).where(Guild.guild_id == guild_id))
-        github_user_id_val = result.scalar_one_or_none()
-        if not github_user_id_val:
+        owner_res = await db.execute(
+            select(GuildMember.user_id)
+            .where(GuildMember.guild_id == guild_id, GuildMember.role == "owner")
+            .limit(1)
+        )
+        owner_user_id = owner_res.scalar_one_or_none()
+        if not owner_user_id:
             raise HTTPException(status_code=404, detail="No GitHub account linked to this guild")
         result = await db.execute(
             select(GithubToken.access_token, GithubToken.github_username).where(
-                GithubToken.github_user_id == github_user_id_val
+                GithubToken.github_user_id == owner_user_id
             )
         )
         token_row = result.first()
@@ -187,12 +191,7 @@ async def get_me(github_user_id: str = Depends(require_user)):
 
 @router.get("/api/me")
 async def api_me(github_user_id: str = Depends(require_user)):
-    """Return the current user's profile + their guild memberships.
-
-    Includes legacy guilds owned via ``guilds.github_user_id`` even when no
-    ``guild_members`` row exists, so the UI never sees a logged-in owner with
-    zero guilds just because their backfill row is missing.
-    """
+    """Return the current user's profile + their guild memberships."""
     db = await get_db()
     try:
         u_res = await db.execute(select(User).where(User.id == github_user_id))
@@ -200,29 +199,15 @@ async def api_me(github_user_id: str = Depends(require_user)):
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
 
-        explicit = await db.execute(
+        members_res = await db.execute(
             select(GuildMember.guild_id, GuildMember.role, Guild.name)
             .join(Guild, Guild.guild_id == GuildMember.guild_id)
             .where(GuildMember.user_id == github_user_id)
         )
-        memberships = {
-            row.guild_id: {
-                "guild_id": row.guild_id,
-                "guild_name": row.name,
-                "role": row.role,
-            }
-            for row in explicit.fetchall()
-        }
-        legacy = await db.execute(
-            select(Guild.guild_id.label("id"), Guild.name).where(
-                Guild.github_user_id == github_user_id
-            )
-        )
-        for row in legacy.fetchall():
-            memberships.setdefault(
-                row.id,
-                {"guild_id": row.id, "guild_name": row.name, "role": "owner"},
-            )
+        memberships = [
+            {"guild_id": row.guild_id, "guild_name": row.name, "role": row.role}
+            for row in members_res.fetchall()
+        ]
         return {
             "user": {
                 "id": user.id,
@@ -232,7 +217,7 @@ async def api_me(github_user_id: str = Depends(require_user)):
                 "display_name": user.display_name,
                 "avatar_url": user.avatar_url,
             },
-            "memberships": list(memberships.values()),
+            "memberships": memberships,
         }
     finally:
         await db.close()

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -95,8 +95,6 @@ async def create_guild(
 async def list_guilds(github_user_id: str = Depends(require_user)):
     db = await get_db()
     try:
-        # Union: guilds the user explicitly belongs to, plus legacy guilds
-        # whose github_user_id matches but never got a guild_members row.
         result = await db.execute(
             select(
                 Guild.guild_id.label("id"),
@@ -105,7 +103,7 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
                 func.count(Agent.id).label("agent_count"),
             )
             .select_from(Guild)
-            .outerjoin(
+            .join(
                 GuildMember,
                 (GuildMember.guild_id == Guild.guild_id) & (GuildMember.user_id == github_user_id),
             )
@@ -115,9 +113,7 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
                 & (Agent.type != "foreman")
                 & (Agent.state != "offline"),
             )
-            .where(
-                (GuildMember.user_id == github_user_id) | (Guild.github_user_id == github_user_id)
-            )
+            .where(GuildMember.user_id == github_user_id)
             .group_by(Guild.guild_id)
             .order_by(Guild.created_at.desc())
         )

--- a/backend/tests/test_credentials_auth.py
+++ b/backend/tests/test_credentials_auth.py
@@ -182,3 +182,45 @@ def test_get_github_token_accepts_worker_token(client):
     )
     assert resp.status_code == 200
     assert "access_token" in resp.json()
+
+
+def test_get_github_token_uses_guild_members_owner(client):
+    """Token endpoint resolves the owner via guild_members, not guilds.github_user_id."""
+    test_client, db_path = client
+    # insert_guild adds owner "gh-user-test" to guild_members; make_auth_token creates their token
+    insert_guild(db_path, "g-gm-tok")
+    _seed_github_token(db_path)  # ensures gh-user-test has a github_tokens row
+    worker = _register_worker(test_client, "g-gm-tok")
+    resp = test_client.get(
+        "/auth/github/token",
+        params={"guild_id": "g-gm-tok"},
+        headers={"Authorization": f"Bearer {worker['auth_token']}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    assert "username" in data
+
+
+def test_get_github_token_no_owner_in_guild_members(client):
+    """Returns 404 when no owner exists in guild_members (legacy-only guild)."""
+    import sqlite3
+    from datetime import UTC, datetime
+
+    test_client, db_path = client
+    now = datetime.now(UTC).isoformat()
+    # Insert a guild with github_user_id but no guild_members row
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO guilds (guild_id, created_at, name, github_user_id) VALUES (?, ?, ?, ?)",
+            ("g-noowner", now, "No Owner", "gh-user-test"),
+        )
+        conn.commit()
+    # Register a worker (bypasses membership check via auth_token)
+    worker = _register_worker(test_client, "g-noowner")
+    resp = test_client.get(
+        "/auth/github/token",
+        params={"guild_id": "g-noowner"},
+        headers={"Authorization": f"Bearer {worker['auth_token']}"},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -5,11 +5,26 @@ from __future__ import annotations
 import os
 import sqlite3
 import sys
+from datetime import UTC, datetime
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 from helpers import insert_guild, make_auth_token
+
+
+def _insert_guild_legacy_only(db_path: str, guild_id: str, user_id: str) -> None:
+    """Insert a guild with github_user_id set but NO guild_members row.
+
+    Simulates a pre-migration guild to verify the legacy fallback is gone.
+    """
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO guilds (guild_id, created_at, name, github_user_id) VALUES (?, ?, ?, ?)",
+            (guild_id, now, "Legacy Guild", user_id),
+        )
+        conn.commit()
 
 
 def test_get_guild_requires_auth(client):
@@ -253,3 +268,30 @@ def test_primary_repo_in_foreman_prompt():
     prompt_both = build_system_prompt("[]", "[]", extra_context="some context", primary_repo="o/r")
     assert "o/r" in prompt_both
     assert "some context" in prompt_both
+
+
+# ---------------------------------------------------------------------------
+# guild_members migration — legacy github_user_id paths must be gone
+# ---------------------------------------------------------------------------
+
+
+def test_list_guilds_excludes_legacy_owner(client):
+    """Guilds where guilds.github_user_id matches but no guild_members row exists
+    must NOT appear in the list; the legacy OR-clause has been removed."""
+    test_client, db_path = client
+    token = make_auth_token(db_path)  # user_id="gh-user-test"
+    _insert_guild_legacy_only(db_path, "g-legacy", "gh-user-test")
+    resp = test_client.get("/guilds", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    guild_ids = [g["id"] for g in resp.json()]
+    assert "g-legacy" not in guild_ids
+
+
+def test_get_guild_rejects_legacy_owner(client):
+    """A user whose id is only in guilds.github_user_id (no guild_members row)
+    must get 403, not 200 — the ensure_membership legacy fallback is gone."""
+    test_client, db_path = client
+    token = make_auth_token(db_path)  # user_id="gh-user-test"
+    _insert_guild_legacy_only(db_path, "g-leg2", "gh-user-test")
+    resp = test_client.get("/guilds/g-leg2", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403

--- a/backend/tests/test_user_members_api.py
+++ b/backend/tests/test_user_members_api.py
@@ -13,6 +13,17 @@ sys.path.insert(0, os.path.dirname(__file__))
 from helpers import insert_guild, insert_member, make_auth_token
 
 
+def _insert_guild_legacy_only(db_path: str, guild_id: str, user_id: str) -> None:
+    """Insert a guild with github_user_id but no guild_members row."""
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO guilds (guild_id, created_at, name, github_user_id) VALUES (?, ?, ?, ?)",
+            (guild_id, now, "Legacy", user_id),
+        )
+        conn.commit()
+
+
 def _seed_user(db_path: str, user_id: str, login: str) -> None:
     """Insert a users row directly so it can be referenced as a member."""
     now = datetime.now(UTC).isoformat()
@@ -174,3 +185,21 @@ def test_invalid_role_rejected(client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# guild_members migration — /api/me must not include legacy guilds
+# ---------------------------------------------------------------------------
+
+
+def test_api_me_excludes_legacy_guilds(client):
+    """Guilds where guilds.github_user_id matches but no guild_members row exists
+    must NOT appear in /api/me memberships; the legacy path has been removed."""
+    test_client, db_path = client
+    _seed_user(db_path, "gh-user-test", "testuser")
+    _insert_guild_legacy_only(db_path, "gm-legacy", "gh-user-test")
+    token = make_auth_token(db_path)
+    resp = test_client.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    guild_ids = [m["guild_id"] for m in resp.json()["memberships"]]
+    assert "gm-legacy" not in guild_ids


### PR DESCRIPTION
## Summary

- **`ensure_membership`** (`auth_deps.py`): remove legacy fallback that granted owner access via `guilds.github_user_id`; always require a `guild_members` row
- **`list_guilds`** (`routes/guilds.py`): drop the OR-clause on `Guild.github_user_id`; switch to a straight inner join on `guild_members`
- **`/api/me`** (`routes/auth.py`): remove the legacy `guilds.github_user_id` union; memberships come solely from `guild_members`
- **`/auth/github/token`** (`routes/auth.py`): find the guild owner via `guild_members` (role=owner) instead of reading `guilds.github_user_id`
- **`_guild_github_token`** (`foreman/tools.py`): join `github_tokens` through `GuildMember` (owner) rather than through `Guild.github_user_id`
- **`_get_guild_user_id`** (`foreman/runner.py`): look up the owner's `user_id` from `guild_members` instead of reading `Guild.github_user_id`

`guilds.github_user_id` column remains in the DB (no migration needed).

## Test plan

- [ ] All 344 existing tests pass
- [ ] New test: `test_list_guilds_excludes_legacy_owner` — legacy-only guild not returned by `GET /guilds`
- [ ] New test: `test_get_guild_rejects_legacy_owner` — `GET /guilds/{id}` returns 403 without a `guild_members` row
- [ ] New test: `test_api_me_excludes_legacy_guilds` — `/api/me` does not surface legacy-only guilds
- [ ] New test: `test_get_github_token_uses_guild_members_owner` — token endpoint resolves owner from `guild_members`
- [ ] New test: `test_get_github_token_no_owner_in_guild_members` — returns 404 for a guild with no `guild_members` owner row

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)