### PR TITLE
Add detailed logging to review_pr tool (#296)

### DIFF
--- a/backend/foreman/a2a_client.py
+++ b/backend/foreman/a2a_client.py
@@ -18,6 +18,8 @@ import asyncio
 import json
 import logging
 import os
+import time
+import urllib.error
 import urllib.request
 from typing import Any
 from urllib.parse import urlparse
@@ -130,12 +132,48 @@ class A2AClient:
             }
         ).encode()
 
-        result = await asyncio.to_thread(
-            _fetch_json,
-            f"{base_url}/a2a",
-            data=body,
-            headers=headers,
+        task_url = f"{base_url}/a2a"
+        log_headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
+        logger.debug(
+            "a2a send_task: url=%s method=POST skill_id=%s headers=%s payload=%.500s",
+            task_url,
+            skill_id,
+            log_headers,
+            body.decode(),
         )
+
+        t0 = time.monotonic()
+        try:
+            result = await asyncio.to_thread(_fetch_json, task_url, data=body, headers=headers)
+        except urllib.error.HTTPError as exc:
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            try:
+                err_body = exc.read().decode(errors="replace")
+            except Exception:
+                err_body = ""
+            logger.error(
+                "a2a send_task: url=%s status=%d elapsed_ms=%d err_body=%.500s",
+                task_url,
+                exc.code,
+                elapsed_ms,
+                err_body,
+                exc_info=True,
+            )
+            raise
+        except Exception:
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            logger.error(
+                "a2a send_task: url=%s elapsed_ms=%d request_failed",
+                task_url,
+                elapsed_ms,
+                exc_info=True,
+            )
+            raise
+
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        logger.info("a2a send_task: url=%s status=200 elapsed_ms=%d", task_url, elapsed_ms)
+        logger.debug("a2a send_task: response_preview=%.500s", str(result))
+
         return result.get("result", result)
 
     async def review_pr(

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -17,6 +17,8 @@ from events import broadcast, emit_terminal_line
 from models import Agent, GithubToken, GuildKey, GuildMember, Task, TaskLog, Worker
 from sqlalchemy import select, update
 
+logger = logging.getLogger(__name__)
+
 # Default soft-delete window (seconds) when finalize_task is called without
 # an explicit expiry. Mirrors backend.main.DEFAULT_FINALIZE_TTL.
 DEFAULT_FINALIZE_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
@@ -1466,6 +1468,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
 
                     elif tu.name == "review_pr":
                         pr_url = inp["pr_url"]
+                        logger.info("guild=%s review_pr: pr_url=%s", guild_id, pr_url)
                         pr_match = _PR_URL_RE.match(pr_url.rstrip("/"))
                         if not pr_match:
                             result_text = (
@@ -1482,12 +1485,41 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 "REVIEWER_AGENT_URL", "https://agent.meyers.life"
                             )
                             client = A2AClient(f"{review_agent.rstrip('/')}/.well-known/agent.json")
-                            a2a_result = await client.review_pr(
-                                pr_url,
-                                caller_domain=_guild_caller_domain(guild_id),
-                                private_key_pem=await _guild_private_key_pem(guild_id),
-                            )
+                            try:
+                                a2a_result = await client.review_pr(
+                                    pr_url,
+                                    caller_domain=_guild_caller_domain(guild_id),
+                                    private_key_pem=await _guild_private_key_pem(guild_id),
+                                )
+                            except urllib.error.HTTPError as exc:
+                                try:
+                                    err_body = exc.read().decode(errors="replace")
+                                except Exception:
+                                    err_body = ""
+                                logger.error(
+                                    "guild=%s review_pr: mcp_request_failed pr_url=%s status=%d err_body=%.500s",
+                                    guild_id,
+                                    pr_url,
+                                    exc.code,
+                                    err_body,
+                                    exc_info=True,
+                                )
+                                raise
+                            except Exception:
+                                logger.error(
+                                    "guild=%s review_pr: mcp_request_failed pr_url=%s",
+                                    guild_id,
+                                    pr_url,
+                                    exc_info=True,
+                                )
+                                raise
                             github_event, review_body = _extract_review_data(a2a_result)
+                            logger.info(
+                                "guild=%s review_pr: verdict=%s summary_preview=%.200s",
+                                guild_id,
+                                github_event,
+                                review_body,
+                            )
                             review_data = await asyncio.to_thread(
                                 _gh_api_post,
                                 f"/repos/{pr_repo}/pulls/{pr_number}/reviews",


### PR DESCRIPTION
## Summary

- **`backend/foreman/tools.py`**: Added a module-level `logger` and instrumented the `review_pr` tool block with:
  - `INFO` on entry: logs the PR URL being reviewed
  - `INFO` on parsed outcome: logs the verdict (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) and a 200-char summary preview
  - `ERROR` with full traceback for both `HTTPError` (including response body up to 500 chars) and generic exceptions — inner try/except logs then re-raises so the outer handler still sets `result_text` unchanged

- **`backend/foreman/a2a_client.py`**: Instrumented `send_task` with:
  - `DEBUG` before the outbound request: logs MCP server URL, method, skill ID, and payload preview — `Authorization` header stripped
  - Monotonic timing around `asyncio.to_thread(_fetch_json, ...)` 
  - `INFO` on success: logs URL, `status=200`, and elapsed ms
  - `DEBUG` on success: logs first 500 chars of the raw response
  - `ERROR` with full traceback on `HTTPError` (status code, elapsed ms, response body) or any other exception

No behaviour changes — logging only.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)