### PR TITLE
fix(worker): stop cloning all accessible repos; scope to configured list + org

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime, timedelta
 
 from database import get_db
 from events import broadcast, emit_terminal_line
-from models import Agent, Guild, GithubToken, GuildKey, GuildMember, Task, TaskLog, Worker
+from models import Agent, GithubToken, Guild, GuildKey, GuildMember, Task, TaskLog, Worker
 from sqlalchemy import select, update
 
 logger = logging.getLogger(__name__)

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1138,7 +1138,8 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     worker_repos: list[str] = json.loads(worker_row.repos or "[]")
                     worker_org: str | None = worker_row.org
                     unreachable = [
-                        r for r in repos
+                        r
+                        for r in repos
                         if r not in worker_repos
                         and not (worker_org and r.startswith(f"{worker_org}/"))
                     ]

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime, timedelta
 
 from database import get_db
 from events import broadcast, emit_terminal_line
-from models import Agent, GithubToken, GuildKey, GuildMember, Task, TaskLog, Worker
+from models import Agent, Guild, GithubToken, GuildKey, GuildMember, Task, TaskLog, Worker
 from sqlalchemy import select, update
 
 logger = logging.getLogger(__name__)
@@ -132,6 +132,16 @@ FOREMAN_TOOLS = [
                 "issue_repo": {
                     "type": "string",
                     "description": "owner/repo for the issue (optional).",
+                },
+                "repos": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Explicit list of owner/repo strings to clone for this task. "
+                        "When provided, the worker clones only these repos instead of "
+                        "falling back to its full configured list. Omit when the full "
+                        "list is appropriate."
+                    ),
                 },
             },
             "required": ["worker_id", "description"],
@@ -1110,6 +1120,11 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 phase = inp.get("phase", "execute")
                 tool = inp.get("tool", "claude")
                 existing_task_id = inp.get("task_id")
+                guild_result = await db.execute(
+                    select(Guild.primary_repo).where(Guild.id == guild_pk)
+                )
+                primary_repo: str | None = guild_result.scalar_one_or_none()
+                repos: list[str] = inp.get("repos") or ([primary_repo] if primary_repo else [])
                 worker_result = await db.execute(
                     select(Worker.id).where(Worker.id == wid, Worker.guild_pk == guild_pk)
                 )
@@ -1154,6 +1169,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             "phase": phase,
                             "issueNumber": inp.get("issue_number"),
                             "issueRepo": inp.get("issue_repo"),
+                            "repos": repos,
                         },
                     )
                     result_text = f"Task {task_id} assigned to {wid}."
@@ -1195,6 +1211,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             "parentTaskId": parent_task_id,
                             "issueNumber": inp.get("issue_number"),
                             "issueRepo": inp.get("issue_repo"),
+                            "repos": repos,
                         },
                     )
                     result_text = f"Task {task_id} queued for {wid}."

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1131,24 +1131,27 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     )
                 )
                 worker_row = worker_result.one_or_none()
-                if worker_row and primary_repo and not inp.get("repos"):
-                    worker_repos: list[str] = json.loads(worker_row.repos or "[]")
-                    worker_org: str | None = worker_row.org
-                    if primary_repo not in worker_repos and not (
-                        worker_org and primary_repo.startswith(f"{worker_org}/")
-                    ):
-                        logger.warning(
-                            "guild=%s assign_task: primary_repo %r not in worker %s repos "
-                            "(registered: %d repos, org=%r) — clone will likely fail",
-                            guild_id,
-                            primary_repo,
-                            wid,
-                            len(worker_repos),
-                            worker_org,
-                        )
                 if not worker_row:
                     result_text = f"Worker {wid} not found — task NOT queued."
