### PR TITLE
Improve thinking block truncation UI

### DIFF
--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -21,17 +21,17 @@
         <template v-if="log.detail.toolType === 'tool_use'">
           <template v-if="log.detail.name === 'Edit'">
             <div class="log-detail-label">OLD</div>
-            <pre class="log-detail-body log-detail-old">{{ log.detail.input?.old_string }}</pre>
+            <pre class="log-detail-body log-detail-old">{{ inputRecord(log.detail.input).old_string }}</pre>
             <div class="log-detail-label log-detail-label--new">NEW</div>
-            <pre class="log-detail-body log-detail-new">{{ log.detail.input?.new_string }}</pre>
+            <pre class="log-detail-body log-detail-new">{{ inputRecord(log.detail.input).new_string }}</pre>
           </template>
           <template v-else-if="log.detail.name === 'Write'">
-            <div class="log-detail-label">{{ log.detail.input?.file_path }}</div>
-            <pre class="log-detail-body">{{ log.detail.input?.content }}</pre>
+            <div class="log-detail-label">{{ inputRecord(log.detail.input).file_path }}</div>
+            <pre class="log-detail-body">{{ inputRecord(log.detail.input).content }}</pre>
           </template>
           <template v-else-if="log.detail.name === 'Bash'">
             <div class="log-detail-label">COMMAND</div>
-            <pre class="log-detail-body">{{ log.detail.input?.command }}</pre>
+            <pre class="log-detail-body">{{ inputRecord(log.detail.input).command }}</pre>
           </template>
           <template v-else>
             <div class="log-detail-label">{{ log.detail.name }}</div>
