### PR TITLE
feat: Vite dev proxy + mobile factory floor layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ GITHUB_CLIENT_SECRET=
 # GITHUB_REDIRECT_URI=http://localhost:8000/auth/github/callback
 # FRONTEND_URL=http://localhost:5173
 
+# Vite dev server proxy: when set, the backend forwards unmatched requests here
+# so GitHub OAuth can redirect to the backend URL while Vite serves the SPA.
+# docker-compose.override.yml sets this to http://frontend:5173 automatically.
+# If running Vite locally (outside Docker) with the backend in a container:
+# VITE_DEV_URL=http://host.docker.internal:5173
+
 # Externally-reachable base URL for GitHub webhook registration.
 # Workers spawned by the backend use this as the webhook callback base, so
 # GitHub can reach them. Set to your public hostname in production.

--- a/backend/main.py
+++ b/backend/main.py
@@ -268,8 +268,36 @@ class _SPAStaticFiles(StaticFiles):
 
 
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
-if _STATIC_DIR.is_dir():
+_VITE_DEV_URL = os.environ.get("VITE_DEV_URL", "").rstrip("/")
+
+if _VITE_DEV_URL:
+    # Dev mode: proxy all unmatched requests to the Vite dev server so GitHub
+    # OAuth can redirect to the backend URL while Vite serves the SPA.
+    # Takes precedence over static/ so it works in the container too.
+    import httpx
+    from starlette.background import BackgroundTask
+    from starlette.responses import StreamingResponse
+
+    _vite_client = httpx.AsyncClient(base_url=_VITE_DEV_URL, follow_redirects=False)
+
+    @app.api_route("/{path:path}", methods=["GET", "HEAD", "OPTIONS"])
+    async def _vite_proxy(request: Request, path: str) -> Response:
+        url = httpx.URL(path=f"/{path}", query=request.url.query.encode("utf-8"))
+        headers = {
+            k: v for k, v in request.headers.items() if k.lower() not in ("host", "connection")
+        }
+        rp_req = _vite_client.build_request(request.method, url, headers=headers)
+        rp_resp = await _vite_client.send(rp_req, stream=True)
+        return StreamingResponse(
+            rp_resp.aiter_raw(),
+            status_code=rp_resp.status_code,
+            headers=dict(rp_resp.headers),
+            background=BackgroundTask(rp_resp.aclose),
+        )
+
+elif _STATIC_DIR.is_dir():
     app.mount("/", _SPAStaticFiles(directory=_STATIC_DIR, html=True), name="spa")
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ python-multipart
 anthropic
 python-dotenv
 docker
+httpx
 pytest
 pytest-asyncio
 ruff

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -9,6 +9,10 @@ services:
     # is served by the Vite dev server on port 5056.
     volumes:
       - ./backend:/app
+    environment:
+      # Proxy unmatched requests to the Vite dev server so GitHub OAuth
+      # (registered to the backend URL) can redirect back and reach the SPA.
+      VITE_DEV_URL: http://frontend:5173
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 
   # To run the worker with verbose logging, either set WORKER_LOG_LEVEL=DEBUG
@@ -21,15 +25,10 @@ services:
     working_dir: /app
     volumes:
       - ./frontend:/app
-      - frontend-node-modules:/app/node_modules
     ports:
       - "5056:5173"
     environment:
       BACKEND_URL: http://backend:8000
-    # npm ci is skipped if node_modules is already populated (volume persists between runs)
-    command: sh -c "[ -d node_modules ] || npm ci && npm run dev -- --host 0.0.0.0"
+    command: sh -c "npm ci && npm run dev -- --host 0.0.0.0"
     depends_on:
       - backend
-
-volumes:
-  frontend-node-modules:

--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="factory-floor">
+  <div class="factory-floor" ref="floorEl">
     <!-- Background grid -->
     <div class="floor-grid"></div>
 
@@ -133,7 +133,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, watch, onMounted, onUnmounted } from 'vue'
+import { computed, reactive, ref, watch, onMounted, onUnmounted } from 'vue'
 import { useAgentsStore } from '../stores/agents'
 import { useTasksStore } from '../stores/tasks'
 import AgentAvatar from './AgentAvatar.vue'
