### PR TITLE
Review agent: resolve/supersede previous reviews on re-run

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -601,6 +601,23 @@ def _gh_api_diff(path: str, token: str) -> str:
         return resp.read().decode("utf-8", errors="replace")
 
 
+def _gh_graphql(token: str, query: str, variables: dict) -> dict:
+    """Execute a GitHub GraphQL query/mutation and return the parsed response."""
+    payload = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(
+        "https://api.github.com/graphql",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github.v3+json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
 def _parse_review_from_claude(text: str) -> dict:
     """Extract a review JSON object from Claude's response.
 
@@ -798,6 +815,133 @@ def _extract_review_data(a2a_result: dict) -> tuple[str, str]:
     github_event = _VERDICT_TO_GH_EVENT.get(str(verdict).lower(), "COMMENT")
     review_body = review_body or f"Automated code review completed (verdict: {verdict})."
     return github_event, review_body
+
+
+_GQL_PR_THREADS = """
+query GetPRThreads($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 10) {
+            nodes {
+              databaseId
+              pullRequestReview { databaseId }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_GQL_RESOLVE_THREAD = """
+mutation ResolveThread($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}
+"""
+
+
+async def _supersede_prior_bot_reviews(
+    pr_repo: str, pr_number: int, bot_username: str, token: str
+) -> int:
+    """Resolve prior inline threads and mark previous bot reviews as superseded.
+
+    Before a new review is posted this function:
+    1. Fetches all existing reviews and filters to those authored by ``bot_username``.
+    2. Resolves any unresolved inline threads that belong to those reviews via
+       the GitHub GraphQL ``resolveReviewThread`` mutation.
+    3. PUTs each prior review body to prepend a "Superseded" strike-through line.
+
+    Returns the count of reviews superseded. Errors in individual steps are
+    logged as warnings rather than raised so that the main review post is never
+    blocked by a cleanup failure.
+    """
+    reviews = await asyncio.to_thread(_gh_api, f"/repos/{pr_repo}/pulls/{pr_number}/reviews", token)
+    if not isinstance(reviews, list):
+        return 0
+
+    bot_reviews = [r for r in reviews if (r.get("user") or {}).get("login") == bot_username]
+    if not bot_reviews:
+        return 0
+
+    bot_review_ids = {r["id"] for r in bot_reviews}
+
+    # Resolve unresolved inline threads that belong to our prior reviews.
+    owner, repo_name = pr_repo.split("/", 1)
+    try:
+        gql_result = await asyncio.to_thread(
+            _gh_graphql,
+            token,
+            _GQL_PR_THREADS,
+            {"owner": owner, "repo": repo_name, "number": pr_number},
+        )
+        threads = (
+            gql_result.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+            .get("nodes", [])
+        )
+        for thread in threads:
+            if thread.get("isResolved"):
+                continue
+            comments = thread.get("comments", {}).get("nodes", [])
+            if any(
+                (c.get("pullRequestReview") or {}).get("databaseId") in bot_review_ids
+                for c in comments
+            ):
+                try:
+                    await asyncio.to_thread(
+                        _gh_graphql,
+                        token,
+                        _GQL_RESOLVE_THREAD,
+                        {"threadId": thread["id"]},
+                    )
+                    logger.info(
+                        "review_pr: resolved thread %s on %s#%d",
+                        thread["id"],
+                        pr_repo,
+                        pr_number,
+                    )
+                except Exception as exc:
+                    logger.warning("review_pr: failed to resolve thread %s: %s", thread["id"], exc)
+    except Exception as exc:
+        logger.warning(
+            "review_pr: GraphQL thread resolution failed for %s#%d: %s",
+            pr_repo,
+            pr_number,
+            exc,
+        )
+
+    # Mark old reviews as superseded.
+    today_iso = datetime.now(UTC).date().isoformat()
+    supersede_prefix = f"~~Superseded by review posted {today_iso}~~\n\n"
+    superseded = 0
+    for review in bot_reviews:
+        review_id = review["id"]
+        old_body = review.get("body") or ""
+        if old_body.startswith("~~Superseded"):
+            continue
+        new_body = supersede_prefix + old_body
+        try:
+            await asyncio.to_thread(
+                _gh_api_post,
+                f"/repos/{pr_repo}/pulls/{pr_number}/reviews/{review_id}",
+                token,
+                {"body": new_body},
+                "PUT",
+            )
+            superseded += 1
+        except Exception as exc:
+            logger.warning("review_pr: failed to supersede review %d: %s", review_id, exc)
+
+    return superseded
 
 
 # ---------------------------------------------------------------------------
@@ -1607,6 +1751,25 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 github_event,
                                 review_body,
                             )
+                            try:
+                                superseded = await _supersede_prior_bot_reviews(
+                                    pr_repo, pr_number, username, token
+                                )
+                                if superseded:
+                                    logger.info(
+                                        "guild=%s review_pr: superseded %d prior review(s)"
+                                        " on %s#%d",
+                                        guild_id,
+                                        superseded,
+                                        pr_repo,
+                                        pr_number,
+                                    )
+                            except Exception as _sup_exc:
+                                logger.warning(
+                                    "guild=%s review_pr: supersede step failed (non-fatal): %s",
+                                    guild_id,
+                                    _sup_exc,
+                                )
                             review_data = await asyncio.to_thread(
                                 _gh_api_post,
                                 f"/repos/{pr_repo}/pulls/{pr_number}/reviews",
@@ -1716,6 +1879,26 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 if c.get("path") and c.get("line") and c.get("body")
                             ]
 
+                            try:
+                                superseded = await _supersede_prior_bot_reviews(
+                                    pr_repo, pr_number, username, token
+                                )
+                                if superseded:
+                                    logger.info(
+                                        "guild=%s review_pr_internal: superseded %d prior"
+                                        " review(s) on %s#%d",
+                                        guild_id,
+                                        superseded,
+                                        pr_repo,
+                                        pr_number,
+                                    )
+                            except Exception as _sup_exc:
+                                logger.warning(
+                                    "guild=%s review_pr_internal: supersede step failed"
+                                    " (non-fatal): %s",
+                                    guild_id,
+                                    _sup_exc,
+                                )
                             try:
                                 review_data = await asyncio.to_thread(
                                     _gh_api_post,

--- a/backend/tests/test_review_pr_tool.py
+++ b/backend/tests/test_review_pr_tool.py
@@ -314,3 +314,222 @@ class TestReviewPrErrors:
 
         assert results[0]["tool_use_id"] == "my-tool-id"
         assert results[0]["type"] == "tool_result"
+
+
+# ---------------------------------------------------------------------------
+# _supersede_prior_bot_reviews unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_review(review_id: int, login: str, body: str = "Old review.") -> dict:
+    return {"id": review_id, "user": {"login": login}, "body": body}
+
+
+def _make_gql_threads(threads: list[dict]) -> dict:
+    """Build a minimal GraphQL response for GetPRThreads."""
+    return {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": threads}}}}}
+
+
+def _make_thread(thread_id: str, review_db_id: int, is_resolved: bool = False) -> dict:
+    return {
+        "id": thread_id,
+        "isResolved": is_resolved,
+        "comments": {
+            "nodes": [{"databaseId": 1, "pullRequestReview": {"databaseId": review_db_id}}]
+        },
+    }
+
+
+class TestSupersedePriorBotReviews:
+    @pytest.mark.asyncio
+    async def test_no_prior_reviews_is_noop(self):
+        """When there are no prior reviews, nothing is called."""
+        from foreman.tools import _supersede_prior_bot_reviews
+
+        with patch("foreman.tools._gh_api", return_value=[]):
+            result = await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_no_bot_reviews_is_noop(self):
+        """When no reviews belong to the bot user, nothing is superseded."""
+        from foreman.tools import _supersede_prior_bot_reviews
+
+        reviews = [_make_review(1, "other-user")]
+        with patch("foreman.tools._gh_api", return_value=reviews):
+            result = await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_already_superseded_review_is_skipped(self):
+        """Reviews whose body already starts with ~~Superseded are not patched again."""
+        from foreman.tools import _supersede_prior_bot_reviews
+
+        reviews = [_make_review(5, "bot", "~~Superseded by review posted 2026-01-01~~\n\nOld.")]
+        gh_api_calls = []
+
+        with (
+            patch("foreman.tools._gh_api", return_value=reviews),
+            patch("foreman.tools._gh_graphql", return_value=_make_gql_threads([])),
+            patch(
+                "foreman.tools._gh_api_post",
+                side_effect=lambda *a, **kw: gh_api_calls.append(a) or {},
+            ),
+        ):
+            result = await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
+
+        assert result == 0
+        assert gh_api_calls == []
+
+    @pytest.mark.asyncio
+    async def test_supersedes_prior_review_body(self):
+        """A prior bot review body is prepended with the superseded notice."""
+        from foreman.tools import _supersede_prior_bot_reviews
+
+        reviews = [_make_review(7, "bot", "Good review.")]
+        put_calls = []
+
+        def capture_post(path, token, payload, method="POST"):
+            put_calls.append({"path": path, "payload": payload, "method": method})
+            return {}
+
+        with (
+            patch("foreman.tools._gh_api", return_value=reviews),
+            patch("foreman.tools._gh_graphql", return_value=_make_gql_threads([])),
+            patch("foreman.tools._gh_api_post", side_effect=capture_post),
+        ):
+            result = await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
+
+        assert result == 1
+        assert len(put_calls) == 1
+        assert put_calls[0]["method"] == "PUT"
+        assert "org/repo/pulls/42/reviews/7" in put_calls[0]["path"]
+        assert put_calls[0]["payload"]["body"].startswith("~~Superseded by review posted ")
+        assert "Good review." in put_calls[0]["payload"]["body"]
+
+    @pytest.mark.asyncio
+    async def test_resolves_unresolved_inline_threads(self):
+        """Unresolved threads from a prior bot review are resolved via GraphQL."""
+        from foreman.tools import _supersede_prior_bot_reviews
+
+        reviews = [_make_review(10, "bot")]
+        thread = _make_thread("TID_xyz", review_db_id=10, is_resolved=False)
+        gql_responses = [_make_gql_threads([thread]), {}]
+        gql_iter = iter(gql_responses)
+        graphql_calls = []
+
+        def fake_graphql(token, query, variables):
+            graphql_calls.append({"query": query, "variables": variables})
+            return next(gql_iter)
+
+        with (
+            patch("foreman.tools._gh_api", return_value=reviews),
+            patch("foreman.tools._gh_graphql", side_effect=fake_graphql),
+            patch("foreman.tools._gh_api_post", return_value={}),
+        ):
+            await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
+
+        resolve_calls = [c for c in graphql_calls if "resolveReviewThread" in c["query"]]
+        assert len(resolve_calls) == 1
+        assert resolve_calls[0]["variables"]["threadId"] == "TID_xyz"
+
+    @pytest.mark.asyncio
+    async def test_already_resolved_threads_are_skipped(self):
+        """Threads already marked isResolved are not re-resolved."""
+        from foreman.tools import _supersede_prior_bot_reviews
+
+        reviews = [_make_review(11, "bot")]
+        thread = _make_thread("TID_done", review_db_id=11, is_resolved=True)
+        graphql_calls = []
+
+        def fake_graphql(token, query, variables):
+            graphql_calls.append({"query": query, "variables": variables})
+            return _make_gql_threads([thread]) if "GetPRThreads" in query else {}
+
+        with (
+            patch("foreman.tools._gh_api", return_value=reviews),
+            patch("foreman.tools._gh_graphql", side_effect=fake_graphql),
+            patch("foreman.tools._gh_api_post", return_value={}),
+        ):
+            await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
+
+        resolve_calls = [c for c in graphql_calls if "resolveReviewThread" in c["query"]]
+        assert len(resolve_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_graphql_failure_does_not_block_supersede(self):
+        """If GraphQL fails, the review body is still superseded (failure is non-fatal)."""
+        from foreman.tools import _supersede_prior_bot_reviews
+
+        reviews = [_make_review(12, "bot", "Some review.")]
+
+        with (
+            patch("foreman.tools._gh_api", return_value=reviews),
+            patch("foreman.tools._gh_graphql", side_effect=RuntimeError("graphql down")),
+            patch("foreman.tools._gh_api_post", return_value={}) as mock_put,
+        ):
+            result = await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
+
+        assert result == 1
+        mock_put.assert_called_once()
+
+
+class TestReviewPrSupersedePriorReviews:
+    """Integration tests: review_pr tool calls _supersede_prior_bot_reviews."""
+
+    @pytest.mark.asyncio
+    async def test_supersede_called_before_posting_new_review(self, db_session):
+        """_supersede_prior_bot_reviews is invoked before the new review is posted."""
+        insert_guild(db_session, "g-rev-sup1")
+
+        mock_client = MagicMock()
+        mock_client.review_pr = AsyncMock(return_value=_mock_a2a_result())
+        supersede_calls = []
+
+        async def fake_supersede(pr_repo, pr_number, bot_username, token):
+            supersede_calls.append((pr_repo, pr_number, bot_username))
+            return 1
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "bot-user")),
+            patch("foreman.a2a_client.A2AClient", return_value=mock_client),
+            patch("foreman.tools._supersede_prior_bot_reviews", side_effect=fake_supersede),
+            patch("foreman.tools._gh_api_post", return_value={"id": 55}),
+        ):
+            results = await exec_tools(
+                "g-rev-sup1",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/20"})],
+            )
+
+        assert results[0].get("is_error") is not True
+        assert len(supersede_calls) == 1
+        assert supersede_calls[0] == ("org/repo", 20, "bot-user")
+
+    @pytest.mark.asyncio
+    async def test_supersede_failure_does_not_block_review_post(self, db_session):
+        """Even if supersede raises, the new review is still posted (non-fatal)."""
+        insert_guild(db_session, "g-rev-sup2")
+
+        mock_client = MagicMock()
+        mock_client.review_pr = AsyncMock(return_value=_mock_a2a_result())
+
+        async def failing_supersede(*args):
+            raise RuntimeError("supersede blew up")
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "bot-user")),
+            patch("foreman.a2a_client.A2AClient", return_value=mock_client),
+            patch("foreman.tools._supersede_prior_bot_reviews", side_effect=failing_supersede),
+            patch("foreman.tools._gh_api_post", return_value={"id": 77}),
+        ):
+            results = await exec_tools(
+                "g-rev-sup2",
+                [_fake_tu("review_pr", {"pr_url": "https://github.com/org/repo/pull/21"})],
+            )
+
+        # Supersede failure is caught and logged; review post proceeds normally.
+        assert results[0].get("is_error") is not True
+        parsed = json.loads(results[0]["content"])
+        assert parsed["review_id"] == 77


