### PR TITLE
Fix worker tab selection on repeated clicks

### DIFF
--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -3,8 +3,8 @@
     <div class="tab-bar">
       <button
         class="tab"
-        :class="{ active: activeTab === 'factory' }"
-        @click="activeTab = 'factory'"
+        :class="{ active: agentsStore.activeTab === 'factory' }"
+        @click="agentsStore.activeTab = 'factory'"
       >
         <span class="tab-icon">⚙</span>
         <span class="tab-label">Factory Floor</span>
@@ -14,7 +14,7 @@
         v-for="agent in visibleAgentTabs"
         :key="'agent-' + agent.id"
         class="tab worker-tab"
-        :class="{ active: activeTab === 'agent-' + agent.id }"
+        :class="{ active: agentsStore.activeTab === 'agent-' + agent.id }"
         @click="onAgentTabClick($event, agent.id)"
       >
         <span class="state-dot" :class="agent.state"></span>
@@ -26,7 +26,7 @@
         v-for="worker in visibleWorkerTabs"
         :key="'worker-' + worker.id"
         class="tab worker-tab"
-        :class="{ active: activeTab === 'worker-' + worker.id }"
+        :class="{ active: agentsStore.activeTab === 'worker-' + worker.id }"
         @click="onWorkerTabClick($event, worker.id)"
       >
         <span class="state-dot" :class="worker.state"></span>
@@ -38,7 +38,7 @@
         v-for="task in visibleTaskTabs"
         :key="'task-' + task.id"
         class="tab task-tab"
-        :class="{ active: activeTab === 'task-' + task.id }"
+        :class="{ active: agentsStore.activeTab === 'task-' + task.id }"
         @click="onTabClick($event, task.id)"
       >
         <span class="task-dot" :class="'task-dot-' + task.state.replace(/[^a-z]/g, '-')"></span>
@@ -47,16 +47,16 @@
       </button>
     </div>
     <div class="tab-content">
-      <FactoryFloor v-if="activeTab === 'factory'" />
-      <LogPane v-else-if="activeTab.startsWith('agent-')" kind="agent" :id="activeTab.slice(6)" />
-      <LogPane v-else-if="activeTab.startsWith('worker-')" kind="worker" :id="activeTab.slice(7)" />
-      <LogPane v-else-if="activeTab.startsWith('task-')" kind="task" :id="activeTab.slice(5)" />
+      <FactoryFloor v-if="agentsStore.activeTab === 'factory'" />
+      <LogPane v-else-if="agentsStore.activeTab.startsWith('agent-')" kind="agent" :id="agentsStore.activeTab.slice(6)" />
+      <LogPane v-else-if="agentsStore.activeTab.startsWith('worker-')" kind="worker" :id="agentsStore.activeTab.slice(7)" />
+      <LogPane v-else-if="agentsStore.activeTab.startsWith('task-')" kind="task" :id="agentsStore.activeTab.slice(5)" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { computed, watch } from 'vue'
 import { useAgentsStore } from '../stores/agents'
 import { useTasksStore } from '../stores/tasks'
 import FactoryFloor from './FactoryFloor.vue'
@@ -64,7 +64,6 @@ import LogPane from './LogPane.vue'
 
 const agentsStore = useAgentsStore()
 const tasksStore = useTasksStore()
