### PR TITLE
Improve worker Codex CLI execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Pioneer Square is split into three main runtimes. `backend/` contains the FastAPI app, SQLite/Alembic schema, WebSocket handlers, and Foreman logic under `backend/foreman/`. `frontend/` is a Vue 3 + Pinia + Vite app; source lives in `frontend/src/`, static files in `frontend/public/`, and end-to-end tests in `frontend/tests/e2e/`. `worker/` contains the standalone Python worker package in `worker/pioneer_worker/` and its tests in `worker/tests/`. Shared operational docs are in `docs/`, prompt text in `prompts/`, and helper scripts in `scripts/`.
+
+## Build, Test, and Development Commands
+
+- `docker compose up --build`: run the backend and SPA quickstart.
+- `cd backend && uvicorn main:app --reload --port 8000`: run the API locally after installing `backend/requirements.txt`.
+- `cd frontend && npm run dev`: start the Vite dev server at `http://localhost:5173`.
+- `cd frontend && npm run build`: type-check and build the frontend.
+- `cd worker && pip install -e . && pioneer-worker`: install and run a worker using `pioneer-worker.toml`.
+- `ruff check .` and `ruff format .`: lint and format Python from the repo root.
+
+## Coding Style & Naming Conventions
+
+Python targets 3.11 with Ruff configured in `ruff.toml` using 100-character lines, import sorting, pyupgrade, and bugbear rules. Use `snake_case` for Python modules, functions, and tests. Frontend code uses TypeScript, Vue single-file components, ESLint, and Prettier; use `PascalCase.vue` for components, `camelCase` for utilities and store members, and keep Pinia stores in `frontend/src/stores/`.
+
+## Testing Guidelines
+
+Backend and worker tests use pytest with `asyncio_mode = auto`; run `python -m pytest` from `backend/` or `worker/`. Frontend unit tests use Vitest: run `npm test` from `frontend/`, or `npm run test:coverage` for coverage. Name Python tests `test_*.py`; place frontend specs as `*.spec.ts` near the code or under `src/**/__tests__/`. Add tests for WebSocket flows, task lifecycle changes, and store updates when touching those paths.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses concise imperative commits, often Conventional Commit style such as `fix(worker): ...`, `style: ...`, or short maintenance messages like `ruff`. Keep commits focused and mention the subsystem when helpful. Pull requests should include a brief problem/solution summary, test commands run, linked issues or tasks, and screenshots for visible frontend changes.
+
+## Security & Configuration Tips
+
+Do not commit secrets or local state. Use `backend/.env` for GitHub OAuth values, copy `worker/pioneer-worker.toml.example` before editing worker configuration, and keep `pioneer_square.db` and generated build output out of review unless explicitly required.

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -45,3 +45,11 @@ token = "env:GITHUB_TOKEN"
 
 [claude]
 max_turns = 50
+
+[codex]
+# Extra args passed to `codex exec` before the prompt. Keep approval policy
+# non-interactive for unattended workers.
+# args = ["--sandbox", "workspace-write", "--ask-for-approval", "never"]
+
+# Run `codex doctor` at worker startup and log the result (non-fatal).
+doctor = true

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -60,6 +60,22 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--claude-path", help="Path to the claude executable (default: claude).")
     parser.add_argument("--codex-path", help="Path to the codex executable (default: codex).")
+    parser.add_argument(
+        "--codex-arg",
+        dest="codex_args",
+        action="append",
+        help=(
+            "Extra argument passed to `codex exec` before the prompt "
+            "(may be repeated, e.g. --codex-arg --sandbox=workspace-write)."
+        ),
+    )
+    parser.add_argument(
+        "--skip-codex-doctor",
+        dest="codex_doctor",
+        action="store_false",
+        default=None,
+        help="Skip `codex doctor` startup diagnostics.",
+    )
     parser.add_argument("--pi-path", help="Path to the pi executable (default: pi).")
 
     # Tuning
@@ -127,6 +143,8 @@ def main(argv: list[str] | None = None) -> int:
             "work_dir": args.work_dir,
             "claude_path": args.claude_path,
             "codex_path": args.codex_path,
+            "codex_args": args.codex_args,
+            "codex_doctor": args.codex_doctor,
             "pi_path": args.pi_path,
             "pull_interval": args.pull_interval,
             "claude_max_turns": args.claude_max_turns,

--- a/worker/pioneer_worker/codex_runner.py
+++ b/worker/pioneer_worker/codex_runner.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
+import os
+import pty
+import tempfile
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -36,23 +41,47 @@ async def run_codex_auto(
     *,
     emit: EmitFn,
     codex_path: str = "codex",
+    codex_args: list[str] | None = None,
 ) -> tuple[bool, str, str]:
     """Run codex on *description* in *cwd*. Returns (success, stop_reason, last_text)."""
