### PR TITLE
feat(worker): clone only task-relevant repos instead of full list

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -133,6 +133,16 @@ FOREMAN_TOOLS = [
                     "type": "string",
                     "description": "owner/repo for the issue (optional).",
                 },
+                "repos": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Explicit list of owner/repo strings to clone for this task. "
+                        "When provided, the worker clones only these repos instead of "
+                        "scanning the description or falling back to its full repo list. "
+                        "Omit to let the worker infer repos from the task description."
+                    ),
+                },
             },
             "required": ["worker_id", "description"],
         },
@@ -1154,6 +1164,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             "phase": phase,
                             "issueNumber": inp.get("issue_number"),
                             "issueRepo": inp.get("issue_repo"),
+                            "repos": inp.get("repos") or [],
                         },
                     )
                     result_text = f"Task {task_id} assigned to {wid}."
@@ -1195,6 +1206,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             "parentTaskId": parent_task_id,
                             "issueNumber": inp.get("issue_number"),
                             "issueRepo": inp.get("issue_repo"),
+                            "repos": inp.get("repos") or [],
                         },
                     )
                     result_text = f"Task {task_id} queued for {wid}."

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -58,6 +58,7 @@ class TaskCreate(BaseModel):
     issue_repo: str | None = None
     parent_task_id: str | None = None
     phase: str | None = "execute"
+    repos: list[str] = []  # explicit repos to clone; worker falls back to description parsing
 
 
 class WorkerMessage(BaseModel):
@@ -278,6 +279,7 @@ async def assign_task(
             "parentTaskId": data.parent_task_id,
             "issueNumber": data.issue_number,
             "issueRepo": data.issue_repo,
+            "repos": data.repos,
         },
     )
 

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -44,6 +44,85 @@ def _slug(text: str, max_len: int = 60) -> str:
 _CANCEL_SENTINEL = object()  # placed in redirect queue to signal task cancellation
 _SHUTDOWN_SENTINEL = object()  # placed in task queue to wake idle agents during shutdown
 
+# Regex patterns for extracting GitHub repo references from task text.
+_GITHUB_URL_RE = re.compile(
+    r"https://github\.com/([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+?)(?:\.git|[/\s#?]|$)"
+)
+_GITHUB_SSH_RE = re.compile(r"git@github\.com:([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+?)(?:\.git|[\s]|$)")
+_OWNER_REPO_RE = re.compile(
+    r"(?<![/\w])([a-zA-Z0-9][a-zA-Z0-9_.-]*/[a-zA-Z0-9][a-zA-Z0-9_.-]*)(?![/\w])"
+)
+
+
+def _repos_for_task(
+    desc: str,
+    name: str,
+    issue_repo: str,
+    explicit_repos: list[str],
+    configured_repos: list[str],
+    org: str | None,
+) -> tuple[list[str], bool]:
+    """Determine which repos to prepare for a task.
+
+    Returns (repos, selective) where selective=True means a targeted subset was
+    identified; selective=False means we fell back to the full configured list.
+
+    Priority:
+    1. Explicit repos list from the task-assigned message
+    2. Repos parsed from the task description / name (filtered to accessible repos)
+    3. Fall back to all configured repos
+    """
+    known = set(configured_repos)
+
+    def _accessible(r: str) -> bool:
+        return r in known or (bool(org) and r.startswith(f"{org}/"))
+
+    def _prepend_issue(result: list[str]) -> list[str]:
+        if issue_repo and _accessible(issue_repo) and issue_repo not in result:
+            result.insert(0, issue_repo)
+        return result
+
+    # 1. Explicit repos from task assignment message
+    if explicit_repos:
+        result = [r for r in explicit_repos if _accessible(r)]
+        if result:
+            return _prepend_issue(result), True
+
+    # 2. Parse description + name for GitHub repo references
+    text = f"{name} {desc}"
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def _add(r: str) -> None:
+        r = r.rstrip("/")
+        if r not in seen and _accessible(r):
+            seen.add(r)
+            found.append(r)
+
+    for m in _GITHUB_URL_RE.finditer(text):
+        _add(m.group(1))
+    for m in _GITHUB_SSH_RE.finditer(text):
+        _add(m.group(1))
+    for m in _OWNER_REPO_RE.finditer(text):
+        _add(m.group(1))
+
+    # issue_repo takes precedence — move it to front if found, add if missing
+    if issue_repo and _accessible(issue_repo):
+        if issue_repo in seen:
+            found.remove(issue_repo)
+        found.insert(0, issue_repo)
+        seen.add(issue_repo)
+
+    if found:
+        return found, True
+
+    # 3. Fall back to all configured repos + any org-based issue_repo
+    result = list(configured_repos)
+    if org and issue_repo and issue_repo.startswith(f"{org}/") and issue_repo not in result:
+        result.insert(0, issue_repo)
+    return result, False
+
+
 # Worktrees are kept around after a task completes so the foreman can send
 # follow-ups without paying for a re-clone. They're swept at startup and on a
 # steady cadence; anything older than this is fair game to remove.