-                elif existing_task_id:
+                    is_error = True
+                elif repos:
+                    worker_repos: list[str] = json.loads(worker_row.repos or "[]")
+                    worker_org: str | None = worker_row.org
+                    unreachable = [
+                        r for r in repos
+                        if r not in worker_repos
+                        and not (worker_org and r.startswith(f"{worker_org}/"))
+                    ]
+                    if unreachable:
+                        result_text = (
+                            f"Worker {wid} cannot access repo(s) {unreachable} — "
+                            f"task NOT queued. Worker has {len(worker_repos)} registered "
+                            f"repo(s) and org={worker_org!r}. Choose a worker that has "
+                            f"access to these repos, or omit repos to use the worker's "
+                            f"full configured list."
+                        )
+                        is_error = True
+                if not is_error and existing_task_id:
                     name_override = inp.get("name")
                     update_values: dict = {
                         "worker_id": wid,
@@ -1190,7 +1193,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         },
                     )
                     result_text = f"Task {task_id} assigned to {wid}."
-                else:
+                elif not is_error:
                     name = inp.get("name") or desc[:60]
                     parent_task_id = inp.get("parent_task_id")
                     task_id = "t-" + "".join(

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1126,9 +1126,26 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 primary_repo: str | None = guild_result.scalar_one_or_none()
                 repos: list[str] = inp.get("repos") or ([primary_repo] if primary_repo else [])
                 worker_result = await db.execute(
-                    select(Worker.id).where(Worker.id == wid, Worker.guild_pk == guild_pk)
+                    select(Worker.id, Worker.repos, Worker.org).where(
+                        Worker.id == wid, Worker.guild_pk == guild_pk
+                    )
                 )
-                worker_row = worker_result.scalar_one_or_none()
+                worker_row = worker_result.one_or_none()
+                if worker_row and primary_repo and not inp.get("repos"):
+                    worker_repos: list[str] = json.loads(worker_row.repos or "[]")
+                    worker_org: str | None = worker_row.org
+                    if primary_repo not in worker_repos and not (
+                        worker_org and primary_repo.startswith(f"{worker_org}/")
+                    ):
+                        logger.warning(
+                            "guild=%s assign_task: primary_repo %r not in worker %s repos "
+                            "(registered: %d repos, org=%r) — clone will likely fail",
+                            guild_id,
+                            primary_repo,
+                            wid,
+                            len(worker_repos),
+                            worker_org,
+                        )
                 if not worker_row:
                     result_text = f"Worker {wid} not found — task NOT queued."
                 elif existing_task_id:

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -56,6 +56,7 @@ class TaskCreate(BaseModel):
     tool: str = "claude"  # "claude" | "codex" | "pi"
     issue_number: int | None = None
     issue_repo: str | None = None
+    repos: list[str] = []
     parent_task_id: str | None = None
     phase: str | None = "execute"
 
@@ -278,6 +279,7 @@ async def assign_task(
             "parentTaskId": data.parent_task_id,
             "issueNumber": data.issue_number,
             "issueRepo": data.issue_repo,
+            "repos": data.repos,
         },
     )
 

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1480,7 +1480,8 @@ class Worker:
         if explicit_repos:
             org_prefix = f"{self.cfg.org}/" if self.cfg.org else None
             repos = [
-                r for r in explicit_repos
+                r
+                for r in explicit_repos
                 if r in self.cfg.repos or (org_prefix and r.startswith(org_prefix))
             ] or list(self.cfg.repos)
         else:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -44,6 +44,7 @@ def _slug(text: str, max_len: int = 60) -> str:
 _CANCEL_SENTINEL = object()  # placed in redirect queue to signal task cancellation
 _SHUTDOWN_SENTINEL = object()  # placed in task queue to wake idle agents during shutdown
 
+
 # Worktrees are kept around after a task completes so the foreman can send
 # follow-ups without paying for a re-clone. They're swept at startup and on a
 # steady cadence; anything older than this is fair game to remove.
@@ -96,6 +97,10 @@ class Worker:
         # Monotonic timestamp of the last successful GitHub repo-list refresh.
         # 0 means never refreshed; _idle_puller compares against this.
         self._last_repo_refresh: float = 0.0
+        # Merged repo list for worker-register broadcasts (static config repos
+        # plus API-discovered repos). Never used for task execution — only for
+        # telling the backend/UI how many repos this worker can see.
+        self._broadcast_repos: list[str] = list(cfg.repos)
 
         self.slots: list[Agent] = [Agent() for i in range(cfg.max_agents)]
         # Set when graceful shutdown is requested (via WS or signal). Idle
