### PR TITLE
fix(foreman): stop browser hijacking external-foreman seat

### DIFF
--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -247,7 +247,12 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         # decide it owns the agent, and stamp the just-joined agent offline.
         async with agent_owner_lock(ctx.guild_id):
             agent_owners[agent_id] = ctx.websocket
-    if agent_type == "foreman":
+    # Only an explicit external foreman client may claim the foreman seat —
+    # the legacy browser join still carries agentType="foreman" but must NOT
+    # be registered in foreman_connections, or every chat trigger gets routed
+    # to the browser (which has no handler) and the embedded foreman AI never
+    # runs. The external client signals its intent with `external: true`.
+    if agent_type == "foreman" and data.get("external") is True:
         # Register as the active external foreman for this guild.
         # Evict any previously connected foreman so there is never more than
         # one active at a time (prevents duplicate task mutations / triggers).
@@ -362,6 +367,7 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
     if "current_task_id" in update_vals:
         msg["taskId"] = update_vals["current_task_id"]
     await broadcast(ctx.guild_id, msg)
+    reset_foreman_poll(ctx.guild_id)
 
 
 async def handle_chat(ctx: WSContext, data: dict) -> None:
@@ -535,6 +541,8 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
         await ctx.db.execute(update(Task).where(Task.id == task_id).values(**update_values))
         await ctx.db.commit()
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    if "state" in update_values:
+        reset_foreman_poll(ctx.guild_id)
 
 
 async def handle_task_complete(ctx: WSContext, data: dict) -> None:
@@ -641,6 +649,7 @@ async def handle_needs_input(ctx: WSContext, data: dict) -> None:
         task_id=task_id or None,
         task_name=f"foreman.needs-input:{task_id or 'unknown'}",
     )
+    reset_foreman_poll(ctx.guild_id)
 
 
 async def handle_claude_auth_required(ctx: WSContext, data: dict) -> None:
@@ -669,6 +678,7 @@ async def handle_claude_auth_required(ctx: WSContext, data: dict) -> None:
         "(or type it into the Foreman Comms input). The worker is waiting.",
         task_name=f"foreman.claude-auth:{worker_id}",
     )
+    reset_foreman_poll(ctx.guild_id)
 
 
 async def handle_foreman_disconnect(ctx: WSContext, data: dict) -> None:

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -65,15 +65,6 @@ const authStore = useAuthStore()
 const ghStore = useGitHubStore()
 const tasksStore = useTasksStore()
 
-function getClientId() {
-  let id = localStorage.getItem('client_id')
-  if (!id) {
-    id = Math.random().toString(36).slice(2, 10)
-    localStorage.setItem('client_id', id)
-  }
-  return id
-}
-
 async function initGuild(guildId: string) {
   if (!authStore.isLoggedIn) {
     // On a subdomain, redirect to the root domain bridge so it can pass
@@ -117,23 +108,10 @@ async function initGuild(guildId: string) {
       )
   }
 
-  const clientId = getClientId()
-  const suffix = clientId.slice(0, 4)
-  const foremanName = authStore.user ? `${authStore.user.login}-${suffix}` : `Foreman-${suffix}`
-
   guildStore.connectWebSocket(guildId, (data) => {
     agentsStore.handleWebSocketMessage(data)
     tasksStore.handleWebSocketMessage(data)
   })
-
-  setTimeout(() => {
-    guildStore.sendMessage({
-      type: 'join',
-      agentId: `foreman-${clientId}`,
-      agentName: foremanName,
-      agentType: 'foreman',
-    })
-  }, 200)
 
   if (ghStore.isConfigured) {
     const reposToFetch = guild.primary_repo ? [guild.primary_repo] : undefined


### PR DESCRIPTION
Phase 2 (commit 11ec2c5) added `foreman_connections[guild_id]` so an
external Foreman AI client could register as the trigger target for
chat/task-complete/etc. Registration was keyed on the WS join carrying
`agentType="foreman"` — but the browser has been sending exactly that
since the earliest frontend commit, as a legacy no-op identifier
(registerAgent skips foreman types, and guild queries filter them out).

After Phase 2, the browser's join now silently captures the foreman seat.
Every chat message gets routed via `foreman-trigger` to the browser, which
has no handler for it, so the embedded foreman AI never runs and the
user sees no reply.

Fix:
- Drop the browser's `agentType: 'foreman'` join — it served no purpose
  in the UI and is the source of the bug.
- Backend-side defense: require an explicit `external: true` in the join
  data before claiming foreman_connections, so a cached/older frontend
  still can't hijack the seat.
- Add the missing `reset_foreman_poll` calls on `agent-state`,
  `task-update` (state changes), `needs-input`, and `claude-auth-required`
  so significant events bring the poll backoff back to its minimum
  instead of leaving the foreman idle through the rest of a long sleep.