-    cmd = [codex_path, "exec", "--json", description]
+    last_message_file = tempfile.NamedTemporaryFile(
+        prefix="pioneer-codex-last-", suffix=".txt", delete=False
+    )
+    last_message_path = last_message_file.name
+    last_message_file.close()
+    cmd = [
+        codex_path,
+        "exec",
+        "--json",
+        "-C",
+        cwd,
+        "--output-last-message",
+        last_message_path,
+        *(codex_args or []),
+        description,
+    ]
     logger.info("Spawning codex in %s; description=%r", cwd, description)
     logger.info("codex argv: %s", cmd)
     await emit(f"[codex] Starting: {description[:80]}")
     last_text = ""
     stop_reason = "no_events"
     event_count = 0
+    master_fd: int | None = None
+    slave_fd: int | None = None
     try:
+        # `codex exec` treats any non-TTY stdin, including /dev/null, as piped
+        # prompt content and tries to drain it. Give it an idle TTY so the
+        # explicit prompt argument is the only task input.
+        master_fd, slave_fd = pty.openpty()
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=cwd,
-            stdin=asyncio.subprocess.DEVNULL,
+            stdin=slave_fd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+        os.close(slave_fd)
+        slave_fd = None
         logger.info("codex subprocess started pid=%s", proc.pid)
 
         async def _drain_stderr() -> None:
