### PR TITLE
fix(backend): move logging setup before startup tasks, remove duplica…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -57,32 +57,7 @@ WORKER_OFFLINE_AFTER_SECONDS = float(os.environ.get("WORKER_OFFLINE_AFTER_SECOND
 WORKER_SWEEP_INTERVAL_SECONDS = float(os.environ.get("WORKER_SWEEP_INTERVAL_SECONDS", "30"))
 
 
-async def init_db() -> None:
-    from alembic import command
-    from alembic.config import Config
-    from sqlalchemy import create_engine, inspect
-
-    def run_migrations():
-        cfg = Config(Path(__file__).resolve().parent / "alembic.ini")
-        db_url = os.environ.get(
-            "DATABASE_URL", f"sqlite+aiosqlite:///{os.environ.get('DB_PATH', 'pioneer_square.db')}"
-        )
-        # Need a sync engine for inspection; strip aiosqlite async driver prefix.
-        sync_url = db_url.replace("+aiosqlite", "")
-        engine = create_engine(sync_url)
-        try:
-            tables = inspect(engine).get_table_names()
-            has_alembic = "alembic_version" in tables
-            has_data = "guilds" in tables
-            # Pre-Alembic database: stamp to current head so upgrade is a no-op.
-            if has_data and not has_alembic:
-                command.stamp(cfg, "head")
-        finally:
-            engine.dispose()
-        command.upgrade(cfg, "head")
-
-    await asyncio.to_thread(run_migrations)
-
+async def reset_connection_state() -> None:
     # On every startup, no worker processes are connected yet.
     async with AsyncSessionLocal() as db:
         await db.execute(update(Worker).values(state="offline"))
@@ -170,9 +145,8 @@ async def _stale_worker_sweeper() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    await init_db()
-    # Uvicorn pins the root logger to WARNING; reconfigure it so all backend
-    # modules (main, foreman.*, utils, etc.) emit at the requested level.
+    # Configure logging before startup tasks so all log output uses consistent
+    # handlers. force=True replaces uvicorn's root handlers.
     _log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
     _level = getattr(logging, _log_level, logging.INFO)
     logging.basicConfig(
@@ -183,6 +157,7 @@ async def lifespan(app: FastAPI):
     # foreman is always at least DEBUG so detailed AI loop output is available
     # when LOG_LEVEL=DEBUG; at INFO it still inherits the root handler above.
     logging.getLogger("foreman").setLevel(logging.DEBUG)
+    await reset_connection_state()
     sweeper = spawn(_stale_worker_sweeper(), name="stale-worker-sweeper")
     try:
         yield

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,7 @@ Each test gets a fresh temporary SQLite database so tests are fully isolated.
 The DB is created synchronously via Alembic before the TestClient starts, which
 avoids the anyio/asyncio.to_thread interaction that can deadlock in pytest.
 AsyncSessionLocal is patched in both the `database` module (used by get_db)
-and in `main` (used directly inside init_db's startup query).
+and in `main` (used directly inside reset_connection_state's startup query).
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ def client(tmp_path, monkeypatch):
     db_url = f"sqlite+aiosqlite:///{db_path}"
 
     # Create DB tables synchronously before the TestClient starts.
-    # This avoids the asyncio.to_thread(run_migrations) call inside init_db()
+    # This avoids any asyncio.to_thread calls during startup
     # which can deadlock under pytest's anyio event loop.
     os.environ["DATABASE_URL"] = db_url
     _create_db(db_path)
@@ -42,12 +42,12 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(database_module, "AsyncSessionLocal", new_session)
     monkeypatch.setattr(main_module, "AsyncSessionLocal", new_session)
 
-    # Stub out init_db: tables already exist (we just created them above) and
-    # there are no workers to reset in a fresh DB, so the stub is a no-op.
-    async def _stubbed_init_db() -> None:
+    # Stub out reset_connection_state: tables already exist (we just created them
+    # above) and there are no workers to reset in a fresh DB, so the stub is a no-op.
+    async def _stubbed_reset_connection_state() -> None:
         pass
 
-    monkeypatch.setattr(main_module, "init_db", _stubbed_init_db)
+    monkeypatch.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
     monkeypatch.setenv("DATABASE_URL", db_url)
     monkeypatch.setenv("DB_PATH", db_path)
 

--- a/backend/tests/test_disconnect.py
+++ b/backend/tests/test_disconnect.py
@@ -47,10 +47,10 @@ def client(tmp_path_factory):
     mp.setattr(database_module, "AsyncSessionLocal", new_session)
     mp.setattr(main_module, "AsyncSessionLocal", new_session)
 
-    async def _stubbed_init_db() -> None:
+    async def _stubbed_reset_connection_state() -> None:
         pass
 
-    mp.setattr(main_module, "init_db", _stubbed_init_db)
+    mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
     mp.setenv("DATABASE_URL", db_url)
     mp.setenv("DB_PATH", db_path)
 

--- a/backend/tests/test_liveness.py
+++ b/backend/tests/test_liveness.py
@@ -47,10 +47,10 @@ def client(tmp_path_factory):
     mp.setattr(database_module, "AsyncSessionLocal", new_session)
     mp.setattr(main_module, "AsyncSessionLocal", new_session)
 
-    async def _stubbed_init_db() -> None:
+    async def _stubbed_reset_connection_state() -> None:
         pass
 
-    mp.setattr(main_module, "init_db", _stubbed_init_db)
+    mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
     mp.setenv("DATABASE_URL", db_url)
     mp.setenv("DB_PATH", db_path)
 

--- a/backend/tests/test_pr_url_ws_persistence.py
+++ b/backend/tests/test_pr_url_ws_persistence.py
@@ -51,10 +51,10 @@ def client(tmp_path_factory):
     mp.setattr(database_module, "AsyncSessionLocal", new_session)
     mp.setattr(main_module, "AsyncSessionLocal", new_session)
 
-    async def _stubbed_init_db() -> None:
+    async def _stubbed_reset_connection_state() -> None:
         pass
 
-    mp.setattr(main_module, "init_db", _stubbed_init_db)
+    mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
     mp.setenv("DATABASE_URL", db_url)
     mp.setenv("DB_PATH", db_path)
 


### PR DESCRIPTION
…te alembic run

basicConfig(force=True) was called after init_db(), tearing down uvicorn's log handlers mid-startup and silencing all subsequent output. Move it first.

Docker already runs alembic migrations before the process starts, so remove the duplicate upgrade call from init_db and rename it reset_connection_state.