@@ -679,7 +684,7 @@ class Worker:
             {
                 "type": "worker-register",
                 "workerId": self.cfg.worker_id,
-                "repos": self.cfg.repos,
+                "repos": self._broadcast_repos,
                 **({"user": self.cfg.user} if self.cfg.user else {}),
             }
         )
@@ -897,6 +902,16 @@ class Worker:
             self.cfg.worker_id,
             len(self.slots),
         )
+
+        if self.cfg.repos:
+            logger.info("Cloning/fetching %d configured repo(s) at startup", len(self.cfg.repos))
+            await asyncio.gather(
+                *(
+                    git_ops.ensure_repo(self.cfg.repos_dir, r, self.cfg.github_token)
+                    for r in self.cfg.repos
+                )
+            )
+
         await self._emit("[worker] Online. Watching for tasks.")
         for slot in self.slots:
             await self._set_state("idle", slot)
@@ -1005,6 +1020,7 @@ class Worker:
                         "tool": msg.get("tool", "claude"),
                         "issue_number": msg.get("issueNumber"),
                         "issue_repo": msg.get("issueRepo"),
+                        "repos": msg.get("repos") or [],
                     }
                 )
 
@@ -1087,6 +1103,7 @@ class Worker:
                         "tool": msg.get("tool", "claude"),
                         "issue_number": msg.get("issueNumber"),
                         "issue_repo": msg.get("issueRepo"),
+                        "repos": msg.get("repos") or [],
                         "followup_instructions": instructions,
                         "followup_branch": msg.get("branch", ""),
                     }
@@ -1180,6 +1197,7 @@ class Worker:
                                 "tool": msg.get("tool", "claude"),
                                 "issue_number": msg.get("issueNumber"),
                                 "issue_repo": msg.get("issueRepo"),
+                                "repos": msg.get("repos") or [],
                                 "followup_instructions": instructions,
                                 "followup_branch": msg.get("branch", ""),
                             }
@@ -1221,12 +1239,17 @@ class Worker:
     async def _refresh_github_repos(self) -> None:
         """Fetch repos accessible to the GitHub token and update the registered list.
 
-        Merges API results with the static config list (static entries keep
-        their order; API-only repos are appended). If the merged set differs
-        from the current list the backend is notified via worker-register so
-        the UI and foreman see the updated repo count without a restart.
+        Static config repos are always included. If cfg.org is set, org repos
+        from the API are appended (case-insensitive prefix match on owner).
+        Without cfg.org, no API repos are added — the broadcast list stays as
+        the static config. If the merged set differs from the current broadcast
+        list the backend is notified via worker-register.
         """
         if not self.cfg.github_token:
+            return
+        if not self.cfg.org:
+            # No org configured — nothing to expand; static repos are already broadcast.
+            self._last_repo_refresh = asyncio.get_event_loop().time()
             return
         try:
             api_repos = await github_pr.fetch_accessible_repos(self.cfg.github_token)
@@ -1238,26 +1261,27 @@ class Worker:
             self._last_repo_refresh = asyncio.get_event_loop().time()
             return
 
+        org_prefix = self.cfg.org.lower() + "/"
         merged = list(self.cfg.repos)
         for r in api_repos:
-            if r not in merged:
+            if r not in merged and r.lower().startswith(org_prefix):
                 merged.append(r)
 
-        prev_count = len(self.cfg.repos)
+        prev_count = len(self._broadcast_repos)
         self._last_repo_refresh = asyncio.get_event_loop().time()
 
-        if set(merged) == set(self.cfg.repos) and len(merged) == prev_count:
+        if set(merged) == set(self._broadcast_repos) and len(merged) == prev_count:
             logger.debug("GitHub repo list unchanged (%d repos)", prev_count)
             return
 
-        self.cfg.repos = merged
+        self._broadcast_repos = merged
         logger.info("GitHub repos refreshed: %d total (was %d)", len(merged), prev_count)
         if self.cfg.worker_id:
             await self._send(
                 {
                     "type": "worker-register",
                     "workerId": self.cfg.worker_id,
-                    "repos": self.cfg.repos,
+                    "repos": self._broadcast_repos,
                     **({"user": self.cfg.user} if self.cfg.user else {}),
                 }
             )
