### PR TITLE
feat(ui): per-state pixel-art bench scenery on workbench rows

### DIFF
--- a/frontend/demo/robots.html
+++ b/frontend/demo/robots.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>RobotWorker pixel-art demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./robots.ts"></script>
+  </body>
+</html>

--- a/frontend/demo/robots.ts
+++ b/frontend/demo/robots.ts
@@ -1,0 +1,127 @@
+import { createApp, h, defineComponent } from 'vue'
+import AgentAvatar from '../src/components/AgentAvatar.vue'
+import type { Agent, AgentState } from '../src/types'
+import '../src/style.css'
+
+const STATES: AgentState[] = ['idle', 'thinking', 'working', 'busy', 'error']
+
+function buildAgent(state: AgentState, type: 'worker' | 'foreman', i: number): Agent {
+  return {
+    id: `a-${state}-${i}`,
+    name: `${state.slice(0, 3)}${i}`.toUpperCase(),
+    type,
+    workerId: `w-demo-${i}`,
+    state,
+    activity: null,
+    logs: [],
+    joinedAt: new Date().toISOString(),
+  }
+}
+
+const App = defineComponent({
+  setup() {
+    return () =>
+      h(
+        'div',
+        {
+          style: {
+            background: '#120900',
+            padding: '32px',
+            minHeight: '100vh',
+            color: '#e8d4a4',
+            fontFamily: 'monospace',
+          },
+        },
+        [
+          h(
+            'div',
+            { style: { fontSize: '14px', letterSpacing: '2px', marginBottom: '24px' } },
+            'PIXEL-ART ROBOT — STATES × {WORKER, FOREMAN} × {STILL, WALKING}',
+          ),
+          ...['worker', 'foreman'].map((t) =>
+            h(
+              'div',
+              { style: { marginBottom: '32px' } },
+              [
+                h(
+                  'div',
+                  {
+                    style: {
+                      fontSize: '10px',
+                      letterSpacing: '2px',
+                      marginBottom: '12px',
+                      color: '#e8aa00',
+                    },
+                  },
+                  String(t).toUpperCase(),
+                ),
+                h(
+                  'div',
+                  {
+                    style: {
+                      display: 'flex',
+                      gap: '24px',
+                      flexWrap: 'wrap',
+                      alignItems: 'flex-start',
+                    },
+                  },
+                  STATES.flatMap((s, i) => [
+                    h(
+                      'div',
+                      {
+                        id: `cell-${t}-${s}-still`,
+                        style: {
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'center',
+                          gap: '6px',
+                          width: '70px',
+                        },
+                      },
+                      [
+                        h(
+                          'div',
+                          { style: { fontSize: '7px', letterSpacing: '1px', opacity: 0.7 } },
+                          s,
+                        ),
+                        h(AgentAvatar, {
+                          agent: buildAgent(s, t as 'worker' | 'foreman', i),
+                          walking: false,
+                        }),
+                      ],
+                    ),
+                    h(
+                      'div',
+                      {
+                        id: `cell-${t}-${s}-walk`,
+                        style: {
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'center',
+                          gap: '6px',
+                          width: '70px',
+                        },
+                      },
+                      [
+                        h(
+                          'div',
+                          { style: { fontSize: '7px', letterSpacing: '1px', opacity: 0.7 } },
+                          `${s} walk`,
+                        ),
+                        h(AgentAvatar, {
+                          agent: buildAgent(s, t as 'worker' | 'foreman', i + 100),
+                          walking: true,
+                        }),
+                      ],
+                    ),
+                  ]),
+                ),
+              ],
+            ),
+          ),
+        ],
+      )
+  },
+})
+
+createApp(App).mount('#app')

--- a/frontend/demo/scenery.html
+++ b/frontend/demo/scenery.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>WorkbenchRow scenery demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./scenery.ts"></script>
+  </body>
+</html>

--- a/frontend/demo/scenery.ts
+++ b/frontend/demo/scenery.ts
@@ -1,0 +1,86 @@
+import { createApp, h, defineComponent } from 'vue'
+import WorkbenchRow from '../src/components/factory-floor/WorkbenchRow.vue'
+import type { Task, TaskState } from '../src/types'
+import '../src/style.css'
+
+const STATIONS = [
+  { key: 'reading', label: 'ARCHIVE', frac: 0.1, component: 'archive' },
+  { key: 'searching', label: 'SCRYING', frac: 0.25, component: 'orb' },
+  { key: 'fetching', label: 'TELEGRAPH', frac: 0.4, component: 'telegraph' },
+  { key: 'thinking', label: 'THINK TANK', frac: 0.56, component: 'tank' },
+  { key: 'running', label: 'ENGINE', frac: 0.72, component: 'engine' },
+  { key: 'editing', label: 'FORGE', frac: 0.88, component: 'forge' },
+] as const
+
+const STATES: TaskState[] = [
+  'pending',
+  'planning',
+  'working',
+  'awaiting-review',
+  'followup',
+  'done',
+  'failed',
+]
+
+function buildTask(state: TaskState, idx: number): Task {
+  return {
+    id: `t-${idx}`,
+    name: `Demo · ${state}`,
+    state,
+  }
+}
+
+const App = defineComponent({
+  setup() {
+    return () =>
+      h(
+        'div',
+        {
+          style: {
+            background: '#120900',
+            padding: '24px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '12px',
+            fontFamily: 'monospace',
+            color: '#e8d4a4',
+            minHeight: '100vh',
+          },
+        },
+        [
+          h('div', { style: { fontSize: '14px', letterSpacing: '2px' } }, 'BENCH SCENERY DEMO'),
+          h(
+            'div',
+            {
+              style: { display: 'flex', flexDirection: 'column', gap: '12px', width: '760px' },
+            },
+            STATES.map((state, i) =>
+              h('div', { id: `row-${state}`, style: { height: '92px' } }, [
+                h(WorkbenchRow, {
+                  task: buildTask(state, i),
+                  index: i,
+                  rowHeight: 92,
+                  activityKey: null,
+                  stations: STATIONS,
+                  stateLabel: (s: string) => s.toUpperCase(),
+                }),
+              ]),
+            ),
+          ),
+          // vacant row for reference
+          h('div', { style: { height: '92px', width: '760px' } }, [
+            h(WorkbenchRow, {
+              task: null,
+              index: 99,
+              rowHeight: 92,
+              activityKey: null,
+              stations: STATIONS,
+              stateLabel: (s: string) => s.toUpperCase(),
+            }),
+          ]),
+        ],
+      )
+  },
+})
+
+createApp(App).mount('#app')

