### PR TITLE
fix(ui): map task→agent by slot id when worker runs concurrent slots

### DIFF
--- a/backend/alembic/versions/20260518_000000_add_current_task_id_to_agents.py
+++ b/backend/alembic/versions/20260518_000000_add_current_task_id_to_agents.py
@@ -1,0 +1,32 @@
+"""add_current_task_id_to_agents
+
+Adds a ``current_task_id`` column to the ``agents`` table. Workers report
+the task each slot is executing via ``agent-state`` messages; persisting
+it lets the frontend map a task row to its agent immediately on initial
+REST fetch instead of having to wait for the next WS update.
+
+Revision ID: 20260518_000000_add_current_task_id_to_agents
+Revises: 20260515_000001_add_tokens_to_foreman_turns
+Create Date: 2026-05-18 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260518_000000_add_current_task_id_to_agents"
+down_revision: str | Sequence[str] | None = "20260515_000001_add_tokens_to_foreman_turns"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.add_column(sa.Column("current_task_id", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("agents") as batch_op:
+        batch_op.drop_column("current_task_id")

--- a/backend/main.py
+++ b/backend/main.py
@@ -75,7 +75,7 @@ async def reset_connection_state() -> None:
         await db.execute(
             update(Agent)
             .where(Agent.worker_id.in_(select(Worker.id).where(Worker.state == "offline")))
-            .values(state="offline")
+            .values(state="offline", activity=None, current_task_id=None)
         )
         await db.commit()
 
@@ -101,7 +101,7 @@ async def _sweep_stale_workers_once() -> int:
             await db.execute(
                 update(Agent)
                 .where(Agent.id == row.id, Agent.guild_pk == row.guild_pk)
-                .values(state="offline", activity=None)
+                .values(state="offline", activity=None, current_task_id=None)
             )
             if row.worker_id:
                 stale_worker_keys.add((row.worker_id, row.guild_pk))

--- a/backend/models.py
+++ b/backend/models.py
@@ -52,6 +52,11 @@ class Agent(Base):
     type = Column(Text, nullable=False, server_default="worker")
     state = Column(Text, nullable=False, server_default="idle")
     activity = Column(Text, nullable=True)
+    # Task this agent is currently executing (NULL when idle/offline). Set
+    # from worker-emitted agent-state messages; lets the UI map a task row
+    # to its agent unambiguously when a worker runs concurrent slots that
+    # share a worker_id.
+    current_task_id = Column(Text, nullable=True)
     joined_at = Column(Text, nullable=False)
     # ISO-8601 UTC timestamp of the last message received from this agent over
     # the WebSocket. Refreshed by every inbound frame (incl. application-level

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -167,7 +167,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                         await db.execute(
                             update(Agent)
                             .where(Agent.id == agent_id, Agent.guild_pk == _guild_pk)
-                            .values(state="offline")
+                            .values(state="offline", activity=None, current_task_id=None)
                         )
                         # Mirror into workers table so foreman sees the worker as offline.
                         await db.execute(

--- a/backend/tests/test_agent_state_ws_persistence.py
+++ b/backend/tests/test_agent_state_ws_persistence.py
@@ -1,0 +1,304 @@
+"""Backend persists ``current_task_id`` from agent-state and forwards it.
+
+Guards the contract that anchors the frontend's task→agent matching:
+
+- ``agent-state`` with ``taskId`` writes ``current_task_id`` on the agents row
+  and forwards ``taskId``/``workerId`` to other listeners on the guild.
+- Idle/offline transitions clear ``current_task_id`` even if the worker
+  forgot to send ``taskId=None`` — the field can't lag a real state change.
+- The page-load REST snapshot (`GET /guilds/{id}`) returns
+  ``current_task_id`` so a reload mid-task shows the right slot at the
+  right bench without waiting for the next WS update.
+
+Patterned on test_pr_url_ws_persistence.py: module-scoped TestClient,
+per-test guild ids, DB checked while the connections are still open
+(commit happens before broadcast).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module  # noqa: E402
+import main as main_module  # noqa: E402
+from helpers import create_db as _create_db  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("agent_state_ws_db")
+    db_path = str(tmp_path / "test.db")
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+
+    os.environ["DATABASE_URL"] = db_url
+    _create_db(db_path)
+
+    new_engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+    new_session = async_sessionmaker(new_engine, expire_on_commit=False, class_=AsyncSession)
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(database_module, "AsyncSessionLocal", new_session)
+    mp.setattr(main_module, "AsyncSessionLocal", new_session)
+
+    async def _stubbed_reset_connection_state() -> None:
+        pass
+
+    mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
+    mp.setenv("DATABASE_URL", db_url)
+    mp.setenv("DB_PATH", db_path)
+
+    with TestClient(main_module.app) as c:
+        yield c, db_path
+
+    mp.undo()
+    os.environ.pop("DATABASE_URL", None)
+
+
+def _insert_guild_worker_task(
+    db_path: str,
+    *,
+    guild_id: str,
+    worker_id: str,
+    task_id: str,
+) -> None:
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO guilds (guild_id, created_at, name) VALUES (?, ?, ?)",
+            (guild_id, now, "Test Guild"),
+        )
+        row = conn.execute(
+            "SELECT id FROM guilds WHERE guild_id = ? AND deleted_at IS NULL", (guild_id,)
+        ).fetchone()
+        guild_pk = row[0]
+        conn.execute(
+            "INSERT OR IGNORE INTO workers (id, guild_pk, repos, state, created_at)"
+            " VALUES (?, ?, '[]', 'online', ?)",
+            (worker_id, guild_pk, now),
+        )
+        # Use "awaiting-review" so the join handler does not replay the task as
+        # task-assigned (it only replays "pending" and "working" tasks). For
+        # these tests the task state is incidental — we're checking the
+        # agent-state path, not the task lifecycle.
+        conn.execute(
+            "INSERT OR IGNORE INTO tasks (id, worker_id, guild_pk, description, tool, state, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (task_id, worker_id, guild_pk, "test task", "claude", "awaiting-review", now),
+        )
+        conn.commit()
+
+
+def _join_ws(ws, agent_id: str, worker_id: str) -> None:
+    ws.send_json(
+        {
+            "type": "join",
+            "agentId": agent_id,
+            "agentName": "Test Slot",
+            "agentType": "worker",
+            "workerId": worker_id,
+        }
+    )
+    msg = ws.receive_json()
+    assert msg["type"] == "agent-joined"
+
+
+def test_agent_state_persists_current_task_id(client):
+    """`agent-state` with taskId writes ``current_task_id`` to the agents row."""
+    test_client, db_path = client
+    guild_id, worker_id, task_id, agent_id = "gas-1", "w-gas1", "t-gas1", "a-gas1"
+    _insert_guild_worker_task(db_path, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs1", "w-obs1")
+            ws_worker.receive_json()  # drain obs's agent-joined broadcast
+
+            ws_worker.send_json(
+                {
+                    "type": "agent-state",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": task_id,
+                    "state": "working",
+                    "activity": "editing",
+                }
+            )
+            msg = ws_obs.receive_json()
+            assert msg["type"] == "agent-state"
+            # Forwarded for the frontend; this is what drives the bench match.
+            assert msg["agentId"] == agent_id
+            assert msg["workerId"] == worker_id
+            assert msg["taskId"] == task_id
+            assert msg["state"] == "working"
+            assert msg["activity"] == "editing"
+
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT state, activity, current_task_id FROM agents WHERE id = ?",
+                    (agent_id,),
+                ).fetchone()
+
+    assert row == ("working", "editing", task_id)
+
+
+def test_agent_state_idle_clears_current_task_id(client):
+    """Going idle must null ``current_task_id`` even if taskId is omitted."""
+    test_client, db_path = client
+    guild_id, worker_id, task_id, agent_id = "gas-2", "w-gas2", "t-gas2", "a-gas2"
+    _insert_guild_worker_task(db_path, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs2", "w-obs2")
+            ws_worker.receive_json()
+
+            # First put the slot into 'working' on a task.
+            ws_worker.send_json(
+                {
+                    "type": "agent-state",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": task_id,
+                    "state": "working",
+                }
+            )
+            ws_obs.receive_json()
+
+            # Then go idle without sending taskId — the handler still clears it.
+            ws_worker.send_json(
+                {
+                    "type": "agent-state",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "state": "idle",
+                }
+            )
+            msg = ws_obs.receive_json()
+            assert msg["state"] == "idle"
+            assert msg["taskId"] is None
+            assert msg["activity"] is None
+
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT state, activity, current_task_id FROM agents WHERE id = ?",
+                    (agent_id,),
+                ).fetchone()
+
+    assert row == ("idle", None, None)
+
+
+def test_agent_state_explicit_task_id_null_clears(client):
+    """Explicit ``taskId: null`` in any state clears ``current_task_id``."""
+    test_client, db_path = client
+    guild_id, worker_id, task_id, agent_id = "gas-3", "w-gas3", "t-gas3", "a-gas3"
+    _insert_guild_worker_task(db_path, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs3", "w-obs3")
+            ws_worker.receive_json()
+
+            ws_worker.send_json(
+                {
+                    "type": "agent-state",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": task_id,
+                    "state": "working",
+                }
+            )
+            ws_obs.receive_json()
+
+            # Same state, but the worker explicitly says "no task" — handler
+            # must honour the null even though state isn't idle/offline.
+            ws_worker.send_json(
+                {
+                    "type": "agent-state",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": None,
+                    "state": "working",
+                }
+            )
+            msg = ws_obs.receive_json()
+            assert msg["taskId"] is None
+
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT current_task_id FROM agents WHERE id = ?", (agent_id,)
+                ).fetchone()
+
+    assert row == (None,)
+
+
+def test_guild_get_returns_current_task_id(client):
+    """REST snapshot exposes ``current_task_id`` so a page reload mid-task
+    can map the bench to the right slot without waiting for the next WS event."""
+    test_client, db_path = client
+    guild_id, worker_id, task_id, agent_id = "gas-4", "w-gas4", "t-gas4", "a-gas4"
+    _insert_guild_worker_task(db_path, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    headers = {"Authorization": "Bearer test-token"}
+    # Seed the test token & guild membership the way other tests do.
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO users (id, github_id, github_login, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("u-gas4", "999004", "tester", now, now),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO user_sessions (token, github_user_id, created_at)"
+            " VALUES (?, ?, ?)",
+            ("test-token", "u-gas4", now),
+        )
+        guild_pk = conn.execute("SELECT id FROM guilds WHERE guild_id = ?", (guild_id,)).fetchone()[
+            0
+        ]
+        conn.execute(
+            "INSERT OR IGNORE INTO guild_members (guild_pk, user_id, role, created_at)"
+            " VALUES (?, ?, 'member', ?)",
+            (guild_pk, "u-gas4", now),
+        )
+        conn.commit()
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs4", "w-obs4")
+            ws_worker.receive_json()
+
+            ws_worker.send_json(
+                {
+                    "type": "agent-state",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": task_id,
+                    "state": "working",
+                    "activity": "editing",
+                }
+            )
+            ws_obs.receive_json()  # ensures handler committed before REST read
+
+            resp = test_client.get(f"/guilds/{guild_id}", headers=headers)
+            assert resp.status_code == 200
+            body = resp.json()
+            agents_by_id = {a["id"]: a for a in body["agents"]}
+            assert agent_id in agents_by_id
+            assert agents_by_id[agent_id]["current_task_id"] == task_id
+            assert agents_by_id[agent_id]["state"] == "working"
+            assert agents_by_id[agent_id]["activity"] == "editing"

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -215,6 +215,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         name=agent_name,
         type=agent_type,
         state="idle",
+        current_task_id=None,
         joined_at=joined_at,
         last_seen=joined_at,
     )