### PR DESCRIPTION
## Summary

When the code-review-agent runs a second (or subsequent) time on the same PR, it now cleans up the previous run's artifacts before posting the new review:

- **Resolves prior inline threads**: fetches all review threads on the PR via GitHub GraphQL and calls `resolveReviewThread` on any unresolved thread that belongs to a prior bot review.
- **Supersedes prior review bodies**: PATCHes each prior bot review to prepend `~~Superseded by review posted <date>~~` so the timeline makes it clear which review is current.
- **Posts the new review** as normal.

The logic is **idempotent**: if there are no prior bot reviews, nothing changes. Already-superseded reviews are skipped. All cleanup steps are individually non-fatal — failures are logged as warnings so the main review post is never blocked.

### New functions added to `backend/foreman/tools.py`

| Function | Purpose |
|---|---|
| `_gh_graphql(token, query, variables)` | Generic GitHub GraphQL helper |
| `_supersede_prior_bot_reviews(pr_repo, pr_number, bot_username, token)` | Orchestrates resolve + supersede |

Both `review_pr` (A2A path) and `review_pr_internal` call `_supersede_prior_bot_reviews` before posting.

## Test plan

- [x] `python3 -m pytest tests/test_review_pr_tool.py -v` — all 19 tests pass (9 new tests added for the supersede logic)
- [x] `ruff check . --fix && ruff format .` — no lint errors
- [ ] Manual: re-run the review agent on a PR with a prior review and verify threads are resolved and old review shows "Superseded" prefix

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)