@@ -1451,12 +1475,20 @@ class Worker:
         task_id = task["id"]
         desc = task.get("description") or ""
         token = self.cfg.github_token
-        # Build effective repo list: static config repos + lazy org repo if applicable.
-        repos = list(self.cfg.repos)
         issue_repo = task.get("issue_repo") or ""
-        if self.cfg.org and issue_repo.startswith(f"{self.cfg.org}/"):
-            if issue_repo not in repos:
+        explicit_repos = task.get("repos") or []
+        if explicit_repos:
+            org_prefix = f"{self.cfg.org}/" if self.cfg.org else None
+            repos = [
+                r for r in explicit_repos
+                if r in self.cfg.repos or (org_prefix and r.startswith(org_prefix))
+            ] or list(self.cfg.repos)
+        else:
+            repos = list(self.cfg.repos)
+        if issue_repo and issue_repo not in repos:
+            if self.cfg.org and issue_repo.startswith(f"{self.cfg.org}/"):
                 repos.insert(0, issue_repo)
+        logger.info("Task %s: repos=%s", task_id, repos)
         followup_instructions = task.get("followup_instructions") or ""
         followup_branch = task.get("followup_branch") or ""
         is_followup = bool(followup_instructions)

--- a/worker/tests/test_repo_refresh.py
+++ b/worker/tests/test_repo_refresh.py
@@ -109,9 +109,10 @@ async def test_fetch_accessible_repos_skips_missing_full_name():
 
 @pytest.mark.asyncio
 async def test_refresh_merges_new_api_repos():
-    """API repos not in the static config are appended and backend is notified."""
+    """Org repos from API not in static config are appended and backend is notified."""
     worker = _make_worker(
         repos=["owner/repo1"],
+        org="owner",
         github_token="ghp_token",
     )
 
@@ -123,7 +124,9 @@ async def test_refresh_merges_new_api_repos():
     ):
         await worker._refresh_github_repos()
 
-    assert worker.cfg.repos == ["owner/repo1", "owner/repo2", "owner/repo3"]
+    # cfg.repos stays as the static config — only _broadcast_repos expands
+    assert worker.cfg.repos == ["owner/repo1"]
+    assert worker._broadcast_repos == ["owner/repo1", "owner/repo2", "owner/repo3"]
     worker._send.assert_awaited_once()
     msg = worker._send.call_args[0][0]
     assert msg["type"] == "worker-register"
@@ -132,9 +135,10 @@ async def test_refresh_merges_new_api_repos():
 
 @pytest.mark.asyncio
 async def test_refresh_preserves_static_order():
-    """Static config repos keep their position; API extras are appended."""
+    """Static config repos keep their position; org extras are appended."""
     worker = _make_worker(
         repos=["owner/z-repo", "owner/a-repo"],
+        org="owner",
         github_token="ghp_token",
     )
 
@@ -146,16 +150,62 @@ async def test_refresh_preserves_static_order():
     ):
         await worker._refresh_github_repos()
 
