### PR TITLE
Add mock worker mode for deterministic e2e testing

### DIFF
--- a/frontend/tests/e2e/mock-worker-helpers.ts
+++ b/frontend/tests/e2e/mock-worker-helpers.ts
@@ -1,0 +1,137 @@
+/**
+ * Helpers for driving a running `pioneer-worker --mock` instance from a
+ * Playwright e2e test. The mock worker exposes an HTTP control API
+ * (default 127.0.0.1:9100) — see `worker/README.md` for the protocol.
+ *
+ * Usage:
+ *
+ *   const mock = new MockWorkerClient('http://127.0.0.1:9100')
+ *   const { slots } = await mock.status()
+ *   await mock.setState(slots[0].agentId, 'thinking', { activity: 'reading' })
+ *   await mock.emitOutput(slots[0].agentId, '[mock] reading file', { taskId })
+ *   await mock.completeTask(taskId, { prUrl: 'https://example.com/pr/1' })
+ */
+
+export type AgentState = 'idle' | 'thinking' | 'working' | 'busy' | 'error' | 'offline'
+
+export interface SlotSnapshot {
+  agentId: string
+  agentName: string
+  state: AgentState
+  activity: string | null
+  taskId: string | null
+}
+
+export interface StatusSnapshot {
+  workerId: string
+  workerName: string
+  guildId: string
+  slots: SlotSnapshot[]
+  activeTasks: string[]
+  queueDepth: number
+}
+
+export interface CompleteOptions {
+  branch?: string
+  prUrl?: string
+  stopReason?: string
+  lastText?: string
+  sessionId?: string
+}
+
+export interface FailOptions {
+  stopReason?: string
+  lastMessage?: string
+}
+
+export class MockWorkerClient {
+  constructor(private readonly baseUrl: string) {}
+
+  async status(): Promise<StatusSnapshot> {
+    return this.request<StatusSnapshot>('GET', '/')
+  }
+
+  async setState(
+    agentId: string,
+    state: AgentState,
+    opts: { activity?: string; taskId?: string } = {},
+  ): Promise<SlotSnapshot> {
+    return this.request<SlotSnapshot>('POST', `/agents/${agentId}/state`, {
+      state,
+      ...opts,
+    })
+  }
+
+  async emitOutput(
+    agentId: string,
+    line: string,
+    opts: { taskId?: string; detail?: Record<string, unknown> } = {},
+  ): Promise<void> {
+    await this.request('POST', `/agents/${agentId}/output`, { line, ...opts })
+  }
+
+  async completeTask(taskId: string, opts: CompleteOptions = {}): Promise<void> {
+    await this.request('POST', `/tasks/${taskId}/complete`, opts)
+  }
+
+  async failTask(taskId: string, opts: FailOptions = {}): Promise<void> {
+    await this.request('POST', `/tasks/${taskId}/fail`, opts)
+  }
+
+  async shutdown(): Promise<void> {
+    await this.request('POST', '/control/shutdown')
+  }
+
+  /**
+   * Poll the mock until a slot reaches a target state, or throw.
+   * Useful for asserting "the slot picked up the task" before driving state.
+   */
+  async waitForSlotState(
+    agentId: string,
+    state: AgentState,
+    timeoutMs = 5000,
+  ): Promise<SlotSnapshot> {
+    const deadline = Date.now() + timeoutMs
+    let last: SlotSnapshot | undefined
+    while (Date.now() < deadline) {
+      const snap = await this.status()
+      last = snap.slots.find((s) => s.agentId === agentId)
+      if (last && last.state === state) return last
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    throw new Error(
+      `slot ${agentId} did not reach state=${state} within ${timeoutMs}ms (last=${
+        last ? JSON.stringify(last) : 'unknown'
+      })`,
+    )
+  }
+
+  /** Wait until a task is registered as active (the agent loop is parked on it). */
+  async waitForActiveTask(taskId: string, timeoutMs = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      const snap = await this.status()
+      if (snap.activeTasks.includes(taskId)) return
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    throw new Error(`task ${taskId} did not become active within ${timeoutMs}ms`)
+  }
+
+  private async request<T = unknown>(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const resp = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    })
+    const text = await resp.text()
+    const data = text ? (JSON.parse(text) as unknown) : ({} as unknown)
+    if (!resp.ok) {
+      throw new Error(`mock-worker ${method} ${path} -> ${resp.status}: ${text || '(empty)'}`)
+    }
+    return data as T
+  }
+}

