### PR TITLE
Enable OIDC for A2A receiver

### DIFF
--- a/backend/auth_deps.py
+++ b/backend/auth_deps.py
@@ -119,10 +119,24 @@ async def authorize_worker_or_member(guild_id: str, token: str | None) -> str:
             select(UserSession.github_user_id).where(UserSession.token == token)
         )
         github_user_id = user_res.scalar_one_or_none()
-        if not github_user_id:
-            raise HTTPException(status_code=401, detail="Invalid credentials")
-        await ensure_membership(db, guild_id, github_user_id)
-        return f"user:{github_user_id}"
+        if github_user_id:
+            await ensure_membership(db, guild_id, github_user_id)
+            return f"user:{github_user_id}"
+
+        # OIDC token fallback — only when the A2A receiver is enabled.
+        # Imported lazily to avoid a circular import (foreman/__init__ → runner → auth_deps).
+        from foreman.oidc import OIDCConfig, is_a2a_receiver_enabled, validate_oidc_token
+
+        if is_a2a_receiver_enabled():
+            try:
+                config = OIDCConfig.from_env()
+                payload = validate_oidc_token(token, config)
+                sub = payload.get("sub") or "oidc-agent"
+                return f"oidc:{sub}"
+            except ValueError:
+                pass
+
+        raise HTTPException(status_code=401, detail="Invalid credentials")
     finally:
         await db.close()
 

