### PR TITLE
chore(build): ship factory-floor demo pages in the production build

### DIFF
--- a/frontend/demo/index.html
+++ b/frontend/demo/index.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pioneer Square — visual demos</title>
+    <style>
+      :root {
+        --color-bg: #120900;
+        --color-bg-2: #1a0e00;
+        --color-cream: #ffe8c0;
+        --color-brass: #e8aa00;
+        --color-brass-dark: #a07800;
+        --color-text-dim: #554433;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: linear-gradient(180deg, #0d0600 0%, var(--color-bg) 50%, var(--color-bg-2) 100%);
+        color: var(--color-cream);
+        font-family: 'Share Tech Mono', monospace;
+        padding: 48px 32px;
+      }
+      .wrap {
+        max-width: 720px;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 14px;
+        letter-spacing: 4px;
+        color: var(--color-brass);
+        text-shadow: 0 0 6px rgba(232, 170, 0, 0.3);
+        margin: 0 0 8px;
+      }
+      .subtitle {
+        font-size: 11px;
+        letter-spacing: 1.5px;
+        color: var(--color-text-dim);
+        margin-bottom: 32px;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        display: grid;
+        gap: 14px;
+      }
+      a.card {
+        display: block;
+        padding: 14px 18px;
+        background: rgba(36, 18, 4, 0.55);
+        border: 2px solid var(--color-brass-dark);
+        border-radius: 0;
+        text-decoration: none;
+        color: var(--color-cream);
+        transition: border-color 0.2s, background 0.2s;
+      }
+      a.card:hover {
+        border-color: var(--color-brass);
+        background: rgba(60, 30, 0, 0.65);
+      }
+      .title {
+        font-size: 12px;
+        letter-spacing: 2px;
+        color: var(--color-brass);
+        margin-bottom: 4px;
+      }
+      .desc {
+        font-size: 11px;
+        color: var(--color-cream);
+        opacity: 0.85;
+        line-height: 1.5;
+      }
+      footer {
+        margin-top: 48px;
+        font-size: 10px;
+        color: var(--color-text-dim);
+      }
+      footer a {
+        color: var(--color-brass-dark);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>⚙ PIONEER SQUARE — VISUAL DEMOS ⚙</h1>
+      <div class="subtitle">
+        Isolated scaffolds for inspecting factory-floor SVG components without
+        a running guild. Useful for regression-checking pixel-art renders.
+      </div>
+      <ul>
+        <li>
+          <a class="card" href="./scenery.html">
+            <div class="title">Bench scenery</div>
+            <div class="desc">
+              One workbench row per task state — pending, planning, working,
+              awaiting-review, followup, done, failed — to inspect the
+              per-state SVG overlays.
+            </div>
+          </a>
+        </li>
+        <li>
+          <a class="card" href="./robots.html">
+            <div class="title">Robot sprite grid</div>
+            <div class="desc">
+              Worker and foreman variants across every agent state (idle,
+              thinking, working, busy, error) in both still and walking
+              poses. Animations run live.
+            </div>
+          </a>
+        </li>
+      </ul>
+      <footer>
+        Pages are built from <a href="https://github.com/jmelloy/pioneer-square/tree/main/frontend/demo">frontend/demo/</a>.
+      </footer>
+    </div>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,20 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  // Extra inputs ship the demo/ pages with the production build so the
+  // SVG showcase is reachable at /demo/* on the deployed site. They are
+  // not linked from the main app — they exist to share specific visual
+  // states (bench scenery, robot sprite variants).
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        'demo-index': path.resolve(__dirname, 'demo/index.html'),
+        'demo-scenery': path.resolve(__dirname, 'demo/scenery.html'),
+        'demo-robots': path.resolve(__dirname, 'demo/robots.html'),
+      },
+    },
+  },
   server: {
     allowedHosts: ['localhost', 'pioneer-square.melloy.life'],
     // Forward backend routes when running `npm run dev` so the SPA can


### PR DESCRIPTION
## Summary

The `frontend/demo/` scaffolds (added in PR #329 and #330) were dev-only — `vite build` skipped them because they aren't reachable from `index.html`. This PR ships them with the production build so the SVG showcase is reachable on the deployed site:

- `/demo/` — landing page linking to each demo (plain HTML, no Vue)
- `/demo/scenery.html` — per-state bench scenery
- `/demo/robots.html` — robot sprite grid

They're not linked from the main app — they only exist to share specific visual states. The dev experience is unchanged (Vite still serves them on `npm run dev`).

## Files

- `frontend/vite.config.ts` — adds `build.rollupOptions.input` map naming each demo
- `frontend/demo/index.html` — small static landing page styled to match the factory-floor palette

## Test plan

- [x] `npm run build` emits `dist/demo/{index,scenery,robots}.html` with correct asset URLs
- [x] `vue-tsc --noEmit` clean
- [x] `eslint .` clean
- [x] `vitest run` — 65 pass / 2 skip (unchanged)
- [ ] Manual: deploy, hit `https://pioneer-square.melloy.life/demo/`
- [ ] Manual: confirm robots demo animations run and scenery demo renders all 7 states

## Follow-up

Once PR #330 (idle-agent behavior tree, which adds `frontend/demo/poses.html`) merges, a one-line follow-up adds `demo-poses` to the `rollupOptions.input` map and a third link to `demo/index.html`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8pK1hSCCr9DP8iimbk9zF)_