### PR TITLE
Lazy repo cloning: clone on demand, not upfront

### DIFF
--- a/worker/pioneer_worker/git_ops.py
+++ b/worker/pioneer_worker/git_ops.py
@@ -125,7 +125,11 @@ async def pull_repos(
     token: str | None,
     emit: EmitFn,
 ) -> None:
-    """Refresh all configured repos; emit progress through *emit*."""
+    """Refresh repos that are already cloned locally; skip repos not yet on disk.
+
+    Repos are cloned lazily the first time a task needs them, so this function
+    only fast-forwards existing clones rather than triggering upfront clones.
+    """
     logger.info("pull_repos: refreshing %d repo(s)", len(repos))
     for repo_full in repos:
         parts = repo_full.split("/", 1)
@@ -135,15 +139,13 @@ async def pull_repos(
         owner, name = parts
         local_path = os.path.join(repos_dir, owner, name)
         if not os.path.exists(os.path.join(local_path, ".git")):
-            logger.info("pull_repos: %s missing locally — cloning", repo_full)
-            await emit(f"[worker] Cloning {repo_full}...")
-            await ensure_repo(repos_dir, repo_full, token)
+            logger.debug("pull_repos: %s not cloned yet — will clone on demand", repo_full)
+            continue
+        rc, _, err = await run_git(["fetch", "origin"], cwd=local_path)
+        await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
+        if rc == 0:
+            logger.info("pull_repos: pulled %s", repo_full)
+            await emit(f"[worker] Pulled {repo_full}")
         else:
-            rc, _, err = await run_git(["fetch", "origin"], cwd=local_path)
-            await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
-            if rc == 0:
-                logger.info("pull_repos: pulled %s", repo_full)
-                await emit(f"[worker] Pulled {repo_full}")
-            else:
-                logger.warning("pull_repos: fetch warn for %s: %s", repo_full, err.strip()[:120])
-                await emit(f"[worker] Pull warn {repo_full}: {err.strip()[:60]}")
+            logger.warning("pull_repos: fetch warn for %s: %s", repo_full, err.strip()[:120])
+            await emit(f"[worker] Pull warn {repo_full}: {err.strip()[:60]}")

--- a/worker/tests/test_org_clone.py
+++ b/worker/tests/test_org_clone.py
@@ -5,6 +5,8 @@ Covers:
   - Task for an already-cloned repo skips ensure_repo
   - Worker with repos list only still works (no org set)
   - _known_repos() includes lazily-cloned repos from the org dir
+  - pull_repos skips repos not yet cloned (lazy clone on demand)
+  - pull_repos updates repos that are already cloned
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from pioneer_worker.config import Config
+from pioneer_worker.git_ops import pull_repos
 from pioneer_worker.worker import Worker
 
 
@@ -290,3 +293,89 @@ def test_known_repos_deduplicates_org_repos(tmp_path):
     )
     known = worker._known_repos()
     assert known.count("myorg/myrepo") == 1
+
+
+# ---------------------------------------------------------------------------
+# pull_repos: lazy clone — skip repos not yet on disk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pull_repos_skips_uncloned_repo(tmp_path):
+    """pull_repos must NOT clone a repo that isn't on disk yet."""
+    repos_dir = tmp_path / "repos"
+    emitted: list[str] = []
+
+    async def fake_emit(msg: str) -> None:
+        emitted.append(msg)
+
+    cloned: list[str] = []
+
+    async def fake_ensure_repo(rd, repo_full, token):
+        cloned.append(repo_full)
+        return str(repos_dir / repo_full.split("/")[0] / repo_full.split("/")[1])
+
+    with patch("pioneer_worker.git_ops.ensure_repo", side_effect=fake_ensure_repo):
+        await pull_repos(str(repos_dir), ["owner/notcloned"], None, fake_emit)
+
+    assert cloned == [], "pull_repos must not clone repos that aren't present yet"
+    assert not any("notcloned" in m for m in emitted if "Cloning" in m)
+
+
+@pytest.mark.asyncio
+async def test_pull_repos_updates_already_cloned_repo(tmp_path):
+    """pull_repos fetches and fast-forwards repos that are already on disk."""
+    repos_dir = tmp_path / "repos"
+    repo_path = repos_dir / "owner" / "myrepo"
+    (repo_path / ".git").mkdir(parents=True)
+
+    emitted: list[str] = []
+
+    async def fake_emit(msg: str) -> None:
+        emitted.append(msg)
+
+    git_calls: list[list[str]] = []
+
+    async def fake_run_git(args, cwd=None):
+        git_calls.append(args)
+        return 0, "", ""
+
+    with patch("pioneer_worker.git_ops.run_git", side_effect=fake_run_git):
+        await pull_repos(str(repos_dir), ["owner/myrepo"], None, fake_emit)
+
+    assert any("fetch" in c for c in git_calls), "should fetch for cloned repo"
+    assert any("Pulled owner/myrepo" in m for m in emitted)
+
+
+@pytest.mark.asyncio
+async def test_pull_repos_skips_uncloned_but_pulls_cloned(tmp_path):
+    """When the list has a mix, only cloned repos are updated."""
+    repos_dir = tmp_path / "repos"
+    cloned_path = repos_dir / "owner" / "cloned"
+    (cloned_path / ".git").mkdir(parents=True)
+
+    emitted: list[str] = []
+
+    async def fake_emit(msg: str) -> None:
+        emitted.append(msg)
+
+    ensure_calls: list[str] = []
+    git_calls: list[list[str]] = []
+
+    async def fake_ensure_repo(rd, repo_full, token):
+        ensure_calls.append(repo_full)
+        return None
+
+    async def fake_run_git(args, cwd=None):
+        git_calls.append(args)
+        return 0, "", ""
+
+    with (
+        patch("pioneer_worker.git_ops.ensure_repo", side_effect=fake_ensure_repo),
+        patch("pioneer_worker.git_ops.run_git", side_effect=fake_run_git),
+    ):
+        await pull_repos(str(repos_dir), ["owner/notcloned", "owner/cloned"], None, fake_emit)
+
+    assert ensure_calls == [], "pull_repos must not clone missing repos"
+    assert any("fetch" in c for c in git_calls), "should still fetch for cloned repo"
+    assert any("Pulled owner/cloned" in m for m in emitted)


### PR DESCRIPTION
## Summary

- `pull_repos` in `git_ops.py` previously cloned any configured repo that wasn't present locally when the worker was idle. This caused upfront network I/O for every configured repo on startup and during idle polling, even if a task never needed that repo.
- Changed `pull_repos` to skip repos not yet on disk (logging at DEBUG level) and only fast-forward repos that are already cloned. The existing `ensure_repo` call inside `_execute_task` already handles lazy cloning the first time a task references a repo.
- Added 3 tests to `test_org_clone.py` covering: skip-on-missing, fetch-on-present, and the mixed-list case.

## Test plan
- [ ] `python -m pytest worker/tests/test_org_clone.py` — all 10 tests pass
- [ ] `python -m pytest` — all 163 worker tests pass with no regressions

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)