### PR TITLE
feat(ui): errand-chain behavior tree for idle agents

### DIFF
--- a/frontend/demo/poses.html
+++ b/frontend/demo/poses.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Agent poses demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./poses.ts"></script>
+  </body>
+</html>

--- a/frontend/demo/poses.ts
+++ b/frontend/demo/poses.ts
@@ -1,0 +1,80 @@
+import { createApp, h, defineComponent } from 'vue'
+import AgentAvatar from '../src/components/AgentAvatar.vue'
+import type { Agent } from '../src/types'
+import type { AgentPose } from '../src/composables/useErrands'
+import '../src/style.css'
+
+const POSES: AgentPose[] = ['stand', 'sit', 'lean']
+
+function buildAgent(name: string, i: number): Agent {
+  return {
+    id: `a-${name}-${i}`,
+    name,
+    type: 'worker',
+    workerId: `w-${i}`,
+    state: 'idle',
+    activity: null,
+    logs: [],
+    joinedAt: new Date().toISOString(),
+  }
+}
+
+const App = defineComponent({
+  setup() {
+    return () =>
+      h(
+        'div',
+        {
+          style: {
+            background: '#120900',
+            padding: '32px',
+            minHeight: '100vh',
+            color: '#e8d4a4',
+            fontFamily: 'monospace',
+          },
+        },
+        [
+          h(
+            'div',
+            { style: { fontSize: '14px', letterSpacing: '2px', marginBottom: '24px' } },
+            'IDLE-AGENT POSES — STAND · SIT (couch) · LEAN (table)',
+          ),
+          h(
+            'div',
+            {
+              style: { display: 'flex', gap: '48px', flexWrap: 'wrap', alignItems: 'flex-end' },
+            },
+            POSES.map((p, i) =>
+              h(
+                'div',
+                {
+                  id: `cell-${p}`,
+                  style: {
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: '8px',
+                    width: '90px',
+                  },
+                },
+                [
+                  h(
+                    'div',
+                    { style: { fontSize: '8px', letterSpacing: '2px', color: '#e8aa00' } },
+                    p.toUpperCase(),
+                  ),
+                  h(AgentAvatar, {
+                    agent: buildAgent(p, i),
+                    walking: false,
+                    pose: p,
+                  }),
+                ],
+              ),
+            ),
+          ),
+        ],
+      )
+  },
+})
+
+createApp(App).mount('#app')

--- a/frontend/src/components/AgentAvatar.vue
+++ b/frontend/src/components/AgentAvatar.vue
@@ -1,16 +1,17 @@
 <template>
   <div
     class="avatar-wrapper"
-    :class="[agent.state, agent.type]"
+    :class="[agent.state, agent.type, `pose-${pose}`]"
     :style="`--agent-color: ${agentColor}; --agent-color-dim: ${agentColorDim}`"
     :title="`${agent.name} [${agent.state}]`"
   >
-    <RobotWorker :state="agent.state" :type="agent.type" :walking="walking" />
+    <RobotWorker :state="agent.state" :type="agent.type" :walking="walking" :pose="pose" />
 
     <div class="avatar-label">{{ agent.name.slice(0, 8) }}</div>
     <div v-if="agent.state === 'thinking'" class="think-bubble">💭</div>
     <div v-if="agent.state === 'working'" class="work-burst">⭐</div>
     <div v-if="agent.state === 'error'" class="error-burst">!</div>
+    <div v-if="pose === 'sit'" class="zzz-bubble">z</div>
   </div>
 </template>
 
@@ -18,14 +19,17 @@
 import { computed } from 'vue'
 import RobotWorker from './sprites/RobotWorker.vue'
 import type { Agent } from '../types'
+import type { AgentPose } from '../composables/useErrands'
 
 const props = withDefaults(
   defineProps<{
     agent: Agent
     walking?: boolean
+    pose?: AgentPose
   }>(),
   {
     walking: false,
+    pose: 'stand',
   },
 )
 
