### PR TITLE
Foreman task loop: exclude finalized, no 6-task limit

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -395,7 +395,7 @@ async def _poll_loop(guild_id: str) -> None:
             )
 
             if active_tasks:
-                task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active_tasks[:8])
+                task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active_tasks)
                 msg = (
                     f"[periodic-check] Automated status poll — {n} non-terminal "
                     f"task(s): {task_summary}. Check whether any are stalled. "
@@ -505,9 +505,12 @@ async def run_foreman_ai(
                 Task.pr_url,
                 Task.finished_at,
             )
-            .where(Task.guild_pk == guild_pk_val, live_tasks_filter())
+            .where(
+                Task.guild_pk == guild_pk_val,
+                ~Task.state.in_(list(_TERMINAL_STATES)),
+                live_tasks_filter(),
+            )
             .order_by(Task.created_at.desc())
-            .limit(10)
         )
         task_rows = [
             {**dict(r._mapping), "description": dict(r._mapping).get("description") or ""}
@@ -537,7 +540,7 @@ async def run_foreman_ai(
     summarized_tasks = [
         s for row in task_rows if (s := _summarize_task(row, cutoff_ts)) is not None
     ]
-    tasks_block = json.dumps(summarized_tasks[:6], indent=2)
+    tasks_block = json.dumps(summarized_tasks, indent=2)
     system_blocks = build_system_blocks(primary_repo=primary_repo)
     state_preamble = build_state_preamble(workers_block, tasks_block, extra_context)
     # Legacy single-string render — persisted for audit only, not sent to the API.


### PR DESCRIPTION
## Summary

- **Exclude terminal tasks**: `run_foreman_ai()` now filters out `done`/`failed`/`cancelled` tasks at the DB query level (`~Task.state.in_(_TERMINAL_STATES)`), replacing the previous approach of relying on `_summarize_task`'s 24-hour cutoff. The foreman's context will only ever contain open, in-progress, or awaiting-review tasks.
- **Remove `.limit(10)`**: The SQL query no longer caps results at 10 rows, so all non-terminal tasks are fetched.
- **Remove `[:6]` slice**: `tasks_block` now includes all summarized (non-terminal) tasks instead of being truncated to 6.
- **Remove `[:8]` slice**: The periodic-check message text in `_poll_loop()` now lists all active tasks instead of capping at 8.

## Test plan
- [ ] Verify that tasks in `done`, `failed`, or `cancelled` state no longer appear in the foreman's context JSON
- [ ] Verify that guilds with more than 6 open tasks send all of them to the foreman AI
- [ ] Confirm the `_poll_loop` periodic-check message lists all non-terminal tasks

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)