--- a/backend/foreman/oidc.py
+++ b/backend/foreman/oidc.py
@@ -1,0 +1,180 @@
+"""OIDC (OpenID Connect) authentication support for the A2A receiver.
+
+When the A2A receiver is enabled (``A2A_RECEIVER_ENABLED=true``), worker
+agents may authenticate using OIDC JWT tokens instead of the opaque bearer
+tokens issued at registration.  The backend validates the token against the
+issuer's JWKS endpoint and checks standard claims (iss, aud, exp).
+
+Environment variables
+---------------------
+A2A_RECEIVER_ENABLED
+    Set to ``true`` / ``1`` / ``yes`` to enable the A2A receiver and OIDC
+    authentication.  When unset or falsy, OIDC tokens are rejected and the
+    AgentCard advertises no OIDC security scheme.
+
+OIDC_ISSUER
+    The expected OIDC issuer URL (e.g. ``https://accounts.example.com``).
+    The JWKS is fetched from ``{OIDC_ISSUER}/.well-known/jwks.json``.
+    If unset, any issuer in the token is accepted and its JWKS is used
+    for signature verification (useful for guild-issued self-signed tokens).
+
+OIDC_AUDIENCE
+    Expected ``aud`` claim value.  Defaults to ``"pioneer-square"``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+import urllib.request
+from dataclasses import dataclass
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+
+def is_a2a_receiver_enabled() -> bool:
+    """Return True when the A2A receiver is configured via environment."""
+    return os.environ.get("A2A_RECEIVER_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+@dataclass
+class OIDCConfig:
+    """OIDC validation configuration derived from environment variables."""
+
+    issuer: str | None
+    audience: str
+
+    @classmethod
+    def from_env(cls) -> OIDCConfig:
+        return cls(
+            issuer=os.environ.get("OIDC_ISSUER") or None,
+            audience=os.environ.get("OIDC_AUDIENCE", "pioneer-square"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# JWT utilities (no external JWT library — uses only stdlib + cryptography)
+# ---------------------------------------------------------------------------
+
+
+def _b64url_decode(s: str) -> bytes:
+    padding = 4 - len(s) % 4
+    if padding != 4:
+        s += "=" * padding
+    return base64.urlsafe_b64decode(s)
+
+
+def _decode_jwt_parts(token: str) -> tuple[dict, dict, bytes, bytes]:
+    """Split *token* into (header, payload, signing_input_bytes, signature_bytes).
+
+    Does NOT verify the signature — call :func:`validate_oidc_token` for that.
+    Raises :class:`ValueError` on malformed tokens.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Not a valid JWT (expected 3 dot-separated parts)")
+    try:
+        header = json.loads(_b64url_decode(parts[0]))
+        payload = json.loads(_b64url_decode(parts[1]))
+    except Exception as exc:
+        raise ValueError(f"Could not decode JWT header/payload: {exc}") from exc
+    signing_input = f"{parts[0]}.{parts[1]}".encode()
+    try:
+        signature = _b64url_decode(parts[2])
+    except Exception as exc:
+        raise ValueError(f"Could not decode JWT signature: {exc}") from exc
+    return header, payload, signing_input, signature
+
+
+def _fetch_jwks(jwks_url: str) -> list[dict]:
+    """Fetch a JWKS document from *jwks_url* (synchronous HTTP GET)."""
+    req = urllib.request.Request(jwks_url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        data = json.loads(resp.read())
+    return data.get("keys", [])
+
+
+def _find_jwk(keys: list[dict], kid: str | None) -> dict | None:
+    """Return the JWK matching *kid*, or the first key when *kid* is None."""
+    if kid:
+        for key in keys:
+            if key.get("kid") == kid:
+                return key
+    return keys[0] if keys else None
+
+
+def _verify_ed25519(jwk: dict, signing_input: bytes, signature: bytes) -> None:
+    """Verify an EdDSA/Ed25519 signature against a JWK.  Raises on failure."""
+    try:
+        x_bytes = _b64url_decode(jwk["x"])
+    except Exception as exc:
+        raise ValueError(f"Invalid JWK 'x' field: {exc}") from exc
+    pub = Ed25519PublicKey.from_public_bytes(x_bytes)
+    try:
+        pub.verify(signature, signing_input)
+    except InvalidSignature as exc:
+        raise ValueError("Token signature is invalid") from exc
+
+
+# ---------------------------------------------------------------------------
+# Public validation entry point
+# ---------------------------------------------------------------------------
+
+
+def validate_oidc_token(token: str, config: OIDCConfig) -> dict:
+    """Validate an OIDC JWT and return the verified payload claims.
+
+    Checks performed:
+    - JWT is structurally valid (3 parts, valid base64url/JSON).
+    - ``exp`` claim has not passed (when present).
+    - ``iss`` matches ``config.issuer`` when that is set.
+    - Signature verified against the issuer's JWKS (Ed25519 / EdDSA only).
+    - ``aud`` contains ``config.audience`` (when present in token).
+
+    Raises :class:`ValueError` with a human-readable message on any failure.
+    Returns the payload dict on success.
+    """
+    header, payload, signing_input, signature = _decode_jwt_parts(token)
+
+    # Expiry check
+    exp = payload.get("exp")
+    if exp is not None and int(time.time()) > int(exp):
+        raise ValueError("OIDC token has expired")
+
+    # Issuer check
+    iss = payload.get("iss")
+    if not iss:
+        raise ValueError("OIDC token is missing the 'iss' claim")
+    if config.issuer and iss != config.issuer:
+        raise ValueError(f"Unexpected issuer {iss!r} (expected {config.issuer!r})")
+
+    # Fetch JWKS and verify signature
+    jwks_url = f"{iss.rstrip('/')}/.well-known/jwks.json"
+    try:
+        keys = _fetch_jwks(jwks_url)
+    except Exception as exc:
+        raise ValueError(f"Could not fetch JWKS from {jwks_url}: {exc}") from exc
+
+    kid = header.get("kid")
+    jwk = _find_jwk(keys, kid)
+    if not jwk:
+        raise ValueError(f"No suitable key found in JWKS (kid={kid!r})")
+
+    alg = header.get("alg", "")
+    if alg in ("EdDSA", "Ed25519"):
+        _verify_ed25519(jwk, signing_input, signature)
+    else:
+        raise ValueError(f"Unsupported signing algorithm {alg!r} — only EdDSA/Ed25519 is supported")
+
+    # Audience check
+    aud = payload.get("aud")
+    if aud is not None:
+        if isinstance(aud, str):
+            aud = [aud]
+        if config.audience not in aud:
+            raise ValueError(f"Audience {config.audience!r} not found in token aud {aud!r}")
+
+    return payload

--- a/backend/routes/wellknown.py
+++ b/backend/routes/wellknown.py
@@ -214,6 +214,10 @@ class AgentCard(_CamelModel):
     skills: list[AgentSkill]
     provider: AgentProvider | None = None
     documentation_url: str | None = None
+    # Security schemes advertised when the A2A receiver + OIDC are enabled.
+    # Excluded from serialisation when None (exclude_none=True in model_dump).
+    security_schemes: dict | None = None
+    security: list[dict] | None = None
 
 
 def _worker_to_skill(worker: Worker) -> AgentSkill:
@@ -241,6 +245,26 @@ def _worker_to_skill(worker: Worker) -> AgentSkill:
         name=name,
         description=description,
         tags=tags,
+    )
+
+
+def _oidc_security_schemes(base_url: str) -> tuple[dict | None, list[dict] | None]:
+    """Return (securitySchemes, security) when OIDC is enabled, else (None, None)."""
+    # Imported lazily to avoid triggering foreman/__init__ circular imports.
+    from foreman.oidc import OIDCConfig, is_a2a_receiver_enabled
+
+    if not is_a2a_receiver_enabled():
+        return None, None
+    config = OIDCConfig.from_env()
+    issuer = config.issuer or base_url
+    return (
+        {
+            "oidc": {
+                "type": "openIdConnect",
+                "openIdConnectUrl": f"{issuer.rstrip('/')}/.well-known/openid-configuration",
+            }
+        },
+        [{"oidc": []}],
     )
 
 
