### PR TITLE
fix(logs): scope worker-pane logs to task_id IS NULL

### DIFF
--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -174,7 +174,7 @@ async def get_guild_logs(
         if task_id:
             stmt = stmt.where(TaskLog.task_id == task_id)
         elif worker_id:
-            stmt = stmt.where(TaskLog.worker_id == worker_id)
+            stmt = stmt.where(TaskLog.worker_id == worker_id, TaskLog.task_id.is_(None))
         else:
             stmt = stmt.where(TaskLog.agent_id == agent_id)
         stmt = stmt.order_by(TaskLog.id.asc())

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -268,7 +268,7 @@ export const useAgentsStore = defineStore('agents', () => {
       const wid =
         data.workerId ||
         (data.agentId ? agents.value.find((a) => a.id === data.agentId)?.workerId : null)
-      if (wid) addWorkerLog(wid, data.line, data.timestamp, data.detail)
+      if (wid && !data.taskId) addWorkerLog(wid, data.line, data.timestamp, data.detail)
     }
   }
 


### PR DESCRIPTION
## Summary

- **Backend** (`backend/routes/tasks.py`): When `GET /guilds/{guild_id}/logs?worker_id=...` is called, the query now adds `TaskLog.task_id IS NULL` so only worker-level (non-task-scoped) log rows are returned.
- **Frontend** (`frontend/src/stores/agents.ts`): The WebSocket `terminal-output` handler now only calls `addWorkerLog` when `data.taskId` is absent, preventing task-scoped log lines from appearing in the worker pane's live stream.

Task panes were already correct: the dedicated `GET /guilds/{guild_id}/tasks/{task_id}/logs` endpoint filters strictly by `task_id`, and the tasks store's WS handler guards with `&& data.taskId`.

## Test plan
- [ ] Open a worker pane while a task is running — task-scoped log lines should not appear
- [ ] Open a task pane — only lines emitted with that `task_id` should appear; worker-level setup/teardown lines should not bleed in
- [ ] Reload a worker pane (historical fetch) — same filtering applies

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)