### PR TITLE
Phase 1 & 2: Foreman split — backend REST + WebSocket prep

### DIFF
--- a/backend/events.py
+++ b/backend/events.py
@@ -30,6 +30,13 @@ pending_claude_auth: dict[str, dict[str, str]] = {}
 # get its just-joined agent stamped offline.
 _agent_owner_locks: dict[str, asyncio.Lock] = {}
 
+# Active external foreman WebSocket per guild — at most one per guild at a
+# time. Set by ws_handlers.handle_join when an agent with agentType="foreman"
+# joins; cleared on graceful disconnect or when the socket drops.
+# Phase 2: ws_handlers reads this to decide whether to send a foreman-trigger
+# WS message or fall back to the embedded run_foreman_ai().
+foreman_connections: dict[str, WebSocket] = {}
+
 
 def agent_owner_lock(guild_id: str) -> asyncio.Lock:
     """Return the per-guild lock used to serialise ``agent_owners`` writes."""

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -371,6 +371,22 @@ async def _poll_loop(guild_id: str) -> None:
             return
 
         try:
+            # If an external foreman is connected for this guild it owns the
+            # poll loop — skip the embedded run to avoid double-triggering.
+            from events import foreman_connections
+
+            if guild_id in foreman_connections:
+                next_interval = min(interval * 2, POLL_MAX_SECS)
+                logger.debug(
+                    "guild=%s external foreman connected, skipping embedded poll", guild_id
+                )
+                interval = next_interval
+                await broadcast(
+                    guild_id,
+                    {"type": "foreman-poll-status", "nextCheckIn": interval},
+                )
+                continue
+
             db = await get_db()
             try:
                 guild_pk_val = await get_guild_pk(db, guild_id)

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -1,22 +1,61 @@
-"""Foreman conversation-history routes (debug + clear).
+"""Foreman REST API — conversation history (existing debug endpoints) and the
+new Phase 1 endpoints that let an external standalone foreman process read
+guild state and write task/message mutations without direct DB access.
 
-The foreman AI itself runs in ``foreman/runner.py``; this module is just the
-HTTP surface for inspecting and clearing per-guild/per-user turn history.
+Auth: all new endpoints accept either a worker auth_token *or* a member
+login_token via ``require_worker_or_member_path``. This matches the existing
+worker credential endpoints and keeps the door open for the standalone
+foreman to register with a worker-style auth_token in Phase 3.
+
+Endpoint summary
+----------------
+Existing (unchanged):
+  GET  /guilds/{guild_id}/foreman/context        — debug: stored turns for calling user
+  POST /guilds/{guild_id}/foreman/clear-context  — debug: delete all turns for calling user
+
+Phase 1 additions — state reads:
+  GET  /guilds/{guild_id}/foreman/state          — online workers, active tasks, guild metadata
+  GET  /guilds/{guild_id}/foreman/history        — raw ForemanTurn rows for a given user_id
+  GET  /guilds/{guild_id}/guild-key              — Ed25519 private key PEM for JWT signing
+
+Phase 1 additions — state writes:
+  POST  /guilds/{guild_id}/foreman/history       — persist one ForemanTurn row
+  POST  /guilds/{guild_id}/tasks                 — create a foreman-owned task
+  PATCH /guilds/{guild_id}/tasks/{task_id}       — update task fields (state, worker, branch, …)
+  POST  /guilds/{guild_id}/messages              — persist a chat message
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import random
+import string
+from datetime import UTC, datetime
 
-from auth_deps import require_member
+from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
 from database import get_db
-from fastapi import APIRouter, Depends, HTTPException
+from events import broadcast
+from fastapi import APIRouter, Depends, HTTPException, Query
 from foreman import clear_foreman_history, get_foreman_history
-from models import Guild
-from sqlalchemy import select
+from models import (
+    ForemanTurn,
+    Guild,
+    GuildKey,
+    Message,
+    Task,
+    live_tasks_filter,
+)
+from pydantic import BaseModel
+from sqlalchemy import select, text, update
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Existing debug endpoints (unchanged)
+# ---------------------------------------------------------------------------
 
 
 @router.get("/guilds/{guild_id}/foreman/context")
