### PR TITLE
feat(worker): droid-style worker name formatting

### DIFF
--- a/backend/tests/test_worker_name.py
+++ b/backend/tests/test_worker_name.py
@@ -1,4 +1,4 @@
-"""Tests for worker identity: name = hostname[:3]/worker_id."""
+"""Tests for worker identity: droid-style name derived from worker ID."""
 
 from __future__ import annotations
 
@@ -8,62 +8,75 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from utils import worker_display_name
+from utils import format_worker_id, worker_display_name
 
 sys.path.insert(0, os.path.dirname(__file__))
 from helpers import insert_guild, make_auth_token
 
 # ---------------------------------------------------------------------------
-# worker_display_name unit tests
+# format_worker_id unit tests
 # ---------------------------------------------------------------------------
 
 
-def test_with_hostname_normal():
-    assert worker_display_name("w-g2otus", "token-machine") == "tok/w-g2otus"
+def test_format_standard():
+    assert format_worker_id("w-vd3566") == "VD-3566"
 
 
-def test_with_hostname_takes_exactly_3_chars():
-    assert worker_display_name("w-abc123", "xy") == "xy/w-abc123"
+def test_format_ab1234():
+    assert format_worker_id("w-ab1234") == "AB-1234"
 
 
-def test_with_hostname_single_char():
-    assert worker_display_name("w-abc123", "z") == "z/w-abc123"
+def test_format_single_letter():
+    assert format_worker_id("w-x9") == "X-9"
 
 
-def test_with_hostname_exactly_3_chars():
-    assert worker_display_name("w-abc123", "tok") == "tok/w-abc123"
+def test_format_three_letters():
+    assert format_worker_id("w-abc123") == "ABC-123"
 
 
-def test_with_hostname_longer_than_3():
-    assert worker_display_name("w-abc123", "foobar") == "foo/w-abc123"
+def test_format_letter_digit_letters():
+    # Letters end at 'g', digits+letters follow from '2otus'
+    assert format_worker_id("w-g2otus") == "G-2OTUS"
 
 
-def test_without_hostname_returns_worker_id():
-    assert worker_display_name("w-abc123") == "w-abc123"
+def test_format_strips_w_prefix():
+    name = format_worker_id("w-vd3566")
+    assert not name.startswith("w-")
+    assert not name.startswith("W-")
 
 
-def test_without_hostname_explicit_none():
-    assert worker_display_name("w-abc123", None) == "w-abc123"
-
-
-def test_hostname_empty_string():
-    # Empty hostname — falsy, so treated as absent; returns bare worker_id.
-    assert worker_display_name("w-abc123", "") == "w-abc123"
-
-
-def test_name_contains_worker_id():
-    wid = "w-g2otus"
-    name = worker_display_name(wid, "pioneer")
-    assert wid in name
-
-
-def test_name_contains_hostname_prefix():
-    name = worker_display_name("w-g2otus", "pioneer")
-    assert name.startswith("pio/")
+def test_format_uppercase():
+    assert format_worker_id("w-vd3566") == format_worker_id("w-vd3566").upper()
 
 
 # ---------------------------------------------------------------------------
-# API tests: registration returns name; list includes name
+# worker_display_name: delegates to format_worker_id, ignores hostname
+# ---------------------------------------------------------------------------
+
+
+def test_worker_display_name_with_hostname():
+    assert worker_display_name("w-vd3566", "token-machine") == "VD-3566"
+
+
+def test_worker_display_name_no_hostname():
+    assert worker_display_name("w-abc123") == "ABC-123"
+
+
+def test_worker_display_name_none_hostname():
+    assert worker_display_name("w-abc123", None) == "ABC-123"
+
+
+def test_worker_display_name_empty_hostname():
+    assert worker_display_name("w-abc123", "") == "ABC-123"
+
+
+def test_worker_display_name_matches_format_worker_id():
+    wid = "w-vd3566"
+    assert worker_display_name(wid, "some-host") == format_worker_id(wid)
+
+
+# ---------------------------------------------------------------------------
+# API tests: registration returns droid-style name
 # ---------------------------------------------------------------------------
 
 
@@ -72,17 +85,17 @@ def _auth(db_path: str) -> dict:
 
 
 def test_register_worker_name_without_hostname(client):
-    """When no hostname is supplied the name falls back to the worker_id."""
+    """Name is the droid-formatted worker ID even without a hostname."""
     test_client, db_path = client
     insert_guild(db_path, "wname01")
     resp = test_client.post("/guilds/wname01/workers", json={"repos": []})
     assert resp.status_code == 200
     data = resp.json()
