### PR TITLE
Fix worker ID persistence on page refresh

### DIFF
--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -13,7 +13,7 @@ from auth_deps import get_guild_pk, require_member, require_user, require_worker
 from database import get_db
 from events import broadcast
 from fastapi import APIRouter, Depends, HTTPException
-from models import Agent, Guild, GuildMember, Message, User
+from models import Agent, Guild, GuildMember, Message, User, Worker
 from pydantic import BaseModel
 from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -178,13 +178,15 @@ async def get_guild(guild_id: str, github_user_id: str = Depends(require_member(
             raise HTTPException(status_code=404, detail="Guild not found")
         guild_pk = guild.id
         result = await db.execute(
-            select(Agent).where(
+            select(Agent, Worker.name.label("worker_name"))
+            .outerjoin(Worker, Worker.id == Agent.worker_id)
+            .where(
                 Agent.guild_pk == guild_pk,
                 Agent.state != "offline",
                 Agent.type != "foreman",
             )
         )
-        agents = result.scalars().all()
+        agent_rows = result.all()
         result = await db.execute(
             select(Message)
             .where(Message.guild_pk == guild_pk)
@@ -195,7 +197,9 @@ async def get_guild(guild_id: str, github_user_id: str = Depends(require_member(
         return {
             **row_to_dict(guild),
             "id": guild.guild_id,  # keep text guild_id as "id" for API compatibility
-            "agents": [row_to_dict(a) for a in agents],
+            "agents": [
+                {**row_to_dict(row.Agent), "worker_name": row.worker_name} for row in agent_rows
+            ],
             "messages": [row_to_dict(m) for m in reversed(messages)],
         }
     finally:

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -248,11 +248,10 @@ export const useAgentsStore = defineStore('agents', () => {
   async function fetchAgentLogs(guildId: string, agentId: string) {
     try {
       const raw = await api<RawLog[]>(`/guilds/${guildId}/logs?agent_id=${agentId}`)
-      const historical = raw.map(_toLogEntry)
       const agent = agents.value.find((a) => a.id === agentId)
       if (agent) {
-        agent.logs = [...historical, ...agent.logs]
-        if (agent.logs.length > 2000) agent.logs = agent.logs.slice(-2000)
+        const historical = raw.map(_toLogEntry)
+        agent.logs = historical.length > 2000 ? historical.slice(-2000) : historical
       }
     } catch (e) {
       console.error('Failed to fetch agent logs', e)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -82,6 +82,7 @@ export interface Guild {
     name: string
     type: string
     worker_id?: string | null
+    worker_name?: string | null
     state: AgentState
     current_task_id?: string | null
     joined_at?: string

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -101,6 +101,7 @@ async function initGuild(guildId: string) {
           agentName: a.name,
           agentType: a.type,
           workerId: a.worker_id || null,
+          workerName: a.worker_name || undefined,
           state: a.state,
           taskId: a.current_task_id ?? null,
           joinedAt: a.joined_at,


### PR DESCRIPTION
## Summary

- **Worker IDs showing as `w-xyz123` on refresh**: The backend `/guilds/{id}` endpoint only returned raw `worker_id` for each agent — the human-readable display name (stored in the `workers` table) was never included. The frontend registered agents from this response without a `workerName`, so the `workers` computed fell back to the raw ID string. Fixed by adding an `OUTER JOIN workers` to the guild endpoint and threading `worker_name` through the frontend type → `registerAgent()` call.

- **Duplicate log entries in agent pane**: `fetchAgentLogs` was merging historical logs with whatever live WebSocket logs had already accumulated — prepending with `[...historical, ...agent.logs]`. This caused duplicates any time the pane was re-opened (watch fires again on prop change) or when WS logs raced ahead of the HTTP fetch. Fixed by replacing instead of prepending, matching the existing strategy in `fetchWorkerLogs`.

## Changes

| File | Change |
|------|--------|
| `backend/routes/guilds.py` | `OUTER JOIN workers` on the agents query; include `worker_name` in response |
| `frontend/src/types.ts` | Add `worker_name?: string` to `Guild.agents` element type |
| `frontend/src/views/AppView.vue` | Pass `workerName: a.worker_name` to `registerAgent()` on initial load |
| `frontend/src/stores/agents.ts` | `fetchAgentLogs` replaces `agent.logs` instead of prepending |

## Test plan

- [ ] Load the app, open a guild with active workers — confirm worker names display correctly (e.g. `myhost/VD-3566`, not `w-vd3566`)
- [ ] Refresh the page — confirm worker names are still correct immediately (before WS reconnect)
- [ ] Open an agent log pane, navigate to another agent and back — confirm no duplicate log lines
- [ ] Confirm the worker log pane (kind=worker) shows logs correctly (unaffected by this change)

Closes #355

🤖 Generated with [Claude Code](https://claude.ai/claude-code)