@@ -90,6 +119,9 @@ async def run_codex_auto(
             logger.warning("codex[%d] produced no stdout events — check PATH/auth", proc.pid)
         if stop_reason == "no_events" and exit_code == 0:
             stop_reason = "success"
+        captured_last = Path(last_message_path).read_text(encoding="utf-8").strip()
+        if captured_last:
+            last_text = captured_last
         return exit_code == 0, stop_reason, last_text
     except FileNotFoundError:
         logger.error("`codex` CLI not found on PATH")
@@ -99,3 +131,10 @@ async def run_codex_auto(
         logger.exception("codex subprocess crashed: %s", exc)
         await emit(f"[codex] ✗ {exc}")
         return False, "error_during_execution", last_text
+    finally:
+        for fd in (slave_fd, master_fd):
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+        with contextlib.suppress(OSError):
+            os.unlink(last_message_path)

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -6,6 +6,7 @@ Reads a TOML file (default: ``./pioneer-worker.toml``).
 from __future__ import annotations
 
 import os
+import shlex
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -38,6 +39,8 @@ class Config:
     work_dir: str = "worktrees"
     claude_path: str = "claude"
     codex_path: str = "codex"
+    codex_args: list[str] = field(default_factory=list)
+    codex_doctor: bool = True
     pi_path: str = "pi"
     pull_interval: float = 300.0
     claude_max_turns: int = 50
@@ -121,6 +124,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
     github_block = raw.get("github") or {}
     paths_block = raw.get("paths") or {}
     claude_block = raw.get("claude") or {}
+    codex_block = raw.get("codex") or {}
 
     token = overrides.get("github_token")
     if token is None:
@@ -141,6 +145,20 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
 
     _repos_env = os.environ.get("PIONEER_REPOS", "")
     _repos_from_env = [r.strip() for r in _repos_env.split(",") if r.strip()] if _repos_env else []
+    _codex_args_env = os.environ.get("PIONEER_CODEX_ARGS", "")
+    _codex_args = (
+        overrides.get("codex_args")
+        if overrides.get("codex_args") is not None
+        else codex_block.get("args")
+        if codex_block.get("args") is not None
+        else shlex.split(_codex_args_env)
+        if _codex_args_env
+        else []
+    )
+    if isinstance(_codex_args, str):
+        _codex_args = shlex.split(_codex_args)
+    if not isinstance(_codex_args, list) or not all(isinstance(arg, str) for arg in _codex_args):
+        raise ValueError("codex args must be a list of strings.")
 
     return Config(
         backend_url=backend_url.rstrip("/"),
@@ -171,6 +189,12 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         ),
         claude_path=overrides.get("claude_path") or paths_block.get("claude", "claude"),
         codex_path=overrides.get("codex_path") or paths_block.get("codex", "codex"),
+        codex_args=list(_codex_args),
+        codex_doctor=bool(
+            overrides.get("codex_doctor")
+            if overrides.get("codex_doctor") is not None
+            else codex_block.get("doctor", True)
+        ),
         pi_path=overrides.get("pi_path") or paths_block.get("pi", "pi"),
         pull_interval=float(
             overrides.get("pull_interval")

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -206,6 +206,42 @@ class Worker:
         else:
             logger.warning("gh auth status: NOT authenticated (rc=%d)\n%s", proc.returncode, output)
 
+    async def _check_codex_doctor(self) -> None:
+        """Run `codex doctor` as a non-fatal startup diagnostic."""
+        if not self.cfg.codex_doctor:
+            logger.info("codex doctor skipped by config")
+            return
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self.cfg.codex_path,
+                "doctor",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+        except FileNotFoundError:
+            logger.warning("codex CLI not found at %r — Codex tasks will fail", self.cfg.codex_path)
+            return
+        except Exception as exc:
+            logger.warning("codex doctor spawn failed: %s", exc)
+            return
+
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=20.0)
+        except TimeoutError:
+            logger.warning("codex doctor timed out after 20s")
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            return
+
+        output = stdout.decode(errors="replace").strip()
+        if proc.returncode == 0:
+            logger.info("codex doctor: ok\n%s", output)
+        else:
+            logger.warning("codex doctor: failed (rc=%d)\n%s", proc.returncode, output)
+
     async def _claude_is_authenticated(self) -> bool:
         """Return True if `claude auth status --json` reports loggedIn=true.
 
@@ -864,7 +900,7 @@ class Worker:
         )
         logger.info(
             "Paths: repos_dir=%s work_dir=%s pull_interval=%.1fs max_turns=%d"
-            " max_agents=%d claude=%s codex=%s pi=%s",
+            " max_agents=%d claude=%s codex=%s codex_args=%s pi=%s",
             self.cfg.repos_dir,
             self.cfg.work_dir,
             self.cfg.pull_interval,
@@ -872,6 +908,7 @@ class Worker:
             self.cfg.max_agents,
             self.cfg.claude_path,
             self.cfg.codex_path,
+            self.cfg.codex_args,
             self.cfg.pi_path,
         )
 
@@ -883,6 +920,7 @@ class Worker:
         await self._fetch_github_token_if_needed()
         await self._refresh_github_repos()
         await self._check_gh_auth()
+        await self._check_codex_doctor()
 
         logger.info("Connecting to backend WebSocket at %s", self.cfg.ws_url)
         self.ws.on_reconnect = self._on_ws_reconnect
@@ -1634,6 +1672,7 @@ class Worker:
                         primary_wt,
                         emit=emit,
                         codex_path=self.cfg.codex_path,
+                        codex_args=self.cfg.codex_args,
                     )
                 elif tool == "pi":
                     logger.info("Task %s: launching pi in %s", task_id, primary_wt)

--- a/worker/tests/test_cli.py
+++ b/worker/tests/test_cli.py
@@ -58,3 +58,34 @@ def test_cli_repos_check_passes_with_cli_override(tmp_path, monkeypatch):
     rc = cli.main(["--config", str(toml_path), "--repo", "owner/repo"])
     assert rc == 0
     assert captured["repos"] == ["owner/repo"]
+
+
+def test_cli_passes_codex_args(tmp_path, monkeypatch):
+    toml_path = _write_toml(
+        tmp_path,
+        'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\nrepos = ["owner/repo"]\n',
+    )
+
+    captured = {}
+
+    class _FakeWorker:
+        def __init__(self, cfg):
+            captured["codex_args"] = list(cfg.codex_args)
+            captured["codex_doctor"] = cfg.codex_doctor
+
+        async def run(self):
+            return None
+
+    monkeypatch.setattr(cli, "Worker", _FakeWorker)
+    rc = cli.main(
+        [
+            "--config",
+            str(toml_path),
+            "--codex-arg=--sandbox",
+            "--codex-arg=workspace-write",
+            "--skip-codex-doctor",
+        ]
+    )
+    assert rc == 0
+    assert captured["codex_args"] == ["--sandbox", "workspace-write"]
+    assert captured["codex_doctor"] is False

--- a/worker/tests/test_codex_runner.py
+++ b/worker/tests/test_codex_runner.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from pioneer_worker.codex_runner import parse_codex_event, run_codex_auto
+
+
+def test_parse_codex_assistant_message() -> None:
+    assert parse_codex_event({"type": "message", "role": "assistant", "content": "done"}) == "done"
+
+
+@pytest.mark.asyncio
+async def test_run_codex_auto_uses_tty_stdin(tmp_path) -> None:
+    fake_codex = tmp_path / "fake-codex"
+    fake_codex.write_text(
+        f"""#!{sys.executable}
+import json
+import os
+import sys
+
+if not os.isatty(0):
+    print("Reading additional input from stdin...", file=sys.stderr, flush=True)
+    sys.stdin.read()
+    sys.exit(2)
+
+assert "-C" in sys.argv
+assert sys.argv[sys.argv.index("-C") + 1] == os.getcwd()
+assert "--sandbox" in sys.argv
+assert sys.argv[sys.argv.index("--sandbox") + 1] == "workspace-write"
+last_message_path = sys.argv[sys.argv.index("--output-last-message") + 1]
+with open(last_message_path, "w", encoding="utf-8") as fh:
+    fh.write("captured final")
+
+print(json.dumps({{"type": "message", "role": "assistant", "content": "finished"}}), flush=True)
+print(json.dumps({{"type": "done"}}), flush=True)
+""",
+        encoding="utf-8",
+    )
+    fake_codex.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text = await run_codex_auto(
+        "do the work",
+        str(tmp_path),
+        emit=emit,
+        codex_path=os.fspath(fake_codex),
+        codex_args=["--sandbox", "workspace-write"],
+    )
+
+    assert success is True
+    assert stop_reason == "success"
+    assert last_text == "captured final"
+    assert "finished" in emitted
+    assert not any("Reading additional input from stdin" in line for line in emitted)

--- a/worker/tests/test_config.py
+++ b/worker/tests/test_config.py
@@ -135,6 +135,31 @@ def test_load_toml_github_token_env_prefix(tmp_path, monkeypatch):
     assert cfg.github_token == "ghp_from_env"
 
 
+def test_load_codex_args_from_toml(tmp_path):
+    toml_path = tmp_path / "pioneer-worker.toml"
+    toml_path.write_text(
+        'backend_url = "ws://x:1"\nguild_id = "g"\n'
+        '[codex]\nargs = ["--sandbox", "workspace-write", "--ask-for-approval", "never"]\n'
+    )
+    cfg = load(str(toml_path))
+    assert cfg.codex_args == ["--sandbox", "workspace-write", "--ask-for-approval", "never"]
+
+
+def test_load_codex_args_from_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("PIONEER_BACKEND_URL", "ws://x:1")
+    monkeypatch.setenv("PIONEER_GUILD_ID", "g")
+    monkeypatch.setenv("PIONEER_CODEX_ARGS", '--sandbox workspace-write -m "gpt-5.4"')
+    cfg = load(str(tmp_path / "missing.toml"))
+    assert cfg.codex_args == ["--sandbox", "workspace-write", "-m", "gpt-5.4"]
+
+
+def test_load_codex_doctor_can_be_disabled(tmp_path):
+    toml_path = tmp_path / "pioneer-worker.toml"
+    toml_path.write_text('backend_url = "ws://x:1"\nguild_id = "g"\n[codex]\ndoctor = false\n')
+    cfg = load(str(toml_path))
+    assert cfg.codex_doctor is False
+
+
 # ---------------------------------------------------------------------------
 # load() — environment variable overrides
 # ---------------------------------------------------------------------------

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -71,6 +71,7 @@ async def test_run_sends_disconnect_before_ws_close():
     worker._register = AsyncMock()
     worker._fetch_github_token_if_needed = AsyncMock()
     worker._check_gh_auth = AsyncMock()
+    worker._check_codex_doctor = AsyncMock()
     worker._check_claude_auth = AsyncMock()
     worker._fetch_pending_tasks = AsyncMock(return_value=[])
     worker.ws.connect = AsyncMock()


### PR DESCRIPTION
## Summary
- Run Codex with a PTY-backed stdin so `codex exec` does not block reading piped stdin.
- Pass `-C` and `--output-last-message`, support configurable extra Codex args, and add a non-fatal `codex doctor` startup check.
- Add `AGENTS.md` contributor guidelines and tests for the Codex runner/config/CLI wiring.

## Tests
- `ruff check worker/pioneer_worker/codex_runner.py worker/pioneer_worker/config.py worker/pioneer_worker/cli.py worker/pioneer_worker/worker.py worker/tests/test_codex_runner.py worker/tests/test_config.py worker/tests/test_cli.py worker/tests/test_disconnect.py`
- `ruff format worker/pioneer_worker/codex_runner.py worker/pioneer_worker/config.py worker/pioneer_worker/cli.py worker/pioneer_worker/worker.py worker/tests/test_codex_runner.py worker/tests/test_config.py worker/tests/test_cli.py worker/tests/test_disconnect.py`
- `python -m pytest worker/tests/test_codex_runner.py worker/tests/test_config.py worker/tests/test_cli.py`
- `python -m pytest worker/tests`