-    assert data["name"] == data["id"]
+    assert data["name"] == format_worker_id(data["id"])
 
 
 def test_register_worker_name_with_hostname(client):
-    """Registration with a hostname produces ``hostname[:3]/worker_id``."""
+    """Hostname is ignored — name is always the droid-formatted worker ID."""
     test_client, db_path = client
     insert_guild(db_path, "wname02")
     resp = test_client.post(
@@ -91,12 +104,11 @@ def test_register_worker_name_with_hostname(client):
     )
     assert resp.status_code == 200
     data = resp.json()
-    wid = data["id"]
-    assert data["name"] == f"pio/{wid}"
+    assert data["name"] == format_worker_id(data["id"])
 
 
 def test_register_worker_name_short_hostname(client):
-    """Hostnames shorter than 3 chars are used in full."""
+    """Short hostnames are also ignored; name is droid-formatted."""
     test_client, db_path = client
     insert_guild(db_path, "wname03")
     resp = test_client.post(
@@ -105,8 +117,7 @@ def test_register_worker_name_short_hostname(client):
     )
     assert resp.status_code == 200
     data = resp.json()
-    wid = data["id"]
-    assert data["name"] == f"ab/{wid}"
+    assert data["name"] == format_worker_id(data["id"])
 
 
 def test_list_workers_includes_name(client):
@@ -125,7 +136,7 @@ def test_list_workers_includes_name(client):
     workers = list_resp.json()
     assert len(workers) == 1
     assert "name" in workers[0]
-    assert workers[0]["name"] == f"tes/{wid}"
+    assert workers[0]["name"] == format_worker_id(wid)
 
 
 def test_list_workers_name_persisted_correctly(client):
@@ -139,7 +150,7 @@ def test_list_workers_name_persisted_correctly(client):
         json={"repos": [], "hostname": "myhost"},
     )
     wid = resp.json()["id"]
-    expected_name = f"myh/{wid}"
+    expected_name = format_worker_id(wid)
 
     with sqlite3.connect(db_path) as conn:
         row = conn.execute("SELECT name FROM workers WHERE id = ?", (wid,)).fetchone()

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -95,16 +95,27 @@ def generate_guild_id(name: str = "", existing_ids: set[str] | None = None) -> s
             return unique
 
 
-def worker_display_name(worker_id: str, hostname: str | None = None) -> str:
-    """Render a worker id as ``hostname[:3]/worker_id`` (e.g. ``tok/w-g2otus``).
+def format_worker_id(worker_id: str) -> str:
+    """Format a worker ID in droid style: ``w-vd3566`` → ``VD-3566``.
 
