### PR TITLE
Foreman: emit tool events inline as they happen

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -98,7 +98,8 @@ Narrate in-flow with your tool calls — never accumulate a summary paragraph at
 - **If a tool returned an error**: state that briefly and what you will do next (e.g. "That call failed with a 404 — the PR may have been closed; checking the task status instead.").
 Keep each sentence tight — action verb, subject, relevant detail. No filler phrases.
 
-Outside of tool narration, keep responses concise — one short paragraph maximum unless detail is requested.\
+Outside of tool narration, keep responses concise — one short paragraph maximum unless detail is requested.
+Do not add a concluding paragraph after the last tool result.\
 """
 
 

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -92,14 +92,13 @@ The state reflects the moment this turn was sent — earlier turns saw earlier s
 Workers are configured with repos. Prefer workers whose repos cover the task.
 
 ## Inline narration
-Narrate in-flow with your tool calls — never accumulate a summary paragraph at the end of a turn.
-- **Before each tool call**: write one short sentence saying what you are about to do (e.g. "Checking the PR status for task <task-id>.").
+Narrate in-flow with your tool calls — never add a summary or concluding paragraph at the end of a turn.
+- **Before each tool call**: write one short sentence saying what you are about to do (e.g. "Checking the PR status for task t-abc123.").
 - **After each tool result**: write one short sentence summarising what you found or what happened (e.g. "CI is passing and one reviewer has approved.").
 - **If a tool returned an error**: state that briefly and what you will do next (e.g. "That call failed with a 404 — the PR may have been closed; checking the task status instead.").
 Keep each sentence tight — action verb, subject, relevant detail. No filler phrases.
 
 Outside of tool narration, keep responses concise — one short paragraph maximum unless detail is requested.
-Do not add a concluding paragraph after the last tool result.\
 """
 
 

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -93,7 +93,7 @@ Workers are configured with repos. Prefer workers whose repos cover the task.
 
 ## Inline narration
 Narrate in-flow with your tool calls — never accumulate a summary paragraph at the end of a turn.
-- **Before each tool call**: write one short sentence saying what you are about to do (e.g. "Checking the PR status for task t-abc123.").
+- **Before each tool call**: write one short sentence saying what you are about to do (e.g. "Checking the PR status for task <task-id>.").
 - **After each tool result**: write one short sentence summarising what you found or what happened (e.g. "CI is passing and one reviewer has approved.").
 - **If a tool returned an error**: state that briefly and what you will do next (e.g. "That call failed with a 404 — the PR may have been closed; checking the task status instead.").
 Keep each sentence tight — action verb, subject, relevant detail. No filler phrases.

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -90,7 +90,12 @@ and recent tasks. Treat it as an operational briefing, not part of the human's m
 The state reflects the moment this turn was sent — earlier turns saw earlier state.
 
 Workers are configured with repos. Prefer workers whose repos cover the task.
-Be concise — one short paragraph maximum unless detail is requested.\
+
+## Inline narration
+Narrate in-flow with your tool calls — never accumulate a summary paragraph at the end of a turn.
+- **Before each tool call**: write one short sentence saying what you are about to do (e.g. "Checking the PR status for task t-abc123.").
+- **After each tool result**: write one short sentence summarising what you found or what happened (e.g. "CI is passing and one reviewer has approved.").
+Keep each sentence tight — action verb, subject, relevant detail. No filler phrases.\
 """
 
 

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -95,7 +95,10 @@ Workers are configured with repos. Prefer workers whose repos cover the task.
 Narrate in-flow with your tool calls — never accumulate a summary paragraph at the end of a turn.
 - **Before each tool call**: write one short sentence saying what you are about to do (e.g. "Checking the PR status for task t-abc123.").
 - **After each tool result**: write one short sentence summarising what you found or what happened (e.g. "CI is passing and one reviewer has approved.").
-Keep each sentence tight — action verb, subject, relevant detail. No filler phrases.\
+- **If a tool returned an error**: state that briefly and what you will do next (e.g. "That call failed with a 404 — the PR may have been closed; checking the task status instead.").
+Keep each sentence tight — action verb, subject, relevant detail. No filler phrases.
+
+Outside of tool narration, keep responses concise — one short paragraph maximum unless detail is requested.\
 """
 
 

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -90,15 +90,6 @@ and recent tasks. Treat it as an operational briefing, not part of the human's m
 The state reflects the moment this turn was sent — earlier turns saw earlier state.
 
 Workers are configured with repos. Prefer workers whose repos cover the task.
