### PR TITLE
Foreman debug pane: clean context view + token tracking

### DIFF
--- a/backend/alembic/versions/20260515_000001_add_tokens_to_foreman_turns.py
+++ b/backend/alembic/versions/20260515_000001_add_tokens_to_foreman_turns.py
@@ -1,0 +1,34 @@
+"""add_tokens_to_foreman_turns
+
+Adds ``input_tokens`` and ``output_tokens`` columns to ``foreman_turns`` so
+the token usage returned by the Anthropic API can be stored per assistant turn.
+Both columns are nullable integers; existing rows and non-assistant turns
+(user/system) will have NULL values.
+
+Revision ID: 20260515_000001_add_tokens_to_foreman_turns
+Revises: 20260515_000000_add_name_to_workers
+Create Date: 2026-05-15 00:01:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260515_000001_add_tokens_to_foreman_turns"
+down_revision: str | Sequence[str] | None = "20260515_000000_add_name_to_workers"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("foreman_turns") as batch_op:
+        batch_op.add_column(sa.Column("input_tokens", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("output_tokens", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("foreman_turns") as batch_op:
+        batch_op.drop_column("output_tokens")
+        batch_op.drop_column("input_tokens")

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -351,6 +351,22 @@ async def _save_turn(
         await db.close()
 
 
+async def _update_turn_tokens(turn_id: int, input_tokens: int, output_tokens: int) -> None:
+    """Write token counts back to an existing ForemanTurn row."""
+    from sqlalchemy import update as sa_update
+
+    db = await get_db()
+    try:
+        await db.execute(
+            sa_update(ForemanTurn)
+            .where(ForemanTurn.id == turn_id)
+            .values(input_tokens=input_tokens, output_tokens=output_tokens)
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
 async def _poll_loop(guild_id: str) -> None:
     """Background loop: check non-terminal tasks and call the foreman if any are found.
 
@@ -600,6 +616,8 @@ async def run_foreman_ai(
                 tools=FOREMAN_TOOLS,
             )
             usage = resp.usage
