### PR TITLE
Fix 422 PR creation: detect existing PR, mark success

### DIFF
--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -195,7 +195,18 @@ async def open_pr(
         pr_url = result.get("html_url", "")
         await emit(f"[worker] ✓ PR: {pr_url}")
         return pr_url
-    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+    except urllib.error.HTTPError as exc:
+        if exc.code == 422:
+            await emit(f"[worker] PR creation returned 422 — checking for existing PR on {branch}")
+            existing = await find_existing_pr(
+                branch=branch, worktree_path=worktree_path, token=token
+            )
+            if existing:
+                await emit(f"[worker] ✓ Found existing PR: {existing}")
+                return existing
+        await emit(f"[worker] PR failed: {exc}")
+        return None
+    except (urllib.error.URLError, OSError) as exc:
         await emit(f"[worker] PR failed: {exc}")
         return None
 

--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -196,6 +196,8 @@ async def open_pr(
         await emit(f"[worker] ✓ PR: {pr_url}")
         return pr_url
     except urllib.error.HTTPError as exc:
+        if exc.fp is not None:
+            exc.fp.close()
         if exc.code == 422:
             await emit(f"[worker] PR creation returned 422 — checking for existing PR on {branch}")
             existing = await find_existing_pr(
@@ -204,8 +206,10 @@ async def open_pr(
             if existing:
                 await emit(f"[worker] ✓ Found existing PR: {existing}")
                 return existing
-        await emit(f"[worker] PR failed: {exc}")
-        return None
+            await emit(f"[worker] PR failed: {exc}")
+            return None
+        logger.error("PR creation failed: %s", exc)
+        raise
     except (urllib.error.URLError, OSError) as exc:
         await emit(f"[worker] PR failed: {exc}")
         return None

--- a/worker/tests/test_open_pr.py
+++ b/worker/tests/test_open_pr.py
@@ -61,11 +61,9 @@ async def test_open_pr_422_finds_existing_pr():
     """A 422 should trigger a lookup; if an existing PR is found, return it."""
     emit = AsyncMock()
     existing_url = "https://github.com/owner/repo/pull/7"
+    mock_find = AsyncMock(return_value=existing_url)
 
-    with patch(
-        "pioneer_worker.github_pr.find_existing_pr",
-        new=AsyncMock(return_value=existing_url),
-    ):
+    with patch("pioneer_worker.github_pr.find_existing_pr", mock_find):
         with patch(
             "urllib.request.urlopen",
             side_effect=_http_error(422),
@@ -79,6 +77,7 @@ async def test_open_pr_422_finds_existing_pr():
             )
 
     assert result == existing_url
+    mock_find.assert_awaited_once_with(branch=_BRANCH, worktree_path=_WORKTREE, token=_TOKEN)
     # Confirm the emit message mentions the branch
     emitted = " ".join(str(c) for c in [call.args[0] for call in emit.call_args_list])
     assert "422" in emitted
@@ -89,11 +88,9 @@ async def test_open_pr_422_finds_existing_pr():
 async def test_open_pr_422_no_existing_pr_returns_none():
     """If 422 and no existing PR found, return None (genuine failure)."""
     emit = AsyncMock()
+    mock_find = AsyncMock(return_value=None)
 
-    with patch(
-        "pioneer_worker.github_pr.find_existing_pr",
-        new=AsyncMock(return_value=None),
-    ):
+    with patch("pioneer_worker.github_pr.find_existing_pr", mock_find):
         with patch(
             "urllib.request.urlopen",
             side_effect=_http_error(422),
@@ -107,28 +104,28 @@ async def test_open_pr_422_no_existing_pr_returns_none():
             )
 
     assert result is None
+    mock_find.assert_awaited_once_with(branch=_BRANCH, worktree_path=_WORKTREE, token=_TOKEN)
 
 
 @pytest.mark.asyncio
-async def test_open_pr_non_422_http_error_returns_none():
-    """Non-422 HTTP errors should not trigger the existing-PR lookup."""
+async def test_open_pr_non_422_http_error_propagates():
+    """Non-422 HTTP errors should be re-raised, not swallowed."""
     emit = AsyncMock()
+    mock_find = AsyncMock(return_value="https://github.com/owner/repo/pull/99")
 
-    with patch(
-        "pioneer_worker.github_pr.find_existing_pr",
-        new=AsyncMock(return_value="https://github.com/owner/repo/pull/99"),
-    ) as mock_find:
+    with patch("pioneer_worker.github_pr.find_existing_pr", mock_find):
         with patch(
             "urllib.request.urlopen",
             side_effect=_http_error(500),
         ):
-            result = await github_pr.open_pr(
-                task=_TASK,
-                branch=_BRANCH,
-                worktree_path=_WORKTREE,
-                token=_TOKEN,
-                emit=emit,
-            )
+            with pytest.raises(urllib.error.HTTPError) as exc_info:
+                await github_pr.open_pr(
+                    task=_TASK,
+                    branch=_BRANCH,
+                    worktree_path=_WORKTREE,
+                    token=_TOKEN,
+                    emit=emit,
+                )
 
-    assert result is None
+    assert exc_info.value.code == 500
     mock_find.assert_not_called()

--- a/worker/tests/test_open_pr.py
+++ b/worker/tests/test_open_pr.py
@@ -1,0 +1,134 @@
+"""Tests for open_pr 422-fallback behaviour."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pioneer_worker import github_pr
+
+_TASK = {
+    "id": "t-abc123",
+    "name": "Fix the thing",
+    "description": "Fix the thing",
+    "issue_repo": "owner/repo",
+}
+_BRANCH = "claude/fix-the-thing"
+_WORKTREE = "/tmp/wt"
+_TOKEN = "gh-tok"
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://api.github.com/repos/owner/repo/pulls",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=MagicMock(),  # type: ignore[arg-type]
+        fp=BytesIO(b""),
+    )
+
+
+def _fake_urlopen_response(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(payload).encode()
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_open_pr_success():
+    emit = AsyncMock()
+    pr_data = {"html_url": "https://github.com/owner/repo/pull/1"}
+
+    with patch("urllib.request.urlopen", return_value=_fake_urlopen_response(pr_data)):
+        result = await github_pr.open_pr(
+            task=_TASK,
+            branch=_BRANCH,
+            worktree_path=_WORKTREE,
+            token=_TOKEN,
+            emit=emit,
+        )
+
+    assert result == "https://github.com/owner/repo/pull/1"
+
+
+@pytest.mark.asyncio
+async def test_open_pr_422_finds_existing_pr():
+    """A 422 should trigger a lookup; if an existing PR is found, return it."""
+    emit = AsyncMock()
+    existing_url = "https://github.com/owner/repo/pull/7"
+
+    with patch(
+        "pioneer_worker.github_pr.find_existing_pr",
+        new=AsyncMock(return_value=existing_url),
+    ):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(422),
+        ):
+            result = await github_pr.open_pr(
+                task=_TASK,
+                branch=_BRANCH,
+                worktree_path=_WORKTREE,
+                token=_TOKEN,
+                emit=emit,
+            )
+
+    assert result == existing_url
+    # Confirm the emit message mentions the branch
+    emitted = " ".join(str(c) for c in [call.args[0] for call in emit.call_args_list])
+    assert "422" in emitted
+    assert existing_url in emitted
+
+
+@pytest.mark.asyncio
+async def test_open_pr_422_no_existing_pr_returns_none():
+    """If 422 and no existing PR found, return None (genuine failure)."""
+    emit = AsyncMock()
+
+    with patch(
+        "pioneer_worker.github_pr.find_existing_pr",
+        new=AsyncMock(return_value=None),
+    ):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(422),
+        ):
+            result = await github_pr.open_pr(
+                task=_TASK,
+                branch=_BRANCH,
+                worktree_path=_WORKTREE,
+                token=_TOKEN,
+                emit=emit,
+            )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_open_pr_non_422_http_error_returns_none():
+    """Non-422 HTTP errors should not trigger the existing-PR lookup."""
+    emit = AsyncMock()
+
+    with patch(
+        "pioneer_worker.github_pr.find_existing_pr",
+        new=AsyncMock(return_value="https://github.com/owner/repo/pull/99"),
+    ) as mock_find:
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(500),
+        ):
+            result = await github_pr.open_pr(
+                task=_TASK,
+                branch=_BRANCH,
+                worktree_path=_WORKTREE,
+                token=_TOKEN,
+                emit=emit,
+            )
+
+    assert result is None
+    mock_find.assert_not_called()


### PR DESCRIPTION
## Summary

- When GitHub returns 422 on `POST /repos/:repo/pulls` (which happens when a PR for that branch already exists), `open_pr()` now calls `find_existing_pr()` to look up the open PR instead of immediately returning `None`.
- If an existing PR is found, it is returned as the PR URL — identical behaviour to a freshly created PR, so the task is marked successful and the PR is associated with the task output.
- If no existing PR is found after the 422, the function still returns `None` (genuine failure), preserving current failure semantics.
- Four new tests cover: successful creation, 422 with existing PR, 422 with no existing PR, and non-422 HTTP errors.

## Test plan

- [x] `pytest worker/tests/test_open_pr.py` — 4 new tests, all pass
- [x] `pytest worker/` — 137 tests total, all pass, no regressions
- [x] `ruff check . --fix && ruff format .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)