--- a/frontend/tests/e2e/mock-worker.spec.ts
+++ b/frontend/tests/e2e/mock-worker.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Example e2e flow against a running mock worker.
+ *
+ * This suite only runs when `MOCK_WORKER_E2E` is set in the environment.
+ * Spinning up the backend + mock worker + Vite + chromium isn't free; the
+ * default `npm test` job stays cheap.
+ *
+ * Prerequisite (run in three shells before invoking this spec):
+ *
+ *   # backend
+ *   cd backend && uvicorn main:app --port 8000
+ *
+ *   # mock worker (after creating a guild in the UI and copying its id)
+ *   pioneer-worker --mock --backend-url http://localhost:8000 \
+ *                  --guild-id <id> --mock-api-port 9100
+ *
+ *   # frontend dev server
+ *   cd frontend && npm run dev
+ *
+ * Then run:
+ *
+ *   MOCK_WORKER_E2E=1 GUILD_ID=<id> npx vitest run tests/e2e/mock-worker.spec.ts
+ *
+ * The point of this file is to *document the integration pattern*. Real
+ * suites should follow this skeleton and add assertions about how the UI
+ * renders each state transition.
+ */
+import { chromium, type Page } from 'playwright'
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { existsSync } from 'fs'
+
+import { MockWorkerClient } from './mock-worker-helpers'
+
+const ENABLED = !!process.env.MOCK_WORKER_E2E
+const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://127.0.0.1:5173'
+const MOCK_URL = process.env.MOCK_WORKER_URL ?? 'http://127.0.0.1:9100'
+const GUILD_ID = process.env.GUILD_ID ?? ''
+const LOGIN_TOKEN = process.env.LOGIN_TOKEN ?? 'test-token'
+
+function findChromium(): string | null {
+  const env = process.env.PLAYWRIGHT_CHROMIUM_PATH
+  if (env && existsSync(env)) return env
+  const candidates = [
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/opt/pw-browsers/chromium/chrome-linux/chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/google-chrome',
+  ]
+  for (const c of candidates) {
+    if (existsSync(c)) return c
+  }
+  return null
+}
+
+const CHROMIUM_PATH = findChromium()
+const shouldRun = ENABLED && CHROMIUM_PATH && GUILD_ID
+const describeMaybe = shouldRun ? describe : describe.skip
+
+let browser: Awaited<ReturnType<typeof chromium.launch>>
+let page: Page
+let mock: MockWorkerClient
+
+describeMaybe('mock worker drives the UI', () => {
+  beforeAll(async () => {
+    mock = new MockWorkerClient(MOCK_URL)
+    browser = await chromium.launch({
+      executablePath: CHROMIUM_PATH!,
+      args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    })
+    page = await browser.newPage()
+    await page.addInitScript((token) => {
+      localStorage.setItem('login_token', token)
+      localStorage.setItem('user', JSON.stringify({ login: 'tester', avatar_url: '', id: 1 }))
+    }, LOGIN_TOKEN)
+    await page.goto(`${FRONTEND_URL}/guild/${GUILD_ID}`, {
+      waitUntil: 'networkidle',
+      timeout: 15_000,
+    })
+  }, 60_000)
+
+  afterAll(async () => {
+    await page?.close()
+    await browser?.close()
+  })
+
+  it('renders an agent transitioning idle → thinking → working → idle', async () => {
+    const status = await mock.status()
+    expect(status.slots.length).toBeGreaterThan(0)
+    const agent = status.slots[0]
+
+    // Drive the slot through a sequence and assert the UI reflects each step.
+    await mock.setState(agent.agentId, 'thinking', { activity: 'reading' })
+    await expect
+      .poll(() => page.locator(`[data-agent-id="${agent.agentId}"]`).getAttribute('data-state'))
+      .toBe('thinking')
+
+    await mock.setState(agent.agentId, 'working', { activity: 'editing' })
+    await expect
+      .poll(() => page.locator(`[data-agent-id="${agent.agentId}"]`).getAttribute('data-state'))
+      .toBe('working')
+
+    await mock.setState(agent.agentId, 'idle')
+    await expect
+      .poll(() => page.locator(`[data-agent-id="${agent.agentId}"]`).getAttribute('data-state'))
+      .toBe('idle')
+  }, 30_000)
+
+  it('completes a backend-assigned task via the mock control API', async () => {
+    // Assumes the test has separately POSTed a task via /guilds/.../workers/.../tasks
+    // and stored the resulting id in TASK_ID. In a real suite this would be a
+    // single helper that creates the task and hands the id back.
+    const taskId = process.env.TASK_ID
+    if (!taskId) {
+      console.warn('TASK_ID not set — skipping the completion path')
+      return
+    }
+    await mock.waitForActiveTask(taskId, 5000)
+    await mock.completeTask(taskId, {
+      prUrl: 'https://example.com/pr/42',
+      lastText: 'done',
+    })
+    // The frontend should update the task row to awaiting-review with the PR.
+    await expect
+      .poll(() => page.locator(`[data-task-id="${taskId}"]`).getAttribute('data-state'))
+      .toBe('awaiting-review')
+  }, 30_000)
+})

