### PR TITLE
Add action-oriented notes to system prompt

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -92,18 +92,22 @@ The state reflects the moment this turn was sent — earlier turns saw earlier s
 Workers are configured with repos. Prefer workers whose repos cover the task.
 
 ## Response structure
-When a turn requires tool calls:
-1. Open with one short sentence of intent before any tool call \
-("Assigning this to w-abc123 now." / "Checking the PR status.")
-2. Make your tool call(s) — group independent calls in the same response so \
-they execute concurrently; use a separate round when the next call needs \
-the result of the previous one
-3. After results arrive, add a follow-up sentence only if the outcome is \
-non-obvious or the human needs to act on it
+Assume the human wants execution, not narration. Default to action.
 
-Keep each text block to one sentence. Save multi-sentence summaries for the \
-final turn when no more tool calls follow. Be concise — one short paragraph \
-maximum unless detail is requested.\
+When a turn requires tool calls:
+1. Skip preamble — go straight to the tool call(s). No "I'll now…" or \
+"Let me check…" sentence before the call.
+2. Group independent calls in the same response so they execute concurrently; \
+use a separate round only when the next call needs the result of the previous one.
+3. After results arrive, add a follow-up sentence **only** if the outcome \
+requires human action or is genuinely surprising. Omit it otherwise.
+
+Text discipline:
+- One sentence maximum per text block.
+- Final turn (no more tool calls): one sentence summary unless detail is \
+explicitly requested.
+- Never explain what you just did — the tool results speak for themselves.
+- Being terse is a feature, not a flaw. Prioritize action over explanation.\
 """
 
 


### PR DESCRIPTION
## Summary
- Rewrites the `Response structure` section of the Foreman AI system prompt (`backend/foreman/prompt.py`) to be more action-oriented and concise
- Removes the "open with one short sentence" requirement — the foreman now jumps straight to tool calls without preamble
- Adds explicit guidance to omit follow-up text unless the outcome requires human action
- Reinforces one-sentence-max discipline and emphasizes that being terse is intentional

## Test plan
- [ ] Review the updated `FOREMAN_SYSTEM` string in `backend/foreman/prompt.py` for correctness
- [ ] Verify existing tests still pass: `cd backend && python -m pytest`
- [ ] Manually trigger a foreman response and confirm it skips unnecessary narration

🤖 Generated with [Claude Code](https://claude.com/claude-code)