### PR TITLE
Foreman in own sidebar — no overlap with tasks/floor

### DIFF
--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -163,18 +163,12 @@ onUnmounted(() => {
 
 <style scoped>
 .chat-pane {
-  position: fixed;
-  bottom: 0;
-  right: 0;
   width: 360px;
-  max-height: 500px;
+  min-width: 360px;
   display: flex;
   flex-direction: column;
-  z-index: 100;
-}
-
-.chat-pane.minimized {
-  max-height: 44px;
+  overflow: hidden;
+  border-left: 2px solid var(--color-brass-dark);
 }
 
 .chat-header {
@@ -260,7 +254,7 @@ onUnmounted(() => {
 
 @media (max-width: 1024px) {
   .chat-pane {
-    max-height: 100% !important;
+    border-left: none;
     border-radius: 0;
   }
 }


### PR DESCRIPTION
## Summary

- Removes `position: fixed` from `ChatPane.vue` so the Foreman COMMS panel flows as a proper third column in the `app-body` flex layout instead of floating over the content
- Adds `min-width: 360px` (matching the left `GuildSidebar` pattern) and a `border-left` separator to visually anchor it as a dedicated sidebar
- Drops the now-redundant `max-height: 500px` and `.minimized { max-height: 44px }` constraints — the chat body is already toggled via `v-if`, so the column stays in place and height is controlled by flex
- Mobile (<1024 px): removes the added left border on mobile since `AppView.vue`'s media query already full-screens each pane; no other mobile changes needed

## Test plan

- [ ] Desktop (≥1280 px): three distinct columns visible — Tasks/Workers sidebar | Factory Floor / main area | Foreman COMMS sidebar — with no overlap
- [ ] Foreman sidebar, task sidebar, and main content are each independently scrollable
- [ ] Minimising the Foreman panel (click header) hides the chat body; header remains visible at the top of the right column
- [ ] Mobile (≤1024 px): tab-bar switching between Tasks / Work / Chat still works; no layout regression

Closes #325

🤖 Generated with [Claude Code](https://claude.ai/claude-code)