### PR TITLE
Fix HTML link colors in task pane

### DIFF
--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -315,7 +315,7 @@ watch(
   font-style: italic;
 }
 
-.terminal-link {
+.log-text :deep(.terminal-link) {
   color: var(--color-blue);
   text-decoration: underline;
   cursor: pointer;


### PR DESCRIPTION
## Summary

- `.terminal-link` was in scoped CSS without `:deep()`, so it compiled to `.terminal-link[data-v-xxx]` — a selector that never matches elements created via `v-html`
- Non-markdown log lines go through `linkify()`, which creates `<a class="terminal-link">` elements inserted via `v-html`; those elements don't receive the Vue scope attribute
- Changed to `.log-text :deep(.terminal-link)` so the selector compiles to `.log-text[data-v-xxx] .terminal-link`, correctly targeting the dynamically rendered links
- Markdown links were unaffected because they already used `:deep(a)` syntax

## Test plan

- [ ] Open the task pane and observe a non-markdown log line containing a URL (e.g. a GitHub PR link from the worker)
- [ ] Verify the URL renders as a clickable link in `--color-blue` (`#44aaee`) rather than browser-default blue
- [ ] Verify markdown-rendered links still display in `--color-teal` (`#00bbaa`)

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)