### PR TITLE
fix(a2a): align client with message/stream SSE protocol and dnsid-cr …

### DIFF
--- a/backend/foreman/a2a_client.py
+++ b/backend/foreman/a2a_client.py
@@ -1,14 +1,15 @@
 """A2A protocol client for the Foreman.
 
 A2AClient — discovers remote agents via their agent card, negotiates auth
-(DNSid challenge-response if declared), and dispatches tasks.
+(DNSid challenge-response if declared), and dispatches tasks via the
+message/stream SSE endpoint.
 
 Typical usage:
     client = A2AClient("https://agent.meyers.life/.well-known/agent.json")
     result = await client.review_pr(
         pr_url,
         caller_domain=_guild_caller_domain(guild_id),
-        config_path=os.environ.get("DNSID_AGENT_CONFIG"),
+        private_key_pem=os.environ.get("GUILD_PRIVATE_KEY_PEM"),
     )
 """
 
@@ -30,12 +31,55 @@ logger = logging.getLogger(__name__)
 
 _JSONRPC_VERSION = "2.0"
 _DEFAULT_TIMEOUT_SECS = 180.0  # reviews can take ~2 min
+_MAX_SSE_STREAM_BYTES = 32 * 1024 * 1024  # 32 MiB
 
 
 def _fetch_json(url: str, *, data: bytes | None = None, headers: dict | None = None) -> Any:
     req = urllib.request.Request(url, data=data, headers=headers or {})
     with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT_SECS) as resp:
         return json.loads(resp.read())