@@ -160,6 +164,31 @@ const agentColorDim = computed(() => {
   }
   75% {
     transform: translateX(3px);
+  }
+}
+
+/* Sleepy "z" while sitting on the couch */
+.zzz-bubble {
+  position: absolute;
+  top: -16px;
+  right: -8px;
+  font-family: var(--font-pixel);
+  font-size: 10px;
+  color: var(--color-sky, #44aaee);
+  text-shadow: 0 0 4px var(--color-sky, #44aaee);
+  animation: zzzFloat 2s steps(2, end) infinite;
+}
+
+@keyframes zzzFloat {
+  0%,
+  49% {
+    opacity: 0.7;
+    transform: translateY(0);
+  }
+  50%,
+  100% {
+    opacity: 1;
+    transform: translateY(-3px);
   }
 }
 </style>

--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -48,7 +48,11 @@
         choreography.getPos(agent.id).y
       }px; --walk-dur: ${choreography.duration[agent.id] || 1.5}s;`"
     >
-      <AgentAvatar :agent="agent" :walking="!!choreography.walking[agent.id]" />
+      <AgentAvatar
+        :agent="agent"
+        :walking="!!choreography.walking[agent.id]"
+        :pose="choreography.pose[agent.id] || 'stand'"
+      />
     </div>
 
     <TickerTape :messages="tickerMessages" />

--- a/frontend/src/components/sprites/RobotWorker.vue
+++ b/frontend/src/components/sprites/RobotWorker.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    :class="['robot-sprite', state, type, { walking }]"
+    :class="['robot-sprite', state, type, { walking }, `pose-${pose}`]"
     viewBox="0 0 40 56"
     xmlns="http://www.w3.org/2000/svg"
     overflow="visible"
@@ -186,14 +186,18 @@
 </template>
 
 <script setup lang="ts">
+import type { AgentPose } from '../../composables/useErrands'
+
 withDefaults(
   defineProps<{
     state: string
     type: string
     walking?: boolean
+    pose?: AgentPose
   }>(),
   {
     walking: false,
+    pose: 'stand',
   },
 )
 </script>
@@ -430,5 +434,33 @@ withDefaults(
   transform-box: fill-box;
   transform-origin: top left;
   animation: leftArmSwing 0.32s steps(1, end) infinite alternate;
+}
+
+/* ── Sit pose (couch) — legs tuck under, body settles ───── */
+/* Walking always wins over sit; an arriving robot drops to sit only after
+   the walking class is removed. */
+.robot-sprite.pose-sit:not(.walking) {
+  transform: translateY(4px);
+}
+.robot-sprite.pose-sit:not(.walking) .left-leg {
+  transform-box: fill-box;
+  transform-origin: top center;
+  transform: translate(2px, -3px) rotate(35deg);
+}
+.robot-sprite.pose-sit:not(.walking) .right-leg {
+  transform-box: fill-box;
+  transform-origin: top center;
+  transform: translate(-2px, -3px) rotate(-35deg);
+}
+/* Cancel the work-bounce while sitting so the body stays still. */
+.robot-sprite.pose-sit.working:not(.walking) {
+  animation: none;
+}
+
+/* ── Lean pose (table) — slight forward tilt ────────────── */
+.robot-sprite.pose-lean:not(.walking) .head-group {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  transform: rotate(8deg) translateY(1px);
 }
 </style>

--- a/frontend/src/composables/__tests__/useErrands.spec.ts
+++ b/frontend/src/composables/__tests__/useErrands.spec.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import {
+  type Poi,
+  type Rng,
+  buildErrandQueue,
+  lingerFor,
+  personalityFor,
+  pickWeighted,
+  poisFromGeometry,
+} from '../useErrands'
+
+const geom = {
+  tableLeft: 28,
+  tableWidth: 800,
+  breakRoomTop: 400,
+  breakRoomHeight: 64,
+}
+
+function seededRng(seed: number): Rng {
+  let s = seed >>> 0
+  return {
+    next() {
+      // Mulberry32 — small deterministic PRNG, good enough for tests.
+      s = (s + 0x6d2b79f5) >>> 0
+      let t = s
+      t = Math.imul(t ^ (t >>> 15), t | 1)
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    },
+  }
+}
+
+describe('useErrands · personalityFor', () => {
+  it('returns the same personality for the same agent id', () => {
+    expect(personalityFor('a-abc')).toEqual(personalityFor('a-abc'))
+  })
+
+  it('returns different weights for different agent ids', () => {
+    const a = personalityFor('a-1')
+    const b = personalityFor('a-different-id')
+    expect(a).not.toEqual(b)
+  })
+
+  it('always assigns a positive weight to every POI kind', () => {
+    for (const id of ['a-1', 'a-2', 'a-zzz', 'foreman']) {
+      const p = personalityFor(id)
+      for (const w of Object.values(p.weights)) expect(w).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('useErrands · poisFromGeometry', () => {
+  it('produces the expected break-room destinations', () => {
+    const pois = poisFromGeometry(geom)
+    const kinds = pois.map((p) => p.kind)
+    expect(kinds).toEqual(['bulletin', 'watercooler', 'couch', 'couch', 'table', 'table', 'table'])
+  })
+
+  it('places couch seats below the tables (higher y)', () => {
+    const pois = poisFromGeometry(geom)
+    const couch = pois.find((p) => p.kind === 'couch')!
+    const table = pois.find((p) => p.kind === 'table')!
+    expect(couch.pos.y).toBeGreaterThan(table.pos.y)
+  })
+
+  it('marks couch as sit, table as lean, others as stand', () => {
+    const pois = poisFromGeometry(geom)
+    expect(pois.find((p) => p.kind === 'couch')!.pose).toBe('sit')
+    expect(pois.find((p) => p.kind === 'table')!.pose).toBe('lean')
+    expect(pois.find((p) => p.kind === 'bulletin')!.pose).toBe('stand')
+    expect(pois.find((p) => p.kind === 'watercooler')!.pose).toBe('stand')
+  })
+
+  it('scales POIs with break-room width', () => {
+    const a = poisFromGeometry(geom)
+    const b = poisFromGeometry({ ...geom, tableWidth: 1600 })
+    const aWater = a.find((p) => p.kind === 'watercooler')!
+    const bWater = b.find((p) => p.kind === 'watercooler')!
+    expect(bWater.pos.x).toBeGreaterThan(aWater.pos.x)
+  })
+})
+
+describe('useErrands · pickWeighted', () => {
+  it('always picks the heaviest item when weights are extreme', () => {
+    const rng = seededRng(42)
+    const items = [
+      { value: 'a', weight: 0.001 },
+      { value: 'b', weight: 1000 },
+    ]
+    for (let i = 0; i < 50; i++) expect(pickWeighted(items, rng)).toBe('b')
+  })
+
+  it('returns each value at least once over enough draws when weights are equal', () => {
+    const rng = seededRng(7)
+    const items = ['a', 'b', 'c'].map((value) => ({ value, weight: 1 }))
+    const seen = new Set<string>()
+    for (let i = 0; i < 100; i++) seen.add(pickWeighted(items, rng))
+    expect(seen).toEqual(new Set(['a', 'b', 'c']))
+  })
+})
+
+describe('useErrands · lingerFor', () => {
+  it('stays inside the lingerMs range', () => {
+    const poi: Poi = {
+      kind: 'couch',
+      pos: { x: 0, y: 0 },
+      lingerMs: [6000, 10000],
+      pose: 'sit',
+    }
+    const rng = seededRng(1)
+    for (let i = 0; i < 200; i++) {
+      const v = lingerFor(poi, rng)
+      expect(v).toBeGreaterThanOrEqual(6000)
+      expect(v).toBeLessThan(10000)
+    }
+  })
+})
+
+describe('useErrands · buildErrandQueue', () => {
+  const pois = poisFromGeometry(geom)
+  const wanderFactory = (): Poi => ({
+    kind: 'wander',
+    pos: { x: 100, y: 100 },
+    lingerMs: [1000, 2000],
+    pose: 'stand',
+  })
+
+  it('produces 3..5 entries', () => {
+    const rng = seededRng(123)
+    for (let i = 0; i < 25; i++) {
+      const q = buildErrandQueue(personalityFor(`a-${i}`), pois, wanderFactory, rng)
+      expect(q.length).toBeGreaterThanOrEqual(3)
+      expect(q.length).toBeLessThanOrEqual(5)
+    }
+  })
+
+  it('does not place the same POI twice in a row', () => {
+    const rng = seededRng(99)
+    for (let i = 0; i < 50; i++) {
+      const q = buildErrandQueue(personalityFor(`agent-${i}`), pois, wanderFactory, rng)
+      for (let k = 1; k < q.length; k++) {
+        const prev = q[k - 1]
+        const cur = q[k]
+        const same =
+          prev.kind === cur.kind && prev.pos.x === cur.pos.x && prev.pos.y === cur.pos.y
+        expect(same).toBe(false)
+      }
+    }
+  })
+
+  it('biases the chain toward kinds with higher personality weight', () => {
+    // Synthetic personality that vastly prefers the couch.
+    const p = {
+      weights: { bulletin: 0.01, watercooler: 0.01, couch: 100, table: 0.01, wander: 0.01 },
+    }
+    const rng = seededRng(55)
+    const counts: Record<string, number> = {}
+    for (let i = 0; i < 30; i++) {
+      const q = buildErrandQueue(p, pois, wanderFactory, rng)
+      for (const poi of q) counts[poi.kind] = (counts[poi.kind] ?? 0) + 1
+    }
+    expect((counts.couch ?? 0)).toBeGreaterThan((counts.table ?? 0) + (counts.bulletin ?? 0))
+  })
+})

--- a/frontend/src/composables/useAgentChoreography.ts
+++ b/frontend/src/composables/useAgentChoreography.ts
@@ -1,5 +1,14 @@
 import { reactive, watch, onUnmounted, type ComputedRef } from 'vue'
 import type { Agent, Task } from '../types'
+import {
+  type AgentPose,
+  type Poi,
+  buildErrandQueue,
+  defaultRng,
+  lingerFor,
+  personalityFor,
+  poisFromGeometry,
+} from './useErrands'
 
 export interface Position {
   x: number
@@ -29,11 +38,18 @@ export interface ChoreographyOptions {
 export function useAgentChoreography(opts: ChoreographyOptions) {
   const positions = reactive<Record<string, Position>>({})
   const walking = reactive<Record<string, boolean>>({})
+  const pose = reactive<Record<string, AgentPose>>({})
   const duration = reactive<Record<string, number>>({})
   const timers: Record<string, ReturnType<typeof setTimeout>> = {}
   const prevTargetKey: Record<string, string> = {}
   // Tracks each robot's current destination for collision avoidance
   const reservedPos: Record<string, Position> = {}
+  // Per-agent errand chain; refilled on demand from useErrands.
+  const errandQueue: Record<string, Poi[]> = {}
+  // Linger duration carried from target selection into the post-arrival timer.
+  const pendingLinger: Record<string, number> = {}
+  // Pose to apply on arrival at the current target.
+  const pendingPose: Record<string, AgentPose> = {}
 
   function rowYFor(rowIndex: number) {
     return opts.tableTop + rowIndex * (opts.rowHeight.value + opts.rowGap)
@@ -132,15 +148,49 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
     return { x: Math.cos(angle) * r, y: Math.sin(angle) * r }
   }
 
+  function nextErrand(agentId: string): Poi {
+    const geom = {
+      tableLeft: opts.tableLeft,
+      tableWidth: opts.tableWidth.value,
+      breakRoomTop: opts.breakRoomTop.value,
+      breakRoomHeight: opts.breakRoomHeight.value,
+    }
+    const pois = poisFromGeometry(geom)
+    // Skip POIs another robot is already reserved on, so the queue surfaces
+    // an open seat rather than queueing two robots on the same couch cushion.
+    const free = pois.filter((p) => !isCrowded(p.pos, agentId, 24))
+    const usable = free.length ? free : pois
+
+    if (!errandQueue[agentId] || errandQueue[agentId].length === 0) {
+      const wanderFactory = (): Poi => ({
+        kind: 'wander',
+        pos: pickWanderPos(agentId),
+        lingerMs: [1200, 2600],
+        pose: 'stand',
+      })
+      errandQueue[agentId] = buildErrandQueue(
+        personalityFor(agentId),
+        usable,
+        wanderFactory,
+        defaultRng,
+      )
+    }
+    return errandQueue[agentId].shift()!
+  }
+
   function targetForAgent(agent: Agent): Position {
     const row = rowForAgent(agent)
     const jitter = slotJitter(agent.id)
     if (row && isWorking(agent)) {
       const key = row.activityKey
       const base = key ? stationPos(row.index, key) : rowCenterPos(row.index)
+      pendingPose[agent.id] = 'stand'
       return { x: base.x + jitter.x, y: base.y + jitter.y }
     }
-    return pickWanderPos(agent.id)
+    const errand = nextErrand(agent.id)
+    pendingLinger[agent.id] = lingerFor(errand, defaultRng)
+    pendingPose[agent.id] = errand.pose
+    return errand.pos
   }
 
   function targetKey(agent: Agent): string {
@@ -164,11 +214,14 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
     const dur = Math.max(0.6, dist / 120)
     duration[id] = dur
     walking[id] = true
+    // Robot is in transit — drop any sit/lean pose until they arrive.
+    pose[id] = 'stand'
     positions[id] = snapped
     clearTimeout(timers[id])
     timers[id] = setTimeout(
       () => {
         walking[id] = false
+        pose[id] = pendingPose[id] ?? 'stand'
         const agent = opts.agents.value.find((a) => a.id === id)
         if (agent && !isWorking(agent)) scheduleIdleStroll(id)
       },
@@ -177,12 +230,14 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
   }
 
   function scheduleIdleStroll(id: string) {
-    const linger = 3500 + Math.random() * 4000
+    // Linger picked at the moment the previous target was selected so each
+    // POI honors its own dwell time (couch lingers way longer than water).
+    const linger = pendingLinger[id] ?? 3500 + Math.random() * 4000
     clearTimeout(timers[id])
     timers[id] = setTimeout(() => {
       const agent = opts.agents.value.find((a) => a.id === id)
       if (!agent || isWorking(agent)) return
-      moveAgent(id, pickWanderPos(id))
+      moveAgent(id, targetForAgent(agent))
     }, linger)
   }
 
@@ -216,6 +271,7 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
   return {
     positions,
     walking,
+    pose,
     duration,
     syncAll,
     getPos,

--- a/frontend/src/composables/useErrands.ts
+++ b/frontend/src/composables/useErrands.ts
@@ -1,0 +1,170 @@
+/**
+ * Idle-agent behavior tree: each agent gets a stable personality (hashed
+ * from their id) that biases which break-room destinations they prefer.
+ * When idle they work through a short errand chain — sit on the couch,
+ * chat at a table, grab water, read the bulletin — instead of picking a
+ * single random point.
+ */
+
+import type { Position } from './useAgentChoreography'
+
+export type PoiKind = 'bulletin' | 'watercooler' | 'couch' | 'table' | 'wander'
+export type AgentPose = 'stand' | 'sit' | 'lean'
+
+export interface Poi {
+  kind: PoiKind
+  pos: Position
+  /** Range of milliseconds to linger when arriving at this POI. */
+  lingerMs: [number, number]
+  pose: AgentPose
+}
+
+export interface Personality {
+  weights: Record<PoiKind, number>
+}
+
+export interface BreakRoomGeometry {
+  tableLeft: number
+  tableWidth: number
+  breakRoomTop: number
+  breakRoomHeight: number
+}
+
+/** djb2-ish hash → unsigned 32-bit. Stable across runs. */
+function hashId(id: string): number {
+  let h = 5381
+  for (let i = 0; i < id.length; i++) {
+    h = ((h << 5) + h + id.charCodeAt(i)) >>> 0
+  }
+  return h
+}
+
+/**
+ * Derive a stable personality from an agent id. Different bits of the
+ * hash drive each preference so agents feel distinguishable.
+ */
+export function personalityFor(agentId: string): Personality {
+  const h = hashId(agentId)
+  // Each slice is 0..7. Add a small base so no weight is ever zero.
+  const lazy = (h >>> 0) & 0x7
+  const social = (h >>> 3) & 0x7
+  const studious = (h >>> 6) & 0x7
+  const restless = (h >>> 9) & 0x7
+  const thirsty = (h >>> 12) & 0x7
+  return {
+    weights: {
+      couch: 1 + lazy * 0.9,
+      table: 1 + social * 0.7,
+      bulletin: 0.6 + studious * 0.45,
+      watercooler: 0.8 + thirsty * 0.35,
+      wander: 0.5 + restless * 0.4,
+    },
+  }
+}
+
+/**
+ * Build the static set of POIs derived from the break-room geometry.
+ * Couch has two seats so two robots can sit at once without overlap.
+ */
+export function poisFromGeometry(geom: BreakRoomGeometry): Poi[] {
+  const { tableLeft: tL, tableWidth: tW, breakRoomTop: brT, breakRoomHeight: brH } = geom
+  const midY = brT + Math.round(brH * 0.45)
+  const couchY = brT + brH - 14
+  return [
+    {
+      kind: 'bulletin',
+      pos: { x: tL + Math.round(tW * 0.04) + 18, y: midY },
+      lingerMs: [3500, 5500],
+      pose: 'stand',
+    },
+    {
+      kind: 'watercooler',
+      pos: { x: tL + tW - Math.round(tW * 0.04) - 18, y: midY },
+      lingerMs: [1800, 3000],
+      pose: 'stand',
+    },
+    {
+      kind: 'couch',
+      pos: { x: tL + Math.round(tW * 0.18) + 14, y: couchY },
+      lingerMs: [6000, 10000],
+      pose: 'sit',
+    },
+    {
+      kind: 'couch',
+      pos: { x: tL + Math.round(tW * 0.18) + 42, y: couchY },
+      lingerMs: [6000, 10000],
+      pose: 'sit',
+    },
+    {
+      kind: 'table',
+      pos: { x: tL + Math.round(tW * 0.33) + 21, y: midY },
+      lingerMs: [2500, 5000],
+      pose: 'lean',
+    },
+    {
+      kind: 'table',
+      pos: { x: tL + Math.round(tW * 0.49) + 21, y: midY },
+      lingerMs: [2500, 5000],
+      pose: 'lean',
+    },
+    {
+      kind: 'table',
+      pos: { x: tL + Math.round(tW * 0.65) + 21, y: midY },
+      lingerMs: [2500, 5000],
+      pose: 'lean',
+    },
+  ]
+}
+
+export interface Rng {
+  /** Returns a float in [0, 1). */
+  next(): number
+}
+
+export const defaultRng: Rng = { next: Math.random }
+
+export function pickWeighted<T>(items: Array<{ value: T; weight: number }>, rng: Rng): T {
+  const total = items.reduce((s, x) => s + x.weight, 0)
+  let r = rng.next() * total
+  for (const it of items) {
+    r -= it.weight
+    if (r <= 0) return it.value
+  }
+  return items[items.length - 1].value
+}
+
+export function lingerFor(poi: Poi, rng: Rng): number {
+  const [lo, hi] = poi.lingerMs
+  return lo + rng.next() * (hi - lo)
+}
+
+/**
+ * Build a short errand chain (3..5 stops) of POIs weighted by personality.
+ * `wanderFactory` produces a fresh wander POI on demand so it picks a new
+ * random spot each time it's drawn (rather than the same one repeatedly).
+ */
+export function buildErrandQueue(
+  personality: Personality,
+  pois: Poi[],
+  wanderFactory: () => Poi,
+  rng: Rng = defaultRng,
+): Poi[] {
+  const length = 3 + Math.floor(rng.next() * 3)
+  const queue: Poi[] = []
+  for (let i = 0; i < length; i++) {
+    const candidates: Array<{ value: Poi; weight: number }> = pois.map((p) => ({
+      value: p,
+      weight: personality.weights[p.kind] ?? 1,
+    }))
+    candidates.push({ value: wanderFactory(), weight: personality.weights.wander })
+    const next = pickWeighted(candidates, rng)
+    // Skip repeat of the immediately previous POI (boring to revisit instantly).
+    const prev = queue[queue.length - 1]
+    if (prev && prev.kind === next.kind && prev.pos.x === next.pos.x && prev.pos.y === next.pos.y) {
+      i--
+      continue
+    }
+    queue.push(next)
+  }
+  return queue
+}


### PR DESCRIPTION
**Stacked on `claude/git-history-robot-animation-kgPaD`** (per-state bench scenery + pixel-art robot retrofit). Review that branch first; this PR's diff is only the wander logic on top.

## Summary

Replaces the random-point idle stroll in `useAgentChoreography.ts` with a small behavior tree so idle robots feel like coworkers with routines rather than RNG dots:

- **Personality (hashed)** — each `agent.id` deterministically hashes into preference weights for couch / table / bulletin / watercooler / wander. Same agent reconnects with the same vibe.
- **Errand chains** — when idle, agents work through a 3-5 stop chain of break-room POIs picked by weighted sampling. Adjacent duplicates are skipped.
- **Per-POI dwell time** — couch lingers 6-10s, watercooler is a 2-3s pit-stop, tables in the middle. Linger picked at target-selection time and ridden through `moveAgent` via `pendingLinger`.
- **Reservation-aware** — POIs another robot is already heading to drop out of the candidate set so two robots don't queue on the same couch cushion.

Adds a `pose` channel (`stand | sit | lean`) flowed from choreography → AgentAvatar → RobotWorker:

- `pose-sit` (couch) tucks the legs under, drops the body 4px, and floats a sleepy `z` next to the head
- `pose-lean` (table) tilts the head forward
- Walking always overrides pose — no sitting mid-walk

## Files

- **New** `frontend/src/composables/useErrands.ts` — pure module (no Vue refs): `personalityFor`, `poisFromGeometry`, `pickWeighted`, `buildErrandQueue`, `lingerFor`
- **New** `frontend/src/composables/__tests__/useErrands.spec.ts` — 13 tests with a seeded PRNG
- `frontend/src/composables/useAgentChoreography.ts` — wires errands + adds `pose` reactive map
- `frontend/src/components/{FactoryFloor,AgentAvatar}.vue` + `sprites/RobotWorker.vue` — thread `pose` prop, add CSS for sit/lean
- **New** `frontend/demo/poses.html` (+ `.ts`) — `vite dev` → `/demo/poses.html` for visual eyeballing

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `eslint .` clean
- [x] `vitest run` — 78 pass / 2 skipped (was 65 pass before this PR)
- [x] `vite build` clean
- [ ] Manual: `vite dev` → `/demo/poses.html`, confirm sit/lean visually distinct
- [ ] Manual: spin up a real guild with 3+ workers, watch idle agents move between couch/tables/bulletin instead of teleporting to random points
- [ ] Manual: confirm two idle agents never sit on the same couch cushion

## Out of scope (still on the brainstorm list)

- "Look-at" attention (head rotation toward last working agent)
- Multi-segment pathing through aisles (currently still direct line)
- Reactions to events (gather around errors, cheer on completion)
- Screenshot harness over historical commits

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8pK1hSCCr9DP8iimbk9zF)_