@@ -226,6 +227,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
             "name": stmt.excluded.name,
             "type": stmt.excluded.type,
             "state": stmt.excluded.state,
+            "current_task_id": stmt.excluded.current_task_id,
             "joined_at": stmt.excluded.joined_at,
             "last_seen": stmt.excluded.last_seen,
         },
@@ -331,6 +333,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
 
 async def handle_agent_state(ctx: WSContext, data: dict) -> None:
     agent_id = data.get("agentId")
+    worker_id = data.get("workerId")
     state = data.get("state", "idle")
     activity = data.get("activity")
     update_vals: dict = {"state": state}
@@ -338,6 +341,13 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
         update_vals["activity"] = activity
     elif state in ("idle", "offline"):
         update_vals["activity"] = None
+    # taskId is the slot's current_task_id. Idle/offline agents are not
+    # executing anything, so we always clear the column for those states even
+    # if the worker forgot to send taskId=null.
+    if "taskId" in data:
+        update_vals["current_task_id"] = data.get("taskId")
+    elif state in ("idle", "offline"):
+        update_vals["current_task_id"] = None
     await ctx.db.execute(
         update(Agent)
         .where(Agent.id == agent_id, Agent.guild_pk == ctx.guild_pk)
@@ -345,8 +355,12 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
     )
     await ctx.db.commit()
     msg: dict = {"type": "agent-state", "agentId": agent_id, "state": state}
