### PR TITLE
Switch Foreman to Claude Sonnet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ After a worker sends `task-complete`, the backend triggers the Foreman AI. The f
 
 ### Foreman AI
 
-Lives in `backend/foreman/` (`runner.py` for the Claude SDK loop, `tools.py` for tool definitions, `prompt.py` for the system prompt, `state.py` for in-memory conversation history). Uses `claude-haiku-4-5-20251001`. Conversation history is kept in-memory (trimmed to 40 messages). The foreman is triggered by:
+Lives in `backend/foreman/` (`runner.py` for the Claude SDK loop, `tools.py` for tool definitions, `prompt.py` for the system prompt, `state.py` for in-memory conversation history). Uses `claude-sonnet-4-6`. Conversation history is kept in-memory (trimmed to 40 messages). The foreman is triggered by:
 1. Human chat messages addressed to `foreman`
 2. `task-complete` WS messages from workers
 3. `task-followup-done` WS messages

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -25,7 +25,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-haiku-4-5-20251001")
+FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 
 MAX_TOOL_RESULT_CHARS = 8_000  # ~2 k tokens; cap per-result content before storing/sending
 MAX_HISTORY_MESSAGES = 20  # sliding window cap on messages sent to Anthropic

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -19,7 +19,7 @@ from sqlalchemy import select, update
 
 logger = logging.getLogger(__name__)
 
-FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-haiku-4-5-20251001")
+FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 
 # Default soft-delete window (seconds) when finalize_task is called without
 # an explicit expiry. Mirrors backend.main.DEFAULT_FINALIZE_TTL.

--- a/foreman/main.py
+++ b/foreman/main.py
@@ -17,7 +17,7 @@ Environment variables:
     DB_PATH          Path to the SQLite database file   (default: pioneer_square.db)
     DATABASE_URL     Full SQLAlchemy URL; overrides DB_PATH
     ANTHROPIC_API_KEY  Anthropic key for the AI loop
-    FOREMAN_MODEL    Claude model for the foreman AI    (default: claude-haiku-4-5-20251001)
+    FOREMAN_MODEL    Claude model for the foreman AI    (default: claude-sonnet-4-6)
     LOG_LEVEL        Logging level                       (default: INFO)
 """
 


### PR DESCRIPTION
## Summary

- Changes the default `FOREMAN_MODEL` from `claude-haiku-4-5-20251001` to `claude-sonnet-4-6` in `backend/foreman/tools.py` and `backend/foreman/runner.py`
- Updates the docstring default in `foreman/main.py` to match
- Updates `CLAUDE.md` to reflect the new model

The `FOREMAN_MODEL` environment variable can still override this at runtime.

## Test plan

- [ ] Start backend and verify foreman triggers use Sonnet (check logs for model name in API calls)
- [ ] Optionally set `FOREMAN_MODEL=claude-haiku-4-5-20251001` and confirm the env override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)