+            _input_tokens = getattr(usage, "input_tokens", 0) or 0
+            _output_tokens = getattr(usage, "output_tokens", 0) or 0
             logger.info(
                 "guild=%s run_foreman_ai round %d: stop_reason=%s content_blocks=%d "
                 "input=%d cache_read=%d cache_write=%d output=%d",
@@ -607,14 +625,15 @@ async def run_foreman_ai(
                 round_num,
                 resp.stop_reason,
                 len(resp.content),
-                getattr(usage, "input_tokens", 0) or 0,
+                _input_tokens,
                 getattr(usage, "cache_read_input_tokens", 0) or 0,
                 getattr(usage, "cache_creation_input_tokens", 0) or 0,
-                getattr(usage, "output_tokens", 0) or 0,
+                _output_tokens,
             )
 
             # Persist assistant turn and append to local messages
             asst_turn_id = await _save_turn(guild_id, user_id, "assistant", resp.content)
+            await _update_turn_tokens(asst_turn_id, _input_tokens, _output_tokens)
             messages.append({"role": "assistant", "content": _serialize_content(resp.content)})
             # Re-parse so messages stays as plain dicts (not SDK objects)
             messages[-1]["content"] = json.loads(messages[-1]["content"])
@@ -714,17 +733,20 @@ async def run_foreman_ai(
                 tool_choice={"type": "none"},
             )
             wrap_usage = wrap_resp.usage
+            _wrap_input = getattr(wrap_usage, "input_tokens", 0) or 0
+            _wrap_output = getattr(wrap_usage, "output_tokens", 0) or 0
             logger.info(
                 "guild=%s run_foreman_ai wrap-up: stop_reason=%s "
                 "input=%d cache_read=%d cache_write=%d output=%d",
                 guild_id,
                 wrap_resp.stop_reason,
-                getattr(wrap_usage, "input_tokens", 0) or 0,
+                _wrap_input,
                 getattr(wrap_usage, "cache_read_input_tokens", 0) or 0,
                 getattr(wrap_usage, "cache_creation_input_tokens", 0) or 0,
-                getattr(wrap_usage, "output_tokens", 0) or 0,
+                _wrap_output,
             )
-            await _save_turn(guild_id, user_id, "assistant", wrap_resp.content)
+            wrap_turn_id = await _save_turn(guild_id, user_id, "assistant", wrap_resp.content)
+            await _update_turn_tokens(wrap_turn_id, _wrap_input, _wrap_output)
             text_parts += [b.text for b in wrap_resp.content if b.type == "text" and b.text.strip()]
             text_parts.append(f"_(Foreman hit {MAX_FOREMAN_ROUNDS}-round safety cap and stopped.)_")
 
@@ -788,8 +810,20 @@ async def clear_foreman_history(guild_id: str, user_id: str) -> int:
         await db.close()
 
 
-async def get_foreman_history(guild_id: str, user_id: str) -> list[dict]:
-    """Return all stored turns as JSON-safe dicts (for the debug endpoint)."""
+async def get_foreman_history(guild_id: str, user_id: str) -> dict:
+    """Return stored turns structured for the debug view.
+
+    Returns::
+
+        {
+            "system": <str | None>,   # most-recent audit system prompt text
+            "messages": [...],        # non-system turns only, in DB order
+        }
+
+    System turns are persisted for auditing but are never part of the
+    ``messages[]`` array sent to the Anthropic API — they appear here once
+    at the top so the debug pane accurately mirrors what would be sent.
+    """
     db = await get_db()
     try:
         guild_pk_val = await get_guild_pk(db, guild_id)
@@ -802,7 +836,16 @@ async def get_foreman_history(guild_id: str, user_id: str) -> list[dict]:
     finally:
         await db.close()
 
-    return [
+    # Grab the most-recent system turn (there's one per invocation; we only
+    # show the latest to avoid duplicates in the debug pane).
+    system_content: str | None = None
+    for t in reversed(turns):
+        if t.role == "system":
+            raw = json.loads(t.content_json)
+            system_content = raw if isinstance(raw, str) else json.dumps(raw)
+            break
+
+    messages = [
         {
             "id": t.id,
             "role": t.role,
@@ -810,6 +853,11 @@ async def get_foreman_history(guild_id: str, user_id: str) -> list[dict]:
             "parent_id": t.parent_id,
             "content": json.loads(t.content_json),
             "created_at": t.created_at,
+            "input_tokens": t.input_tokens,
+            "output_tokens": t.output_tokens,
         }
         for t in turns
+        if t.role != "system"
     ]
+
+    return {"system": system_content, "messages": messages}

--- a/backend/models.py
+++ b/backend/models.py
@@ -229,6 +229,9 @@ class ForemanTurn(Base):
     # For tool_result turns: id of the assistant turn whose tool_use blocks this answers
     parent_id = Column(Integer, ForeignKey("foreman_turns.id"), nullable=True)
     created_at = Column(Text, nullable=False)
+    # Token usage from the API response (assistant turns only; NULL for user/system turns)
+    input_tokens = Column(Integer, nullable=True)
+    output_tokens = Column(Integer, nullable=True)
 
 
 class GithubEvent(Base):

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -32,8 +32,12 @@ async def get_foreman_context(
             raise HTTPException(status_code=404, detail="Guild not found")
     finally:
         await db.close()
-    turns = await get_foreman_history(guild_id, github_user_id)
-    return {"messages": turns, "count": len(turns)}
+    history = await get_foreman_history(guild_id, github_user_id)
+    return {
+        "system": history["system"],
+        "messages": history["messages"],
+        "count": len(history["messages"]),
+    }
 
 
 @router.post("/guilds/{guild_id}/foreman/clear-context")

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1195,10 +1195,12 @@ class TestForemanHistory:
         await _save_turn("g-hist-sys2", "u-1", "system", "System prompt content")
         await _save_turn("g-hist-sys2", "u-1", "user", "Human message")
         history = await get_foreman_history("g-hist-sys2", "u-1")
-        roles = [t["role"] for t in history]
-        assert "system" in roles
+        # System turn is surfaced via the dedicated "system" key, not in messages[]
+        assert history["system"] == "System prompt content"
+        roles = [t["role"] for t in history["messages"]]
         assert "user" in roles
-        assert len(history) == 2
+        assert "system" not in roles
+        assert len(history["messages"]) == 1
 
     async def test_system_turns_not_counted_in_sliding_window(self, db_session):
         """System turns interspersed with human turns must not affect the 5-turn

--- a/frontend/src/components/DebugSidebar.vue
+++ b/frontend/src/components/DebugSidebar.vue
@@ -19,10 +19,17 @@
       </div>
 
       <div class="debug-messages" ref="debugEl">
-        <div v-if="debugContext.length === 0 && !debugLoading" class="debug-empty">
+        <div v-if="debugContext.length === 0 && !debugLoading && !systemPrompt" class="debug-empty">
           No context — foreman hasn't run yet.
         </div>
         <div v-if="debugLoading" class="debug-empty">Loading...</div>
+
+        <!-- System prompt rendered once at top -->
+        <div v-if="systemPrompt" class="debug-msg debug-system">
+          <span class="debug-role">SYSTEM</span>
+          <span class="debug-text">{{ systemPrompt }}</span>
+        </div>
+
         <div
           v-for="(msg, i) in debugContext"
           :key="i"
@@ -35,9 +42,19 @@
                 : 'debug-user'
           "
         >
-          <span class="debug-role">{{
-            isToolResponseMsg(msg) ? 'TOOL RESPONSE' : msg.role.toUpperCase()
-          }}</span>
+          <div class="debug-msg-header">
+            <span class="debug-role">{{
+              isToolResponseMsg(msg) ? 'TOOL RESPONSE' : msg.role.toUpperCase()
+            }}</span>
+            <span
+              v-if="msg.role === 'assistant' && (msg.input_tokens || msg.output_tokens)"
+              class="debug-tokens"
+              title="input / output tokens for this API call"
+            >
+              ↑ {{ (msg.input_tokens ?? 0).toLocaleString() }} / ↓
+              {{ (msg.output_tokens ?? 0).toLocaleString() }} tokens
+            </span>
+          </div>
           <template v-if="typeof msg.content === 'string'">
             <span class="debug-text">{{ msg.content }}</span>
           </template>
@@ -92,11 +109,16 @@ interface DebugBlock {
 }
 
 interface DebugMessage {
+  id?: number
   role: string
   content: string | DebugBlock[]
+  is_tool_response?: boolean
+  input_tokens?: number | null
+  output_tokens?: number | null
 }
 
 const debugContext = ref<DebugMessage[]>([])
+const systemPrompt = ref<string | null>(null)
 const debugLoading = ref(false)
 const debugClearing = ref(false)
 const debugEl = ref<HTMLElement | null>(null)
@@ -114,8 +136,11 @@ async function refreshDebug() {
   if (!guildId) return
   debugLoading.value = true
   try {
-    const data = await api<{ messages?: DebugMessage[] }>(`/guilds/${guildId}/foreman/context`)
+    const data = await api<{ messages?: DebugMessage[]; system?: string | null }>(
+      `/guilds/${guildId}/foreman/context`,
+    )
     debugContext.value = data?.messages ?? []
+    systemPrompt.value = data?.system ?? null
   } catch (e) {
     console.error('Failed to load foreman context', e)
   } finally {
@@ -132,6 +157,7 @@ async function clearContext() {
   try {
     await api(`/guilds/${guildId}/foreman/clear-context`, { method: 'POST' })
     debugContext.value = []
+    systemPrompt.value = null
   } catch (e) {
     console.error('Failed to clear foreman context', e)
   } finally {
@@ -270,6 +296,19 @@ onMounted(() => refreshDebug())
   border-radius: 2px;
 }
 
+.debug-msg-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+
+.debug-system {
+  background: rgba(120, 80, 200, 0.07);
+  border-left: 3px solid #8b5cf6;
+}
+
 .debug-assistant {
   background: rgba(0, 187, 170, 0.06);
   border-left: 3px solid var(--color-teal);
@@ -290,9 +329,11 @@ onMounted(() => refreshDebug())
   font-size: 6px;
   letter-spacing: 1px;
   color: var(--color-text-dim);
-  margin-bottom: 2px;
 }
 
+.debug-system .debug-role {
+  color: #8b5cf6;
+}
 .debug-assistant .debug-role {
   color: var(--color-teal);
 }
@@ -301,6 +342,14 @@ onMounted(() => refreshDebug())
 }
 .debug-tool-response .debug-role {
   color: #50c878;
+}
+
+.debug-tokens {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--color-teal);
+  opacity: 0.8;
+  white-space: nowrap;
 }
 
 .debug-text {


### PR DESCRIPTION
## Summary

- **Fix duplicate system prompt in debug pane**: `get_foreman_history` now returns `{system, messages}` — the most-recent audit system turn is extracted and returned separately; all system-role rows are excluded from the `messages[]` list. The frontend renders the system prompt once at the top (purple border) and the conversation messages below, mirroring exactly what would be sent to the LLM.

- **Per-turn token tracking**: Added `input_tokens` / `output_tokens` nullable integer columns to `foreman_turns` (Alembic migration `20260515_000001`). A new `_update_turn_tokens` helper writes token counts back to the assistant turn row immediately after every Anthropic API call (main tool-call loop and wrap-up). The debug pane now shows "↑ N / ↓ N tokens" next to each assistant response.

## Changed files

| File | Change |
|------|--------|
| `backend/models.py` | Add `input_tokens`, `output_tokens` to `ForemanTurn` |
| `backend/alembic/versions/20260515_000001_add_tokens_to_foreman_turns.py` | Migration to add the two columns |
| `backend/foreman/runner.py` | `_update_turn_tokens` helper; capture + persist usage after each API call; restructure `get_foreman_history` return value |
| `backend/routes/foreman.py` | Pass through `system` field in `/foreman/context` response |
| `frontend/src/components/DebugSidebar.vue` | System prompt section at top; token count badge on assistant turns; updated TypeScript interfaces |

## Test plan

- [ ] Start backend + frontend; trigger the foreman with a message
- [ ] Open debug pane — system prompt appears once at top (purple), no system rows in message list
- [ ] Run multiple foreman invocations; reopen debug pane — system prompt still appears only once
- [ ] Check assistant turns — "↑ N / ↓ N tokens" badge visible next to each
- [ ] CLR CTX clears both the system prompt section and all messages
- [ ] `SELECT input_tokens, output_tokens FROM foreman_turns WHERE role='assistant'` returns non-NULL values

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)