-    When *hostname* is absent the bare *worker_id* is returned so callers
-    always have a usable label.  Edge cases: hostnames shorter than 3 chars
-    are used in full.
+    Strips the ``w-`` prefix, splits at the first digit boundary, uppercases
+    both parts, and joins with a hyphen.  Examples: ``w-ab1234`` → ``AB-1234``,
+    ``w-x9`` → ``X-9``, ``w-g2otus`` → ``G-2OTUS``.
     """
-    if hostname:
-        return f"{hostname[:3]}/{worker_id}"
-    return worker_id
+    bare = worker_id.removeprefix("w-")
+    m = re.search(r"\d", bare)
+    if m and m.start() > 0:
+        return f"{bare[: m.start()].upper()}-{bare[m.start() :].upper()}"
+    return bare.upper()
+
+
+def worker_display_name(worker_id: str, hostname: str | None = None) -> str:
+    """Render a worker ID in droid style (e.g. ``VD-3566``).
+
+    The *hostname* parameter is accepted for backwards compatibility but is
+    no longer used — the droid-style format derives entirely from the worker ID.
+    """
+    return format_worker_id(worker_id)
 
 
 def decode_claude_oauth_token(blob: str | None) -> str | None:

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useGuildStore } from './guild'
 import { api } from '../utils/api'
+import { formatWorkerId } from '../utils/format'
 import type { Agent, AgentActivity, AgentState, LogDetail, LogEntry, Worker, WSInbound } from '../types'
 
 const STATE_RANK: Record<string, number> = {
@@ -54,8 +55,8 @@ export const useAgentsStore = defineStore('agents', () => {
         map.set(agent.workerId, {
           id: agent.workerId,
           // Prefer the backend-supplied workerName; older backends that omit it
-          // fall back to the workerId itself as a stable label.
-          name: agent.workerName || agent.workerId,
+          // fall back to the droid-formatted workerId as a stable label.
+          name: agent.workerName || (agent.workerId ? formatWorkerId(agent.workerId) : agent.workerId),
           state: agent.state,
         })
       } else {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,5 +1,15 @@
 // Shared time formatters. Keep these tiny and pure — they show up everywhere.
 
+// "w-vd3566" → "VD-3566": strip prefix, split at first digit, uppercase both parts.
+export function formatWorkerId(workerId: string): string {
+  const bare = workerId.replace(/^w-/, '')
+  const m = bare.search(/\d/)
+  if (m > 0) {
+    return `${bare.slice(0, m).toUpperCase()}-${bare.slice(m).toUpperCase()}`
+  }
+  return bare.toUpperCase()
+}
+
 export function formatClock(iso?: string, withSeconds = false): string {
   if (!iso) return withSeconds ? '00:00:00' : ''
   const d = new Date(iso)

--- a/worker/tests/test_worker_name.py
+++ b/worker/tests/test_worker_name.py
@@ -1,7 +1,8 @@
-"""Tests for worker name: stored from registration response, format hostname[:3]/worker_id."""
+"""Tests for worker name: stored from registration response, droid-style format."""
 
 from __future__ import annotations
 
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -39,7 +40,7 @@ async def test_register_stores_name_from_response():
     mock_response.raise_for_status = MagicMock()
     mock_response.json.return_value = {
         "id": "w-abc123",
-        "name": "tok/w-abc123",
+        "name": "ABC-123",
         "auth_token": "secret-token",
     }
 
@@ -51,7 +52,7 @@ async def test_register_stores_name_from_response():
     with patch.object(w, "_http", return_value=mock_client):
         await w._register()
 
-    assert w._worker_name == "tok/w-abc123"
+    assert w._worker_name == "ABC-123"
     assert w.cfg.worker_id == "w-abc123"
 
 
@@ -81,21 +82,28 @@ async def test_register_name_falls_back_to_worker_id_when_absent():
 
 
 # ---------------------------------------------------------------------------
-# Name format invariants (black-box, driven by the backend formula)
+# Name format invariants (droid-style: leading-letters + '-' + rest, uppercased)
 # ---------------------------------------------------------------------------
 
 
+def _droid_format(worker_id: str) -> str:
+    bare = worker_id.removeprefix("w-")
+    m = re.search(r"\d", bare)
+    if m and m.start() > 0:
+        return f"{bare[: m.start()].upper()}-{bare[m.start() :].upper()}"
+    return bare.upper()
+
+
 @pytest.mark.parametrize(
-    "hostname, worker_id, expected",
+    "worker_id, expected",
     [
-        ("tokenhost", "w-g2otus", "tok/w-g2otus"),
-        ("ab", "w-short0", "ab/w-short0"),
-        ("z", "w-single0", "z/w-single0"),
-        ("xyz", "w-abc123", "xyz/w-abc123"),
-        ("longhost", "w-abc123", "lon/w-abc123"),
+        ("w-vd3566", "VD-3566"),
+        ("w-ab1234", "AB-1234"),
+        ("w-x9", "X-9"),
+        ("w-abc123", "ABC-123"),
+        ("w-g2otus", "G-2OTUS"),
     ],
 )
-def test_name_format(hostname, worker_id, expected):
-    """The name format ``hostname[:3]/worker_id`` holds for various inputs."""
-    prefix = hostname[:3]
-    assert f"{prefix}/{worker_id}" == expected
+def test_name_format(worker_id, expected):
+    """Droid-style: leading letters uppercased, '-', then rest uppercased."""
+    assert _droid_format(worker_id) == expected


### PR DESCRIPTION
## Summary

- Add `format_worker_id(worker_id)` to `backend/utils.py` — strips the `w-` prefix, splits at the first digit boundary, and uppercases both parts (e.g. `w-vd3566` → `VD-3566`, `w-abc123` → `ABC-123`)
- Add matching `formatWorkerId` utility to `frontend/src/utils/format.ts` used as a fallback when the backend doesn't supply a `workerName`
- `worker_display_name` now delegates to `format_worker_id`; the `hostname` parameter is kept for API compatibility but is no longer used
- Update all related tests (`backend/tests/test_worker_name.py`, `worker/tests/test_worker_name.py`) to expect the new droid-style format

## Test plan

- [ ] `python -m pytest backend/tests/test_worker_name.py` passes with new assertions
- [ ] `python -m pytest worker/tests/test_worker_name.py` passes with new assertions
- [ ] Workers registered via the backend display names like `VD-3566` in the UI instead of `tok/w-vd3566`

🤖 Generated with [Claude Code](https://claude.com/claude-code)