@@ -145,22 +145,36 @@ const agents = computed(() => agentsStore.agents.filter((a) => a.state !== 'offl
 
 const beltItems = ['🔩', '⚙️', '🔧', '🪙', '⭐', '🔨']
 
-// 4-wide × 2-tall grid of work stations. Positions are fixed pixels relative
-// to the floor wrapper — keeps the layout predictable on the steampunk
-// backdrop and matches the README screenshot.
-const stationPositions = [
-  { x: 60, y: 120 },
-  { x: 200, y: 120 },
-  { x: 340, y: 120 },
-  { x: 480, y: 120 },
-  { x: 60, y: 280 },
-  { x: 200, y: 280 },
-  { x: 340, y: 280 },
-  { x: 480, y: 280 },
-]
+const floorEl = ref<HTMLElement | null>(null)
+const containerWidth = ref(640)
+let _ro: ResizeObserver | null = null
 
-const WALK_AREA = { xMin: 30, xMax: 540, yMin: 80, yMax: 330 }
-const MAX_STATIONS = stationPositions.length
+// 4-column on wide screens, 2-column on phones. Computed so agents re-sync on resize.
+const stationPositions = computed(() => {
+  const w = containerWidth.value
+  if (w < 480) {
+    const col1 = 16
+    const col2 = w - 136  // 16px margin + 120px station width
+    return [
+      { x: col1, y: 170 }, { x: col2, y: 170 },
+      { x: col1, y: 350 }, { x: col2, y: 350 },
+      { x: col1, y: 530 }, { x: col2, y: 530 },
+    ]
+  }
+  return [
+    { x: 60, y: 100 }, { x: 220, y: 100 }, { x: 380, y: 100 },
+    { x: 60, y: 340 }, { x: 220, y: 340 }, { x: 380, y: 340 },
+  ]
+})
+
+const WALK_AREA = computed(() => {
+  const w = containerWidth.value
+  return w < 480
+    ? { xMin: 16, xMax: w - 36, yMin: 170, yMax: 610 }
+    : { xMin: 30, xMax: 480, yMin: 80, yMax: 330 }
+})
+
+const MAX_STATIONS = 6
 
 interface Station {
   x: number
@@ -180,7 +194,7 @@ const activeTasks = computed<Task[]>(() =>
 )
 
 const visibleStations = computed<Station[]>(() =>
-  stationPositions.map((pos, i) => ({ ...pos, task: activeTasks.value[i] || null })),
+  stationPositions.value.map((pos, i) => ({ ...pos, task: activeTasks.value[i] || null })),
 )
 
 // Per-agent position + walking-flag. Walking is set briefly when the agent
@@ -199,9 +213,10 @@ function isWalking(agentId: string) {
 }
 
 function randomPos() {
+  const { xMin, xMax, yMin, yMax } = WALK_AREA.value
   return {
-    x: WALK_AREA.xMin + Math.random() * (WALK_AREA.xMax - WALK_AREA.xMin),
-    y: WALK_AREA.yMin + Math.random() * (WALK_AREA.yMax - WALK_AREA.yMin),
+    x: xMin + Math.random() * (xMax - xMin),
+    y: yMin + Math.random() * (yMax - yMin),
   }
 }
 
@@ -252,6 +267,13 @@ function tickWalk() {
 }
 
 onMounted(() => {
+  if (floorEl.value) {
+    containerWidth.value = floorEl.value.clientWidth
+    _ro = new ResizeObserver(([entry]) => {
+      containerWidth.value = entry.contentRect.width
+    })
+    _ro.observe(floorEl.value)
+  }
   syncPositions()
   walkTimer = setInterval(tickWalk, 2000)
 })
@@ -259,10 +281,12 @@ onMounted(() => {
 onUnmounted(() => {
   if (walkTimer) clearInterval(walkTimer)
   Object.values(walkTimers).forEach(clearTimeout)
+  _ro?.disconnect()
 })
 
 watch(agents, syncPositions, { deep: true })
 watch(visibleStations, syncPositions)
+watch(containerWidth, syncPositions)
 
 const tickerMessages = computed(() => {
   const msgs: string[] = []
@@ -945,6 +969,41 @@ function stateLabel(state: string) {
   }
   to {
     transform: translateX(-100%);
+  }
+}
+
+@media (max-width: 479px) {
+  .g4,
+  .g5 {
+    display: none;
+  }
+  .conveyor-belt {
+    display: none;
+  }
+  .factory-info {
+    padding: 3px 8px;
+    gap: 8px;
+  }
+  .factory-title {
+    font-size: 5px;
+    letter-spacing: 1px;
+  }
+  .work-station {
+    width: 120px;
+  }
+  .station-monitor {
+    width: 76px;
+    height: 60px;
+  }
+  .station-table {
+    height: 18px;
+  }
+  .station-label {
+    font-size: 6px;
+    max-width: 120px;
+  }
+  .task-badge {
+    font-size: 6px;
   }
 }
 </style>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     },
   },
   server: {
-    allowedHosts: ['localhost', 'pioneer-square.melloy.life'],
+    allowedHosts: ['localhost', 'frontend', 'pioneer-square.melloy.life'],
     // Forward backend routes when running `npm run dev` so the SPA can
     // call /auth, /guilds, /ws against the dev server. In production
     // these are handled by nginx-in-container (see frontend/nginx.conf).


### PR DESCRIPTION
## Summary

- **Backend dev proxy**: When `VITE_DEV_URL` is set, the backend forwards all unmatched requests to the Vite dev server. This lets GitHub OAuth (registered to the backend URL, e.g. `localhost:8056`) redirect back and reach the SPA without needing a static build. Takes precedence over `static/` so it works in the container too. `docker-compose.override.yml.example` wires this up automatically via `http://frontend:5173`.
- **docker-compose.override.yml fixes**: Always run `npm ci` on frontend startup; remove the `node_modules` named volume that caused a boot loop (stale volume → vite binary missing → restart loop).
- **Mobile factory floor**: Station positions are now computed from container width via `ResizeObserver`. Below 480px, switches to a 2-column layout so stations don't clip off-screen. Stations are larger on mobile, shifted down to clear the furnace, and decorative elements hardcoded off-screen (g4/g5 gears, conveyor belt) are hidden. Desktop reduced from 8 → 6 stations (3×2) with more vertical row spacing for the robots.

## Test plan

- [ ] `docker compose up` starts backend + frontend; GitHub OAuth login redirects correctly to `localhost:8056` and lands on the SPA
- [ ] Removing `VITE_DEV_URL` falls back to serving `static/` as before
- [ ] Factory floor looks correct at desktop width (6 stations, 3×2)
- [ ] Factory floor looks correct in mobile emulation (2-column, stations clear the furnace)
- [ ] Frontend container starts cleanly on first boot (no vite-not-found loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)