@@ -100,6 +100,10 @@ function isMarkdownLine(line: string): boolean {
 function renderLine(line: string): string {
   if (isMarkdownLine(line)) return renderMarkdown(line)
   return linkify(line)
+}
+
+function inputRecord(input: Record<string, unknown> | string | undefined): Record<string, unknown> {
+  return typeof input === 'object' && input !== null ? input : {}
 }
 
 function lineClass(line: string) {

--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -6,8 +6,8 @@
     <div v-for="(log, i) in logs" :key="i" class="log-entry">
       <div
         class="log-line"
-        :class="{ 'log-line--expandable': !!log.detail }"
-        @click="log.detail && toggleDetail(i)"
+        :class="{ 'log-line--expandable': !!log.detail?.toolType }"
+        @click="log.detail?.toolType && toggleDetail(i)"
       >
         <span class="log-time">{{ formatTime(log.timestamp) }}</span>
         <span
@@ -15,9 +15,9 @@
           :class="[lineClass(log.line), { 'log-text--markdown': isMarkdownLine(log.line) }]"
           v-html="renderLine(log.line)"
         ></span>
-        <span v-if="log.detail" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
+        <span v-if="log.detail?.toolType" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
       </div>
-      <div v-if="log.detail && expandedIdx === i" class="log-detail">
+      <div v-if="log.detail?.toolType && expandedIdx === i" class="log-detail">
         <template v-if="log.detail.toolType === 'tool_use'">
           <template v-if="log.detail.name === 'Edit'">
             <div class="log-detail-label">OLD</div>
@@ -41,6 +41,10 @@
         <template v-else-if="log.detail.toolType === 'tool_result'">
           <div class="log-detail-label">OUTPUT</div>
           <pre class="log-detail-body">{{ log.detail.output }}</pre>
+        </template>
+        <template v-else-if="log.detail.toolType === 'thinking'">
+          <div class="log-detail-label">FULL THOUGHT</div>
+          <pre class="log-detail-body log-detail-thinking">{{ log.detail.fullText }}</pre>
         </template>
       </div>
     </div>
@@ -212,6 +216,12 @@ watch(
   background: rgba(0, 120, 60, 0.08);
   border-color: rgba(0, 187, 100, 0.3);
   color: #70c090;
+}
+.log-detail-thinking {
+  background: rgba(30, 60, 120, 0.1);
+  border-color: rgba(80, 140, 220, 0.25);
+  color: var(--color-blue);
+  font-style: italic;
 }
 
 .log-time {

--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -55,7 +55,7 @@
 import { ref, watch, nextTick } from 'vue'
 import { renderMarkdown } from '../../utils/markdown'
 import { formatClock } from '../../utils/format'
-import type { LogEntry } from '../../types'
+import type { LogEntry, LogDetail } from '../../types'
 
 const props = defineProps<{ logs: LogEntry[] }>()
 

--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -55,7 +55,7 @@
 import { ref, watch, nextTick } from 'vue'
 import { renderMarkdown } from '../../utils/markdown'
 import { formatClock } from '../../utils/format'
-import type { LogEntry, LogDetail } from '../../types'
+import type { LogEntry } from '../../types'
 
 const props = defineProps<{ logs: LogEntry[] }>()
 

--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -6,8 +6,8 @@
     <div v-for="(log, i) in logs" :key="i" class="log-entry">
       <div
         class="log-line"
-        :class="{ 'log-line--expandable': !!log.detail?.toolType }"
-        @click="log.detail?.toolType && toggleDetail(i)"
+        :class="{ 'log-line--expandable': isExpandable(log) }"
+        @click="isExpandable(log) && toggleDetail(i)"
       >
         <span class="log-time">{{ formatTime(log.timestamp) }}</span>
         <span
@@ -15,9 +15,9 @@
           :class="[lineClass(log.line), { 'log-text--markdown': isMarkdownLine(log.line) }]"
           v-html="renderLine(log.line)"
         ></span>
-        <span v-if="log.detail?.toolType" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
+        <span v-if="isExpandable(log)" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
       </div>
-      <div v-if="log.detail?.toolType && expandedIdx === i" class="log-detail">
+      <div v-if="isExpandable(log) && expandedIdx === i" class="log-detail">
         <template v-if="log.detail.toolType === 'tool_use'">
           <template v-if="log.detail.name === 'Edit'">
             <div class="log-detail-label">OLD</div>
@@ -61,6 +61,12 @@ const props = defineProps<{ logs: LogEntry[] }>()
 
 const bodyEl = ref<HTMLElement | null>(null)
 const expandedIdx = ref<number | null>(null)
+
+function isExpandable(log: LogEntry): boolean {
+  if (!log.detail?.toolType) return false
+  if (log.detail.toolType === 'thinking') return log.detail.input !== log.detail.summary
+  return true
+}
 
 function toggleDetail(i: number) {
   expandedIdx.value = expandedIdx.value === i ? null : i

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,10 +12,11 @@ export type AgentActivity =
 export type AgentType = 'foreman' | 'worker' | string
 
 export interface LogDetail {
-  toolType?: 'tool_use' | 'tool_result'
+  toolType?: 'tool_use' | 'tool_result' | 'thinking'
   name?: string
   input?: Record<string, unknown>
   output?: string
+  fullText?: string
   [key: string]: unknown
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,9 +14,10 @@ export type AgentType = 'foreman' | 'worker' | string
 export interface LogDetail {
   toolType?: 'tool_use' | 'tool_result' | 'thinking'
   name?: string
-  input?: Record<string, unknown>
+  input?: Record<string, unknown> | string
   output?: string
   fullText?: string
+  summary?: string
   [key: string]: unknown
 }
 

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -76,9 +76,13 @@ def parse_claude_event(event: dict) -> list[tuple[str, dict | None]]:
                     is_long = len(flat) > _THINKING_PREVIEW_LEN
                     preview = _truncate_at_word(flat, _THINKING_PREVIEW_LEN)
                     suffix = "..." if is_long else ""
-                    detail: dict = {"activity": "thinking"}
+                    detail: dict = {
+                        "activity": "thinking",
+                        "toolType": "thinking",
+                        "input": thinking,
+                        "summary": preview,
+                    }
                     if is_long:
-                        detail["toolType"] = "thinking"
                         detail["fullText"] = thinking
                     pairs.append(
                         (

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -26,6 +26,17 @@ def _summarize_lines(lines: list[str], prefix: str = "  → ") -> str:
     )
 
 
+_THINKING_PREVIEW_LEN = 300
+
+
+def _truncate_at_word(text: str, limit: int) -> str:
+    """Truncate text at a word boundary at or before limit characters."""
+    if len(text) <= limit:
+        return text
+    idx = text.rfind(" ", 0, limit)
+    return text[: idx if idx > 0 else limit]
+
+
 _TOOL_ACTIVITY: dict[str, str] = {
     "Bash": "running",
     "Read": "reading",
@@ -61,11 +72,18 @@ def parse_claude_event(event: dict) -> list[tuple[str, dict | None]]:
             elif btype == "thinking":
                 thinking = blk.get("thinking", "").strip()
                 if thinking:
-                    preview = thinking[:100].replace("\n", " ")
+                    flat = thinking.replace("\n", " ")
+                    is_long = len(flat) > _THINKING_PREVIEW_LEN
+                    preview = _truncate_at_word(flat, _THINKING_PREVIEW_LEN)
+                    suffix = "..." if is_long else ""
+                    detail: dict = {"activity": "thinking"}
+                    if is_long:
+                        detail["toolType"] = "thinking"
+                        detail["fullText"] = thinking
                     pairs.append(
                         (
-                            f"[thinking] {preview}{'...' if len(thinking) > 100 else ''}",
-                            {"activity": "thinking"},
+                            f"[thinking] {preview}{suffix}",
+                            detail,
                         )
                     )
             elif btype == "tool_use":

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -78,11 +78,11 @@ def parse_claude_event(event: dict) -> list[tuple[str, dict | None]]:
                     suffix = "..." if is_long else ""
                     detail: dict = {
                         "activity": "thinking",
-                        "toolType": "thinking",
                         "input": thinking,
                         "summary": preview,
                     }
                     if is_long:
+                        detail["toolType"] = "thinking"
                         detail["fullText"] = thinking
                     pairs.append(
                         (

--- a/worker/tests/test_claude_runner.py
+++ b/worker/tests/test_claude_runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from pioneer_worker.claude_runner import _summarize_lines, parse_claude_event
+from pioneer_worker.claude_runner import _summarize_lines, _truncate_at_word, parse_claude_event
 
 # ---------------------------------------------------------------------------
 # _summarize_lines
@@ -73,14 +73,43 @@ def test_parse_assistant_thinking_block():
     assert "I should do X" in pairs[0][0]
 
 
-def test_parse_assistant_thinking_truncates_at_100():
-    long_thought = "x" * 200
+def test_parse_assistant_thinking_truncates_at_300():
+    long_thought = "x" * 400
     event = {
         "type": "assistant",
         "message": {"content": [{"type": "thinking", "thinking": long_thought}]},
     }
     pairs = parse_claude_event(event)
     assert "..." in pairs[0][0]
+    text, detail = pairs[0]
+    assert detail is not None
+    assert detail["toolType"] == "thinking"
+    assert detail["fullText"] == long_thought
+
+
+def test_parse_assistant_thinking_word_boundary():
+    long_thought = ("hello world " * 30).strip()  # spaces at word boundaries
+    event = {
+        "type": "assistant",
+        "message": {"content": [{"type": "thinking", "thinking": long_thought}]},
+    }
+    pairs = parse_claude_event(event)
+    text, _ = pairs[0]
+    preview = text[len("[thinking] ") :]
+    assert not preview.endswith("...") or preview[:-3].endswith(("o", "d", " "))
+
+
+def test_parse_assistant_thinking_short_no_tooltype():
+    short_thought = "I should do Y"
+    event = {
+        "type": "assistant",
+        "message": {"content": [{"type": "thinking", "thinking": short_thought}]},
+    }
+    pairs = parse_claude_event(event)
+    assert len(pairs) == 1
+    _, detail = pairs[0]
+    assert detail is not None
+    assert "toolType" not in detail
 
 
 def test_parse_assistant_bash_tool():


### PR DESCRIPTION
## Summary

- **Truncate longer**: Increased thinking block preview limit from 100 → 300 characters, giving users more context before needing to expand
- **Word-boundary truncation**: Preview now breaks at the last space before the limit, avoiding mid-word cuts (`_truncate_at_word` helper in `claude_runner.py`)
- **Disclosure widget**: Truncated thinking blocks now show a ▼/▲ triangle (matching the existing code block pattern), making them clickable to expand
- **Expand/collapse**: Clicking the triangle expands the full thinking content in a styled panel (blue/italic, matching the inline thinking style)
- **Fix**: Expand icon is now hidden for entries that have no expandable content (e.g., short thinking blocks with only `activity` metadata), resolving a UX inconsistency where a ▼ icon appeared but opened an empty panel

### Implementation details

**Worker (`claude_runner.py`)**: Thinking blocks with content > 300 chars now include `toolType: "thinking"` and `fullText` in their `detail` payload alongside the existing `activity` key. Short blocks omit `toolType` so the frontend knows not to render an expand control.

**Frontend (`LogList.vue`)**: Expand icon and expandable cursor are now conditioned on `log.detail?.toolType` (not just `!!log.detail`). A new `<template v-else-if="log.detail.toolType === 'thinking'">` branch renders the full thought in a scrollable styled block.

**Types (`types.ts`)**: Added `'thinking'` to the `toolType` union and `fullText?: string` to `LogDetail`.

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)