-    assert worker.cfg.repos[0] == "owner/z-repo"
-    assert worker.cfg.repos[1] == "owner/a-repo"
-    assert worker.cfg.repos[2] == "owner/new-repo"
+    # cfg.repos stays as the static config — only _broadcast_repos expands
+    assert worker.cfg.repos == ["owner/z-repo", "owner/a-repo"]
+    assert worker._broadcast_repos[0] == "owner/z-repo"
+    assert worker._broadcast_repos[1] == "owner/a-repo"
+    assert worker._broadcast_repos[2] == "owner/new-repo"
+
+
+@pytest.mark.asyncio
+async def test_refresh_filters_out_other_org_repos():
+    """Repos from other orgs in the API response are not added to broadcast list."""
+    worker = _make_worker(
+        repos=["myorg/repo1"],
+        org="myorg",
+        github_token="ghp_token",
+    )
+
+    api_repos = ["myorg/repo1", "myorg/repo2", "otherorg/repo3", "unrelated/thing"]
+
+    with patch(
+        "pioneer_worker.worker.github_pr.fetch_accessible_repos",
+        new=AsyncMock(return_value=api_repos),
+    ):
+        await worker._refresh_github_repos()
+
+    assert worker.cfg.repos == ["myorg/repo1"]
+    assert worker._broadcast_repos == ["myorg/repo1", "myorg/repo2"]
+    assert "otherorg/repo3" not in worker._broadcast_repos
+    assert "unrelated/thing" not in worker._broadcast_repos
+
+
+@pytest.mark.asyncio
+async def test_refresh_noop_when_no_org():
+    """Without cfg.org, no API call is made and broadcast list stays as static config."""
+    worker = _make_worker(
+        repos=["owner/repo1", "owner/repo2"],
+        github_token="ghp_token",
+    )
+
+    with patch(
+        "pioneer_worker.worker.github_pr.fetch_accessible_repos",
+        new=AsyncMock(return_value=["owner/repo1", "owner/repo2", "owner/extra"]),
+    ) as mock_fetch:
+        await worker._refresh_github_repos()
+
+    mock_fetch.assert_not_awaited()
+    worker._send.assert_not_awaited()
+    assert worker.cfg.repos == ["owner/repo1", "owner/repo2"]
+    assert worker._broadcast_repos == ["owner/repo1", "owner/repo2"]
 
 
 @pytest.mark.asyncio
 async def test_refresh_noop_when_list_unchanged():
-    """No worker-register message is sent when the repo set hasn't changed."""
+    """No worker-register message is sent when the org repo set hasn't changed."""
     worker = _make_worker(
         repos=["owner/repo1", "owner/repo2"],
+        org="owner",
         github_token="ghp_token",
     )
 
@@ -190,7 +240,7 @@ async def test_refresh_skips_when_no_token():
 @pytest.mark.asyncio
 async def test_refresh_sets_last_refresh_timestamp():
     """_last_repo_refresh is updated after a successful refresh."""
-    worker = _make_worker(repos=[], github_token="ghp_token")
+    worker = _make_worker(repos=[], org="owner", github_token="ghp_token")
 
     assert worker._last_repo_refresh == 0.0
 
@@ -206,7 +256,7 @@ async def test_refresh_sets_last_refresh_timestamp():
 @pytest.mark.asyncio
 async def test_refresh_noop_when_api_returns_empty():
     """Empty API response is treated as a transient error — config unchanged."""
-    worker = _make_worker(repos=["owner/existing"], github_token="ghp_token")
+    worker = _make_worker(repos=["owner/existing"], org="owner", github_token="ghp_token")
 
     with patch(
         "pioneer_worker.worker.github_pr.fetch_accessible_repos",


### PR DESCRIPTION
## Summary

- **`_refresh_github_repos` no longer mutates `cfg.repos`** — a new `_broadcast_repos` attribute holds the merged API list used only for `worker-register` messages. `cfg.repos` stays frozen as the static config. Expansion is also filtered to `cfg.org` only; without `cfg.org`, no GitHub API call is made at all.
- **Per-task repo list restored to static config** — `_execute_task` uses `list(cfg.repos)`, with explicit `repos` from the task-assigned message respected (filtered to `cfg.repos` + org prefix). `issue_repo` org handling is preserved inline.
- **Startup clone** — `run()` now `asyncio.gather`s `ensure_repo` over `cfg.repos` after joining, so repos are pre-warmed before the first task arrives.
- **Foreman `assign_task` tool** gains a `repos` parameter; when omitted it defaults to `[primary_repo]` for the guild, so workers clone only the relevant repo by default. Both task-assigned broadcast paths and the `TaskCreate` REST model also accept `repos`.

## Test plan

- [ ] Worker starts and logs cloning only the 4 configured repos, not the full accessible list
- [ ] Task assigned without explicit `repos` clones only the guild's `primary_repo`
- [ ] Task assigned with explicit `repos` clones only those repos (if accessible)
- [ ] `cfg.org` set: idle refresh expands broadcast list to org repos but does not affect task cloning
- [ ] `cfg.org` not set: no GitHub API call made during refresh
- [ ] All 409 backend + 163 worker tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)