@@ -282,6 +306,8 @@ def _build_agent_card(
     )
     skills.insert(0, foreman_skill)
 
+    security_schemes, security = _oidc_security_schemes(base_url)
+
     return AgentCard(
         name=guild_name,
         description=guild_description,
@@ -296,6 +322,8 @@ def _build_agent_card(
             url="https://github.com/jmelloy/pioneer-square",
         ),
         documentation_url="https://github.com/jmelloy/pioneer-square#readme",
+        security_schemes=security_schemes,
+        security=security,
     )
 
 

--- a/backend/tests/test_oidc_auth.py
+++ b/backend/tests/test_oidc_auth.py
@@ -1,0 +1,480 @@
+"""Tests for OIDC authentication and A2A receiver enablement.
+
+All network calls are mocked — no real HTTP is issued.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import time
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from foreman.oidc import (
+    OIDCConfig,
+    _b64url_decode,
+    _decode_jwt_parts,
+    _verify_ed25519,
+    is_a2a_receiver_enabled,
+    validate_oidc_token,
+)
+from helpers import insert_guild, make_auth_token
+
+# ---------------------------------------------------------------------------
+# Helpers — create Ed25519 keys and sign JWTs without an external library
+# ---------------------------------------------------------------------------
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _make_ed25519_keypair():
+    """Return (private_key, public_key) as cryptography objects."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    return priv, priv.public_key()
+
+
+def _public_key_to_jwk(pub, kid: str = "test-key-1") -> dict:
+    from cryptography.hazmat.primitives import serialization
+
+    raw = pub.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    return {"kty": "OKP", "crv": "Ed25519", "x": _b64url(raw), "kid": kid}
+
+
+def _make_jwt(payload: dict, priv, kid: str = "test-key-1") -> str:
+    """Produce a compact EdDSA JWT signed with *priv*."""
+    header = {"alg": "EdDSA", "kid": kid}
+    h = _b64url(json.dumps(header, separators=(",", ":")).encode())
+    p = _b64url(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{h}.{p}".encode()
+    sig = priv.sign(signing_input)
+    return f"{h}.{p}.{_b64url(sig)}"
+
+
+# ---------------------------------------------------------------------------
+# is_a2a_receiver_enabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "env_val, expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_a2a_receiver_enabled(env_val, expected, monkeypatch):
+    if env_val is None:
+        monkeypatch.delenv("A2A_RECEIVER_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("A2A_RECEIVER_ENABLED", env_val)
+    assert is_a2a_receiver_enabled() == expected
+
+
+# ---------------------------------------------------------------------------
+# OIDCConfig.from_env
+# ---------------------------------------------------------------------------
+
+
+def test_oidc_config_defaults(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("OIDC_AUDIENCE", raising=False)
+    cfg = OIDCConfig.from_env()
+    assert cfg.issuer is None
+    assert cfg.audience == "pioneer-square"
+
+
+def test_oidc_config_from_env(monkeypatch):
+    monkeypatch.setenv("OIDC_ISSUER", "https://auth.example.com")
+    monkeypatch.setenv("OIDC_AUDIENCE", "my-service")
+    cfg = OIDCConfig.from_env()
+    assert cfg.issuer == "https://auth.example.com"
+    assert cfg.audience == "my-service"
+
+
+def test_oidc_config_empty_issuer_treated_as_none(monkeypatch):
+    monkeypatch.setenv("OIDC_ISSUER", "")
+    cfg = OIDCConfig.from_env()
+    assert cfg.issuer is None
+
+
+# ---------------------------------------------------------------------------
+# JWT parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def test_decode_jwt_parts_rejects_non_jwt():
+    with pytest.raises(ValueError, match="3 dot-separated"):
+        _decode_jwt_parts("not.a.valid.jwt.token.with.too.many.parts")
+
+
+def test_decode_jwt_parts_rejects_bad_base64():
+    with pytest.raises(ValueError):
+        _decode_jwt_parts("!!!!.!!!!.!!!!")
+
+
+def test_decode_jwt_parts_returns_correct_types():
+    priv, pub = _make_ed25519_keypair()
+    payload = {"sub": "u1", "iss": "https://example.com", "exp": int(time.time()) + 300}
+    token = _make_jwt(payload, priv)
+    header, claims, signing_input, signature = _decode_jwt_parts(token)
+    assert header["alg"] == "EdDSA"
+    assert claims["sub"] == "u1"
+    assert isinstance(signing_input, bytes)
+    assert isinstance(signature, bytes)
+
+
+# ---------------------------------------------------------------------------
+# validate_oidc_token — success paths
+# ---------------------------------------------------------------------------
+
+
+def test_validate_oidc_token_valid_ed25519(monkeypatch):
+    """A correctly signed EdDSA token passes validation."""
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "agent-x",
+        "iss": "https://auth.example.com",
+        "aud": "pioneer-square",
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer="https://auth.example.com", audience="pioneer-square")
+
+    with patch("foreman.oidc._fetch_jwks", return_value=[jwk]):
+        result = validate_oidc_token(token, cfg)
+
+    assert result["sub"] == "agent-x"
+    assert result["iss"] == "https://auth.example.com"
+
+
+def test_validate_oidc_token_any_issuer_when_config_issuer_none(monkeypatch):
+    """When config.issuer is None, any iss value is accepted."""
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "u2",
+        "iss": "https://whatever.example.com",
+        "aud": "pioneer-square",
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with patch("foreman.oidc._fetch_jwks", return_value=[jwk]):
+        result = validate_oidc_token(token, cfg)
+
+    assert result["sub"] == "u2"
+
+
+def test_validate_oidc_token_audience_as_list(monkeypatch):
+    """Token aud as a list containing the expected audience passes."""
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "u3",
+        "iss": "https://auth.example.com",
+        "aud": ["other-service", "pioneer-square"],
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with patch("foreman.oidc._fetch_jwks", return_value=[jwk]):
+        result = validate_oidc_token(token, cfg)
+
+    assert result["sub"] == "u3"
+
+
+def test_validate_oidc_token_no_aud_claim_passes(monkeypatch):
+    """Token without an aud claim skips the audience check."""
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "u4",
+        "iss": "https://auth.example.com",
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with patch("foreman.oidc._fetch_jwks", return_value=[jwk]):
+        result = validate_oidc_token(token, cfg)
+
+    assert result["sub"] == "u4"
+
+
+# ---------------------------------------------------------------------------
+# validate_oidc_token — failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_validate_rejects_expired_token():
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "u5",
+        "iss": "https://auth.example.com",
+        "exp": int(time.time()) - 10,  # already expired
+    }
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with (
+        patch("foreman.oidc._fetch_jwks", return_value=[jwk]),
+        pytest.raises(ValueError, match="expired"),
+    ):
+        validate_oidc_token(token, cfg)
+
+
+def test_validate_rejects_wrong_issuer():
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "u6",
+        "iss": "https://wrong.example.com",
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer="https://correct.example.com", audience="pioneer-square")
+
+    with (
+        patch("foreman.oidc._fetch_jwks", return_value=[jwk]),
+        pytest.raises(ValueError, match="Unexpected issuer"),
+    ):
+        validate_oidc_token(token, cfg)
+
+
+def test_validate_rejects_wrong_audience():
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "u7",
+        "iss": "https://auth.example.com",
+        "aud": "other-service",
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with (
+        patch("foreman.oidc._fetch_jwks", return_value=[jwk]),
+        pytest.raises(ValueError, match="Audience"),
+    ):
+        validate_oidc_token(token, cfg)
+
+
+def test_validate_rejects_invalid_signature():
+    priv, pub = _make_ed25519_keypair()
+    priv2, _pub2 = _make_ed25519_keypair()
+    # Sign with priv but validate against pub (which is paired with priv, not priv2)
+    # Corrupt the signature by signing with a different key
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "u8",
+        "iss": "https://auth.example.com",
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv2)  # signed with wrong key
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with (
+        patch("foreman.oidc._fetch_jwks", return_value=[jwk]),
+        pytest.raises(ValueError, match="[Ii]nvalid"),
+    ):
+        validate_oidc_token(token, cfg)
+
+
+def test_validate_rejects_missing_iss():
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {"sub": "u9", "exp": int(time.time()) + 300}  # no iss
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with (
+        patch("foreman.oidc._fetch_jwks", return_value=[jwk]),
+        pytest.raises(ValueError, match="'iss'"),
+    ):
+        validate_oidc_token(token, cfg)
+
+
+def test_validate_rejects_jwks_fetch_failure():
+    priv, _ = _make_ed25519_keypair()
+    payload = {"sub": "u10", "iss": "https://auth.example.com", "exp": int(time.time()) + 300}
+    token = _make_jwt(payload, priv)
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with (
+        patch("foreman.oidc._fetch_jwks", side_effect=OSError("connection refused")),
+        pytest.raises(ValueError, match="Could not fetch JWKS"),
+    ):
+        validate_oidc_token(token, cfg)
+
+
+def test_validate_rejects_unsupported_algorithm():
+    """Tokens using RS256 (not EdDSA) are rejected."""
+    # Build a fake RS256-headered JWT (signature won't be real but we'll mock JWKS)
+    header = {"alg": "RS256", "kid": "k1"}
+    payload = {"sub": "u11", "iss": "https://auth.example.com", "exp": int(time.time()) + 300}
+    h = _b64url(json.dumps(header, separators=(",", ":")).encode())
+    p = _b64url(json.dumps(payload, separators=(",", ":")).encode())
+    token = f"{h}.{p}.fakesig"
+    cfg = OIDCConfig(issuer=None, audience="pioneer-square")
+
+    with (
+        patch("foreman.oidc._fetch_jwks", return_value=[{"kid": "k1", "kty": "RSA"}]),
+        pytest.raises(ValueError, match="Unsupported"),
+    ):
+        validate_oidc_token(token, cfg)
+
+
+# ---------------------------------------------------------------------------
+# AgentCard security scheme inclusion
+# ---------------------------------------------------------------------------
+
+
+def test_agent_card_no_oidc_scheme_when_receiver_disabled(client, monkeypatch):
+    """When A2A_RECEIVER_ENABLED is unset, securitySchemes is absent from the card."""
+    monkeypatch.delenv("A2A_RECEIVER_ENABLED", raising=False)
+    test_client, _ = client
+    resp = test_client.get("/.well-known/agent.json")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "securitySchemes" not in data
+    assert "security" not in data
+
+
+def test_agent_card_includes_oidc_scheme_when_receiver_enabled(client, monkeypatch):
+    """When A2A_RECEIVER_ENABLED=true, securitySchemes contains the oidc entry."""
+    monkeypatch.setenv("A2A_RECEIVER_ENABLED", "true")
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    test_client, _ = client
+    resp = test_client.get("/.well-known/agent.json")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "securitySchemes" in data
+    assert "oidc" in data["securitySchemes"]
+    oidc_scheme = data["securitySchemes"]["oidc"]
+    assert oidc_scheme["type"] == "openIdConnect"
+    assert "openIdConnectUrl" in oidc_scheme
+    assert "security" in data
+    assert data["security"] == [{"oidc": []}]
+
+
+def test_agent_card_oidc_uses_configured_issuer(client, monkeypatch):
+    """When OIDC_ISSUER is set, openIdConnectUrl is derived from it."""
+    monkeypatch.setenv("A2A_RECEIVER_ENABLED", "true")
+    monkeypatch.setenv("OIDC_ISSUER", "https://auth.example.com")
+    test_client, _ = client
+    resp = test_client.get("/.well-known/agent.json")
+    assert resp.status_code == 200
+    data = resp.json()
+    oidc_url = data["securitySchemes"]["oidc"]["openIdConnectUrl"]
+    assert oidc_url.startswith("https://auth.example.com")
+
+
+# ---------------------------------------------------------------------------
+# authorize_worker_or_member — OIDC path (integration with auth_deps)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_accepted_when_receiver_enabled(monkeypatch):
+    """authorize_worker_or_member returns oidc:<sub> for a valid OIDC token."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import auth_deps
+
+    monkeypatch.setenv("A2A_RECEIVER_ENABLED", "true")
+    monkeypatch.setenv("OIDC_AUDIENCE", "pioneer-square")
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "external-agent-1",
+        "iss": "https://auth.example.com",
+        "aud": "pioneer-square",
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv)
+
+    # execute() is awaited; scalar_one_or_none() is synchronous on the result.
+    # Use MagicMock for the execute result so scalar_one_or_none returns None (not a coroutine).
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = None
+
+    mock_db = AsyncMock()
+    mock_db.execute.return_value = exec_result
+
+    async def fake_get_db():
+        return mock_db
+
+    monkeypatch.setattr("auth_deps.get_db", fake_get_db)
+    monkeypatch.setattr("auth_deps.get_guild_pk", AsyncMock(return_value=1))
+
+    with patch("foreman.oidc._fetch_jwks", return_value=[jwk]):
+        result = await auth_deps.authorize_worker_or_member("g-test", token)
+
+    assert result == "oidc:external-agent-1"
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_rejected_when_receiver_disabled(monkeypatch):
+    """When A2A_RECEIVER_ENABLED is off, OIDC tokens are rejected with 401."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import auth_deps
+    from fastapi import HTTPException
+
+    monkeypatch.delenv("A2A_RECEIVER_ENABLED", raising=False)
+
+    priv, pub = _make_ed25519_keypair()
+    jwk = _public_key_to_jwk(pub)
+    payload = {
+        "sub": "external-agent-2",
+        "iss": "https://auth.example.com",
+        "aud": "pioneer-square",
+        "exp": int(time.time()) + 300,
+    }
+    token = _make_jwt(payload, priv)
+
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = None
+
+    mock_db = AsyncMock()
+    mock_db.execute.return_value = exec_result
+
+    async def fake_get_db():
+        return mock_db
+
+    monkeypatch.setattr("auth_deps.get_db", fake_get_db)
+    monkeypatch.setattr("auth_deps.get_guild_pk", AsyncMock(return_value=1))
+
+    with (
+        patch("foreman.oidc._fetch_jwks", return_value=[jwk]),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await auth_deps.authorize_worker_or_member("g-test", token)
+
+    assert exc_info.value.status_code == 401


### PR DESCRIPTION
## Summary

- Adds `backend/foreman/oidc.py`: new module with `is_a2a_receiver_enabled()`, `OIDCConfig`, and `validate_oidc_token()` — Ed25519/EdDSA JWT validation via the issuer's JWKS endpoint
- Updates `authorize_worker_or_member` in `auth_deps.py` to accept OIDC JWT tokens as a fallback auth path when `A2A_RECEIVER_ENABLED=true`; authenticated principal is `oidc:<sub>`
- Updates `AgentCard` in `routes/wellknown.py` to advertise an `openIdConnect` security scheme when the A2A receiver is enabled, so external agents know the auth mechanism

## Configuration

| Env var | Default | Description |
|---|---|---|
| `A2A_RECEIVER_ENABLED` | unset (disabled) | Set to `true`/`1`/`yes` to enable OIDC auth and update the AgentCard |
| `OIDC_ISSUER` | none | Expected issuer URL; JWKS fetched from `{issuer}/.well-known/jwks.json`. If unset, any issuer is accepted |
| `OIDC_AUDIENCE` | `pioneer-square` | Expected `aud` claim in the token |

## Test plan

- [x] 32 new tests in `backend/tests/test_oidc_auth.py` covering `is_a2a_receiver_enabled`, `OIDCConfig.from_env`, JWT parsing, token validation (success + 7 failure cases), AgentCard scheme inclusion/exclusion, and the `authorize_worker_or_member` OIDC path
- [x] Full suite: 409 tests pass (`python -m pytest` in `backend/`)
- [x] `ruff check` + `ruff format` clean

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)