--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -387,9 +387,10 @@ function stateLabel(state: string) {
   position: absolute;
   z-index: 6;
   transform: translate(-50%, -50%);
+  /* Stepped position transitions — pixel-art motion, not smooth glide */
   transition:
-    left var(--walk-dur, 1.5s) ease-in-out,
-    top var(--walk-dur, 1.5s) ease-in-out;
+    left var(--walk-dur, 1.5s) steps(8, end),
+    top var(--walk-dur, 1.5s) steps(8, end);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/factory-floor/WorkbenchRow.vue
+++ b/frontend/src/components/factory-floor/WorkbenchRow.vue
@@ -15,6 +15,192 @@
     </div>
 
     <div class="row-bench">
+      <!-- Pixel-art per-state scenery (sits behind stations) -->
+      <svg
+        v-if="sceneState !== 'idle'"
+        class="bench-scene"
+        :class="`scene-${sceneState}`"
+        viewBox="0 0 480 48"
+        preserveAspectRatio="xMidYMax meet"
+        shape-rendering="crispEdges"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <!-- PLANNING — blueprint + pencil + ruler -->
+        <g v-if="sceneState === 'planning'">
+          <!-- blueprint sheet (integer coords, no rx) -->
+          <rect x="170" y="6" width="84" height="38" class="bp-sheet" />
+          <rect x="170" y="6" width="84" height="6" class="bp-band" />
+          <!-- grid (integer ticks) -->
+          <rect x="176" y="18" width="72" height="1" class="bp-grid" />
+          <rect x="176" y="26" width="72" height="1" class="bp-grid" />
+          <rect x="176" y="34" width="72" height="1" class="bp-grid" />
+          <rect x="190" y="14" width="1" height="26" class="bp-grid" />
+          <rect x="208" y="14" width="1" height="26" class="bp-grid" />
+          <rect x="226" y="14" width="1" height="26" class="bp-grid" />
+          <rect x="244" y="14" width="1" height="26" class="bp-grid" />
+          <!-- pencil (stepped diagonal: 1-px rectangles) -->
+          <rect x="262" y="14" width="3" height="3" class="pencil-tip" />
+          <rect x="265" y="17" width="2" height="2" class="pencil-tip" />
+          <rect x="267" y="19" width="14" height="3" class="pencil-body" />
+          <rect x="281" y="19" width="3" height="3" class="pencil-eraser" />
+          <!-- ruler -->
+          <rect x="290" y="30" width="48" height="6" class="ruler" />
+          <rect x="296" y="30" width="1" height="2" class="ruler-tick" />
+          <rect x="304" y="30" width="1" height="2" class="ruler-tick" />
+          <rect x="312" y="30" width="1" height="2" class="ruler-tick" />
+          <rect x="320" y="30" width="1" height="2" class="ruler-tick" />
+          <rect x="328" y="30" width="1" height="2" class="ruler-tick" />
+        </g>
+
+        <!-- WORKING — laptop screen with code + coffee mug -->
+        <g v-if="sceneState === 'working'">
+          <!-- laptop chassis -->
+          <rect x="174" y="4" width="100" height="34" class="laptop-shell" />
+          <rect x="178" y="8" width="92" height="26" class="laptop-screen" />
+          <!-- code lines (staggered widths, all on integer y) -->
+          <rect x="182" y="12" width="42" height="2" class="code-ln c1" />
+          <rect x="182" y="16" width="60" height="2" class="code-ln c2" />
+          <rect x="186" y="20" width="30" height="2" class="code-ln c3" />
+          <rect x="182" y="24" width="48" height="2" class="code-ln c4" />
+          <rect x="186" y="28" width="40" height="2" class="code-ln c5" />
+          <!-- blinking cursor (steps(2) toggles visibility) -->
+          <rect x="228" y="28" width="3" height="2" class="code-cursor" />
+          <!-- laptop base + keyboard -->
+          <rect x="168" y="38" width="112" height="4" class="laptop-base" />
+          <rect x="180" y="40" width="88" height="1" class="kbd-row" />
+          <!-- coffee mug -->
+          <rect x="296" y="20" width="20" height="18" class="mug-body" />
+          <rect x="296" y="20" width="20" height="3" class="mug-rim" />
+          <rect x="316" y="24" width="3" height="8" class="mug-handle" />
+          <rect x="319" y="25" width="1" height="6" class="mug-handle" />
+          <!-- steam (3 stepped puffs, animated on steps(3)) -->
+          <g class="steam">
+            <rect x="300" y="14" width="2" height="2" />
+            <rect x="304" y="10" width="2" height="2" />
+            <rect x="308" y="6" width="2" height="2" />
+          </g>
+        </g>
+
+        <!-- AWAITING-REVIEW — paper stack + desk lamp w/ light cone -->
+        <g v-if="sceneState === 'awaiting-review'">
+          <!-- paper stack (3 staggered sheets) -->
+          <rect x="166" y="32" width="100" height="6" class="paper-bot" />
+          <rect x="164" y="26" width="102" height="6" class="paper-mid" />
+          <rect x="162" y="8" width="104" height="20" class="paper-top" />
+          <!-- doc lines on top sheet (1-px tall, integer y) -->
+          <rect x="168" y="12" width="80" height="1" class="doc-line" />
+          <rect x="168" y="16" width="72" height="1" class="doc-line" />
+          <rect x="168" y="20" width="78" height="1" class="doc-line" />
+          <rect x="168" y="24" width="58" height="1" class="doc-line" />
+          <!-- lamp light cone (pure rects, no gradient) -->
+          <polygon points="296,16 320,16 326,40 290,40" class="lamp-cone" />
+          <!-- lamp pole + shade -->
+          <rect x="300" y="10" width="16" height="6" class="lamp-shade" />
+          <rect x="306" y="16" width="4" height="22" class="lamp-pole" />
+          <rect x="298" y="38" width="20" height="4" class="lamp-base" />
+        </g>
+
+        <!-- FOLLOWUP — three sticky notes at slight angles (stair-stepped) -->
+        <g v-if="sceneState === 'followup'">
+          <!-- left sticky -->
+          <rect x="172" y="8" width="40" height="34" class="sticky-a" />
+          <rect x="178" y="14" width="28" height="1" class="sticky-ln-a" />
+          <rect x="178" y="20" width="24" height="1" class="sticky-ln-a" />
+          <rect x="178" y="26" width="26" height="1" class="sticky-ln-a" />
+          <!-- center sticky (tilted via stair-step rects, no rotate transform) -->
+          <rect x="222" y="10" width="40" height="32" class="sticky-b" />
+          <rect x="223" y="9" width="40" height="1" class="sticky-b" />
+          <rect x="224" y="8" width="40" height="1" class="sticky-b" />
+          <rect x="228" y="16" width="28" height="1" class="sticky-ln-b" />
+          <rect x="228" y="22" width="32" height="1" class="sticky-ln-b" />
+          <rect x="228" y="28" width="26" height="1" class="sticky-ln-b" />
+          <!-- right sticky -->
+          <rect x="272" y="6" width="40" height="36" class="sticky-c" />
+          <rect x="278" y="12" width="28" height="1" class="sticky-ln-c" />
+          <rect x="278" y="18" width="30" height="1" class="sticky-ln-c" />
+          <rect x="278" y="24" width="24" height="1" class="sticky-ln-c" />
+          <rect x="278" y="30" width="28" height="1" class="sticky-ln-c" />
+        </g>
+
+        <!-- DONE — big stepped checkmark + sparkles -->
+        <g v-if="sceneState === 'done'">
+          <!-- check stroke drawn as a staircase of 4×4 blocks (clearly pixelated) -->
+          <g class="check-blocks">
+            <rect x="160" y="22" width="4" height="4" />
+            <rect x="164" y="26" width="4" height="4" />
+            <rect x="168" y="30" width="4" height="4" />
+            <rect x="172" y="34" width="4" height="4" />
+            <rect x="176" y="30" width="4" height="4" />
+            <rect x="180" y="26" width="4" height="4" />
+            <rect x="184" y="22" width="4" height="4" />
+            <rect x="188" y="18" width="4" height="4" />
+            <rect x="192" y="14" width="4" height="4" />
+            <rect x="196" y="10" width="4" height="4" />
+            <rect x="200" y="6" width="4" height="4" />
+          </g>
+          <!-- sparkles (plus-sign pixels) -->
+          <g class="sparkle s1">
+            <rect x="240" y="10" width="2" height="6" />
+            <rect x="238" y="12" width="6" height="2" />
+          </g>
+          <g class="sparkle s2">
+            <rect x="280" y="28" width="2" height="6" />
+            <rect x="278" y="30" width="6" height="2" />
+          </g>
+          <g class="sparkle s3">
+            <rect x="320" y="14" width="2" height="6" />
+            <rect x="318" y="16" width="6" height="2" />
+          </g>
+        </g>
+
+        <!-- FAILED — crumpled papers + stepped X -->
+        <g v-if="sceneState === 'failed'">
+          <rect x="168" y="22" width="48" height="18" class="crumple" />
+          <rect x="170" y="20" width="44" height="2" class="crumple" />
+          <rect x="290" y="14" width="44" height="22" class="crumple" />
+          <rect x="292" y="12" width="40" height="2" class="crumple" />
+          <!-- stepped X mark (two staircase diagonals of 4×4) -->
+          <g class="x-mark">
+            <rect x="228" y="6" width="4" height="4" />
+            <rect x="232" y="10" width="4" height="4" />
+            <rect x="236" y="14" width="4" height="4" />
+            <rect x="240" y="18" width="4" height="4" />
+            <rect x="244" y="22" width="4" height="4" />
+            <rect x="248" y="26" width="4" height="4" />
+            <rect x="252" y="30" width="4" height="4" />
+            <rect x="256" y="34" width="4" height="4" />
+            <rect x="228" y="34" width="4" height="4" />
+            <rect x="232" y="30" width="4" height="4" />
+            <rect x="236" y="26" width="4" height="4" />
+            <rect x="240" y="22" width="4" height="4" />
+            <rect x="248" y="14" width="4" height="4" />
+            <rect x="252" y="10" width="4" height="4" />
+            <rect x="256" y="6" width="4" height="4" />
+          </g>
+        </g>
+
+        <!-- PENDING — a single hourglass icon (stepped) -->
+        <g v-if="sceneState === 'pending'">
+          <rect x="226" y="8" width="28" height="2" class="hg-frame" />
+          <rect x="226" y="36" width="28" height="2" class="hg-frame" />
+          <rect x="228" y="10" width="24" height="2" class="hg-glass" />
+          <rect x="230" y="12" width="20" height="2" class="hg-glass" />
+          <rect x="232" y="14" width="16" height="2" class="hg-glass" />
+          <rect x="234" y="16" width="12" height="2" class="hg-glass" />
+          <rect x="236" y="18" width="8" height="2" class="hg-glass" />
+          <rect x="238" y="20" width="4" height="2" class="hg-glass" />
+          <rect x="238" y="22" width="4" height="2" class="hg-glass" />
+          <rect x="236" y="24" width="8" height="2" class="hg-glass" />
+          <rect x="234" y="26" width="12" height="2" class="hg-glass" />
+          <rect x="232" y="28" width="16" height="2" class="hg-glass" />
+          <rect x="230" y="30" width="20" height="2" class="hg-glass" />
+          <rect x="228" y="32" width="24" height="2" class="hg-glass" />
+          <!-- falling sand pixel -->
+          <rect class="hg-sand" x="239" y="20" width="2" height="2" />
+        </g>
+      </svg>
+
       <div class="bench-rail"></div>
       <div class="bench-bolts">
         <span class="bolt" v-for="n in 6" :key="n"></span>
@@ -68,9 +254,10 @@
 </template>
 
 <script setup lang="ts">
-import type { Task } from '../../types'
+import { computed } from 'vue'
+import type { Task, TaskState } from '../../types'
 
-defineProps<{
+const props = defineProps<{
   task: Task | null
   index: number
   rowHeight: number
@@ -83,6 +270,31 @@ defineProps<{
   }>
   stateLabel: (state: string) => string
 }>()
+
+type SceneState =
+  | 'idle'
+  | 'pending'
+  | 'planning'
+  | 'working'
+  | 'awaiting-review'
+  | 'followup'
+  | 'done'
+  | 'failed'
+
+const STATE_TO_SCENE: Record<TaskState, SceneState> = {
+  pending: 'pending',
+  planning: 'planning',
+  working: 'working',
+  'awaiting-review': 'awaiting-review',
+  followup: 'followup',
+  done: 'done',
+  failed: 'failed',
+  cancelled: 'failed',
+}
+
+const sceneState = computed<SceneState>(() =>
+  props.task ? STATE_TO_SCENE[props.task.state] : 'idle',
+)
 
 function truncate(str?: string, len = 28) {
   if (!str) return ''
@@ -496,6 +708,285 @@ function truncate(str?: string, len = 28) {
   }
   to {
     transform: rotate(360deg);
+  }
+}
+
+/* ── Per-state bench scenery (pixel-art SVG) ───────────────── */
+.bench-scene {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 16px;
+  width: 100%;
+  height: calc(100% - 16px);
+  pointer-events: none;
+  opacity: 0.6;
+  z-index: 0;
+  image-rendering: pixelated;
+}
+.task-row.occupied .bench-scene {
+  opacity: 0.78;
+}
+.bench-station,
+.bench-rail,
+.bench-bolts {
+  z-index: 1;
+}
+
+/* PLANNING — blueprint scene */
+.bp-sheet {
+  fill: #0e2452;
+}
+.bp-band {
+  fill: #1a3a72;
+}
+.bp-grid {
+  fill: #4488bb;
+}
+.pencil-body {
+  fill: #ffd644;
+}
+.pencil-tip {
+  fill: #dd9944;
+}
+.pencil-eraser {
+  fill: #ee5544;
+}
+.ruler {
+  fill: #c8b88a;
+}
+.ruler-tick {
+  fill: #5a3a18;
+}
+
+/* WORKING — laptop scene */
+.laptop-shell {
+  fill: #1a1a1a;
+}
+.laptop-screen {
+  fill: #0a1a0a;
+}
+.laptop-base {
+  fill: #222;
+}
+.kbd-row {
+  fill: #444;
+}
+.code-ln {
+  fill: #33aa44;
+}
+.code-ln.c2 {
+  fill: #88dd22;
+}
+.code-ln.c3 {
+  fill: #44aadd;
+}
+.code-ln.c5 {
+  fill: #ffaa22;
+}
+.code-cursor {
+  fill: #88dd22;
+  animation: pxCursorBlink 0.9s steps(2, end) infinite;
+}
+@keyframes pxCursorBlink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+.mug-body {
+  fill: #8b4513;
+}
+.mug-rim {
+  fill: #5c2b08;
+}
+.mug-handle {
+  fill: #6b3010;
+}
+.steam rect {
+  fill: #c8b89a;
+}
+.scene-working .steam {
+  animation: pxSteam 1.5s steps(3, end) infinite;
+}
+@keyframes pxSteam {
+  0%,
+  33% {
+    opacity: 0.9;
+    transform: translateY(0);
+  }
+  34%,
+  66% {
+    opacity: 0.6;
+    transform: translateY(-2px);
+  }
+  67%,
+  100% {
+    opacity: 0.25;
+    transform: translateY(-4px);
+  }
+}
+
+/* AWAITING-REVIEW — paper + lamp */
+.paper-top {
+  fill: #e4d8bc;
+}
+.paper-mid {
+  fill: #d4c4a4;
+}
+.paper-bot {
+  fill: #c8b89a;
+}
+.doc-line {
+  fill: #7a6a52;
+}
+.lamp-shade {
+  fill: #cc9922;
+}
+.lamp-pole {
+  fill: #aaa;
+}
+.lamp-base {
+  fill: #888;
+}
+.lamp-cone {
+  fill: #ffd644;
+  opacity: 0.18;
+  animation: pxLampFlicker 1.6s steps(2, end) infinite;
+}
+@keyframes pxLampFlicker {
+  0%,
+  49% {
+    opacity: 0.18;
+  }
+  50%,
+  100% {
+    opacity: 0.12;
+  }
+}
+
+/* FOLLOWUP — sticky notes */
+.sticky-a {
+  fill: #ffee55;
+}
+.sticky-b {
+  fill: #ff9944;
+}
+.sticky-c {
+  fill: #55ddbb;
+}
+.sticky-ln-a {
+  fill: #bb9900;
+}
+.sticky-ln-b {
+  fill: #aa5500;
+}
+.sticky-ln-c {
+  fill: #228877;
+}
+
+/* DONE — stepped checkmark + sparkles */
+.check-blocks rect {
+  fill: #88dd22;
+  opacity: 0;
+  animation: pxCheckIn 0.8s steps(11, end) forwards;
+}
+.check-blocks rect:nth-child(1) {
+  animation-delay: 0s;
+}
+.check-blocks rect:nth-child(2) {
+  animation-delay: 0.06s;
+}
+.check-blocks rect:nth-child(3) {
+  animation-delay: 0.12s;
+}
+.check-blocks rect:nth-child(4) {
+  animation-delay: 0.18s;
+}
+.check-blocks rect:nth-child(5) {
+  animation-delay: 0.24s;
+}
+.check-blocks rect:nth-child(6) {
+  animation-delay: 0.3s;
+}
+.check-blocks rect:nth-child(7) {
+  animation-delay: 0.36s;
+}
+.check-blocks rect:nth-child(8) {
+  animation-delay: 0.42s;
+}
+.check-blocks rect:nth-child(9) {
+  animation-delay: 0.48s;
+}
+.check-blocks rect:nth-child(10) {
+  animation-delay: 0.54s;
+}
+.check-blocks rect:nth-child(11) {
+  animation-delay: 0.6s;
+}
+@keyframes pxCheckIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.sparkle rect {
+  fill: #ffd644;
+}
+.sparkle {
+  animation: pxSparkle 1.4s steps(4, end) infinite;
+}
+.sparkle.s2 {
+  animation-delay: 0.35s;
+}
+.sparkle.s3 {
+  animation-delay: 0.7s;
+}
+@keyframes pxSparkle {
+  0%,
+  74% {
+    opacity: 1;
+  }
+  75%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* FAILED — crumpled paper + stepped X */
+.crumple {
+  fill: #b8a884;
+}
+.x-mark rect {
+  fill: #ee3322;
+}
+
+/* PENDING — hourglass */
+.hg-frame {
+  fill: #c8b88a;
+}
+.hg-glass {
+  fill: #2a1a08;
+}
+.hg-sand {
+  fill: #ffd644;
+  animation: pxHgSand 1.6s steps(8, end) infinite;
+}
+@keyframes pxHgSand {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(10px);
+    opacity: 0;
   }
 }
 </style>

--- a/frontend/src/components/factory-floor/__tests__/WorkbenchRow.spec.ts
+++ b/frontend/src/components/factory-floor/__tests__/WorkbenchRow.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import WorkbenchRow from '../WorkbenchRow.vue'
+import type { Task, TaskState } from '../../../types'
+
+const STATIONS = [
+  { key: 'reading', label: 'ARCHIVE', frac: 0.1, component: 'archive' },
+  { key: 'searching', label: 'SCRYING', frac: 0.25, component: 'orb' },
+] as const
+
+function buildTask(state: TaskState): Task {
+  return {
+    id: 't-1',
+    name: 'Demo task',
+    state,
+  }
+}
+
+function mountRow(task: Task | null) {
+  return mount(WorkbenchRow, {
+    props: {
+      task,
+      index: 0,
+      rowHeight: 90,
+      activityKey: null,
+      stations: STATIONS,
+      stateLabel: (s: string) => s.toUpperCase(),
+    },
+  })
+}
+
+describe('WorkbenchRow scenery', () => {
+  it('omits the scenery layer when the row is vacant', () => {
+    const wrapper = mountRow(null)
+    expect(wrapper.find('svg.bench-scene').exists()).toBe(false)
+  })
+
+  const cases: Array<[TaskState, string]> = [
+    ['pending', 'scene-pending'],
+    ['planning', 'scene-planning'],
+    ['working', 'scene-working'],
+    ['awaiting-review', 'scene-awaiting-review'],
+    ['followup', 'scene-followup'],
+    ['done', 'scene-done'],
+    ['failed', 'scene-failed'],
+    ['cancelled', 'scene-failed'],
+  ]
+  it.each(cases)('renders scenery for state %s with class %s', (state, klass) => {
+    const wrapper = mountRow(buildTask(state))
+    const svg = wrapper.find('svg.bench-scene')
+    expect(svg.exists()).toBe(true)
+    expect(svg.classes()).toContain(klass)
+  })
+
+  it('applies pixel-art crisp rendering on the scenery SVG', () => {
+    const wrapper = mountRow(buildTask('working'))
+    const svg = wrapper.find('svg.bench-scene')
+    expect(svg.attributes('shape-rendering')).toBe('crispEdges')
+  })
+})

--- a/frontend/src/components/sprites/RobotWorker.vue
+++ b/frontend/src/components/sprites/RobotWorker.vue
@@ -4,24 +4,25 @@
     viewBox="0 0 40 56"
     xmlns="http://www.w3.org/2000/svg"
     overflow="visible"
+    shape-rendering="crispEdges"
   >
     <!-- HEAD GROUP — tilt/shake animations target this whole group -->
     <g class="head-group">
-      <!-- Crown (foreman only) — three prongs with gem accents -->
+      <!-- Crown (foreman only) — three prongs with square gem accents -->
       <g v-if="type === 'foreman'" class="crown">
-        <rect x="9" y="3" width="22" height="2" rx="1" fill="var(--color-gold, #ffd644)" />
-        <rect x="12" y="-1" width="4" height="5" rx="1" fill="var(--color-gold, #ffd644)" />
-        <rect x="18" y="-4" width="4" height="8" rx="1" fill="var(--color-gold, #ffd644)" />
-        <rect x="24" y="-1" width="4" height="5" rx="1" fill="var(--color-gold, #ffd644)" />
-        <circle cx="14" cy="-0.5" r="1.2" fill="var(--color-red, #ee3322)" />
-        <circle cx="20" cy="-3" r="1.2" fill="var(--color-blue, #44aaee)" />
-        <circle cx="26" cy="-0.5" r="1.2" fill="var(--color-green, #88dd22)" />
+        <rect x="9" y="3" width="22" height="2" fill="var(--color-gold, #ffd644)" />
+        <rect x="12" y="-1" width="4" height="5" fill="var(--color-gold, #ffd644)" />
+        <rect x="18" y="-4" width="4" height="8" fill="var(--color-gold, #ffd644)" />
+        <rect x="24" y="-1" width="4" height="5" fill="var(--color-gold, #ffd644)" />
+        <rect x="13" y="-1" width="2" height="2" fill="var(--color-red, #ee3322)" />
+        <rect x="19" y="-4" width="2" height="2" fill="var(--color-blue, #44aaee)" />
+        <rect x="25" y="-1" width="2" height="2" fill="var(--color-green, #88dd22)" />
       </g>
 
-      <!-- Antenna (workers) -->
+      <!-- Antenna (workers) — square ball -->
       <template v-if="type !== 'foreman'">
         <rect x="19" y="1" width="2" height="3" fill="var(--agent-color)" />
-        <circle class="antenna-ball" cx="20" cy="1" r="2.2" fill="var(--agent-color)" />
+        <rect class="antenna-ball" x="18" y="-2" width="4" height="4" fill="var(--agent-color)" />
       </template>
 
       <!-- Head box -->
@@ -31,28 +32,27 @@
         y="5"
         width="22"
         height="18"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
 
       <!-- Eyes -->
-      <rect class="eye" x="12" y="10" width="6" height="5" rx="1" />
-      <rect class="eye" x="22" y="10" width="6" height="5" rx="1" />
+      <rect class="eye" x="12" y="10" width="6" height="5" />
+      <rect class="eye" x="22" y="10" width="6" height="5" />
 
-      <!-- Ear bolts -->
-      <circle cx="10" cy="14" r="1.2" fill="var(--agent-color)" opacity="0.75" />
-      <circle cx="30" cy="14" r="1.2" fill="var(--agent-color)" opacity="0.75" />
+      <!-- Ear bolts (square dots) -->
+      <rect x="9" y="13" width="2" height="2" fill="var(--agent-color)" opacity="0.75" />
+      <rect x="29" y="13" width="2" height="2" fill="var(--agent-color)" opacity="0.75" />
 
       <!-- Speaker grill -->
-      <rect x="13" y="20" width="3" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.65" />
-      <rect x="18" y="20" width="3" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.65" />
-      <rect x="23" y="20" width="3" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.65" />
+      <rect x="13" y="20" width="3" height="1" fill="var(--agent-color)" opacity="0.65" />
+      <rect x="18" y="20" width="3" height="1" fill="var(--agent-color)" opacity="0.65" />
+      <rect x="23" y="20" width="3" height="1" fill="var(--agent-color)" opacity="0.65" />
     </g>
 
     <!-- Neck -->
-    <rect x="16" y="23" width="8" height="3" rx="1" fill="var(--agent-color)" opacity="0.45" />
+    <rect x="16" y="23" width="8" height="3" fill="var(--agent-color)" opacity="0.45" />
 
     <!-- Body -->
     <rect
@@ -60,10 +60,9 @@
       y="26"
       width="26"
       height="18"
-      rx="2"
       fill="rgba(18,9,0,0.93)"
       stroke="var(--agent-color)"
-      stroke-width="1.5"
+      stroke-width="2"
     />
     <!-- Chest panel recess -->
     <rect
@@ -71,30 +70,28 @@
       y="29"
       width="14"
       height="12"
-      rx="1"
       fill="rgba(0,0,0,0.65)"
       stroke="var(--agent-color)"
-      stroke-width="0.75"
+      stroke-width="1"
     />
-    <!-- LED indicator -->
-    <circle class="led" cx="20" cy="35" r="3.5" />
-    <!-- Shoulder rivets -->
-    <circle cx="9" cy="28" r="1.5" fill="var(--agent-color)" opacity="0.85" />
-    <circle cx="31" cy="28" r="1.5" fill="var(--agent-color)" opacity="0.85" />
+    <!-- LED indicator — square pixel LED -->
+    <rect class="led" x="17" y="32" width="6" height="6" />
+    <!-- Shoulder rivets — square pixels -->
+    <rect x="8" y="27" width="2" height="2" fill="var(--agent-color)" opacity="0.85" />
+    <rect x="30" y="27" width="2" height="2" fill="var(--agent-color)" opacity="0.85" />
     <!-- Side exhaust vents -->
-    <rect x="29" y="33" width="3.5" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.55" />
-    <rect x="29" y="36" width="3.5" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.55" />
-    <rect x="29" y="39" width="3.5" height="1" rx="0.5" fill="var(--agent-color)" opacity="0.55" />
+    <rect x="29" y="33" width="3" height="1" fill="var(--agent-color)" opacity="0.55" />
+    <rect x="29" y="36" width="3" height="1" fill="var(--agent-color)" opacity="0.55" />
+    <rect x="29" y="39" width="3" height="1" fill="var(--agent-color)" opacity="0.55" />
     <!-- Belt line -->
     <rect
       x="7"
       y="42"
       width="26"
       height="2"
-      rx="0"
       fill="rgba(0,0,0,0.35)"
       stroke="var(--agent-color)"
-      stroke-width="0.5"
+      stroke-width="1"
     />
 
     <!-- Left arm -->
@@ -104,21 +101,19 @@
         y="27"
         width="6"
         height="12"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
-      <circle cx="4" cy="31" r="1.5" fill="var(--agent-color)" opacity="0.7" />
+      <rect x="3" y="30" width="2" height="2" fill="var(--agent-color)" opacity="0.7" />
       <rect
         x="0"
         y="38"
         width="8"
         height="5"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
     </g>
 
@@ -129,21 +124,19 @@
         y="27"
         width="6"
         height="12"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
-      <circle cx="36" cy="31" r="1.5" fill="var(--agent-color)" opacity="0.7" />
+      <rect x="35" y="30" width="2" height="2" fill="var(--agent-color)" opacity="0.7" />
       <rect
         x="32"
         y="38"
         width="8"
         height="5"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
     </g>
 
@@ -154,20 +147,18 @@
         y="44"
         width="9"
         height="10"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
       <rect
         x="8"
         y="51"
         width="13"
         height="5"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
     </g>
     <!-- Right leg + foot -->
@@ -177,20 +168,18 @@
         y="44"
         width="9"
         height="10"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
       <rect
         x="19"
         y="51"
         width="13"
         height="5"
-        rx="2"
         fill="rgba(18,9,0,0.93)"
         stroke="var(--agent-color)"
-        stroke-width="1.5"
+        stroke-width="2"
       />
     </g>
   </svg>
@@ -271,7 +260,8 @@ withDefaults(
   filter: drop-shadow(0 0 4px var(--color-green, #88dd22));
   transform-box: fill-box;
   transform-origin: center;
-  animation: ledPulse 0.5s infinite alternate;
+  /* Stepped pulse — toggles between two sizes, no smooth scale */
+  animation: ledPulse 0.5s steps(1, end) infinite alternate;
 }
 .robot-sprite.busy .led {
   fill: var(--color-orange, #ff7700);
@@ -293,7 +283,7 @@ withDefaults(
 
 /* ── Antenna pulse when thinking ─────────────────────── */
 .robot-sprite.thinking .antenna-ball {
-  animation: antennaPulse 1.5s infinite alternate;
+  animation: antennaPulse 1.5s steps(1, end) infinite alternate;
 }
 @keyframes antennaPulse {
   from {
@@ -316,20 +306,27 @@ withDefaults(
 .robot-sprite.thinking .head-group {
   transform-box: fill-box;
   transform-origin: bottom center;
-  animation: tiltHead 1.5s infinite ease-in-out;
+  /* Stepped head tilt — 3-frame cycle via 3 distinct keyframes + steps(1) */
+  animation: tiltHead 1.2s steps(1, end) infinite;
 }
 @keyframes tiltHead {
   0%,
-  100% {
-    transform: rotate(-5deg);
+  33% {
+    transform: rotate(-4deg);
   }
-  50% {
-    transform: rotate(5deg);
+  34%,
+  66% {
+    transform: rotate(0deg);
+  }
+  67%,
+  100% {
+    transform: rotate(4deg);
   }
 }
 
 .robot-sprite.working {
-  animation: workBounce 0.4s infinite alternate;
+  /* Bounce snaps between two y positions — not smooth */
+  animation: workBounce 0.4s steps(1, end) infinite alternate;
 }
 @keyframes workBounce {
   from {
@@ -343,12 +340,12 @@ withDefaults(
 .robot-sprite.busy .left-arm {
   transform-box: fill-box;
   transform-origin: top right;
-  animation: leftArmSwing 0.5s infinite alternate;
+  animation: leftArmSwing 0.5s steps(1, end) infinite alternate;
 }
 .robot-sprite.busy .right-arm {
   transform-box: fill-box;
   transform-origin: top left;
-  animation: rightArmSwing 0.5s infinite alternate;
+  animation: rightArmSwing 0.5s steps(1, end) infinite alternate;
 }
 @keyframes leftArmSwing {
   from {
@@ -383,9 +380,10 @@ withDefaults(
   }
 }
 
-/* ── Walking ──────────────────────────────────────────── */
+/* ── Walking — 2-frame stepped cycle, sprite-sheet feel ── */
 .robot-sprite.walking {
-  animation: walkBob 0.36s infinite alternate ease-in-out;
+  /* Hop snaps between 2 vertical positions, no tween */
+  animation: walkBob 0.32s steps(1, end) infinite alternate;
 }
 @keyframes walkBob {
   from {
@@ -399,12 +397,12 @@ withDefaults(
 .robot-sprite.walking .left-leg {
   transform-box: fill-box;
   transform-origin: top center;
-  animation: legSwingA 0.36s infinite alternate ease-in-out;
+  animation: legSwingA 0.32s steps(1, end) infinite alternate;
 }
 .robot-sprite.walking .right-leg {
   transform-box: fill-box;
   transform-origin: top center;
-  animation: legSwingB 0.36s infinite alternate ease-in-out;
+  animation: legSwingB 0.32s steps(1, end) infinite alternate;
 }
 @keyframes legSwingA {
   from {
@@ -426,11 +424,11 @@ withDefaults(
 .robot-sprite.walking .left-arm {
   transform-box: fill-box;
   transform-origin: top right;
-  animation: rightArmSwing 0.36s infinite alternate ease-in-out;
+  animation: rightArmSwing 0.32s steps(1, end) infinite alternate;
 }
 .robot-sprite.walking .right-arm {
   transform-box: fill-box;
   transform-origin: top left;
-  animation: leftArmSwing 0.36s infinite alternate ease-in-out;
+  animation: leftArmSwing 0.32s steps(1, end) infinite alternate;
 }
 </style>

--- a/frontend/src/composables/useAgentChoreography.ts
+++ b/frontend/src/composables/useAgentChoreography.ts
@@ -151,14 +151,20 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
     return 'idle'
   }
 
+  // Snap to integer pixels so stepped CSS transitions land on the pixel grid.
+  function snap(p: Position): Position {
+    return { x: Math.round(p.x), y: Math.round(p.y) }
+  }
+
   function moveAgent(id: string, target: Position) {
-    reservedPos[id] = target
-    const cur = positions[id] || target
-    const dist = Math.hypot(target.x - cur.x, target.y - cur.y)
+    const snapped = snap(target)
+    reservedPos[id] = snapped
+    const cur = positions[id] || snapped
+    const dist = Math.hypot(snapped.x - cur.x, snapped.y - cur.y)
     const dur = Math.max(0.6, dist / 120)
     duration[id] = dur
     walking[id] = true
-    positions[id] = target
+    positions[id] = snapped
     clearTimeout(timers[id])
     timers[id] = setTimeout(
       () => {
@@ -185,7 +191,7 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
     if (prevTargetKey[agent.id] === key && positions[agent.id]) return
     prevTargetKey[agent.id] = key
     if (!positions[agent.id]) {
-      positions[agent.id] = pickWanderPos(agent.id)
+      positions[agent.id] = snap(pickWanderPos(agent.id))
     }
     moveAgent(agent.id, targetForAgent(agent))
   }


### PR DESCRIPTION
Cherry-picks the per-state overlays from reverted PR #322 (commit 7b6bf8d)
back into the current WorkbenchRow.vue, redrawn with pixel-art SVG
techniques so they read as sprites rather than smooth vector art:

  * shape-rendering="crispEdges" disables AA on geometry
  * all coordinates are integers, no rx/ry rounded corners
  * stepped staircases stand in for diagonal lines (checkmark, X, pencil)
  * animations use steps() timing (cursor blink, steam puffs, lamp
    flicker, sparkle, hourglass sand) so motion advances in pixel jumps
    rather than smooth tween

Scenery covers all live TaskStates: pending (hourglass), planning
(blueprint + pencil + ruler), working (laptop with code + cursor blink +
coffee mug with stepped steam), awaiting-review (paper stack + desk lamp
with flickering cone), followup (three sticky notes), done (animated
stepped checkmark + plus-sign sparkles), failed/cancelled (crumpled
papers + stepped X). The existing row chrome (header strip, brass rail,
bolts, six activity stations) is unchanged and renders on top of the
scenery via z-index.

Adds a demo/ entrypoint that mounts a row per state for visual review
via `vite dev` at /demo/scenery.html, and a Vitest spec covering scene
selection and the crisp-edges attribute.