### PR TITLE
fix(ui): foreman comms max-height and collapse behavior

### DIFF
--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -8,7 +8,7 @@
           {{ foreman.state }}
         </span>
         <span v-if="pollLabel" class="poll-indicator">⏱ {{ pollLabel }}</span>
-        <span class="minimize-btn">{{ minimized ? '▲' : '▼' }}</span>
+        <span class="minimize-btn">{{ minimized ? '▶' : '◀' }}</span>
       </div>
     </div>
 
@@ -169,6 +169,18 @@ onUnmounted(() => {
   flex-direction: column;
   overflow: hidden;
   border-left: 2px solid var(--color-brass-dark);
+  transition: width 0.2s ease, min-width 0.2s ease;
+}
+
+.chat-pane.minimized {
+  width: 44px;
+  min-width: 44px;
+}
+
+.chat-pane.minimized .chat-title,
+.chat-pane.minimized .agent-status,
+.chat-pane.minimized .poll-indicator {
+  display: none;
 }
 
 .chat-header {

--- a/frontend/src/components/chat-pane/ChatTab.vue
+++ b/frontend/src/components/chat-pane/ChatTab.vue
@@ -193,8 +193,7 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-height: 180px;
-  max-height: 340px;
+  min-height: 0;
 }
 
 .chat-empty {
@@ -482,11 +481,4 @@ watch(
   font-size: 10px;
 }
 
-@media (max-width: 1024px) {
-  .chat-messages {
-    min-height: 0;
-    max-height: none;
-    flex: 1;
-  }
-}
 </style>


### PR DESCRIPTION
## Summary
- Removes hardcoded `max-height: 340px` (and `min-height: 180px`) from `.chat-messages` so the message area fills available vertical space on desktop instead of capping at 340px
- Replaces the up/down `▼`/`▲` toggle with `◀`/`▶` arrows that collapse the pane to 44px via a CSS width transition, actually reclaiming space for the factory floor view
- Cleans up the now-redundant mobile media query that was undoing the max-height

## Test plan
- [ ] On desktop: open Foreman Comms — messages should fill the full panel height without a 340px cap
- [ ] Click `◀` — pane collapses to a narrow strip, factory floor gains width
- [ ] Click `▶` — pane re-expands smoothly with transition
- [ ] On mobile: chat pane still fills the full screen tab view correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)