### PR TITLE
fix(worker): prevent worktree sweeper from blocking worker startup

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -908,7 +908,7 @@ class Worker:
         # prune/remove hang indefinitely, blocking the entire startup sequence.
         try:
             await asyncio.wait_for(self._initial_worktree_sweep(), timeout=30.0)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             logger.warning("Worktree startup sweep timed out after 30s — skipping")
 
         initial = await self._fetch_pending_tasks()

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -904,7 +904,12 @@ class Worker:
         # Reclaim any worktrees the previous incarnation of this worker left
         # behind. Tasks within the TTL window are re-registered so a follow-up
         # arriving for them can reuse the existing checkout.
-        await self._initial_worktree_sweep()
+        # Guard with a timeout: a git lock left by a crashed process can make
+        # prune/remove hang indefinitely, blocking the entire startup sequence.
+        try:
+            await asyncio.wait_for(self._initial_worktree_sweep(), timeout=30.0)
+        except TimeoutError:
+            logger.warning("Worktree startup sweep timed out after 30s — skipping")
 
         initial = await self._fetch_pending_tasks()
         logger.info("Initial pending-task fetch: %d task(s)", len(initial))

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -908,7 +908,7 @@ class Worker:
         # prune/remove hang indefinitely, blocking the entire startup sequence.
         try:
             await asyncio.wait_for(self._initial_worktree_sweep(), timeout=30.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning("Worktree startup sweep timed out after 30s — skipping")
 
         initial = await self._fetch_pending_tasks()


### PR DESCRIPTION
## Root cause

`_initial_worktree_sweep()` runs **synchronously at startup** (awaited directly before background tasks start). It calls `git worktree prune` and `git worktree remove` via `run_git()`, which uses `asyncio.create_subprocess_exec` + `proc.communicate()` with **no timeout**.

When a worker process crashes mid-task, git can leave a lock file (`.git/worktrees/<name>.lock`). Any subsequent `git worktree prune` on that repo will block indefinitely waiting to acquire the lock — and since the sweep runs synchronously before the WebSocket listener, heartbeat, or task runners start, the entire worker hangs silently on startup.

## Fix

Wrap the `_initial_worktree_sweep()` call with `asyncio.wait_for(timeout=30.0)`. If the sweep takes longer than 30 seconds (indicating a stale git lock), it is cancelled and a warning is logged. The worker comes online normally; the periodic `_worktree_sweeper` task will retry cleanup later.

```python
try:
    await asyncio.wait_for(self._initial_worktree_sweep(), timeout=30.0)
except TimeoutError:
    logger.warning("Worktree startup sweep timed out after 30s — skipping")
```

**Change size:** 6 lines added, 1 removed. No logic changes to the sweep itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)