-const activeTab = ref('factory')
 
 const visibleAgentTabs = computed(() =>
   agentsStore.openedAgentIds
@@ -83,50 +82,34 @@ const visibleTaskTabs = computed(() =>
 )
 
 watch(
-  [() => agentsStore.selectedAgentId, () => agentsStore.agentSelectSeq],
-  ([id]) => {
-    if (id) activeTab.value = 'agent-' + id
-  },
-)
-
-watch(
-  [() => agentsStore.selectedWorkerId, () => agentsStore.workerSelectSeq],
-  ([id]) => {
-    if (id) activeTab.value = 'worker-' + id
-  },
-)
-
-watch(
   () => tasksStore.selectedTaskId,
   (id) => {
-    if (id) activeTab.value = 'task-' + id
+    if (id) agentsStore.activeTab = 'task-' + id
   },
 )
 
 function onWorkerTabClick(event: MouseEvent, workerId: string) {
   if ((event.target as HTMLElement).closest('.tab-close')) {
     agentsStore.closeWorker(workerId)
-    if (activeTab.value === 'worker-' + workerId) activeTab.value = 'factory'
   } else {
-    activeTab.value = 'worker-' + workerId
+    agentsStore.activeTab = 'worker-' + workerId
   }
 }
 
 function onAgentTabClick(event: MouseEvent, agentId: string) {
   if ((event.target as HTMLElement).closest('.tab-close')) {
     agentsStore.closeAgent(agentId)
-    if (activeTab.value === 'agent-' + agentId) activeTab.value = 'factory'
   } else {
-    activeTab.value = 'agent-' + agentId
+    agentsStore.activeTab = 'agent-' + agentId
   }
 }
 
 function onTabClick(event: MouseEvent, taskId: string) {
   if ((event.target as HTMLElement).closest('.tab-close')) {
     tasksStore.closeTask(taskId)
-    if (activeTab.value === 'task-' + taskId) activeTab.value = 'factory'
+    if (agentsStore.activeTab === 'task-' + taskId) agentsStore.activeTab = 'factory'
   } else {
-    activeTab.value = 'task-' + taskId
+    agentsStore.activeTab = 'task-' + taskId
   }
 }
 </script>

--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -83,15 +83,15 @@ const visibleTaskTabs = computed(() =>
 )
 
 watch(
-  () => agentsStore.selectedAgentId,
-  (id) => {
+  [() => agentsStore.selectedAgentId, () => agentsStore.agentSelectSeq],
+  ([id]) => {
     if (id) activeTab.value = 'agent-' + id
   },
 )
 
 watch(
-  () => agentsStore.selectedWorkerId,
-  (id) => {
+  [() => agentsStore.selectedWorkerId, () => agentsStore.workerSelectSeq],
+  ([id]) => {
     if (id) activeTab.value = 'worker-' + id
   },
 )

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -43,10 +43,9 @@ export const useAgentsStore = defineStore('agents', () => {
   const workerLogs = ref<Record<string, LogEntry[]>>({})
   const selectedWorkerId = ref<string | null>(null)
   const openedWorkerIds = ref<string[]>([])
-  const workerSelectSeq = ref(0)
   const selectedAgentId = ref<string | null>(null)
   const openedAgentIds = ref<string[]>([])
-  const agentSelectSeq = ref(0)
+  const activeTab = ref<string>('factory')
 
   // Unique workers derived from agent slots
   const workers = computed<Worker[]>(() => {
@@ -130,9 +129,9 @@ export const useAgentsStore = defineStore('agents', () => {
 
   function selectWorker(workerId: string | null) {
     selectedWorkerId.value = workerId
-    if (workerId) workerSelectSeq.value++
-    if (workerId && !openedWorkerIds.value.includes(workerId)) {
-      openedWorkerIds.value.push(workerId)
+    if (workerId) {
+      if (!openedWorkerIds.value.includes(workerId)) openedWorkerIds.value.push(workerId)
+      activeTab.value = 'worker-' + workerId
     }
   }
 
@@ -140,13 +139,14 @@ export const useAgentsStore = defineStore('agents', () => {
     const idx = openedWorkerIds.value.indexOf(workerId)
     if (idx !== -1) openedWorkerIds.value.splice(idx, 1)
     if (selectedWorkerId.value === workerId) selectedWorkerId.value = null
+    if (activeTab.value === 'worker-' + workerId) activeTab.value = 'factory'
   }
 
   function selectAgent(agentId: string | null) {
     selectedAgentId.value = agentId
-    if (agentId) agentSelectSeq.value++
-    if (agentId && !openedAgentIds.value.includes(agentId)) {
-      openedAgentIds.value.push(agentId)
+    if (agentId) {
+      if (!openedAgentIds.value.includes(agentId)) openedAgentIds.value.push(agentId)
+      activeTab.value = 'agent-' + agentId
     }
   }
 
@@ -154,6 +154,7 @@ export const useAgentsStore = defineStore('agents', () => {
     const idx = openedAgentIds.value.indexOf(agentId)
     if (idx !== -1) openedAgentIds.value.splice(idx, 1)
     if (selectedAgentId.value === agentId) selectedAgentId.value = null
+    if (activeTab.value === 'agent-' + agentId) activeTab.value = 'factory'
   }
 
   function sendMessage(agentId: string, content: string) {
@@ -231,6 +232,7 @@ export const useAgentsStore = defineStore('agents', () => {
     openedWorkerIds.value = []
     selectedAgentId.value = null
     openedAgentIds.value = []
+    activeTab.value = 'factory'
   }
 
   type RawLog = { line: string; timestamp: string; detail?: unknown }
@@ -289,10 +291,9 @@ export const useAgentsStore = defineStore('agents', () => {
     workerLogs,
     selectedWorkerId,
     openedWorkerIds,
-    workerSelectSeq,
     selectedAgentId,
     openedAgentIds,
-    agentSelectSeq,
+    activeTab,
     registerAgent,
     updateAgentState,
     addLog,

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -43,8 +43,10 @@ export const useAgentsStore = defineStore('agents', () => {
   const workerLogs = ref<Record<string, LogEntry[]>>({})
   const selectedWorkerId = ref<string | null>(null)
   const openedWorkerIds = ref<string[]>([])
+  const workerSelectSeq = ref(0)
   const selectedAgentId = ref<string | null>(null)
   const openedAgentIds = ref<string[]>([])
+  const agentSelectSeq = ref(0)
 
   // Unique workers derived from agent slots
   const workers = computed<Worker[]>(() => {
@@ -128,6 +130,7 @@ export const useAgentsStore = defineStore('agents', () => {
 
   function selectWorker(workerId: string | null) {
     selectedWorkerId.value = workerId
+    if (workerId) workerSelectSeq.value++
     if (workerId && !openedWorkerIds.value.includes(workerId)) {
       openedWorkerIds.value.push(workerId)
     }
@@ -141,6 +144,7 @@ export const useAgentsStore = defineStore('agents', () => {
 
   function selectAgent(agentId: string | null) {
     selectedAgentId.value = agentId
+    if (agentId) agentSelectSeq.value++
     if (agentId && !openedAgentIds.value.includes(agentId)) {
       openedAgentIds.value.push(agentId)
     }
@@ -285,8 +289,10 @@ export const useAgentsStore = defineStore('agents', () => {
     workerLogs,
     selectedWorkerId,
     openedWorkerIds,
+    workerSelectSeq,
     selectedAgentId,
     openedAgentIds,
+    agentSelectSeq,
     registerAgent,
     updateAgentState,
     addLog,


### PR DESCRIPTION
## Summary
- Vue watchers silently skip updates when a `ref` is set to its existing value, so clicking the same worker name a second time left `activeTab` stale
- Add `workerSelectSeq` and `agentSelectSeq` counters (incremented on every `selectWorker`/`selectAgent` call) to `agents.ts` store
- Watch both the ID ref and the sequence counter in `MainView.vue` so the active tab is updated on every click, not just when the selection changes

## Test plan
- [ ] Click a worker name in the sidebar — tab appears
- [ ] Click a different tab (e.g. factory floor)
- [ ] Click the same worker name again — tab reappears
- [ ] Repeat several times; tab should appear each time
- [ ] Same behaviour for agent tabs

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)