### PR TITLE
fix(worker): sweep worktrees before announcing idle to prevent startup hang

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -898,13 +898,16 @@ class Worker:
             len(self.slots),
         )
         await self._emit("[worker] Online. Watching for tasks.")
-        for slot in self.slots:
-            await self._set_state("idle", slot)
 
         # Reclaim any worktrees the previous incarnation of this worker left
         # behind. Tasks within the TTL window are re-registered so a follow-up
         # arriving for them can reuse the existing checkout.
+        # Run BEFORE announcing idle so the foreman doesn't dispatch tasks
+        # while git-prune / worktree-remove operations are still in flight.
         await self._initial_worktree_sweep()
+
+        for slot in self.slots:
+            await self._set_state("idle", slot)
 
         initial = await self._fetch_pending_tasks()
         logger.info("Initial pending-task fetch: %d task(s)", len(initial))
@@ -1318,10 +1321,12 @@ class Worker:
                         except Exception as exc:
                             logger.debug("startup-sweep remove_worktree failed: %s", exc)
                 # Whatever git left behind, drop the directory.
+                # Use asyncio.to_thread so rmtree (which walks the whole
+                # checkout) doesn't block the event loop for large repos.
                 import shutil
 
                 try:
-                    shutil.rmtree(full, ignore_errors=True)
+                    await asyncio.to_thread(shutil.rmtree, full, True)
                 except Exception as exc:
                     logger.debug("startup-sweep rmtree failed for %s: %s", full, exc)
             # Prune dangling worktree references in each repo.


### PR DESCRIPTION
## Diagnosis

The worktree sweeper introduced in cec9df9 ran **after** the worker broadcast its `idle` state, creating a window where:

1. Worker joins guild and sets all slots to `idle` → foreman sees an available worker
2. `_initial_worktree_sweep()` runs — calls `git worktree remove --force` and `git worktree prune` across every known repo
3. Agent loop tasks are created and start processing

During step 2, if the foreman dispatches a task, the listener queues it but the agent loops haven't started yet. The task sits in the queue unprocessed; the worker appears hung.

With lazy-cloning landed in 718d679, repos are no longer pre-cloned at startup. On a worker restart with previous worktrees still on disk, the sweep has more work to do (prune stale entries, `shutil.rmtree` whole checkouts) while the worker is already broadcasting idle — making the hang window larger and more consistently observable.

## Changes

- **Move `_initial_worktree_sweep()` before `_set_state("idle", ...)`**: the foreman cannot dispatch tasks until the worker actually announces idle, so the sweep completes before any task can be assigned.
- **Wrap `shutil.rmtree` in `asyncio.to_thread`**: removing a worktree checkout (potentially thousands of files) is a synchronous operation. Running it in a thread pool avoids blocking the event loop during startup.

## Test plan

- [ ] 163 existing worker tests pass (`python -m pytest`)
- [ ] `ruff check . --fix && ruff format .` — no changes
- [ ] Manual: start a worker that has stale worktrees on disk; verify it completes the sweep before showing idle in the UI, and that tasks assigned immediately after startup are processed without delay