### PR TITLE
Review agent: resolve/supersede previous reviews on re-run

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -852,15 +852,14 @@ mutation ResolveThread($threadId: ID!) {
 async def _supersede_prior_bot_reviews(
     pr_repo: str, pr_number: int, bot_username: str, token: str
 ) -> int:
-    """Resolve prior inline threads and mark previous bot reviews as superseded.
+    """Resolve prior inline threads from previous bot reviews.
 
     Before a new review is posted this function:
     1. Fetches all existing reviews and filters to those authored by ``bot_username``.
     2. Resolves any unresolved inline threads that belong to those reviews via
        the GitHub GraphQL ``resolveReviewThread`` mutation.
-    3. PUTs each prior review body to prepend a "Superseded" strike-through line.
 
-    Returns the count of reviews superseded. Errors in individual steps are
+    Returns the count of threads resolved. Errors in individual steps are
     logged as warnings rather than raised so that the main review post is never
     blocked by a cleanup failure.
     """
@@ -875,6 +874,7 @@ async def _supersede_prior_bot_reviews(
     bot_review_ids = {r["id"] for r in bot_reviews}
 
     # Resolve unresolved inline threads that belong to our prior reviews.
+    threads_resolved = 0
     owner, repo_name = pr_repo.split("/", 1)
     try:
         gql_result = await asyncio.to_thread(
@@ -905,6 +905,7 @@ async def _supersede_prior_bot_reviews(
                         _GQL_RESOLVE_THREAD,
                         {"threadId": thread["id"]},
                     )
+                    threads_resolved += 1
                     logger.info(
                         "review_pr: resolved thread %s on %s#%d",
                         thread["id"],
@@ -921,29 +922,7 @@ async def _supersede_prior_bot_reviews(
             exc,
         )
 
-    # Mark old reviews as superseded.
-    today_iso = datetime.now(UTC).date().isoformat()
-    supersede_prefix = f"~~Superseded by review posted {today_iso}~~\n\n"
-    superseded = 0
-    for review in bot_reviews:
-        review_id = review["id"]
-        old_body = review.get("body") or ""
-        if old_body.startswith("~~Superseded"):
-            continue
-        new_body = supersede_prefix + old_body
-        try:
-            await asyncio.to_thread(
-                _gh_api_post,
-                f"/repos/{pr_repo}/pulls/{pr_number}/reviews/{review_id}",
-                token,
-                {"body": new_body},
-                "PUT",
-            )
-            superseded += 1
-        except Exception as exc:
-            logger.warning("review_pr: failed to supersede review %d: %s", review_id, exc)
-
-    return superseded
+    return threads_resolved
 
 
 # ---------------------------------------------------------------------------
@@ -1754,21 +1733,21 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 review_body,
                             )
                             try:
-                                superseded = await _supersede_prior_bot_reviews(
+                                threads_resolved = await _supersede_prior_bot_reviews(
                                     pr_repo, pr_number, username, token
                                 )
-                                if superseded:
+                                if threads_resolved:
                                     logger.info(
-                                        "guild=%s review_pr: superseded %d prior review(s)"
-                                        " on %s#%d",
+                                        "guild=%s review_pr: resolved %d thread(s) from"
+                                        " prior review(s) on %s#%d",
                                         guild_id,
-                                        superseded,
+                                        threads_resolved,
                                         pr_repo,
                                         pr_number,
                                     )
                             except Exception as _sup_exc:
                                 logger.warning(
-                                    "guild=%s review_pr: supersede step failed (non-fatal): %s",
+                                    "guild=%s review_pr: thread resolution step failed (non-fatal): %s",
                                     guild_id,
                                     _sup_exc,
                                 )
@@ -1882,21 +1861,21 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             ]
 
                             try:
-                                superseded = await _supersede_prior_bot_reviews(
+                                threads_resolved = await _supersede_prior_bot_reviews(
                                     pr_repo, pr_number, username, token
                                 )
-                                if superseded:
+                                if threads_resolved:
                                     logger.info(
-                                        "guild=%s review_pr_internal: superseded %d prior"
-                                        " review(s) on %s#%d",
+                                        "guild=%s review_pr_internal: resolved %d thread(s)"
+                                        " from prior review(s) on %s#%d",
                                         guild_id,
-                                        superseded,
+                                        threads_resolved,
                                         pr_repo,
                                         pr_number,
                                     )
                             except Exception as _sup_exc:
                                 logger.warning(
-                                    "guild=%s review_pr_internal: supersede step failed"
+                                    "guild=%s review_pr_internal: thread resolution step failed"
                                     " (non-fatal): %s",
                                     guild_id,
                                     _sup_exc,

--- a/backend/tests/test_review_pr_tool.py
+++ b/backend/tests/test_review_pr_tool.py
@@ -363,53 +363,6 @@ class TestSupersedePriorBotReviews:
         assert result == 0
 
     @pytest.mark.asyncio
-    async def test_already_superseded_review_is_skipped(self):
-        """Reviews whose body already starts with ~~Superseded are not patched again."""
-        from foreman.tools import _supersede_prior_bot_reviews
-
-        reviews = [_make_review(5, "bot", "~~Superseded by review posted 2026-01-01~~\n\nOld.")]
-        gh_api_calls = []
-
-        with (
-            patch("foreman.tools._gh_api", return_value=reviews),
-            patch("foreman.tools._gh_graphql", return_value=_make_gql_threads([])),
-            patch(
-                "foreman.tools._gh_api_post",
-                side_effect=lambda *a, **kw: gh_api_calls.append(a) or {},
-            ),
-        ):
-            result = await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
-
-        assert result == 0
-        assert gh_api_calls == []
-
-    @pytest.mark.asyncio
-    async def test_supersedes_prior_review_body(self):
-        """A prior bot review body is prepended with the superseded notice."""
-        from foreman.tools import _supersede_prior_bot_reviews
-
-        reviews = [_make_review(7, "bot", "Good review.")]
-        put_calls = []
-
-        def capture_post(path, token, payload, method="POST"):
-            put_calls.append({"path": path, "payload": payload, "method": method})
-            return {}
-
-        with (
-            patch("foreman.tools._gh_api", return_value=reviews),
-            patch("foreman.tools._gh_graphql", return_value=_make_gql_threads([])),
-            patch("foreman.tools._gh_api_post", side_effect=capture_post),
-        ):
-            result = await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
-
-        assert result == 1
-        assert len(put_calls) == 1
-        assert put_calls[0]["method"] == "PUT"
-        assert "org/repo/pulls/42/reviews/7" in put_calls[0]["path"]
-        assert put_calls[0]["payload"]["body"].startswith("~~Superseded by review posted ")
-        assert "Good review." in put_calls[0]["payload"]["body"]
-
-    @pytest.mark.asyncio
     async def test_resolves_unresolved_inline_threads(self):
         """Unresolved threads from a prior bot review are resolved via GraphQL."""
         from foreman.tools import _supersede_prior_bot_reviews
@@ -458,22 +411,6 @@ class TestSupersedePriorBotReviews:
         resolve_calls = [c for c in graphql_calls if "resolveReviewThread" in c["query"]]
         assert len(resolve_calls) == 0
 
-    @pytest.mark.asyncio
-    async def test_graphql_failure_does_not_block_supersede(self):
-        """If GraphQL fails, the review body is still superseded (failure is non-fatal)."""
-        from foreman.tools import _supersede_prior_bot_reviews
-
-        reviews = [_make_review(12, "bot", "Some review.")]
-
-        with (
-            patch("foreman.tools._gh_api", return_value=reviews),
-            patch("foreman.tools._gh_graphql", side_effect=RuntimeError("graphql down")),
-            patch("foreman.tools._gh_api_post", return_value={}) as mock_put,
-        ):
-            result = await _supersede_prior_bot_reviews("org/repo", 42, "bot", "tok")
-
-        assert result == 1
-        mock_put.assert_called_once()
 
 
 class TestReviewPrSupersedePriorReviews:

--- a/backend/tests/test_review_pr_tool.py
+++ b/backend/tests/test_review_pr_tool.py
@@ -412,7 +412,6 @@ class TestSupersedePriorBotReviews:
         assert len(resolve_calls) == 0
 
 
-
 class TestReviewPrSupersedePriorReviews:
     """Integration tests: review_pr tool calls _supersede_prior_bot_reviews."""
 


### PR DESCRIPTION
## Summary

- Replace the body-edit "~~Superseded~~" approach with GraphQL thread resolution: when a new review is posted, unresolved inline comment threads from prior bot reviews are resolved via `resolveReviewThread` mutation instead of prepending strike-through text to old review bodies.
- `_supersede_prior_bot_reviews` now returns the count of threads resolved (previously: reviews edited); both callers (`review_pr`, `review_pr_internal`) updated accordingly with refreshed log messages.
- Removed three body-supersede unit tests (`test_already_superseded_review_is_skipped`, `test_supersedes_prior_review_body`, `test_graphql_failure_does_not_block_supersede`); all 16 remaining tests pass.

## Test plan

- [x] `pytest backend/tests/test_review_pr_tool.py` — 16 passed
- [ ] Verify on a real PR: re-running a review resolves old inline threads and does not add "Superseded" text to the old review body

🤖 Generated with [Claude Code](https://claude.com/claude-code)