@@ -1005,6 +1084,7 @@ class Worker:
                         "tool": msg.get("tool", "claude"),
                         "issue_number": msg.get("issueNumber"),
                         "issue_repo": msg.get("issueRepo"),
+                        "repos": msg.get("repos") or [],
                     }
                 )
 
@@ -1087,6 +1167,7 @@ class Worker:
                         "tool": msg.get("tool", "claude"),
                         "issue_number": msg.get("issueNumber"),
                         "issue_repo": msg.get("issueRepo"),
+                        "repos": msg.get("repos") or [],
                         "followup_instructions": instructions,
                         "followup_branch": msg.get("branch", ""),
                     }
@@ -1180,6 +1261,7 @@ class Worker:
                                 "tool": msg.get("tool", "claude"),
                                 "issue_number": msg.get("issueNumber"),
                                 "issue_repo": msg.get("issueRepo"),
+                                "repos": msg.get("repos") or [],
                                 "followup_instructions": instructions,
                                 "followup_branch": msg.get("branch", ""),
                             }
@@ -1451,12 +1533,24 @@ class Worker:
         task_id = task["id"]
         desc = task.get("description") or ""
         token = self.cfg.github_token
-        # Build effective repo list: static config repos + lazy org repo if applicable.
-        repos = list(self.cfg.repos)
         issue_repo = task.get("issue_repo") or ""
-        if self.cfg.org and issue_repo.startswith(f"{self.cfg.org}/"):
-            if issue_repo not in repos:
-                repos.insert(0, issue_repo)
+        explicit_repos = task.get("repos") or []
+        repos, selective = _repos_for_task(
+            desc,
+            task.get("name") or "",
+            issue_repo,
+            explicit_repos,
+            self.cfg.repos,
+            self.cfg.org,
+        )
+        if selective:
+            logger.info("Task %s: selective repo prep (%d): %s", task_id, len(repos), repos)
+        else:
+            logger.info(
+                "Task %s: no specific repos identified, using full list (%d repos)",
+                task_id,
+                len(repos),
+            )
         followup_instructions = task.get("followup_instructions") or ""
         followup_branch = task.get("followup_branch") or ""
         is_followup = bool(followup_instructions)


### PR DESCRIPTION
## Summary

- Adds `_repos_for_task()` helper in `worker.py` that determines the minimal set of repos to prepare for a task, eliminating 30+ second delays when a worker has 54 configured repos but a task only needs one
- Worker now uses a three-tier priority: (1) explicit `repos` list from the task-assigned message, (2) repos parsed from the task description/name filtered to accessible repos, (3) fall back to all configured repos
- Adds `repos` parameter to the foreman's `assign_task` tool so the foreman can hint exactly which repos are needed
- Adds `repos: list[str]` to `TaskCreate` REST schema and passes it through all `task-assigned` broadcast paths

## How it works

`_repos_for_task()` extracts repo references via three regex patterns (GitHub HTTPS URLs, SSH URLs, bare `owner/repo` patterns) and filters matches to repos the worker can actually access (configured list or org prefix). The `issue_repo` field always takes first position when present.

## Test plan

- [ ] Single-repo task: verify only that repo is cloned (seconds, not 30s+)
- [ ] Task with GitHub URL in description: verify only the mentioned repo is cloned
- [ ] Task with no repo references: verify fallback to full list still works
- [ ] Foreman-assigned task with explicit `repos` field: verify only those repos are cloned
- [ ] Follow-up task: verify `repos` field flows through the follow-up path

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)