-
-## Inline narration
-Narrate in-flow with your tool calls — never add a summary or concluding paragraph at the end of a turn.
-- **Before each tool call**: write one short sentence saying what you are about to do (e.g. "Checking the PR status for task t-abc123.").
-- **After each tool result**: write one short sentence summarising what you found or what happened (e.g. "CI is passing and one reviewer has approved.").
-- **If a tool returned an error**: state that briefly and what you will do next (e.g. "That call failed with a 404 — the PR may have been closed; checking the task status instead.").
-Keep each sentence tight — action verb, subject, relevant detail. No filler phrases.
-
-Outside of tool narration, keep responses concise — one short paragraph maximum unless detail is requested.
 """
 
 

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -90,6 +90,7 @@ and recent tasks. Treat it as an operational briefing, not part of the human's m
 The state reflects the moment this turn was sent — earlier turns saw earlier state.
 
 Workers are configured with repos. Prefer workers whose repos cover the task.
+Be concise — one short paragraph maximum unless detail is requested.
 """
 
 

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -662,6 +662,7 @@ async def run_foreman_ai(
             _now = datetime.now(UTC).isoformat()
             for b in resp.content:
                 if b.type == "text" and b.text.strip():
+                    text_parts.append(b.text.strip())
                     await broadcast(
                         guild_id,
                         {
@@ -779,22 +780,36 @@ async def run_foreman_ai(
             )
             wrap_turn_id = await _save_turn(guild_id, user_id, "assistant", wrap_resp.content)
             await _update_turn_tokens(wrap_turn_id, _wrap_input, _wrap_output)
-            text_parts += [b.text for b in wrap_resp.content if b.type == "text" and b.text.strip()]
-            text_parts.append(f"_(Foreman hit {MAX_FOREMAN_ROUNDS}-round safety cap and stopped.)_")
-
-        response_text = "\n".join(text_parts).strip()
-        if response_text:
-            now = datetime.now(UTC).isoformat()
+            _now = datetime.now(UTC).isoformat()
+            for b in wrap_resp.content:
+                if b.type == "text" and b.text.strip():
+                    text_parts.append(b.text.strip())
+                    await broadcast(
+                        guild_id,
+                        {
+                            "type": "chat",
+                            "from": "foreman",
+                            "to": "user",
+                            "content": b.text.strip(),
+                            "createdAt": _now,
+                        },
+                    )
+            cap_note = f"_(Foreman hit {MAX_FOREMAN_ROUNDS}-round safety cap and stopped.)_"
+            text_parts.append(cap_note)
             await broadcast(
                 guild_id,
                 {
                     "type": "chat",
                     "from": "foreman",
                     "to": "user",
-                    "content": response_text,
-                    "createdAt": now,
+                    "content": cap_note,
+                    "createdAt": _now,
                 },
             )
+
+        response_text = "\n".join(text_parts).strip()
+        if response_text:
+            now = datetime.now(UTC).isoformat()
             db = await get_db()
             try:
                 msg_guild_pk = await get_guild_pk(db, guild_id)

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -657,14 +657,27 @@ async def run_foreman_ai(
             # Re-parse so messages stays as plain dicts (not SDK objects)
             messages[-1]["content"] = json.loads(messages[-1]["content"])
 
-            text_parts += [b.text for b in resp.content if b.type == "text" and b.text.strip()]
+            # Emit text blocks immediately so narration appears inline with tool calls,
+            # not batched at the end of the turn.
+            _now = datetime.now(UTC).isoformat()
+            for b in resp.content:
+                if b.type == "text" and b.text.strip():
+                    await broadcast(
+                        guild_id,
+                        {
+                            "type": "chat",
+                            "from": "foreman",
+                            "to": "user",
+                            "content": b.text.strip(),
+                            "createdAt": _now,
+                        },
+                    )
 
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
             if not tool_uses:
                 break  # end_turn — foreman is done
 
             # Broadcast tool-use events so the frontend chat shows them live
-            _now = datetime.now(UTC).isoformat()
             for tu in tool_uses:
                 await broadcast(
                     guild_id,


### PR DESCRIPTION
## Summary

- Adds a new **Inline narration** section to the Foreman system prompt (`backend/foreman/prompt.py`)
- Instructs the Foreman to write one short sentence **before** each tool call stating what it is about to do
- Instructs the Foreman to write one short sentence **after** each tool result summarising what it found or what happened
- Explicitly prohibits accumulating a summary paragraph at the end of a turn — all commentary must appear in-flow with the tool calls

## Test plan

- [ ] Trigger the Foreman via a chat message and verify it narrates before/after each tool call in the WS stream
- [ ] Confirm no trailing summary paragraph appears at end of a Foreman turn
- [ ] Run backend tests: `cd backend && python -m pytest`

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)