+
+
+def _read_sse_events(
+    url: str,
+    *,
+    data: bytes,
+    headers: dict,
+) -> list[dict]:
+    """POST to url, read SSE (text/event-stream) response, return all parsed events."""
+    req = urllib.request.Request(url, data=data, headers=headers)
+    events: list[dict] = []
+    buf: list[str] = []
+    stream_bytes = 0
+
+    with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT_SECS) as resp:
+        for raw_line in resp:
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            stream_bytes += len(line) + 1
+            if stream_bytes > _MAX_SSE_STREAM_BYTES:
+                logger.warning("a2a SSE stream exceeded byte cap, truncating")
+                break
+
+            if line == "":
+                if buf:
+                    payload = "\n".join(buf)
+                    buf = []
+                    try:
+                        events.append(json.loads(payload))
+                    except json.JSONDecodeError:
+                        logger.debug("a2a SSE non-JSON frame: %.200s", payload)
+            elif line.startswith("data:"):
+                buf.append(line[5:].lstrip(" "))
+            # event:/id:/retry:/comment lines silently ignored
+
+    if buf:
+        payload = "\n".join(buf)
+        try:
+            events.append(json.loads(payload))
+        except json.JSONDecodeError:
+            pass
+
+    return events
 
 
 def _guild_caller_domain(
@@ -50,7 +94,8 @@ def _guild_caller_domain(
 class A2AClient:
     """Client for A2A-protocol agents.
 
-    Fetches the remote agent card, negotiates authentication, and sends tasks.
+    Fetches the remote agent card, negotiates authentication, and sends tasks
+    via the message/stream SSE endpoint.
     """
 
     def __init__(
@@ -93,12 +138,14 @@ class A2AClient:
                     raise ValueError(
                         f"Agent {self._card_url} requires DNSid auth but no private key is available for guild"
                     )
-                skills = card.get("skills", [])
-                purpose = skills[0].get("id", "a2a-pr-review") if skills else "a2a-pr-review"
+                # purpose is a protocol constant, not the skill id
+                service_domain = spec.get("serviceDomain")
+                purpose = "a2a-pr-review"
                 return DNSidAuthScheme(
                     caller_domain=caller_domain,
                     private_key_pem=private_key_pem,
                     purpose=purpose,
+                    service_domain=service_domain,
                 )
         return None
 
@@ -110,7 +157,11 @@ class A2AClient:
         caller_domain: str | None = None,
         private_key_pem: str | None = None,
     ) -> dict:
-        """Send a task to the agent and return the raw result."""
+        """Send a task via message/stream and return collected artifacts.
+
+        Auth token (if needed) is placed in the JSON-RPC params as
+        `authorization: "DNSid <jwt>"` per the protocol spec.
+        """
         card = await self.fetch_agent_card()
         base_url = self._agent_base_url(card)
 
@@ -123,33 +174,45 @@ class A2AClient:
         if auth is None and caller_domain:
             auth = self._resolve_auth_scheme(card, caller_domain, private_key_pem)
 
-        headers: dict[str, str] = {"Content-Type": "application/json"}
+        # Resolve auth token — challenge-response runs here.
+        auth_token: str | None = None
         if auth is not None:
             auth_headers = await auth.get_auth_headers(base_url)
-            headers.update(auth_headers)
+            raw = auth_headers.get("Authorization", "")
+            auth_token = raw  # e.g. "DNSid <jwt>"
+
+        params: dict[str, Any] = {
+            "skill": skill_id,
+            "parts": message.get("parts", []),
+        }
+        if auth_token:
+            params["authorization"] = auth_token
 
         body = json.dumps(
             {
                 "jsonrpc": _JSONRPC_VERSION,
-                "method": "tasks/send",
-                "params": {"skill_id": skill_id, "message": message},
+                "method": "message/stream",
+                "params": params,
                 "id": 1,
             }
         ).encode()
 
         task_url = f"{base_url}/jsonrpc"
-        log_headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
         logger.debug(
-            "a2a send_task: url=%s method=POST skill_id=%s headers=%s payload=%.500s",
+            "a2a send_task: url=%s method=POST skill_id=%s payload=%.500s",
             task_url,
             skill_id,
-            log_headers,
             body.decode(),
         )
 
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        }
+
         t0 = time.monotonic()
         try:
-            result = await asyncio.to_thread(_fetch_json, task_url, data=body, headers=headers)
+            events = await asyncio.to_thread(_read_sse_events, task_url, data=body, headers=headers)
         except urllib.error.HTTPError as exc:
             elapsed_ms = int((time.monotonic() - t0) * 1000)
             try:
@@ -176,10 +239,15 @@ class A2AClient:
             raise
 
         elapsed_ms = int((time.monotonic() - t0) * 1000)
-        logger.info("a2a send_task: url=%s status=200 elapsed_ms=%d", task_url, elapsed_ms)
-        logger.debug("a2a send_task: response_preview=%.500s", str(result))
+        logger.info(
+            "a2a send_task: url=%s status=200 elapsed_ms=%d events=%d",
+            task_url,
+            elapsed_ms,
+            len(events),
+        )
+        logger.debug("a2a send_task: events=%.500s", str(events))
 
-        return result.get("result", result)
+        return _assemble_result(events)
 
     async def review_pr(
         self,
@@ -191,7 +259,36 @@ class A2AClient:
         """Submit a GitHub PR URL to the pr-review skill and return the task result."""
         return await self.send_task(
             "pr-review",
-            {"parts": [{"type": "github-pr-url", "text": pr_url}]},
+            {"parts": [{"type": "github-pr-url", "url": pr_url}]},
             caller_domain=caller_domain,
             private_key_pem=private_key_pem,
         )
+
+
+def _assemble_result(events: list[dict]) -> dict:
+    """Collect SSE events into a task result dict compatible with the existing foreman tools."""
+    artifacts: list[dict] = []
+    terminal_state: str | None = None
+    error_code: str | None = None
+    message: str | None = None
+
+    for event in events:
+        kind = event.get("kind")
+        if kind == "status-update":
+            state = event.get("state")
+            if state in ("completed", "failed", "rejected"):
+                terminal_state = state
+                error_code = event.get("error_code")
+                message = event.get("message")
+        elif kind == "artifact-update":
+            art = event.get("artifact")
+            if art:
+                artifacts.append(art)
+
+    if terminal_state in ("failed", "rejected"):
+        raise RuntimeError(f"a2a agent {terminal_state}: {error_code or message or 'no detail'}")
+
+    return {
+        "status": {"state": terminal_state or "unknown"},
+        "artifacts": artifacts,
+    }

--- a/backend/foreman/auth.py
+++ b/backend/foreman/auth.py
@@ -1,9 +1,12 @@
 """DNSid challenge-response authentication for A2A protocol connections.
 
-When an A2A agent declares a dnsid-based security scheme the caller must:
-  1. POST dnsid.challenge to the agent to receive a server {nonce, challenge_id}.
-  2. Sign a JWT (EdDSA/Ed25519) via the dnsid-sdk CLI containing those values.
-  3. Include Authorization: DNSid <jwt> on subsequent task requests.
+When an A2A agent declares a dnsid-cr security scheme the caller must:
+  1. POST dnsid.challenge {caller_domain, client_nonce} to receive
+     {server_nonce, challenge_id, server_assertion, exp}.
+  2. Sign a JWT (EdDSA/Ed25519) via the dnsid-sdk CLI with claims:
+     iss/sub=caller_domain, aud=service_domain, nonce=server_nonce,
+     challenge_id, purpose, iat, exp (≤60s), jti.
+  3. Include Authorization: DNSid <jwt> on the message/stream call.
 
 The caller's identity is a subdomain of the guild's base domain
 (e.g. {guild_id}.pioneer-square.melloy.life), and the remote agent can
@@ -18,6 +21,7 @@ import os
 import subprocess
 import time
 import urllib.request
+import uuid
 from abc import ABC, abstractmethod
 
 # ---------------------------------------------------------------------------
@@ -76,8 +80,8 @@ class A2AAuthScheme(ABC):
 class DNSidAuthScheme(A2AAuthScheme):
     """Mutual DNSid challenge-response (dnsid-cr security scheme).
 
-    Step 1 — POST dnsid.challenge (JSON-RPC 2.0) to {base_url}/jsonrpc.
-    Step 2 — Sign an EdDSA JWT with nonce/challenge_id/purpose/iss/sub via dnsid-sdk.
+    Step 1 — POST dnsid.challenge {caller_domain, client_nonce} to /jsonrpc.
+    Step 2 — Sign an EdDSA JWT with the returned server_nonce/challenge_id.
     Step 3 — Return Authorization: DNSid <jwt>.
     """
 
@@ -86,41 +90,59 @@ class DNSidAuthScheme(A2AAuthScheme):
         caller_domain: str,
         private_key_pem: str,
         purpose: str = "a2a-pr-review",
+        service_domain: str | None = None,
     ) -> None:
         self.caller_domain = caller_domain
         self.private_key_pem = private_key_pem
         self.purpose = purpose
+        self.service_domain = service_domain  # aud claim; inferred from base_url if None
 
     def _challenge_sync(self, agent_base_url: str) -> dict:
         """Synchronous POST to dnsid.challenge; returns unwrapped result dict."""
+        import secrets as _secrets
+
         url = agent_base_url.rstrip("/") + "/jsonrpc"
         body = json.dumps(
             {
                 "jsonrpc": "2.0",
                 "method": "dnsid.challenge",
-                "params": {"caller_id": self.caller_domain},
+                "params": {
+                    "caller_domain": self.caller_domain,
+                    "client_nonce": _secrets.token_hex(16),
+                },
                 "id": 1,
             }
         ).encode()
         req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
-        return data.get("result", data)
+        result = data.get("result", data)
+        if "error" in data and "server_nonce" not in result:
+            raise RuntimeError(
+                f"dnsid.challenge failed: {data['error'].get('message', data['error'])}"
+            )
+        return result
 
     async def get_auth_headers(self, agent_base_url: str) -> dict[str, str]:
         result = await asyncio.to_thread(self._challenge_sync, agent_base_url)
-        nonce = result["nonce"]
+        server_nonce = result["server_nonce"]
         challenge_id = result["challenge_id"]
+
+        from urllib.parse import urlparse
+
+        aud = self.service_domain or urlparse(agent_base_url).hostname or agent_base_url
 
         now = int(time.time())
         claims = {
             "iss": self.caller_domain,
             "sub": self.caller_domain,
-            "nonce": nonce,
+            "aud": aud,
+            "nonce": server_nonce,
             "challenge_id": challenge_id,
             "purpose": self.purpose,
+            "jti": str(uuid.uuid4()),
             "iat": now,
-            "exp": now + 300,
+            "exp": now + 60,
         }
         token = await asyncio.to_thread(_dnsid_sign_sync, claims, self.private_key_pem)
         return {"Authorization": f"DNSid {token}"}

--- a/backend/tests/test_dnsid_auth.py
+++ b/backend/tests/test_dnsid_auth.py
@@ -5,6 +5,7 @@ All network calls and subprocess calls are mocked — no real I/O.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from unittest.mock import patch
@@ -29,7 +30,9 @@ async def test_dnsid_auth_returns_authorization_header():
     )
     with (
         patch.object(
-            scheme, "_challenge_sync", return_value={"nonce": "abc", "challenge_id": "ch-1"}
+            scheme,
+            "_challenge_sync",
+            return_value={"server_nonce": "abc", "challenge_id": "ch-1"},
         ),
         patch("foreman.auth._dnsid_sign_sync", return_value="fake.jwt.token"),
     ):
@@ -39,11 +42,12 @@ async def test_dnsid_auth_returns_authorization_header():
 
 
 async def test_dnsid_auth_passes_correct_claims():
-    """JWT claims include nonce, challenge_id, purpose, iss, sub, iat, exp."""
+    """JWT claims include server_nonce as nonce, challenge_id, aud, jti, purpose, iss, sub, iat, exp."""
     scheme = DNSidAuthScheme(
         caller_domain="g1.pioneer-square.melloy.life",
         private_key_pem="fake-pem",
         purpose="pr-review",
+        service_domain="agent.example.com",
     )
     captured_claims: list[dict] = []
 
@@ -53,20 +57,25 @@ async def test_dnsid_auth_passes_correct_claims():
 
     with (
         patch.object(
-            scheme, "_challenge_sync", return_value={"nonce": "n42", "challenge_id": "c99"}
+            scheme,
+            "_challenge_sync",
+            return_value={"server_nonce": "n42", "challenge_id": "c99"},
         ),
         patch("foreman.auth._dnsid_sign_sync", side_effect=capture_sign),
     ):
-        await scheme.get_auth_headers("https://example.com")
+        await scheme.get_auth_headers("https://agent.example.com")
 
     claims = captured_claims[0]
-    assert claims["nonce"] == "n42"
+    assert claims["nonce"] == "n42"  # server_nonce goes into nonce claim
     assert claims["challenge_id"] == "c99"
     assert claims["purpose"] == "pr-review"
     assert claims["iss"] == "g1.pioneer-square.melloy.life"
     assert claims["sub"] == "g1.pioneer-square.melloy.life"
+    assert claims["aud"] == "agent.example.com"
+    assert "jti" in claims
     assert "iat" in claims
     assert "exp" in claims
+    assert claims["exp"] <= claims["iat"] + 60
     assert claims["exp"] > claims["iat"]
 
 
@@ -83,7 +92,9 @@ async def test_dnsid_auth_forwards_private_key_pem():
         return "tok"
 
     with (
-        patch.object(scheme, "_challenge_sync", return_value={"nonce": "n", "challenge_id": "c"}),
+        patch.object(
+            scheme, "_challenge_sync", return_value={"server_nonce": "n", "challenge_id": "c"}
+        ),
         patch("foreman.auth._dnsid_sign_sync", side_effect=capture_sign),
     ):
         await scheme.get_auth_headers("https://example.com")
@@ -134,7 +145,7 @@ def test_resolve_dnsid_scheme():
     assert isinstance(scheme, DNSidAuthScheme)
     assert scheme.caller_domain == "g.pioneer-square.melloy.life"
     assert scheme.private_key_pem == "my-pem"
-    assert scheme.purpose == "pr-review"
+    assert scheme.purpose == "a2a-pr-review"
 
 
 def test_resolve_dnsid_scheme_raises_without_key():
@@ -159,25 +170,25 @@ def test_guild_caller_domain_custom():
     assert _guild_caller_domain("abc123", "custom.example.com") == "abc123.custom.example.com"
 
 
-async def test_review_pr_attaches_dnsid_header():
-    """review_pr runs the challenge, attaches Authorization: DNSid, and POSTs."""
+async def test_review_pr_attaches_dnsid_param():
+    """review_pr runs the challenge and passes authorization in message/stream params."""
     client = A2AClient("https://agent.meyers.life/.well-known/agent.json")
     client._card = SAMPLE_CARD
 
     captured: dict = {}
-    fake_task_result = {"task_id": "t-1", "status": "complete"}
+    fake_events = [{"kind": "status-update", "state": "completed"}]
 
-    def fake_fetch(url, *, data=None, headers=None):
+    def fake_stream(url, *, data=None, headers=None):
         captured["url"] = url
         captured["headers"] = dict(headers or {})
-        captured["data"] = data
-        return {"result": fake_task_result}
+        captured["params"] = json.loads(data)["params"]
+        return fake_events
 
     with (
-        patch("foreman.a2a_client._fetch_json", side_effect=fake_fetch),
+        patch("foreman.a2a_client._read_sse_events", side_effect=fake_stream),
         patch(
             "foreman.auth.DNSidAuthScheme._challenge_sync",
-            return_value={"nonce": "n1", "challenge_id": "c1"},
+            return_value={"server_nonce": "n1", "challenge_id": "c1"},
         ),
         patch("foreman.auth._dnsid_sign_sync", return_value="signed.jwt.value"),
     ):
@@ -187,13 +198,14 @@ async def test_review_pr_attaches_dnsid_header():
             private_key_pem="fake-pem",
         )
 
-    assert captured["headers"].get("Authorization") == "DNSid signed.jwt.value"
+    assert captured["params"].get("authorization") == "DNSid signed.jwt.value"
+    assert "Authorization" not in captured["headers"]
     assert captured["url"] == "https://agent.meyers.life/jsonrpc"
-    assert result == fake_task_result
+    assert result["status"]["state"] == "completed"
 
 
 async def test_review_pr_no_auth_when_no_scheme():
-    """review_pr sends request without auth header when card has no auth scheme."""
+    """review_pr sends request without authorization param when card has no auth scheme."""
     card_no_auth = {**SAMPLE_CARD, "securitySchemes": {}, "security": []}
 
     client = A2AClient("https://example.com/.well-known/agent.json")
@@ -201,11 +213,11 @@ async def test_review_pr_no_auth_when_no_scheme():
 
     captured: dict = {}
 
-    def fake_fetch(url, *, data=None, headers=None):
-        captured["headers"] = dict(headers or {})
-        return {"result": {}}
+    def fake_stream(url, *, data=None, headers=None):
+        captured["params"] = json.loads(data)["params"]
+        return [{"kind": "status-update", "state": "completed"}]
 
-    with patch("foreman.a2a_client._fetch_json", side_effect=fake_fetch):
+    with patch("foreman.a2a_client._read_sse_events", side_effect=fake_stream):
         await client.review_pr("https://github.com/o/r/pull/1")
 
-    assert "Authorization" not in captured["headers"]
+    assert "authorization" not in captured["params"]

--- a/scripts/run_a2a_review.py
+++ b/scripts/run_a2a_review.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Live test: call review_pr on the code-review-agent at agent.meyers.life.
+
+Run from inside the backend Docker container:
+    docker exec pioneer-square-backend-1 python3 /app/../scripts/run_a2a_review.py
+
+Or with overrides:
+    REVIEWER_AGENT_URL=https://agent.meyers.life \
+    PR_URL=https://github.com/org/repo/pull/1 \
+    CALLER_DOMAIN=dnsid.pioneer-square.melloy.life \
+    PRIVATE_KEY_PEM="$(cat key.pem)" \
+    python3 scripts/run_a2a_review.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from foreman.a2a_client import A2AClient  # noqa: E402
+
+logging.basicConfig(level=logging.DEBUG, format="%(levelname)s %(name)s: %(message)s")
+
+AGENT_CARD_URL = (
+    os.environ.get("REVIEWER_AGENT_URL", "https://agent.meyers.life").rstrip("/")
+    + "/.well-known/agent.json"
+)
+
+PR_URL = os.environ.get("PR_URL", "https://github.com/Identity-Digital/dnsid/pull/861")
+CALLER_DOMAIN = os.environ.get("CALLER_DOMAIN", "dnsid.pioneer-square.melloy.life")
+PRIVATE_KEY_PEM = os.environ.get("PRIVATE_KEY_PEM", "")
+
+
+async def main() -> int:
+    if not PRIVATE_KEY_PEM:
+        print("ERROR: set PRIVATE_KEY_PEM env var to the Ed25519 private key PEM", file=sys.stderr)
+        return 1
+
+    client = A2AClient(AGENT_CARD_URL)
+
+    print(f"Fetching agent card from {AGENT_CARD_URL} ...")
+    card = await client.fetch_agent_card()
+    print(f"  name:     {card.get('name')}")
+    print(f"  skills:   {[s.get('id') for s in card.get('skills', [])]}")
+    print(f"  security: {card.get('security')}")
+
+    print(f"\nCalling review_pr on {PR_URL} ...")
+    print(f"  caller_domain: {CALLER_DOMAIN}")
+    result = await client.review_pr(
+        PR_URL,
+        caller_domain=CALLER_DOMAIN,
+        private_key_pem=PRIVATE_KEY_PEM,
+    )
+    print("\n=== Result ===")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
…spec

- Switch send_task from tasks/send (JSON) to message/stream (SSE)
- Move auth token from HTTP Authorization header into JSON-RPC params (authorization field) as required by the server spec
- Fix dnsid.challenge params: caller_domain + client_nonce (was caller_id)
- Use server_nonce from challenge response (was nonce) in caller JWT
- Add aud, jti to caller JWT claims; cap exp at 60s per spec
- Hardcode purpose as a2a-pr-review (protocol constant, not skill id)
- Pass serviceDomain from agent card as JWT aud
- Fix _assemble_result to parse SSE events into result dict
- Update tests to match new transport and protocol behavior