@@ -57,3 +96,492 @@ async def clear_foreman_context(
         removed,
     )
     return {"status": "cleared", "removed": removed}
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — State reads
+# ---------------------------------------------------------------------------
+
+
+@router.get("/guilds/{guild_id}/foreman/state")
+async def get_foreman_state(
+    guild_id: str,
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Return a snapshot of guild state for an external foreman process.
+
+    Response shape::
+
+        {
+          "guild": { "name": str, "primary_repo": str | null },
+          "workers": [
+            {
+              "id": str,
+              "state": str,          # "online" | "offline"
+              "repos": list[str],
+              "org": str | null,
+              "agent_count": int,
+              "agents": str          # "agentId:state,…" summary
+            }
+          ],
+          "tasks": [
+            {
+              "id": str, "worker_id": str, "name": str, "description": str,
+              "state": str, "phase": str, "branch": str | null,
+              "pr_url": str | null, "finished_at": str | null
+            }
+          ]
+        }
+
+    ``workers`` lists only online workers (state == 'online'). ``tasks``
+    lists all non-terminal, non-soft-deleted tasks, most recent first.
+    Mirrors the state snapshot built by ``run_foreman_ai()`` so the
+    standalone foreman can construct the same system-prompt preamble.
+    """
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+
+        # Guild metadata
+        guild_res = await db.execute(
+            select(Guild.name, Guild.primary_repo).where(Guild.guild_id == guild_id)
+        )
+        guild_row = guild_res.one_or_none()
+        guild_data = {
+            "name": guild_row.name if guild_row else None,
+            "primary_repo": guild_row.primary_repo if guild_row else None,
+        }
+
+        # Online workers with their active agents
+        workers_res = await db.execute(
+            text(
+                "SELECT w.id, w.repos, w.org, w.state as worker_state,"
+                " COUNT(a.id) as agent_count,"
+                " GROUP_CONCAT(a.id || ':' || a.state) as agents"
+                " FROM workers w"
+                " LEFT JOIN agents a ON a.worker_id = w.id AND a.state != 'offline'"
+                " WHERE w.guild_pk = :guild_pk AND w.state = 'online'"
+                " GROUP BY w.id"
+                " UNION ALL"
+                " SELECT a.id, '[]', NULL, a.state, 1, a.id || ':' || a.state"
+                " FROM agents a"
+                " WHERE a.guild_pk = :guild_pk AND a.type = 'worker'"
+                " AND a.worker_id IS NULL AND a.state != 'offline'"
+            ),
+            {"guild_pk": guild_pk},
+        )
+        worker_rows = [dict(r._mapping) for r in workers_res.fetchall()]
+        workers_data = [
+            {
+                "id": r["id"],
+                "state": r["worker_state"] or "idle",
+                "repos": json.loads(r["repos"] or "[]"),
+                **({"org": r["org"]} if r.get("org") else {}),
+                "agent_count": r["agent_count"] or 0,
+                "agents": r["agents"] or "",
+            }
+            for r in worker_rows
+        ]
+
+        # Active (non-terminal, non-soft-deleted) tasks
+        _TERMINAL = {"done", "failed", "cancelled"}
+        tasks_res = await db.execute(
+            select(
+                Task.id,
+                Task.worker_id,
+                Task.name,
+                Task.description,
+                Task.state,
+                Task.phase,
+                Task.branch,
+                Task.pr_url,
+                Task.finished_at,
+                Task.created_at,
+                Task.user_id,
+            )
+            .where(
+                Task.guild_pk == guild_pk,
+                ~Task.state.in_(list(_TERMINAL)),
+                live_tasks_filter(),
+            )
+            .order_by(Task.created_at.desc())
+        )
+        tasks_data = [dict(r._mapping) for r in tasks_res.fetchall()]
+    finally:
+        await db.close()
+
+    return {"guild": guild_data, "workers": workers_data, "tasks": tasks_data}
+
+
+@router.get("/guilds/{guild_id}/foreman/history")
+async def get_foreman_history_for_user(
+    guild_id: str,
+    user_id: str = Query(..., description="GitHub user_id whose thread to fetch"),
+    limit: int | None = Query(default=None, description="Max rows to return (newest first)"),
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Return raw ForemanTurn rows for a given user, ordered oldest→newest.
+
+    Response shape::
+
+        [
+          {
+            "id": int,
+            "role": str,              # "user" | "assistant" | "system"
+            "content_json": str,      # JSON-serialised content blocks
+            "is_tool_response": bool,
+            "parent_id": int | null,
+            "created_at": str
+          }
+        ]
+
+    The standalone foreman applies its own sliding-window logic (equivalent
+    to ``_load_history()``) on top of these raw rows. ``limit`` caps the
+    number of rows returned (applied before the sliding window).
+    """
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+
+        stmt = (
+            select(
+                ForemanTurn.id,
+                ForemanTurn.role,
+                ForemanTurn.content_json,
+                ForemanTurn.is_tool_response,
+                ForemanTurn.parent_id,
+                ForemanTurn.created_at,
+            )
+            .where(ForemanTurn.guild_pk == guild_pk, ForemanTurn.user_id == user_id)
+            .order_by(ForemanTurn.id)
+        )
+        if limit is not None and limit > 0:
+            stmt = stmt.limit(limit)
+        result = await db.execute(stmt)
+        turns = result.fetchall()
+    finally:
+        await db.close()
+
+    return [
+        {
+            "id": t.id,
+            "role": t.role,
+            "content_json": t.content_json,
+            "is_tool_response": bool(t.is_tool_response),
+            "parent_id": t.parent_id,
+            "created_at": t.created_at,
+        }
+        for t in turns
+    ]
+
+
+@router.get("/guilds/{guild_id}/guild-key")
+async def get_guild_key(
+    guild_id: str,
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Return the guild's Ed25519 signing key for JWT operations.
+
+    Response shape::
+
+        { "key_id": str, "private_key_pem": str }
+
+    Used by the standalone foreman's ``dnsid sign`` tool to create JWTs
+    without direct DB access. Returns 404 if no key has been generated yet.
+    """
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+        result = await db.execute(
+            select(GuildKey.key_id, GuildKey.private_key_pem).where(GuildKey.guild_pk == guild_pk)
+        )
+        row = result.one_or_none()
+    finally:
+        await db.close()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="No signing key found for this guild")
+    return {"key_id": row.key_id, "private_key_pem": row.private_key_pem}
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — State writes
+# ---------------------------------------------------------------------------
+
+
+class ForemanTurnCreate(BaseModel):
+    """Body for POST /guilds/{guild_id}/foreman/history."""
+
+    user_id: str
+    role: str  # "user" | "assistant" | "system"
+    content_json: str  # JSON-serialised content blocks (string, list, …)
+    is_tool_response: bool = False
+    parent_id: int | None = None
+
+
+@router.post("/guilds/{guild_id}/foreman/history")
+async def create_foreman_turn(
+    guild_id: str,
+    body: ForemanTurnCreate,
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Persist one foreman conversation turn to the DB.
+
+    Replaces ``_save_turn()`` in ``foreman/runner.py`` for the standalone
+    foreman — it calls this endpoint instead of writing the DB directly.
+
+    Response: ``{ "id": int, "created_at": str }``
+    """
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+        created_at = datetime.now(UTC).isoformat()
+        turn = ForemanTurn(
+            guild_pk=guild_pk,
+            user_id=body.user_id,
+            role=body.role,
+            content_json=body.content_json,
+            is_tool_response=1 if body.is_tool_response else 0,
+            parent_id=body.parent_id,
+            created_at=created_at,
+        )
+        db.add(turn)
+        await db.commit()
+        await db.refresh(turn)
+        return {"id": turn.id, "created_at": created_at}
+    finally:
+        await db.close()
+
+
+class ForemanTaskCreate(BaseModel):
+    """Body for POST /guilds/{guild_id}/tasks."""
+
+    name: str
+    description: str
+    phase: str = "execute"
+    user_id: str | None = None
+
+
+@router.post("/guilds/{guild_id}/tasks")
+async def create_foreman_task(
+    guild_id: str,
+    body: ForemanTaskCreate,
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Create a foreman-owned task (worker_id='foreman').
+
+    Used by the standalone foreman's ``create_task`` tool in place of the
+    direct DB insert currently in ``foreman/tools.py``.
+
+    Response: ``{ "task_id": str, "created_at": str }``
+
+    Also broadcasts a ``task-created`` WS event so the UI sidebar updates.
+    """
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+
+        task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+        name = (body.name or "")[:80]
+        created_at = datetime.now(UTC).isoformat()
+        db.add(
+            Task(
+                id=task_id,
+                worker_id="foreman",
+                guild_pk=guild_pk,
+                name=name,
+                description=body.description,
+                tool="claude",
+                state="pending",
+                phase=body.phase,
+                created_at=created_at,
+                user_id=body.user_id,
+            )
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+    await broadcast(
+        guild_id,
+        {
+            "type": "task-created",
+            "taskId": task_id,
+            "name": name,
+            "description": body.description,
+            "phase": body.phase,
+            "state": "pending",
+            "createdAt": created_at,
+        },
+    )
+    return {"task_id": task_id, "created_at": created_at}
+
+
+class TaskPatch(BaseModel):
+    """Body for PATCH /guilds/{guild_id}/tasks/{task_id}.
+
+    All fields are optional — only non-None values are written to the DB.
+    """
+
+    state: str | None = None
+    worker_id: str | None = None
+    branch: str | None = None
+    pr_url: str | None = None
+    finished_at: str | None = None
+    deleted_at: str | None = None
+    phase: str | None = None
+
+
+@router.patch("/guilds/{guild_id}/tasks/{task_id}")
+async def patch_task(
+    guild_id: str,
+    task_id: str,
+    body: TaskPatch,
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Partially update a task's mutable fields.
+
+    Used by the standalone foreman's tools (``assign_task``, ``finalize_task``,
+    ``cancel_task``, ``send_followup``, ``redirect_task``) to write state
+    changes without direct DB access.
+
+    Accepted body fields:
+
+    - ``state``: new task state
+    - ``worker_id``: reassign to a different worker
+    - ``branch``: git branch name
+    - ``pr_url``: GitHub PR URL
+    - ``finished_at``: ISO-8601 completion timestamp
+    - ``deleted_at``: ISO-8601 soft-delete timestamp
+    - ``phase``: task phase (plan / execute / review / followup)
+
+    Broadcasts a ``task-update`` WS event with the changed fields so the
+    frontend sidebar stays in sync.
+
+    Response: ``{ "task_id": str, "updated": dict }``
+    """
+    update_values: dict = {}
+    for field, col in (
+        ("state", "state"),
+        ("worker_id", "worker_id"),
+        ("branch", "branch"),
+        ("pr_url", "pr_url"),
+        ("finished_at", "finished_at"),
+        ("deleted_at", "deleted_at"),
+        ("phase", "phase"),
+    ):
+        val = getattr(body, field)
+        if val is not None:
+            update_values[col] = val
+
+    if not update_values:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+
+        # Verify task exists in this guild
+        exists = await db.execute(
+            select(Task.id).where(Task.id == task_id, Task.guild_pk == guild_pk)
+        )
+        if exists.scalar_one_or_none() is None:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        await db.execute(update(Task).where(Task.id == task_id).values(**update_values))
+        await db.commit()
+    finally:
+        await db.close()
+
+    # Broadcast task-update with changed fields (camelCase keys for WS protocol)
+    _KEY_MAP = {
+        "state": "state",
+        "worker_id": "workerId",
+        "branch": "branch",
+        "pr_url": "prUrl",
+        "finished_at": "finishedAt",
+        "deleted_at": "deletedAt",
+        "phase": "phase",
+    }
+    ws_payload: dict = {"type": "task-update", "taskId": task_id}
+    for col, ws_key in _KEY_MAP.items():
+        if col in update_values:
+            ws_payload[ws_key] = update_values[col]
+    await broadcast(guild_id, ws_payload)
+
+    return {"task_id": task_id, "updated": update_values}
+
+
+class MessageCreate(BaseModel):
+    """Body for POST /guilds/{guild_id}/messages."""
+
+    from_agent: str
+    to_agent: str
+    content: str
+    message_type: str = "chat"
+    user_id: str | None = None
+
+
+@router.post("/guilds/{guild_id}/messages")
+async def create_message(
+    guild_id: str,
+    body: MessageCreate,
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Persist a chat message sent by the external foreman.
+
+    Used by the standalone foreman at the end of a ``run_foreman_ai()`` run
+    to store the final text response in the ``messages`` table (the same
+    write that the embedded foreman does in ``runner.py``).
+
+    Also broadcasts a ``chat`` WS event so the frontend chat panel updates.
+
+    Response: ``{ "message_id": int, "created_at": str }``
+    """
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+
+        created_at = datetime.now(UTC).isoformat()
+        msg = Message(
+            guild_pk=guild_pk,
+            from_agent=body.from_agent,
+            to_agent=body.to_agent,
+            content=body.content,
+            message_type=body.message_type,
+            created_at=created_at,
+            user_id=body.user_id,
+        )
+        db.add(msg)
+        await db.commit()
+        await db.refresh(msg)
+        msg_id = msg.id
+    finally:
+        await db.close()
+
+    await broadcast(
+        guild_id,
+        {
+            "type": "chat",
+            "from": body.from_agent,
+            "to": body.to_agent,
+            "content": body.content,
+            "createdAt": created_at,
+            **({"userId": body.user_id} if body.user_id else {}),
+        },
+    )
+    return {"message_id": msg_id, "created_at": created_at}

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 import anyio
 import ws_handlers
 from database import get_db
-from events import agent_owner_lock, agent_owners, broadcast, connections
+from events import agent_owner_lock, agent_owners, broadcast, connections, foreman_connections
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from models import Agent, Guild, UserSession, Worker
 from sqlalchemy import select, update
@@ -148,6 +148,12 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
         # group to cancel sibling connections.
         with anyio.CancelScope(shield=True):
             try:
+                # If this socket was the active external foreman, evict it so
+                # subsequent trigger events fall back to the embedded foreman.
+                if foreman_connections.get(guild_id) is websocket:
+                    foreman_connections.pop(guild_id, None)
+                    logger.info("guild=%s external foreman WS closed (socket disconnect)", guild_id)
+
                 # Only mark agents offline if this WS is still the current owner.
                 # The per-guild lock pairs with handle_join's ownership write so a
                 # reconnect's just-installed agent can't be stamped offline by the

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -22,6 +22,7 @@ from events import (
     agent_owners,
     broadcast,
     connections,
+    foreman_connections,
     pending_claude_auth,
 )
 from fastapi import WebSocket
@@ -95,6 +96,78 @@ async def _task_user_id(db, task_id: str | None) -> str | None:
         return None
     res = await db.execute(select(Task.user_id).where(Task.id == task_id))
     return res.scalar_one_or_none()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: External-foreman dispatch helper
+# ---------------------------------------------------------------------------
+
+
+async def _trigger_foreman(
+    guild_id: str,
+    event: str,
+    human_message: str,
+    *,
+    user_id: str | None = None,
+    task_id: str | None = None,
+    task_name: str = "foreman.unknown",
+) -> None:
+    """Send a ``foreman-trigger`` WS message to an external foreman if one is
+    connected for this guild; otherwise fall back to the embedded foreman.
+
+    The ``foreman-trigger`` payload carries all context the standalone process
+    needs to call its own ``run_foreman_ai()``:
+
+    .. code-block:: json
+
+        {
+          "type": "foreman-trigger",
+          "event": "<event-type>",
+          "guildId": "<guild_id>",
+          "humanMessage": "<message>",
+          "userId": "<user_id>",   // omitted when None
+          "taskId": "<task_id>"    // omitted when None
+        }
+
+    If the send fails (broken socket) the foreman is evicted and the embedded
+    fallback fires so the trigger is never lost.
+
+    ``event`` mirrors the plan's trigger-type vocabulary:
+    ``chat``, ``task-complete``, ``followup-done``, ``needs-input``,
+    ``claude-auth``, ``periodic-check``.
+    """
+    ws = foreman_connections.get(guild_id)
+    if ws is not None:
+        payload: dict = {
+            "type": "foreman-trigger",
+            "event": event,
+            "guildId": guild_id,
+            "humanMessage": human_message,
+        }
+        if user_id:
+            payload["userId"] = user_id
+        if task_id:
+            payload["taskId"] = task_id
+        try:
+            await ws.send_json(payload)
+            logger.debug(
+                "guild=%s foreman-trigger dispatched to external foreman: event=%s",
+                guild_id,
+                event,
+            )
+            return
+        except Exception:
+            logger.warning(
+                "guild=%s external foreman WS broken (event=%s), falling back to embedded",
+                guild_id,
+                event,
+            )
+            foreman_connections.pop(guild_id, None)
+    # Embedded fallback — identical to the pre-Phase-2 behaviour.
+    spawn(
+        run_foreman_ai(guild_id, human_message, user_id=user_id),
+        name=task_name,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -172,7 +245,37 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         # decide it owns the agent, and stamp the just-joined agent offline.
         async with agent_owner_lock(ctx.guild_id):
             agent_owners[agent_id] = ctx.websocket
-    if agent_type == "worker":
+    if agent_type == "foreman":
+        # Register as the active external foreman for this guild.
+        # Evict any previously connected foreman so there is never more than
+        # one active at a time (prevents duplicate task mutations / triggers).
+        existing_ws = foreman_connections.get(ctx.guild_id)
+        if existing_ws is not None and existing_ws is not ctx.websocket:
+            logger.info(
+                "guild=%s evicting previous external foreman (new foreman connected)",
+                ctx.guild_id,
+            )
+            try:
+                await existing_ws.send_json(
+                    {
+                        "type": "foreman-evicted",
+                        "guildId": ctx.guild_id,
+                        "reason": "superseded by new foreman connection",
+                    }
+                )
+            except Exception:
+                pass
+        foreman_connections[ctx.guild_id] = ctx.websocket
+        logger.info("guild=%s external foreman registered: agentId=%s", ctx.guild_id, agent_id)
+        # Acknowledge registration so the foreman knows it is the active one.
+        await ctx.websocket.send_json(
+            {
+                "type": "foreman-registered",
+                "guildId": ctx.guild_id,
+                "agentId": agent_id,
+            }
+        )
+    elif agent_type == "worker":
         reset_foreman_poll(ctx.guild_id)
         # Replay any pending tasks already assigned to this worker so they
         # aren't lost if the backend sent task-assigned while the socket was
@@ -304,9 +407,12 @@ async def handle_chat(ctx: WSContext, data: dict) -> None:
             },
         )
     else:
-        spawn(
-            run_foreman_ai(ctx.guild_id, content, user_id=ctx.ws_user_id),
-            name=f"foreman.chat:{ctx.guild_id}",
+        await _trigger_foreman(
+            ctx.guild_id,
+            "chat",
+            content,
+            user_id=ctx.ws_user_id,
+            task_name=f"foreman.chat:{ctx.guild_id}",
         )
         reset_foreman_poll(ctx.guild_id)
 
@@ -452,21 +558,21 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
 
     task_uid = await _task_user_id(ctx.db, task_id)
     pr_line = f" PR: {pr_url}." if pr_url else ""
-    spawn(
-        run_foreman_ai(
-            ctx.guild_id,
-            f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
-            f'"{desc[:80]}" — branch: {branch}.{pr_line} '
-            "The worker has returned to its idle pool; the task is parked in "
-            "awaiting-review for human review. "
-            "Default behaviour: leave PR-bearing tasks open so reviewers can "
-            "comment — call send_followup if a comment or CI failure asks for "
-            "an iteration on the same branch (any idle worker can pick it up). "
-            "Only call finalize_task when the work is genuinely closed (PR "
-            "merged, task abandoned, or it was an ephemeral/automation task).",
-            user_id=task_uid,
-        ),
-        name=f"foreman.task-complete:{task_id}",
+    await _trigger_foreman(
+        ctx.guild_id,
+        "task-complete",
+        f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
+        f'"{desc[:80]}" — branch: {branch}.{pr_line} '
+        "The worker has returned to its idle pool; the task is parked in "
+        "awaiting-review for human review. "
+        "Default behaviour: leave PR-bearing tasks open so reviewers can "
+        "comment — call send_followup if a comment or CI failure asks for "
+        "an iteration on the same branch (any idle worker can pick it up). "
+        "Only call finalize_task when the work is genuinely closed (PR "
+        "merged, task abandoned, or it was an ephemeral/automation task).",
+        user_id=task_uid,
+        task_id=task_id,
+        task_name=f"foreman.task-complete:{task_id}",
     )
     reset_foreman_poll(ctx.guild_id)
 
@@ -488,14 +594,14 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
     if not task_id:
         return
     task_uid = await _task_user_id(ctx.db, task_id)
-    spawn(
-        run_foreman_ai(
-            ctx.guild_id,
-            f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
-            "Decide: call send_followup for more work, or call finalize_task to mark it done.",
-            user_id=task_uid,
-        ),
-        name=f"foreman.followup-done:{task_id}",
+    await _trigger_foreman(
+        ctx.guild_id,
+        "followup-done",
+        f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
+        "Decide: call send_followup for more work, or call finalize_task to mark it done.",
+        user_id=task_uid,
+        task_id=task_id,
+        task_name=f"foreman.followup-done:{task_id}",
     )
     reset_foreman_poll(ctx.guild_id)
 
@@ -513,9 +619,13 @@ async def handle_needs_input(ctx: WSContext, data: dict) -> None:
         f"Stop reason: {stop_reason}" + (f"\nLast message: {last_msg}" if last_msg else "")
     )
     task_uid = await _task_user_id(ctx.db, task_id) if task_id else None
-    spawn(
-        run_foreman_ai(ctx.guild_id, escalation, user_id=task_uid),
-        name=f"foreman.needs-input:{task_id or 'unknown'}",
+    await _trigger_foreman(
+        ctx.guild_id,
+        "needs-input",
+        escalation,
+        user_id=task_uid,
+        task_id=task_id or None,
+        task_name=f"foreman.needs-input:{task_id or 'unknown'}",
     )
 
 
@@ -535,16 +645,35 @@ async def handle_claude_auth_required(ctx: WSContext, data: dict) -> None:
         len(pending_claude_auth.get(ctx.guild_id, {})),
         ctx.guild_id,
     )
-    spawn(
-        run_foreman_ai(
+    await _trigger_foreman(
+        ctx.guild_id,
+        "claude-auth",
+        f"Worker {worker_id} needs Claude authentication. "
+        f"Auth URL: {auth_url}. "
+        "A human must visit this URL, complete authentication, then paste the "
+        "resulting code into the auth panel that has appeared in the chat UI "
+        "(or type it into the Foreman Comms input). The worker is waiting.",
+        task_name=f"foreman.claude-auth:{worker_id}",
+    )
+
+
+async def handle_foreman_disconnect(ctx: WSContext, data: dict) -> None:
+    """External foreman announcing a graceful shutdown.
+
+    Removes the guild's foreman_connections entry so subsequent trigger events
+    fall back to the embedded foreman immediately rather than waiting for a
+    failed send to discover the socket is gone.
+    """
+    if foreman_connections.get(ctx.guild_id) is ctx.websocket:
+        foreman_connections.pop(ctx.guild_id, None)
+        logger.info(
+            "guild=%s external foreman disconnected gracefully",
             ctx.guild_id,
-            f"Worker {worker_id} needs Claude authentication. "
-            f"Auth URL: {auth_url}. "
-            "A human must visit this URL, complete authentication, then paste the "
-            "resulting code into the auth panel that has appeared in the chat UI "
-            "(or type it into the Foreman Comms input). The worker is waiting.",
-        ),
-        name=f"foreman.claude-auth:{worker_id}",
+        )
+    await broadcast(
+        ctx.guild_id,
+        {"type": "foreman-disconnect", "guildId": ctx.guild_id},
+        exclude=ctx.websocket,
     )
 
 
@@ -585,6 +714,7 @@ HANDLERS: dict[str, callable] = {
     "task-followup-done": handle_task_followup_done,
     "needs-input": handle_needs_input,
     "claude-auth-required": handle_claude_auth_required,
+    "foreman-disconnect": handle_foreman_disconnect,
     "worker-auth-response": handle_worker_auth_response,
     "offer": handle_webrtc_signal,
     "answer": handle_webrtc_signal,


### PR DESCRIPTION
## Summary

Implements Phases 1 and 2 of the foreman-split plan (`docs/foreman-split-plan.md`). The embedded foreman remains **fully functional** — zero behaviour change for existing deployments.

### Phase 1 — REST endpoints for external foreman (`routes/foreman.py`)

Seven new endpoints behind `require_worker_or_member_path` auth (accepts worker auth_token or user login_token):

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/guilds/{guild_id}/foreman/state` | Online workers, active tasks, guild metadata |
| GET | `/guilds/{guild_id}/foreman/history` | Raw `ForemanTurn` rows for a `user_id` |
| POST | `/guilds/{guild_id}/foreman/history` | Persist one `ForemanTurn` row |
| GET | `/guilds/{guild_id}/guild-key` | Ed25519 private key PEM for JWT signing |
| POST | `/guilds/{guild_id}/tasks` | Create a foreman-owned task + broadcast `task-created` |
| PATCH | `/guilds/{guild_id}/tasks/{task_id}` | Update task fields + broadcast `task-update` |
| POST | `/guilds/{guild_id}/messages` | Persist chat message + broadcast `chat` |

These replace the direct DB calls that `foreman/runner.py` and `foreman/tools.py` currently make, giving the future standalone foreman process (Phase 3) a complete REST surface.

### Phase 2 — `foreman-trigger` WebSocket dispatch

- **`events.py`**: `foreman_connections: dict[str, WebSocket]` — one active external foreman socket per guild.
- **`ws_handlers.py`**: `_trigger_foreman()` helper — sends `foreman-trigger` WS message to external foreman if connected; falls back to embedded `run_foreman_ai()` if not.
- **`handle_join`**: detects `agentType="foreman"`, registers in `foreman_connections`, sends `foreman-registered` ack, evicts prior foreman with `foreman-evicted`.
- **`handle_foreman_disconnect`**: new handler for graceful foreman shutdown message.
- All 5 trigger sites (`chat`, `task-complete`, `followup-done`, `needs-input`, `claude-auth-required`) route through `_trigger_foreman()`.
- **`foreman/runner.py`**: embedded `_poll_loop` skips when external foreman is connected, avoiding double-triggering.
- **`routes/websocket.py`**: WS disconnect cleanup removes `foreman_connections` entry.

## Test plan

- [x] All 360 existing backend tests pass
- [x] `ruff check .` clean
- [x] Existing foreman context API tests (`test_foreman_context_api.py`) unchanged
- [x] Embedded foreman remains the active path until a foreman agent joins via WS

Closes #311