+    if worker_id:
+        msg["workerId"] = worker_id
     if "activity" in update_vals:
         msg["activity"] = update_vals["activity"]
+    if "current_task_id" in update_vals:
+        msg["taskId"] = update_vals["current_task_id"]
     await broadcast(ctx.guild_id, msg)
 
 
@@ -478,7 +492,7 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
         await ctx.db.execute(
             update(Agent)
             .where(Agent.id == agent_id, Agent.guild_pk == ctx.guild_pk)
-            .values(state="offline")
+            .values(state="offline", activity=None, current_task_id=None)
         )
     if worker_id:
         await ctx.db.execute(

--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -174,16 +174,11 @@ const taskRows = computed(() => {
   const rows = []
   for (let i = 0; i < visibleRowCount.value; i++) {
     const task = tasks[i] || null
-    // Match by agent_id (the slot that picked up the task) so concurrent
-    // tasks on the same worker map to distinct slots. Fall back to workerId
-    // only for tasks the worker hasn't claimed yet — those have no agent
-    // doing the work, so the lookup will be discarded anyway when the
-    // matched agent isn't actually `working` this task.
-    const agent = task
-      ? agents.value.find((a) => a.id === task.agent_id) ||
-        (task.agent_id ? null : agents.value.find((a) => a.workerId === task.worker_id)) ||
-        null
-      : null
+    // Agents carry the taskId they're working on (reported via agent-state).
+    // That's the source of truth for which slot owns which row when a worker
+    // runs concurrent slots; matching by workerId would collapse all rows
+    // onto slot[0].
+    const agent = task ? agents.value.find((a) => a.taskId === task.id) || null : null
     const activityKey: StationKey | null =
       agent && agent.activity ? ACTIVITY_TO_STATION[agent.activity] : null
     rows.push({ index: i, task, agent, activityKey })

--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -174,7 +174,16 @@ const taskRows = computed(() => {
   const rows = []
   for (let i = 0; i < visibleRowCount.value; i++) {
     const task = tasks[i] || null
-    const agent = task ? agents.value.find((a) => a.workerId === task.worker_id) || null : null
+    // Match by agent_id (the slot that picked up the task) so concurrent
+    // tasks on the same worker map to distinct slots. Fall back to workerId
+    // only for tasks the worker hasn't claimed yet — those have no agent
+    // doing the work, so the lookup will be discarded anyway when the
+    // matched agent isn't actually `working` this task.
+    const agent = task
+      ? agents.value.find((a) => a.id === task.agent_id) ||
+        (task.agent_id ? null : agents.value.find((a) => a.workerId === task.worker_id)) ||
+        null
+      : null
     const activityKey: StationKey | null =
       agent && agent.activity ? ACTIVITY_TO_STATION[agent.activity] : null
     rows.push({ index: i, task, agent, activityKey })

--- a/frontend/src/composables/useAgentChoreography.ts
+++ b/frontend/src/composables/useAgentChoreography.ts
@@ -113,7 +113,9 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
     return positions[id] || { x: opts.tableLeft + 60, y: opts.tableTop + opts.rowHeight.value }
   }
 
-  // Match by agentId so each robot goes to its own table, not all to the same one.
+  // Each row belongs to one agent (the slot that reported taskId === task.id),
+  // so this returns at most one row per agent — no jitter needed to spread
+  // multiple robots that used to collapse onto the same bench.
   function rowForAgent(agent: Agent): ChoreographyRow | null {
     return opts.taskRows.value.find((r) => r.agentId === agent.id) ?? null
   }
@@ -122,23 +124,11 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
     return !['idle', 'offline'].includes(agent.state)
   }
 
-  // Small golden-angle spiral offset per slot index prevents robots from stacking
-  // exactly on top of each other when they share a workbench position.
-  function slotJitter(agentId: string): Position {
-    const idx = opts.agents.value.findIndex((a) => a.id === agentId)
-    if (idx <= 0) return { x: 0, y: 0 }
-    const angle = (idx * 137.508 * Math.PI) / 180
-    const r = Math.min(idx * 5, 16)
-    return { x: Math.cos(angle) * r, y: Math.sin(angle) * r }
-  }
-
   function targetForAgent(agent: Agent): Position {
     const row = rowForAgent(agent)
-    const jitter = slotJitter(agent.id)
     if (row && isWorking(agent)) {
       const key = row.activityKey
-      const base = key ? stationPos(row.index, key) : rowCenterPos(row.index)
-      return { x: base.x + jitter.x, y: base.y + jitter.y }
+      return key ? stationPos(row.index, key) : rowCenterPos(row.index)
     }
     return pickWanderPos(agent.id)
   }
@@ -200,10 +190,13 @@ export function useAgentChoreography(opts: ChoreographyOptions) {
     opts.agents.value.forEach(syncAgent)
   }
 
+  // Re-run choreography when any property that changes an agent's target
+  // moves: state (working ↔ idle), activity (which station), or taskId
+  // (which bench). taskRows changes are covered by the second watcher.
   watch(
     () =>
       opts.agents.value
-        .map((a) => `${a.id}:${a.state}:${a.workerId}:${a.activity ?? ''}`)
+        .map((a) => `${a.id}:${a.state}:${a.activity ?? ''}:${a.taskId ?? ''}`)
         .join(','),
     syncAll,
   )

--- a/frontend/src/stores/__tests__/agents.spec.ts
+++ b/frontend/src/stores/__tests__/agents.spec.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAgentsStore } from '../agents'
+
+describe('useAgentsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('registerAgent', () => {
+    it('captures taskId from the agent-joined payload', () => {
+      const store = useAgentsStore()
+      store.registerAgent({
+        agentId: 'a-1',
+        agentName: 'slot-1',
+        agentType: 'worker',
+        workerId: 'w-x',
+        state: 'working',
+        taskId: 't-42',
+      })
+      expect(store.agents).toHaveLength(1)
+      expect(store.agents[0].taskId).toBe('t-42')
+      expect(store.agents[0].state).toBe('working')
+    })
+
+    it('defaults taskId to null when omitted', () => {
+      const store = useAgentsStore()
+      store.registerAgent({ agentId: 'a-1', workerId: 'w-x' })
+      expect(store.agents[0].taskId).toBeNull()
+    })
+
+    it('updates taskId on a re-register (worker reconnect)', () => {
+      const store = useAgentsStore()
+      store.registerAgent({ agentId: 'a-1', workerId: 'w-x', state: 'idle', taskId: null })
+      store.registerAgent({ agentId: 'a-1', workerId: 'w-x', state: 'working', taskId: 't-9' })
+      expect(store.agents).toHaveLength(1)
+      expect(store.agents[0].taskId).toBe('t-9')
+    })
+  })
+
+  describe('updateAgentState', () => {
+    it('writes taskId from an agent-state WS message', () => {
+      const store = useAgentsStore()
+      store.registerAgent({ agentId: 'a-1', workerId: 'w-x', state: 'idle', taskId: null })
+
+      store.handleWebSocketMessage({
+        type: 'agent-state',
+        agentId: 'a-1',
+        workerId: 'w-x',
+        taskId: 't-99',
+        state: 'working',
+        activity: 'editing',
+      })
+
+      const agent = store.agents.find((a) => a.id === 'a-1')!
+      expect(agent.taskId).toBe('t-99')
+      expect(agent.state).toBe('working')
+      expect(agent.activity).toBe('editing')
+    })
+
+    it('clears taskId when the agent goes idle', () => {
+      // Regression: a slot that finished a task must drop its taskId so the
+      // frontend doesn't keep matching it to the just-completed bench.
+      const store = useAgentsStore()
+      store.registerAgent({ agentId: 'a-1', workerId: 'w-x', state: 'working', taskId: 't-1' })
+
+      store.handleWebSocketMessage({
+        type: 'agent-state',
+        agentId: 'a-1',
+        state: 'idle',
+      })
+
+      expect(store.agents[0].taskId).toBeNull()
+      expect(store.agents[0].state).toBe('idle')
+    })
+
+    it('clears taskId when the agent goes offline', () => {
+      const store = useAgentsStore()
+      store.registerAgent({ agentId: 'a-1', workerId: 'w-x', state: 'working', taskId: 't-1' })
+
+      store.handleWebSocketMessage({
+        type: 'agent-state',
+        agentId: 'a-1',
+        state: 'offline',
+      })
+
+      expect(store.agents[0].taskId).toBeNull()
+    })
+
+    it('preserves taskId when going to error (the failure is tied to that task)', () => {
+      const store = useAgentsStore()
+      store.registerAgent({ agentId: 'a-1', workerId: 'w-x', state: 'working', taskId: 't-bad' })
+
+      store.handleWebSocketMessage({
+        type: 'agent-state',
+        agentId: 'a-1',
+        state: 'error',
+      })
+
+      expect(store.agents[0].taskId).toBe('t-bad')
+      expect(store.agents[0].state).toBe('error')
+    })
+
+    it('ignores agent-state for an unknown agentId', () => {
+      const store = useAgentsStore()
+      store.handleWebSocketMessage({
+        type: 'agent-state',
+        agentId: 'a-ghost',
+        state: 'working',
+        taskId: 't-1',
+      })
+      expect(store.agents).toHaveLength(0)
+    })
+  })
+
+  describe('concurrent slots on the same worker', () => {
+    it('tracks distinct taskIds per slot even when workerId matches', () => {
+      // Regression: prior matching by workerId collapsed concurrent slots
+      // onto slot[0]. Now each agent carries its own taskId, so a task→agent
+      // lookup by `agent.taskId === task.id` resolves the right slot.
+      const store = useAgentsStore()
+      store.registerAgent({ agentId: 'a-1', workerId: 'w-shared', state: 'idle' })
+      store.registerAgent({ agentId: 'a-2', workerId: 'w-shared', state: 'idle' })
+
+      store.handleWebSocketMessage({
+        type: 'agent-state',
+        agentId: 'a-1',
+        workerId: 'w-shared',
+        taskId: 't-A',
+        state: 'working',
+      })
+      store.handleWebSocketMessage({
+        type: 'agent-state',
+        agentId: 'a-2',
+        workerId: 'w-shared',
+        taskId: 't-B',
+        state: 'working',
+      })
+
+      const owners = new Map(store.agents.map((a) => [a.taskId, a.id]))
+      expect(owners.get('t-A')).toBe('a-1')
+      expect(owners.get('t-B')).toBe('a-2')
+    })
+  })
+})

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -205,14 +205,11 @@ export const useAgentsStore = defineStore('agents', () => {
 
   function firstIdleWorker() {
     const workerAgents = agents.value.filter((a) => a.workerId && a.state !== 'offline')
-    const idleAgent =
+    const pick =
       workerAgents.find((a) => a.state === 'idle') ||
       workerAgents.find((a) => !['working', 'error'].includes(a.state)) ||
       workerAgents[0]
-    if (idleAgent) return { id: idleAgent.workerId, name: idleAgent.name, state: idleAgent.state }
-
-    const legacy = agents.value.filter((a) => a.id.startsWith('w-') && a.state !== 'offline')
-    return legacy.find((a) => a.state === 'idle') || legacy[0] || null
+    return pick ? { id: pick.workerId, name: pick.name, state: pick.state } : null
   }
 
   function clearAgents() {

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -20,6 +20,7 @@ interface RegisterAgentData {
   workerId?: string | null
   workerName?: string
   state?: AgentState
+  taskId?: string | null
   joinedAt?: string
 }
 
@@ -75,6 +76,7 @@ export const useAgentsStore = defineStore('agents', () => {
       existing.name = agentData.agentName || existing.name
       if (agentData.workerId) existing.workerId = agentData.workerId
       if (agentData.workerName) existing.workerName = agentData.workerName
+      if (agentData.taskId !== undefined) existing.taskId = agentData.taskId
     } else {
       agents.value.push({
         id: agentData.agentId,
@@ -83,17 +85,27 @@ export const useAgentsStore = defineStore('agents', () => {
         workerId: agentData.workerId || null,
         workerName: agentData.workerName,
         state: agentData.state || 'idle',
+        taskId: agentData.taskId ?? null,
         logs: [],
         joinedAt: agentData.joinedAt || new Date().toISOString(),
       })
     }
   }
 
-  function updateAgentState(agentId: string, state: AgentState, activity?: AgentActivity | null) {
+  function updateAgentState(
+    agentId: string,
+    state: AgentState,
+    activity?: AgentActivity | null,
+    taskId?: string | null,
+  ) {
     const agent = agents.value.find((a) => a.id === agentId)
     if (!agent) return
     agent.state = state
     if (activity !== undefined) agent.activity = activity
+    if (taskId !== undefined) agent.taskId = taskId
+    // Idle/offline agents are by definition not working a task; clear the
+    // link so a stale taskId from a prior run can't latch the agent to a row.
+    if (state === 'idle' || state === 'offline') agent.taskId = null
   }
 
   function addLog(agentId: string, line: string, timestamp?: string, detail?: LogDetail | null) {
@@ -246,7 +258,12 @@ export const useAgentsStore = defineStore('agents', () => {
     if (data.type === 'agent-joined') {
       registerAgent(data)
     } else if (data.type === 'agent-state') {
-      updateAgentState(data.agentId, data.state, data.activity ?? undefined)
+      updateAgentState(
+        data.agentId,
+        data.state,
+        data.activity ?? undefined,
+        data.taskId ?? undefined,
+      )
     } else if (data.type === 'terminal-output') {
       // Route to per-agent log buffer (includes task logs for agent-tab view)
       if (data.agentId) addLog(data.agentId, data.line, data.timestamp, data.detail)

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -9,9 +9,8 @@ const STATE_RANK: Record<string, number> = {
   thinking: 1,
   busy: 2,
   error: 3,
-  'awaiting-review': 4,
-  idle: 5,
-  offline: 6,
+  idle: 4,
+  offline: 5,
 }
 
 interface RegisterAgentData {
@@ -37,13 +36,6 @@ interface AssignTaskOpts {
   issueRepo?: string | null
 }
 
-// Fallback label when the backend hasn't supplied a workerName.
-// New backends return ``hostname[:3]/worker_id`` (e.g. ``tok/w-g2otus``);
-// this handles older backends that omit the field.
-function _workerDroidName(workerId: string): string {
-  return workerId
-}
-
 export const useAgentsStore = defineStore('agents', () => {
   const agents = ref<Agent[]>([])
   const workerLogs = ref<Record<string, LogEntry[]>>({})
@@ -60,9 +52,9 @@ export const useAgentsStore = defineStore('agents', () => {
       if (!map.has(agent.workerId)) {
         map.set(agent.workerId, {
           id: agent.workerId,
-          // Prefer the backend-supplied workerName from the agent-joined payload;
-          // fall back to local derivation for agents from older backends or REST init.
-          name: agent.workerName || _workerDroidName(agent.workerId),
+          // Prefer the backend-supplied workerName; older backends that omit it
+          // fall back to the workerId itself as a stable label.
+          name: agent.workerName || agent.workerId,
           state: agent.state,
         })
       } else {
@@ -203,7 +195,7 @@ export const useAgentsStore = defineStore('agents', () => {
     const workerAgents = agents.value.filter((a) => a.workerId && a.state !== 'offline')
     const idleAgent =
       workerAgents.find((a) => a.state === 'idle') ||
-      workerAgents.find((a) => !['working', 'awaiting-review', 'error'].includes(a.state)) ||
+      workerAgents.find((a) => !['working', 'error'].includes(a.state)) ||
       workerAgents[0]
     if (idleAgent) return { id: idleAgent.workerId, name: idleAgent.name, state: idleAgent.state }
 

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -154,6 +154,7 @@ export const useTasksStore = defineStore('tasks', () => {
     } else if (data.type === 'task-update') {
       const task = tasks.value.find((t) => t.id === data.taskId)
       if (task) {
+        if (data.agentId) task.agent_id = data.agentId
         if (data.state) task.state = data.state
         if (data.branch) task.branch = data.branch
         if (data.prUrl) task.pr_url = data.prUrl
@@ -168,11 +169,15 @@ export const useTasksStore = defineStore('tasks', () => {
       const task = tasks.value.find((t) => t.id === data.taskId)
       if (task) {
         task.state = 'awaiting-review'
+        if (data.agentId) task.agent_id = data.agentId
         if (data.branch) task.branch = data.branch
       }
     } else if (data.type === 'task-followup-done') {
       const task = tasks.value.find((t) => t.id === data.taskId)
-      if (task) task.state = 'awaiting-review'
+      if (task) {
+        task.state = 'awaiting-review'
+        if (data.agentId) task.agent_id = data.agentId
+      }
     } else if (data.type === 'terminal-output' && data.taskId) {
       const { taskId, line, timestamp, detail } = data
       if (line) {

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -154,7 +154,6 @@ export const useTasksStore = defineStore('tasks', () => {
     } else if (data.type === 'task-update') {
       const task = tasks.value.find((t) => t.id === data.taskId)
       if (task) {
-        if (data.agentId) task.agent_id = data.agentId
         if (data.state) task.state = data.state
         if (data.branch) task.branch = data.branch
         if (data.prUrl) task.pr_url = data.prUrl
@@ -169,15 +168,11 @@ export const useTasksStore = defineStore('tasks', () => {
       const task = tasks.value.find((t) => t.id === data.taskId)
       if (task) {
         task.state = 'awaiting-review'
-        if (data.agentId) task.agent_id = data.agentId
         if (data.branch) task.branch = data.branch
       }
     } else if (data.type === 'task-followup-done') {
       const task = tasks.value.find((t) => t.id === data.taskId)
-      if (task) {
-        task.state = 'awaiting-review'
-        if (data.agentId) task.agent_id = data.agentId
-      }
+      if (task) task.state = 'awaiting-review'
     } else if (data.type === 'terminal-output' && data.taskId) {
       const { taskId, line, timestamp, detail } = data
       if (line) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,11 +1,4 @@
-export type AgentState =
-  | 'idle'
-  | 'thinking'
-  | 'working'
-  | 'busy'
-  | 'error'
-  | 'offline'
-  | 'awaiting-review'
+export type AgentState = 'idle' | 'thinking' | 'working' | 'busy' | 'error' | 'offline'
 
 export type AgentActivity =
   | 'reading'
@@ -67,6 +60,10 @@ export interface Task {
   phase?: string
   state: TaskState
   worker_id?: string
+  // Agent slot currently (or most recently) executing this task. Set on each
+  // task-update broadcast from the worker; lets the UI map task→agent when a
+  // worker runs multiple concurrent slots.
+  agent_id?: string | null
   parent_task_id?: string | null
   branch?: string
   pr_url?: string
@@ -210,6 +207,7 @@ export interface TaskAssignedWS {
 export interface TaskUpdateWS {
   type: 'task-update'
   taskId: string
+  agentId?: string | null
   state?: TaskState
   branch?: string
   prUrl?: string
@@ -222,6 +220,7 @@ export interface TaskCompleteWS {
   type: 'task-complete'
   taskId: string
   workerId?: string
+  agentId?: string | null
   branch?: string
   prUrl?: string | null
 }
@@ -229,6 +228,7 @@ export interface TaskCompleteWS {
 export interface TaskFollowupDoneWS {
   type: 'task-followup-done'
   taskId: string
+  agentId?: string | null
 }
 
 export interface NeedsInputWS {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -33,6 +33,10 @@ export interface Agent {
   workerName?: string
   state: AgentState
   activity?: AgentActivity | null
+  // ID of the task this agent is currently executing (set when state is
+  // working/thinking/busy/error, null when idle/offline). Source of truth for
+  // mapping a task row to its agent on the factory floor.
+  taskId?: string | null
   logs: LogEntry[]
   joinedAt: string
 }
@@ -60,10 +64,6 @@ export interface Task {
   phase?: string
   state: TaskState
   worker_id?: string
-  // Agent slot currently (or most recently) executing this task. Set on each
-  // task-update broadcast from the worker; lets the UI map task→agent when a
-  // worker runs multiple concurrent slots.
-  agent_id?: string | null
   parent_task_id?: string | null
   branch?: string
   pr_url?: string
@@ -83,6 +83,7 @@ export interface Guild {
     type: string
     worker_id?: string | null
     state: AgentState
+    current_task_id?: string | null
     joined_at?: string
   }>
   messages?: ChatMessage[]
@@ -164,12 +165,15 @@ export interface AgentJoinedWS {
   workerId?: string | null
   workerName?: string
   state?: AgentState
+  taskId?: string | null
   joinedAt?: string
 }
 
 export interface AgentStateWS {
   type: 'agent-state'
   agentId: string
+  workerId?: string | null
+  taskId?: string | null
   state: AgentState
   activity?: AgentActivity | null
 }

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -111,6 +111,7 @@ async function initGuild(guildId: string) {
           agentType: a.type,
           workerId: a.worker_id || null,
           state: a.state,
+          taskId: a.current_task_id ?? null,
           joinedAt: a.joined_at,
         }),
       )

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -631,18 +631,27 @@ class Worker:
                 new_activity = detail.get("activity")
                 if new_activity and new_activity != slot.activity:
                     slot.activity = new_activity
-                    await self._send(
-                        {
-                            "type": "agent-state",
-                            "workerId": self.cfg.worker_id,
-                            "agentId": slot.agent_id,
-                            "taskId": slot.current_task_id,
-                            "state": slot.state,
-                            "activity": new_activity,
-                        }
-                    )
+                    await self._emit_agent_state(slot)
 
         return _emit_task
+
+    async def _emit_agent_state(self, slot: Agent) -> None:
+        """Broadcast the slot's full identity + runtime state.
+
+        Every ``agent-state`` frame carries workerId/agentId/taskId so the
+        frontend can map a task row to the slot that owns it without
+        falling back to ambiguous worker-level matching.
+        """
+        await self._send(
+            {
+                "type": "agent-state",
+                "workerId": self.cfg.worker_id,
+                "agentId": slot.agent_id,
+                "taskId": slot.current_task_id,
+                "state": slot.state,
+                "activity": slot.activity,
+            }
+        )
 
     async def _set_state(self, state: str, slot: Agent) -> None:
         slot.state = state
@@ -653,16 +662,7 @@ class Worker:
         # stale association from the previous run.
         if state in ("idle", "offline"):
             slot.current_task_id = None
-        await self._send(
-            {
-                "type": "agent-state",
-                "workerId": self.cfg.worker_id,
-                "agentId": slot.agent_id,
-                "taskId": slot.current_task_id,
-                "state": state,
-                "activity": slot.activity,
-            }
-        )
+        await self._emit_agent_state(slot)
 
     async def _join(self) -> None:
         for slot in self.slots:
@@ -701,16 +701,7 @@ class Worker:
         # state so a mid-task reconnect doesn't show us as idle while we work.
         for slot in self.slots:
             if slot.state and slot.state != "idle":
-                await self._send(
-                    {
-                        "type": "agent-state",
-                        "workerId": self.cfg.worker_id,
-                        "agentId": slot.agent_id,
-                        "taskId": slot.current_task_id,
-                        "state": slot.state,
-                        "activity": slot.activity,
-                    }
-                )
+                await self._emit_agent_state(slot)
         # Re-fetch any tasks that were assigned while the WS was down; without
         # this they'd be missed until the idle puller fires (up to 300s later).
         try:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -634,7 +634,9 @@ class Worker:
                     await self._send(
                         {
                             "type": "agent-state",
+                            "workerId": self.cfg.worker_id,
                             "agentId": slot.agent_id,
+                            "taskId": slot.current_task_id,
                             "state": slot.state,
                             "activity": new_activity,
                         }
@@ -646,10 +648,17 @@ class Worker:
         slot.state = state
         if state != "working":
             slot.activity = None
+        # Idle/offline slots aren't working anything; drop the task link so the
+        # frontend can match `agent.taskId === task.id` without picking up a
+        # stale association from the previous run.
+        if state in ("idle", "offline"):
+            slot.current_task_id = None
         await self._send(
             {
                 "type": "agent-state",
+                "workerId": self.cfg.worker_id,
                 "agentId": slot.agent_id,
+                "taskId": slot.current_task_id,
                 "state": state,
                 "activity": slot.activity,
             }
@@ -695,8 +704,11 @@ class Worker:
                 await self._send(
                     {
                         "type": "agent-state",
+                        "workerId": self.cfg.worker_id,
                         "agentId": slot.agent_id,
+                        "taskId": slot.current_task_id,
                         "state": slot.state,
+                        "activity": slot.activity,
                     }
                 )
         # Re-fetch any tasks that were assigned while the WS was down; without

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -711,15 +711,20 @@ class Worker:
         except Exception as exc:
             logger.warning("Reconnect: pending-task fetch failed: %s", exc)
 
-    async def _task_update(self, task_id: str, **fields: object) -> None:
-        await self._send(
-            {
-                "type": "task-update",
-                "workerId": self.cfg.worker_id,
-                "taskId": task_id,
-                **fields,
-            }
-        )
+    async def _task_update(
+        self, task_id: str, *, slot: Agent | None = None, **fields: object
+    ) -> None:
+        payload: dict = {
+            "type": "task-update",
+            "workerId": self.cfg.worker_id,
+            "taskId": task_id,
+            **fields,
+        }
+        # Include the slot identity so the UI can map task→agent unambiguously
+        # when a worker runs multiple concurrent slots (workerId is shared).
+        if slot is not None:
+            payload["agentId"] = slot.agent_id
+        await self._send(payload)
 
     async def _ensure_pr_webhook(self, pr_url: str, emit) -> None:
         """Best-effort: install/refresh a Pioneer Square webhook on the PR's repo.
@@ -1422,7 +1427,9 @@ class Worker:
             except Exception as exc:
                 logger.exception("Task %s crashed: %s", task_id, exc)
                 await self._emit(f"[worker] ✗ Internal error on task {task_id}: {exc}")
-                await self._task_update(task["id"], state="failed", finishedAt=_now_iso())
+                await self._task_update(
+                    task["id"], slot=slot, state="failed", finishedAt=_now_iso()
+                )
             finally:
                 slot.current_task_id = None
         try:
@@ -1454,7 +1461,7 @@ class Worker:
             desc[:120],
         )
         await self._set_state("working", slot)
-        await self._task_update(task_id, state="working")
+        await self._task_update(task_id, slot=slot, state="working")
 
         name = task.get("name") or desc
         # On follow-ups we must continue on the existing branch — the original
@@ -1521,11 +1528,11 @@ class Worker:
         if not primary_wt:
             logger.error("Task %s: no worktrees created — aborting", task_id)
             await emit("[worker] ✗ No worktrees — aborting.")
-            await self._task_update(task_id, state="failed", finishedAt=_now_iso())
+            await self._task_update(task_id, slot=slot, state="failed", finishedAt=_now_iso())
             await self._set_state("error", slot)
             return
 
-        await self._task_update(task_id, branch=branch, worktreePath=primary_wt)
+        await self._task_update(task_id, slot=slot, branch=branch, worktreePath=primary_wt)
         # Register worktrees for the deferred sweeper — touched again below in
         # finally so the timestamp reflects the most recent activity.
         self._register_worktrees(task_id, worktree_entries)
@@ -1624,7 +1631,9 @@ class Worker:
 
                 if task_id in self._cancelled_tasks:
                     await emit("[worker] Task cancelled.")
-                    await self._task_update(task_id, state="cancelled", finishedAt=_now_iso())
+                    await self._task_update(
+                        task_id, slot=slot, state="cancelled", finishedAt=_now_iso()
+                    )
                     await self._release_task_worktrees(task_id)
                     await self._set_state("idle", slot)
                     return
@@ -1636,7 +1645,9 @@ class Worker:
 
                 if redirect_instr is _CANCEL_SENTINEL:
                     await emit("[worker] Task cancelled.")
-                    await self._task_update(task_id, state="cancelled", finishedAt=_now_iso())
+                    await self._task_update(
+                        task_id, slot=slot, state="cancelled", finishedAt=_now_iso()
+                    )
                     await self._release_task_worktrees(task_id)
                     await self._set_state("idle", slot)
                     return
@@ -1644,7 +1655,7 @@ class Worker:
                 if redirect_instr is not None and not self._shutdown_event.is_set():
                     await emit(f"[worker] ↩ Redirected: {redirect_instr[:120]}")
                     current_desc = redirect_instr
-                    await self._task_update(task_id, state="working")
+                    await self._task_update(task_id, slot=slot, state="working")
                     continue
 
                 break  # normal exit from redirect loop
@@ -1688,6 +1699,7 @@ class Worker:
 
                 await self._task_update(
                     task_id,
+                    slot=slot,
                     branch=branch,
                     worktreePath=primary_wt,
                     prUrl=pr_url or "",
@@ -1702,6 +1714,7 @@ class Worker:
                         {
                             "type": "task-followup-done",
                             "workerId": self.cfg.worker_id,
+                            "agentId": slot.agent_id,
                             "taskId": task_id,
                             "success": True,
                             "stopReason": stop_reason,
@@ -1715,6 +1728,7 @@ class Worker:
                         {
                             "type": "task-complete",
                             "workerId": self.cfg.worker_id,
+                            "agentId": slot.agent_id,
                             "taskId": task_id,
                             "branch": branch,
                             "description": desc,
@@ -1729,6 +1743,7 @@ class Worker:
                 # that resumes the same worktree/session.
                 await self._task_update(
                     task_id,
+                    slot=slot,
                     branch=branch,
                     worktreePath=primary_wt,
                     state="failed",
@@ -1737,6 +1752,7 @@ class Worker:
                     {
                         "type": "needs-input",
                         "workerId": self.cfg.worker_id,
+                        "agentId": slot.agent_id,
                         "taskId": task_id,
                         "description": desc,
                         "branch": branch,

--- a/worker/tests/test_agent_state_messages.py
+++ b/worker/tests/test_agent_state_messages.py
@@ -1,0 +1,179 @@
+"""Worker emits the slot's identifying IDs on every agent-state message.
+
+These tests guard against the regression where ``agent-state`` only carried
+``agentId`` + ``state``. The frontend now matches task rows to agents by
+``agent.taskId``, so each agent-state must include:
+
+- ``workerId``: which worker process the slot belongs to
+- ``agentId``: the slot's id (== ``Agent.id``)
+- ``taskId``: the slot's current task (or ``None`` when idle/offline)
+- ``state`` / ``activity``: the runtime state
+
+It also verifies that ``_set_state`` clears ``slot.current_task_id`` on
+transitions to ``idle`` and ``offline``, so the frontend can't latch onto
+a stale task id from a previous run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_worker() -> Worker:
+    cfg = Config(
+        backend_url="ws://localhost:8000",
+        guild_id="g-test",
+        worker_id="w-test01",
+        max_agents=2,
+        pull_interval=3600.0,
+    )
+    worker = Worker(cfg)
+    worker._send = AsyncMock()
+    return worker
+
+
+def _last_sent(worker: Worker) -> dict:
+    """Return the payload of the most recent ``_send`` call."""
+    assert worker._send.await_count > 0, "no _send calls were made"
+    args, _ = worker._send.await_args
+    return args[0]
+
+
+@pytest.mark.asyncio
+async def test_set_state_working_emits_all_three_ids():
+    """`working` state must broadcast workerId, agentId, taskId together."""
+    worker = _make_worker()
+    slot = worker.slots[0]
+    slot.current_task_id = "t-abc123"
+
+    await worker._set_state("working", slot)
+
+    msg = _last_sent(worker)
+    assert msg["type"] == "agent-state"
+    assert msg["workerId"] == "w-test01"
+    assert msg["agentId"] == slot.agent_id
+    assert msg["taskId"] == "t-abc123"
+    assert msg["state"] == "working"
+
+
+@pytest.mark.asyncio
+async def test_set_state_idle_clears_task_id_on_slot_and_message():
+    """Transitioning to idle must null the slot's task link and the message."""
+    worker = _make_worker()
+    slot = worker.slots[0]
+    slot.current_task_id = "t-abc123"
+    slot.activity = "editing"
+
+    await worker._set_state("idle", slot)
+
+    assert slot.current_task_id is None, "idle slot must drop its task link"
+    assert slot.activity is None, "idle slot must drop its activity"
+    msg = _last_sent(worker)
+    assert msg["state"] == "idle"
+    assert msg["taskId"] is None
+    assert msg["activity"] is None
+    # workerId/agentId stay populated for routing.
+    assert msg["workerId"] == "w-test01"
+    assert msg["agentId"] == slot.agent_id
+
+
+@pytest.mark.asyncio
+async def test_set_state_offline_clears_task_id_on_slot_and_message():
+    """Offline transitions (shutdown) must also drop the stale task link."""
+    worker = _make_worker()
+    slot = worker.slots[0]
+    slot.current_task_id = "t-zzz"
+
+    await worker._set_state("offline", slot)
+
+    assert slot.current_task_id is None
+    msg = _last_sent(worker)
+    assert msg["state"] == "offline"
+    assert msg["taskId"] is None
+
+
+@pytest.mark.asyncio
+async def test_set_state_error_preserves_task_id():
+    """Error state is still tied to the task that failed; don't drop it."""
+    worker = _make_worker()
+    slot = worker.slots[0]
+    slot.current_task_id = "t-failing"
+
+    await worker._set_state("error", slot)
+
+    assert slot.current_task_id == "t-failing"
+    msg = _last_sent(worker)
+    assert msg["state"] == "error"
+    assert msg["taskId"] == "t-failing"
+
+
+@pytest.mark.asyncio
+async def test_task_emit_activity_change_includes_ids():
+    """The activity-change branch of ``_task_emit`` must mirror the same IDs.
+
+    Regression: previously this path emitted only agentId/state/activity,
+    so the frontend would receive an activity flip without enough context
+    to keep the agent-to-task mapping in sync after a reconnect.
+    """
+    worker = _make_worker()
+    slot = worker.slots[0]
+    slot.current_task_id = "t-emit1"
+    slot.state = "working"
+    slot.activity = "reading"
+
+    emit = worker._task_emit("t-emit1", slot)
+    await emit("hello", detail={"activity": "editing"})
+
+    # _task_emit calls _send twice: once for terminal-output, once for
+    # the activity-change agent-state. The agent-state message is last.
+    msg = _last_sent(worker)
+    assert msg["type"] == "agent-state"
+    assert msg["workerId"] == "w-test01"
+    assert msg["agentId"] == slot.agent_id
+    assert msg["taskId"] == "t-emit1"
+    assert msg["state"] == "working"
+    assert msg["activity"] == "editing"
+    assert slot.activity == "editing"
+
+
+@pytest.mark.asyncio
+async def test_task_emit_no_activity_change_does_not_send_state():
+    """Same activity → no spurious agent-state emit (only terminal-output)."""
+    worker = _make_worker()
+    slot = worker.slots[0]
+    slot.current_task_id = "t-emit2"
+    slot.state = "working"
+    slot.activity = "editing"
+
+    emit = worker._task_emit("t-emit2", slot)
+    await emit("noop", detail={"activity": "editing"})
+
+    # Only the terminal-output frame; no agent-state delta.
+    sent_types = [c.args[0]["type"] for c in worker._send.await_args_list]
+    assert sent_types == ["terminal-output"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_slots_emit_distinct_ids():
+    """Two slots on the same worker must emit distinct agentIds with the
+    same workerId — the regression that caused multiple agents to render
+    as 'working' on one bench depended on slots being indistinguishable
+    on the wire."""
+    worker = _make_worker()
+    slot_a, slot_b = worker.slots
+    slot_a.current_task_id = "t-A"
+    slot_b.current_task_id = "t-B"
+
+    await worker._set_state("working", slot_a)
+    msg_a = _last_sent(worker)
+    await worker._set_state("working", slot_b)
+    msg_b = _last_sent(worker)
+
+    assert msg_a["workerId"] == msg_b["workerId"] == "w-test01"
+    assert msg_a["agentId"] != msg_b["agentId"]
+    assert msg_a["taskId"] == "t-A"
+    assert msg_b["taskId"] == "t-B"


### PR DESCRIPTION
Workers default to 4 agent slots that share one worker_id. The factory
floor matched task→agent by workerId, so concurrent tasks all resolved
to the same first slot — the other agents never walked to their benches
and the rendered state didn't match the rendered task.

Thread the slot's agentId through task-update/task-complete/
task-followup-done/needs-input and match on it in FactoryFloor. Also
drop the unused 'awaiting-review' agent state and a no-op helper.

https://claude.ai/code/session_01VZYBk3GCaCuvweyRb3w4Pz