### PR TITLE
Make bash output expandable only when different from preview

### DIFF
--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -65,6 +65,10 @@ const expandedIdx = ref<number | null>(null)
 function isExpandable(log: LogEntry): boolean {
   if (!log.detail?.toolType) return false
   if (log.detail.toolType === 'thinking') return log.detail.input !== log.detail.summary
+  if (log.detail.toolType === 'tool_result') {
+    // _summarize_lines shows all lines when count <= 4; only expand when output is truncated
+    return (log.detail.output?.trim().split('\n').length ?? 0) > 4
+  }
   return true
 }
 


### PR DESCRIPTION
## Summary

- Updated `isExpandable` in `LogList.vue` to skip the expand button for `tool_result` entries when the full output is already visible in the preview
- The worker's `_summarize_lines` shows all content when output is ≤4 lines; only truncates with `… (N more lines)` for longer output — so the check is `output.trim().split('\n').length > 4`
- Short bash outputs (≤4 lines) now render inline without an unnecessary expand icon; longer outputs still show the expand button

## Test plan

- [ ] Run a bash command that produces 1–4 lines of output — verify no expand icon appears
- [ ] Run a bash command that produces 5+ lines of output — verify expand icon appears and clicking it shows the full output
- [ ] Verify thinking blocks and tool_use entries (Edit, Write, Bash command) still show expand icons as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)