--- a/worker/README.md
+++ b/worker/README.md
@@ -124,3 +124,52 @@ mkdir -p ~/.pioneer/builder ~/.pioneer/tester
 pioneer-worker --config ~/.pioneer/builder/pioneer-worker.toml &
 pioneer-worker --config ~/.pioneer/tester/pioneer-worker.toml  &
 ```
+
+## Mock mode (for e2e tests)
+
+```bash
+pioneer-worker --mock --backend-url http://localhost:8000 --guild-id <id>
+pioneer-worker --mock --mock-api-port 9100   # default
+```
+
+In mock mode the worker:
+
+- still registers with the backend and joins the guild over WebSocket using
+  the same `join` / `worker-register` / `agent-state` / `terminal-output` /
+  `task-*` frames a real worker emits, so the frontend (and foreman) see a
+  real-looking worker;
+- skips the GitHub token fetch, the `claude` and `gh` auth checks, all
+  cloning/worktree/PR work, and the claude/codex/pi subprocesses;
+- exposes a small HTTP control API (default `127.0.0.1:9100`) so test code
+  can drive agent state and task lifecycle deterministically.
+
+### HTTP control API
+
+| Method | Path                              | Body                                                                     | Effect                                                       |
+| ------ | --------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| GET    | `/`                               | —                                                                        | Worker + slots + active tasks snapshot                       |
+| GET    | `/agents`                         | —                                                                        | Just the slots array                                         |
+| POST   | `/agents/{agentId}/state`         | `{state, activity?, taskId?}`                                            | Emit an `agent-state` frame                                  |
+| POST   | `/agents/{agentId}/output`        | `{line, taskId?, detail?}`                                               | Emit a `terminal-output` frame                               |
+| POST   | `/tasks/{taskId}/complete`        | `{branch?, prUrl?, stopReason?, lastText?, sessionId?}`                  | Send `task-complete` (or `task-followup-done`); slot → idle  |
+| POST   | `/tasks/{taskId}/fail`            | `{stopReason?, lastMessage?}`                                            | Send `needs-input`; slot → error → idle                      |
+| POST   | `/control/shutdown`               | —                                                                        | Graceful shutdown                                            |
+
+### Per-task scripts
+
+Embed a `MOCK_SCRIPT:` line in the task description and the mock will run it
+without waiting for HTTP control. Each step is one of:
+
+```json
+[
+  {"state": "thinking", "delay_ms": 100},
+  {"output": "[mock] reading source", "delay_ms": 50},
+  {"state": "working", "activity": "editing"},
+  {"complete": {"prUrl": "https://example.com/pr/1", "lastText": "done"}}
+]
+```
+
+If the script doesn't end with `complete` / `fail`, the slot parks on the
+future and finishes once the HTTP API resolves it. Mixed mode (script then
+HTTP) lets you script the noisy bits and have the test assert the terminal
+state.

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -12,6 +12,7 @@ import sys
 from . import __version__
 from . import config as config_mod
 from .logging_config import get_logging_config
+from .mock_worker import MockWorker
 from .worker import Worker
 
 
@@ -83,6 +84,26 @@ def _build_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"pioneer-worker {__version__}",
     )
+
+    # Mock mode (for e2e tests). Skips all subprocess/git/claude work and
+    # exposes an HTTP control API so Playwright tests can drive agent state
+    # and task lifecycle deterministically.
+    parser.add_argument(
+        "--mock",
+        action="store_true",
+        help="Run as a mock worker for e2e tests (no real claude/git/gh).",
+    )
+    parser.add_argument(
+        "--mock-api-port",
+        type=int,
+        default=9100,
+        help="Port for the mock-mode HTTP control API (default: 9100).",
+    )
+    parser.add_argument(
+        "--mock-api-host",
+        default="127.0.0.1",
+        help="Bind host for the mock-mode HTTP control API (default: 127.0.0.1).",
+    )
     return parser
 
 
@@ -122,6 +143,14 @@ def main(argv: list[str] | None = None) -> int:
 
     log.info("Config loaded from %s", cfg.config_path)
 
+    if args.mock and not cfg.repos:
+        # The mock worker needs to register against the backend, which expects a
+        # non-empty repos list on the worker row. Inject a placeholder so the
+        # registration call succeeds without forcing the test harness to set
+        # one explicitly.
+        cfg.repos = ["mock/mock"]
+        log.info("Mock mode: defaulting repos to %s", cfg.repos)
+
     if not cfg.repos:
         msg = (
             "Worker cannot start: no repos configured. "
@@ -132,7 +161,19 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {msg}", file=sys.stderr)
         return 2
 
-    worker = Worker(cfg)
+    if args.mock:
+        log.info(
+            "Starting in MOCK mode (HTTP API on %s:%d)",
+            args.mock_api_host,
+            args.mock_api_port,
+        )
+        worker = MockWorker(
+            cfg,
+            mock_api_port=args.mock_api_port,
+            mock_api_host=args.mock_api_host,
+        )
+    else:
+        worker = Worker(cfg)
     try:
         asyncio.run(worker.run())
     except KeyboardInterrupt:

--- a/worker/pioneer_worker/mock_worker.py
+++ b/worker/pioneer_worker/mock_worker.py
@@ -1,0 +1,502 @@
+"""Mock worker for e2e tests.
+
+Subclass of :class:`Worker` that connects to the backend over WebSocket the
+same way a real worker does (same ``join`` / ``worker-register`` /
+``agent-state`` / ``terminal-output`` / ``task-*`` frames), but skips every
+side effect — no GitHub clones, no worktrees, no claude subprocess, no
+``gh`` invocations. A small HTTP API on ``--mock-api-port`` lets the test
+harness (Playwright) drive agent state and task lifecycle deterministically.
+
+HTTP endpoints (default ``127.0.0.1:9100``):
+
+    GET  /                              status JSON
+    GET  /agents                        list of slots with current state
+    POST /agents/{agentId}/state        body: {state, activity?, taskId?}
+    POST /agents/{agentId}/output       body: {line, taskId?, detail?}
+    POST /tasks/{taskId}/complete       body: {branch?, prUrl?, stopReason?,
+                                               lastText?, sessionId?}
+    POST /tasks/{taskId}/fail           body: {stopReason?, lastMessage?}
+    POST /control/shutdown              graceful shutdown
+
+Per-task scripted runs are supported by embedding ``MOCK_SCRIPT: [...]`` in
+the task description; if present the mock runs the script to completion. If
+absent the slot stays in ``working`` until a ``/tasks/{taskId}/complete`` or
+``/tasks/{taskId}/fail`` request lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from . import config as config_mod
+from .worker import Worker, _now_iso
+
+logger = logging.getLogger(__name__)
+
+
+_MOCK_SCRIPT_PREFIX = "MOCK_SCRIPT:"
+
+
+def _extract_script(task: dict) -> list[dict] | None:
+    """Return a parsed script from the task description, or None.
+
+    Looks for a line beginning with ``MOCK_SCRIPT:`` followed by a JSON array.
+    Each step is one of:
+
+      {"state": "<idle|thinking|working|busy|error>", "activity": "...", "delay_ms": 0}
+      {"output": "<line>", "taskId?": "...", "delay_ms": 0}
+      {"complete": {"prUrl?": "...", "stopReason?": "...", "lastText?": "..."}}
+      {"fail": {"stopReason?": "...", "lastMessage?": "..."}}
+    """
+    desc = task.get("description") or ""
+    for line in desc.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(_MOCK_SCRIPT_PREFIX):
+            payload = stripped[len(_MOCK_SCRIPT_PREFIX) :].strip()
+            try:
+                parsed = json.loads(payload)
+            except json.JSONDecodeError as exc:
+                logger.warning("MOCK_SCRIPT JSON parse failed: %s", exc)
+                return None
+            if isinstance(parsed, list):
+                return parsed
+            logger.warning("MOCK_SCRIPT must be a JSON array (got %s)", type(parsed).__name__)
+            return None
+    return None
+
+
+class MockWorker(Worker):
+    """Worker that fakes every external dependency and exposes an HTTP control API."""
+
+    def __init__(
+        self,
+        cfg: config_mod.Config,
+        *,
+        mock_api_port: int = 9100,
+        mock_api_host: str = "127.0.0.1",
+    ) -> None:
+        super().__init__(cfg)
+        self.mock_api_port = mock_api_port
+        self.mock_api_host = mock_api_host
+        # Future per active task; resolved by the HTTP handler to signal the
+        # agent loop that the task should complete or fail.
+        self._task_outcomes: dict[str, asyncio.Future] = {}
+        # Captured at run() start so the HTTP handler thread can schedule
+        # coroutines onto the worker's loop via run_coroutine_threadsafe.
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._http_server: ThreadingHTTPServer | None = None
+        self._http_thread: threading.Thread | None = None
+
+    # ── Skip real-world setup ───────────────────────────────────────────────
+    async def _fetch_github_token_if_needed(self) -> None:
+        logger.info("[mock] skipping GitHub token fetch")
+
+    async def _refresh_github_repos(self) -> None:
+        logger.debug("[mock] skipping GitHub repo refresh")
+
+    async def _check_gh_auth(self) -> None:
+        logger.info("[mock] skipping gh auth check")
+
+    async def _check_claude_auth(self) -> None:
+        logger.info("[mock] skipping claude auth check")
+
+    async def _initial_worktree_sweep(self) -> None:
+        return  # nothing on disk to sweep
+
+    async def _worktree_sweeper(self) -> None:
+        # Park until shutdown; no worktrees to manage.
+        await self._shutdown_event.wait()
+
+    async def _idle_puller(self) -> None:
+        """REST-poll loop without the git-pull side effect."""
+        logger.info("[mock] idle puller started (interval=%.1fs)", self.cfg.pull_interval)
+        while not self._shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=self.cfg.pull_interval)
+                return
+            except TimeoutError:
+                pass
+            try:
+                pending = await self._fetch_pending_tasks()
+                for task in pending:
+                    if task["id"] in self._known_task_ids:
+                        continue
+                    logger.info("[mock] picked up missed task %s via poll", task["id"])
+                    self._known_task_ids.add(task["id"])
+                    await self.task_queue.put(task)
+            except Exception as exc:
+                logger.warning("[mock] pending-task poll failed: %s", exc)
+
+    # ── Run lifecycle ───────────────────────────────────────────────────────
+    async def run(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._start_http_server()
+        try:
+            await super().run()
+        finally:
+            self._stop_http_server()
+
+    def _start_http_server(self) -> None:
+        handler_cls = _make_handler(self)
+        try:
+            self._http_server = ThreadingHTTPServer(
+                (self.mock_api_host, self.mock_api_port), handler_cls
+            )
+        except OSError as exc:
+            logger.error(
+                "[mock] could not bind HTTP API to %s:%d — %s",
+                self.mock_api_host,
+                self.mock_api_port,
+                exc,
+            )
+            raise
+        bound_host, bound_port = self._http_server.server_address[:2]
+        self.mock_api_port = bound_port  # in case 0 was passed in
+        self._http_thread = threading.Thread(
+            target=self._http_server.serve_forever,
+            name="mock-api",
+            daemon=True,
+        )
+        self._http_thread.start()
+        logger.info("[mock] HTTP control API listening on %s:%d", bound_host, bound_port)
+
+    def _stop_http_server(self) -> None:
+        if self._http_server is not None:
+            self._http_server.shutdown()
+            self._http_server.server_close()
+            self._http_server = None
+        if self._http_thread is not None:
+            self._http_thread.join(timeout=2.0)
+            self._http_thread = None
+
+    # ── Task execution (replaces claude/codex/pi runners) ──────────────────
+    async def _execute_task(self, task: dict, slot) -> None:
+        task_id = task["id"]
+        desc = task.get("description") or ""
+        is_followup = bool(task.get("followup_instructions"))
+        branch = task.get("followup_branch") or f"mock/{task_id[:8]}"
+
+        await self._set_state("working", slot)
+        await self._task_update(task_id, slot=slot, state="working", branch=branch)
+
+        emit = self._task_emit(task_id, slot)
+        await emit(f"[mock] Task {task_id}: {desc[:120]}")
+        await emit(f"[mock] Branch: {branch}")
+
+        script = _extract_script(task)
+        outcome: dict | None = None
+        if script is not None:
+            outcome = await self._run_script(task_id, slot, script, emit)
+
+        if outcome is None:
+            # No script (or script didn't terminate the task) — wait for HTTP.
+            assert self._loop is not None
+            future = self._loop.create_future()
+            self._task_outcomes[task_id] = future
+            try:
+                outcome = await future
+            finally:
+                self._task_outcomes.pop(task_id, None)
+
+        await self._finalize_task(task_id, slot, outcome, desc, branch, is_followup)
+
+    async def _run_script(self, task_id: str, slot, script: list[dict], emit) -> dict | None:
+        """Execute a script of steps. Returns an outcome dict if the script
+        terminated the task; otherwise None (caller will wait on HTTP)."""
+        for step in script:
+            if not isinstance(step, dict):
+                logger.warning("[mock] skipping non-dict script step: %r", step)
+                continue
+            delay_ms = step.get("delay_ms")
+            if delay_ms:
+                await asyncio.sleep(float(delay_ms) / 1000.0)
+            if "state" in step:
+                new_state = step["state"]
+                if "activity" in step:
+                    slot.activity = step["activity"]
+                await self._set_state(new_state, slot)
+                if new_state == "working" and slot.current_task_id is None:
+                    slot.current_task_id = task_id
+                continue
+            if "output" in step:
+                detail = step.get("detail")
+                await emit(step["output"], detail=detail)
+                continue
+            if "complete" in step:
+                spec = step["complete"] or {}
+                return {"kind": "complete", **spec}
+            if "fail" in step:
+                spec = step["fail"] or {}
+                return {"kind": "fail", **spec}
+            logger.warning("[mock] unrecognized script step: %r", step)
+        return None
+
+    async def _finalize_task(
+        self,
+        task_id: str,
+        slot,
+        outcome: dict,
+        desc: str,
+        branch: str,
+        is_followup: bool,
+    ) -> None:
+        kind = outcome.get("kind", "complete")
+        if kind == "complete":
+            pr_url = outcome.get("prUrl", "")
+            session_id = outcome.get("sessionId", "")
+            last_text = outcome.get("lastText", "mock complete")
+            stop_reason = outcome.get("stopReason", "end_turn")
+            final_branch = outcome.get("branch", branch)
+
+            await self._task_update(
+                task_id,
+                slot=slot,
+                branch=final_branch,
+                prUrl=pr_url,
+                state="awaiting-review",
+            )
+            if is_followup:
+                await self._send(
+                    {
+                        "type": "task-followup-done",
+                        "workerId": self.cfg.worker_id,
+                        "agentId": slot.agent_id,
+                        "taskId": task_id,
+                        "success": True,
+                        "stopReason": stop_reason,
+                        "branch": final_branch,
+                        "sessionId": session_id,
+                        "prUrl": pr_url,
+                    }
+                )
+            else:
+                await self._send(
+                    {
+                        "type": "task-complete",
+                        "workerId": self.cfg.worker_id,
+                        "agentId": slot.agent_id,
+                        "taskId": task_id,
+                        "branch": final_branch,
+                        "description": desc,
+                        "prUrl": pr_url,
+                        "sessionId": session_id,
+                        "lastText": last_text,
+                    }
+                )
+        else:  # fail
+            stop_reason = outcome.get("stopReason", "mock_failure")
+            last_message = outcome.get("lastMessage", "mock failure")
+            await self._task_update(task_id, slot=slot, branch=branch, state="failed")
+            await self._send(
+                {
+                    "type": "needs-input",
+                    "workerId": self.cfg.worker_id,
+                    "agentId": slot.agent_id,
+                    "taskId": task_id,
+                    "description": desc,
+                    "branch": branch,
+                    "sessionId": "",
+                    "stopReason": stop_reason,
+                    "lastMessage": last_message,
+                }
+            )
+            await self._set_state("error", slot)
+        await self._set_state("idle", slot)
+
+    # ── Called from HTTP handler thread via run_coroutine_threadsafe ──────
+    async def _http_set_state(
+        self, agent_id: str, state: str, activity: str | None, task_id: str | None
+    ) -> dict:
+        slot = next((s for s in self.slots if s.id == agent_id), None)
+        if slot is None:
+            return {"error": f"unknown agentId {agent_id!r}"}
+        if task_id is not None:
+            slot.current_task_id = task_id
+        await self._set_state(state, slot)
+        # _set_state nulls activity on non-working transitions; reapply if the
+        # caller explicitly asked for one so tests can pin any (state, activity)
+        # combination they want.
+        if activity is not None and slot.activity != activity:
+            slot.activity = activity
+            await self._emit_agent_state(slot)
+        return {
+            "ok": True,
+            "agentId": slot.id,
+            "state": slot.state,
+            "activity": slot.activity,
+            "taskId": slot.current_task_id,
+        }
+
+    async def _http_emit_output(
+        self, agent_id: str, line: str, task_id: str | None, detail: dict | None
+    ) -> dict:
+        slot = next((s for s in self.slots if s.id == agent_id), None)
+        if slot is None:
+            return {"error": f"unknown agentId {agent_id!r}"}
+        msg: dict = {
+            "type": "terminal-output",
+            "agentId": slot.id,
+            "line": line,
+            "timestamp": _now_iso(),
+        }
+        if task_id:
+            msg["taskId"] = task_id
+        if detail:
+            msg["detail"] = detail
+        await self._send(msg)
+        return {"ok": True}
+
+    def _resolve_task_outcome(self, task_id: str, outcome: dict) -> dict:
+        future = self._task_outcomes.get(task_id)
+        if future is None or future.done():
+            return {"error": f"no active task {task_id!r}"}
+        future.set_result(outcome)
+        return {"ok": True, "taskId": task_id, "kind": outcome.get("kind")}
+
+    def _status_snapshot(self) -> dict:
+        return {
+            "workerId": self.cfg.worker_id,
+            "workerName": self._worker_name,
+            "guildId": self.cfg.guild_id,
+            "slots": [
+                {
+                    "agentId": s.id,
+                    "agentName": s.name,
+                    "state": s.state,
+                    "activity": s.activity,
+                    "taskId": s.current_task_id,
+                }
+                for s in self.slots
+            ],
+            "activeTasks": list(self._task_outcomes.keys()),
+            "queueDepth": self.task_queue.qsize(),
+        }
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# HTTP handler factory
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _make_handler(worker: MockWorker) -> type[BaseHTTPRequestHandler]:
+    """Build a request handler class bound to *worker*."""
+
+    def _run_coro(coro):
+        """Schedule *coro* on the worker's event loop and wait for the result."""
+        assert worker._loop is not None
+        fut = asyncio.run_coroutine_threadsafe(coro, worker._loop)
+        return fut.result(timeout=10.0)
+
+    def _call_sync(fn, *args, **kwargs):
+        """Run a callable on the worker's loop (the loop owns shared state)."""
+        assert worker._loop is not None
+        result: dict = {}
+
+        def _runner():
+            result["value"] = fn(*args, **kwargs)
+
+        worker._loop.call_soon_threadsafe(_runner)
+        # Spin briefly until the call_soon ran. The loop's tick is fast enough
+        # for test traffic; this avoids needing an extra coroutine wrapper.
+        deadline = 5.0
+        step = 0.005
+        elapsed = 0.0
+        while "value" not in result and elapsed < deadline:
+            threading.Event().wait(step)
+            elapsed += step
+        return result.get("value", {"error": "timeout"})
+
+    class Handler(BaseHTTPRequestHandler):
+        # Quiet down the default access log.
+        def log_message(self, format: str, *args) -> None:  # noqa: A003 - stdlib name
+            logger.debug("[mock-api] %s - %s", self.address_string(), format % args)
+
+        def _send_json(self, status: int, payload: dict) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _read_json(self) -> dict:
+            length = int(self.headers.get("Content-Length") or 0)
+            if not length:
+                return {}
+            try:
+                return json.loads(self.rfile.read(length).decode() or "{}")
+            except json.JSONDecodeError:
+                return {}
+
+        # ── GET ────────────────────────────────────────────────────────────
+        def do_GET(self) -> None:  # noqa: N802 - stdlib name
+            if self.path in ("/", "/status"):
+                self._send_json(200, _call_sync(worker._status_snapshot))
+                return
+            if self.path == "/agents":
+                snap = _call_sync(worker._status_snapshot)
+                self._send_json(200, {"agents": snap.get("slots", [])})
+                return
+            self._send_json(404, {"error": "not found"})
+
+        # ── POST ───────────────────────────────────────────────────────────
+        def do_POST(self) -> None:  # noqa: N802 - stdlib name
+            parts = [p for p in self.path.split("/") if p]
+            body = self._read_json()
+            try:
+                if len(parts) == 3 and parts[0] == "agents" and parts[2] == "state":
+                    agent_id = parts[1]
+                    state = body.get("state")
+                    if not state:
+                        self._send_json(400, {"error": "state is required"})
+                        return
+                    result = _run_coro(
+                        worker._http_set_state(
+                            agent_id, state, body.get("activity"), body.get("taskId")
+                        )
+                    )
+                    self._send_json(200 if "ok" in result else 404, result)
+                    return
+
+                if len(parts) == 3 and parts[0] == "agents" and parts[2] == "output":
+                    agent_id = parts[1]
+                    line = body.get("line", "")
+                    result = _run_coro(
+                        worker._http_emit_output(
+                            agent_id, line, body.get("taskId"), body.get("detail")
+                        )
+                    )
+                    self._send_json(200 if "ok" in result else 404, result)
+                    return
+
+                if len(parts) == 3 and parts[0] == "tasks" and parts[2] == "complete":
+                    task_id = parts[1]
+                    outcome = {"kind": "complete", **body}
+                    result = worker._resolve_task_outcome(task_id, outcome)
+                    self._send_json(200 if "ok" in result else 404, result)
+                    return
+
+                if len(parts) == 3 and parts[0] == "tasks" and parts[2] == "fail":
+                    task_id = parts[1]
+                    outcome = {"kind": "fail", **body}
+                    result = worker._resolve_task_outcome(task_id, outcome)
+                    self._send_json(200 if "ok" in result else 404, result)
+                    return
+
+                if self.path == "/control/shutdown":
+                    _run_coro(worker._initiate_shutdown("mock HTTP shutdown"))
+                    self._send_json(200, {"ok": True})
+                    return
+
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("[mock-api] handler crashed: %s", exc)
+                self._send_json(500, {"error": str(exc)})
+                return
+
+            self._send_json(404, {"error": "not found", "path": self.path})
+
+    return Handler

--- a/worker/tests/test_mock_worker.py
+++ b/worker/tests/test_mock_worker.py
@@ -1,0 +1,418 @@
+"""Tests for the mock worker (``pioneer-worker --mock``).
+
+Two layers of coverage:
+
+  Unit: the script parser, the script runner, and the HTTP-driven outcome
+        path of ``_execute_task`` exercised by directly resolving the future
+        the agent loop is waiting on. The WebSocket and registration steps
+        are stubbed out so these stay fast and offline.
+
+  Integration: a fully-wired ``MockWorker`` instance is constructed with its
+        ``_send`` replaced by a sink, the HTTP server is started against a
+        real port (bound to 127.0.0.1), and end-to-end requests drive state
+        transitions. ``run()`` is not invoked; we exercise the same callable
+        surface the HTTP handler thread uses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.mock_worker import MockWorker, _extract_script
+
+
+def _make_cfg() -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="g-test",
+        worker_id="w-mock01",
+        max_agents=2,
+        pull_interval=3600.0,
+        repos=["mock/mock"],
+    )
+
+
+def _make_worker() -> MockWorker:
+    worker = MockWorker(_make_cfg(), mock_api_port=0)
+    worker._send = AsyncMock()
+    worker._worker_name = "MockWorker-1"
+    return worker
+
+
+def _sent_types(worker: MockWorker) -> list[str]:
+    return [c.args[0]["type"] for c in worker._send.await_args_list]
+
+
+def _last_send_of(worker: MockWorker, mtype: str) -> dict | None:
+    for call in reversed(worker._send.await_args_list):
+        if call.args[0]["type"] == mtype:
+            return call.args[0]
+    return None
+
+
+# ── Script extraction ──────────────────────────────────────────────────────
+
+
+def test_extract_script_parses_inline_json():
+    task = {
+        "description": 'Do the thing\nMOCK_SCRIPT: [{"state": "working"}, {"complete": {}}]\nmore'
+    }
+    script = _extract_script(task)
+    assert script == [{"state": "working"}, {"complete": {}}]
+
+
+def test_extract_script_returns_none_when_absent():
+    assert _extract_script({"description": "nothing special here"}) is None
+    assert _extract_script({}) is None
+
+
+def test_extract_script_returns_none_on_bad_json():
+    assert _extract_script({"description": "MOCK_SCRIPT: not-json"}) is None
+
+
+def test_extract_script_rejects_non_array():
+    assert _extract_script({"description": 'MOCK_SCRIPT: {"state": "working"}'}) is None
+
+
+# ── Setup methods are no-ops ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_setup_methods_are_noops():
+    worker = _make_worker()
+    # All of these would normally make network/subprocess calls — verify they
+    # return without doing anything observable.
+    await worker._fetch_github_token_if_needed()
+    await worker._refresh_github_repos()
+    await worker._check_gh_auth()
+    await worker._check_claude_auth()
+    await worker._initial_worktree_sweep()
+    assert worker._send.await_count == 0
+
+
+# ── _execute_task: HTTP-driven completion ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_execute_task_waits_for_http_complete():
+    """No MOCK_SCRIPT → task parks on the future until /tasks/{id}/complete."""
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    slot = worker.slots[0]
+    task = {"id": "t-abc123", "description": "Fix the thing", "name": "Fix"}
+
+    async def _drive() -> None:
+        # Wait for _execute_task to install its future, then resolve it.
+        for _ in range(50):
+            if "t-abc123" in worker._task_outcomes:
+                break
+            await asyncio.sleep(0.005)
+        worker._resolve_task_outcome(
+            "t-abc123",
+            {"kind": "complete", "prUrl": "https://example.com/pr/1", "lastText": "done!"},
+        )
+
+    driver = asyncio.create_task(_drive())
+    await worker._execute_task(task, slot)
+    await driver
+
+    types = _sent_types(worker)
+    assert "task-complete" in types, types
+    complete = _last_send_of(worker, "task-complete")
+    assert complete["taskId"] == "t-abc123"
+    assert complete["prUrl"] == "https://example.com/pr/1"
+    assert complete["lastText"] == "done!"
+    # Final state must be idle on the slot.
+    idle = _last_send_of(worker, "agent-state")
+    assert idle["state"] == "idle"
+    # Slot is no longer in active tasks.
+    assert "t-abc123" not in worker._task_outcomes
+
+
+@pytest.mark.asyncio
+async def test_execute_task_followup_sends_followup_done():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    slot = worker.slots[0]
+    task = {
+        "id": "t-fu1",
+        "description": "Follow up",
+        "followup_instructions": "Tweak it",
+        "followup_branch": "mock/fu-branch",
+    }
+
+    async def _drive() -> None:
+        for _ in range(50):
+            if "t-fu1" in worker._task_outcomes:
+                break
+            await asyncio.sleep(0.005)
+        worker._resolve_task_outcome("t-fu1", {"kind": "complete"})
+
+    driver = asyncio.create_task(_drive())
+    await worker._execute_task(task, slot)
+    await driver
+
+    assert "task-followup-done" in _sent_types(worker)
+    assert "task-complete" not in _sent_types(worker)
+    done = _last_send_of(worker, "task-followup-done")
+    assert done["branch"] == "mock/fu-branch"
+    assert done["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_task_http_fail_emits_needs_input_and_error():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    slot = worker.slots[0]
+    task = {"id": "t-fail1", "description": "Will fail"}
+
+    async def _drive() -> None:
+        for _ in range(50):
+            if "t-fail1" in worker._task_outcomes:
+                break
+            await asyncio.sleep(0.005)
+        worker._resolve_task_outcome(
+            "t-fail1",
+            {"kind": "fail", "stopReason": "max_turns", "lastMessage": "stuck"},
+        )
+
+    driver = asyncio.create_task(_drive())
+    await worker._execute_task(task, slot)
+    await driver
+
+    needs = _last_send_of(worker, "needs-input")
+    assert needs is not None
+    assert needs["stopReason"] == "max_turns"
+    assert needs["lastMessage"] == "stuck"
+
+    # Slot went through error before settling on idle.
+    states_seen = [
+        c.args[0]["state"]
+        for c in worker._send.await_args_list
+        if c.args[0].get("type") == "agent-state"
+    ]
+    assert "error" in states_seen
+    assert states_seen[-1] == "idle"
+
+
+# ── Scripted execution ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scripted_task_runs_to_completion_without_http():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    slot = worker.slots[0]
+    script = [
+        {"state": "thinking", "delay_ms": 0},
+        {"output": "[mock] reading source"},
+        {"state": "working", "activity": "editing"},
+        {"output": "[mock] applying patch"},
+        {"complete": {"prUrl": "https://example.com/pr/42", "lastText": "all green"}},
+    ]
+    task = {
+        "id": "t-script1",
+        "description": f"Headline\nMOCK_SCRIPT: {json.dumps(script)}\n",
+        "name": "scripted",
+    }
+
+    await worker._execute_task(task, slot)
+
+    states = [
+        c.args[0]["state"]
+        for c in worker._send.await_args_list
+        if c.args[0].get("type") == "agent-state"
+    ]
+    # Final transition must end at idle; we should have seen thinking and working.
+    assert "thinking" in states
+    assert "working" in states
+    assert states[-1] == "idle"
+
+    complete = _last_send_of(worker, "task-complete")
+    assert complete is not None
+    assert complete["prUrl"] == "https://example.com/pr/42"
+    assert complete["lastText"] == "all green"
+
+    output_lines = [
+        c.args[0]["line"]
+        for c in worker._send.await_args_list
+        if c.args[0].get("type") == "terminal-output"
+    ]
+    assert any("reading source" in line for line in output_lines)
+    assert any("applying patch" in line for line in output_lines)
+
+
+@pytest.mark.asyncio
+async def test_scripted_task_can_fail():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    slot = worker.slots[0]
+    script = [{"fail": {"stopReason": "boom", "lastMessage": "scripted failure"}}]
+    task = {"id": "t-script-fail", "description": f"MOCK_SCRIPT: {json.dumps(script)}"}
+
+    await worker._execute_task(task, slot)
+
+    needs = _last_send_of(worker, "needs-input")
+    assert needs is not None
+    assert needs["stopReason"] == "boom"
+
+
+# ── HTTP server integration ────────────────────────────────────────────────
+
+
+def _wait_until(predicate, timeout: float = 2.0, step: float = 0.01):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(step)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_http_api_set_state_emits_agent_state():
+    """End-to-end: bind the HTTP server, POST set-state, verify _send fires."""
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    worker._start_http_server()
+    try:
+        port = worker.mock_api_port
+        agent_id = worker.slots[0].id
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.post(
+                f"/agents/{agent_id}/state",
+                json={"state": "thinking", "activity": "reading", "taskId": "t-xyz"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["state"] == "thinking"
+            assert body["activity"] == "reading"
+            assert body["taskId"] == "t-xyz"
+
+            status = (await client.get("/")).json()
+            assert status["workerId"] == "w-mock01"
+            slot_info = next(s for s in status["slots"] if s["agentId"] == agent_id)
+            assert slot_info["state"] == "thinking"
+            assert slot_info["activity"] == "reading"
+
+        # The _send mock was called with the agent-state frame on the worker's loop.
+        sent_state = _last_send_of(worker, "agent-state")
+        assert sent_state is not None
+        assert sent_state["workerId"] == "w-mock01"
+        assert sent_state["agentId"] == agent_id
+        assert sent_state["state"] == "thinking"
+        assert sent_state["activity"] == "reading"
+        assert sent_state["taskId"] == "t-xyz"
+    finally:
+        worker._stop_http_server()
+
+
+@pytest.mark.asyncio
+async def test_http_api_emit_output_includes_task_id():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    worker._start_http_server()
+    try:
+        port = worker.mock_api_port
+        agent_id = worker.slots[1].id
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.post(
+                f"/agents/{agent_id}/output",
+                json={"line": "[mock] hi", "taskId": "t-out1"},
+            )
+            assert resp.status_code == 200, resp.text
+
+        emitted = _last_send_of(worker, "terminal-output")
+        assert emitted is not None
+        assert emitted["line"] == "[mock] hi"
+        assert emitted["taskId"] == "t-out1"
+        assert emitted["agentId"] == agent_id
+    finally:
+        worker._stop_http_server()
+
+
+@pytest.mark.asyncio
+async def test_http_api_complete_resolves_waiting_task():
+    """Spawn _execute_task in the background, then complete via HTTP."""
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    worker._start_http_server()
+    try:
+        port = worker.mock_api_port
+        slot = worker.slots[0]
+        task = {"id": "t-http-c1", "description": "Wait for HTTP"}
+        exec_task = asyncio.create_task(worker._execute_task(task, slot))
+
+        # Wait until the future is installed.
+        for _ in range(50):
+            if "t-http-c1" in worker._task_outcomes:
+                break
+            await asyncio.sleep(0.01)
+        assert "t-http-c1" in worker._task_outcomes
+
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.post(
+                "/tasks/t-http-c1/complete",
+                json={"prUrl": "https://example.com/pr/9", "lastText": "ship it"},
+            )
+            assert resp.status_code == 200, resp.text
+
+        await asyncio.wait_for(exec_task, timeout=2.0)
+        complete = _last_send_of(worker, "task-complete")
+        assert complete is not None
+        assert complete["prUrl"] == "https://example.com/pr/9"
+    finally:
+        worker._stop_http_server()
+
+
+@pytest.mark.asyncio
+async def test_http_api_complete_unknown_task_returns_404():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    worker._start_http_server()
+    try:
+        port = worker.mock_api_port
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.post("/tasks/t-nope/complete", json={})
+            assert resp.status_code == 404
+            assert "error" in resp.json()
+    finally:
+        worker._stop_http_server()
+
+
+@pytest.mark.asyncio
+async def test_http_api_set_state_unknown_agent_returns_404():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    worker._start_http_server()
+    try:
+        port = worker.mock_api_port
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.post(
+                "/agents/a-bogus/state",
+                json={"state": "working"},
+            )
+            assert resp.status_code == 404
+    finally:
+        worker._stop_http_server()
+
+
+@pytest.mark.asyncio
+async def test_http_api_set_state_requires_state_field():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    worker._start_http_server()
+    try:
+        port = worker.mock_api_port
+        agent_id = worker.slots[0].id
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.post(f"/agents/{agent_id}/state", json={})
+            assert resp.status_code == 400
+    finally:
+        worker._stop_http_server()


### PR DESCRIPTION
## Summary

Introduces a `MockWorker` subclass and HTTP control API to enable deterministic end-to-end testing without external dependencies (GitHub, Claude, git). The mock worker connects to the backend over WebSocket identically to a real worker but skips all side effects and exposes an HTTP API for test harnesses to drive agent state and task lifecycle.

## Key Changes

- **`worker/pioneer_worker/mock_worker.py`** (502 lines): New `MockWorker` class that:
  - Inherits from `Worker` and overrides setup methods (`_fetch_github_token_if_needed`, `_check_gh_auth`, etc.) to be no-ops
  - Replaces `_execute_task` with a mock implementation that either runs an embedded `MOCK_SCRIPT` (parsed from task description) or waits for HTTP-driven completion
  - Starts a `ThreadingHTTPServer` on `--mock-api-port` (default 9100) with endpoints for:
    - `GET /` and `GET /agents` — status snapshots
    - `POST /agents/{agentId}/state` — emit agent-state frames
    - `POST /agents/{agentId}/output` — emit terminal-output frames
    - `POST /tasks/{taskId}/complete` and `/tasks/{taskId}/fail` — resolve waiting tasks
    - `POST /control/shutdown` — graceful shutdown
  - Supports per-task scripted runs via `MOCK_SCRIPT: [...]` embedded in task descriptions; each step can transition state, emit output, or complete/fail the task with optional delays

- **`worker/tests/test_mock_worker.py`** (418 lines): Comprehensive test suite covering:
  - Script extraction and parsing
  - HTTP-driven task completion and failure paths
  - Scripted task execution with state transitions and output
  - Full HTTP server integration tests (binding, request/response handling, error cases)

- **`frontend/tests/e2e/mock-worker-helpers.ts`** (137 lines): TypeScript client library for Playwright tests to:
  - Query worker status and slot state
  - Drive agent state transitions
  - Emit terminal output
  - Complete or fail tasks
  - Poll for state changes with timeout

- **`frontend/tests/e2e/mock-worker.spec.ts`** (128 lines): Example Playwright e2e suite demonstrating:
  - Agent state transitions (idle → thinking → working → idle)
  - Task completion via HTTP control API
  - Integration with the frontend UI

- **`worker/pioneer_worker/cli.py`**: Added `--mock`, `--mock-api-port`, and `--mock-api-host` CLI arguments; auto-defaults `repos` to `["mock/mock"]` in mock mode to satisfy backend registration requirements

- **`worker/README.md`**: Documentation of mock mode, HTTP control API endpoints, and usage examples

## Implementation Details

- The mock worker uses `asyncio.run_coroutine_threadsafe` to schedule coroutines from the HTTP handler thread onto the worker's event loop, ensuring thread-safe access to shared state
- Task outcomes are stored in `_task_outcomes` futures; HTTP handlers resolve these to signal the agent loop
- Script steps support `delay_ms` for timing control and optional `detail` payloads for terminal output
- The HTTP server uses `call_soon_threadsafe` with polling for synchronous operations to avoid extra coroutine overhead
- All WebSocket frames (`agent-state`, `terminal-output`, `task-complete`, `task-followup-done`, `needs-input`) are emitted identically to a real worker, so the backend and frontend see a fully realistic worker

https://claude.ai/code/session_016AAiScgQMrhfwAJ2bWn4KZ