### PR TITLE
feat: dev/test guest login (TEST_MODE gate)

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -6,6 +6,8 @@ storage, the ``/auth/me`` + ``/api/me`` profile endpoints, and logout.
 
 from __future__ import annotations
 
+import os
+import secrets
 import urllib.parse
 from datetime import UTC, datetime
 
@@ -30,7 +32,9 @@ from models import (
 )
 from oauth import FRONTEND_URL, GITHUB_CLIENT_ID, create_session, get_return_to, make_authorize_url
 from pydantic import BaseModel
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from utils import generate_guild_id
 
 router = APIRouter()
 
@@ -233,6 +237,106 @@ async def api_me(github_user_id: str = Depends(require_user)):
         }
     finally:
         await db.close()
+
+
+@router.post("/auth/guest")
+async def guest_login():
+    """Create a dev session without GitHub OAuth.
+
+    Only available when TEST_MODE=1 is set. Idempotent: always creates a new
+    session token but reuses the same dev-guest user and guild across calls.
+    """
+    if not os.environ.get("TEST_MODE"):
+        raise HTTPException(status_code=403, detail="Test mode not enabled (set TEST_MODE=1)")
+
+    now = datetime.now(UTC).isoformat()
+    guest_user_id = "dev-guest"
+    login_token = secrets.token_urlsafe(32)
+
+    db = await get_db()
+    try:
+        # Upsert github_tokens (required FK target for user_sessions)
+        gh_stmt = sqlite_insert(GithubToken).values(
+            github_user_id=guest_user_id,
+            github_username="dev-guest",
+            access_token="dev-no-token",
+            token_type="bearer",
+            scope="",
+            created_at=now,
+            updated_at=now,
+        )
+        gh_stmt = gh_stmt.on_conflict_do_update(
+            index_elements=["github_user_id"],
+            set_={"updated_at": gh_stmt.excluded.updated_at},
+        )
+        await db.execute(gh_stmt)
+
+        # Upsert user
+        user_stmt = sqlite_insert(User).values(
+            id=guest_user_id,
+            github_id=guest_user_id,
+            github_login="dev-guest",
+            email=None,
+            display_name="Dev Guest",
+            avatar_url=None,
+            created_at=now,
+            updated_at=now,
+        )
+        user_stmt = user_stmt.on_conflict_do_update(
+            index_elements=["id"],
+            set_={"updated_at": user_stmt.excluded.updated_at},
+        )
+        await db.execute(user_stmt)
+
+        # Fresh session each call (so re-login after logout works)
+        db.add(UserSession(token=login_token, github_user_id=guest_user_id, created_at=now))
+
+        # Find or create the persistent dev guild
+        guild_res = await db.execute(
+            text(
+                "SELECT guild_id FROM guilds"
+                " WHERE github_user_id = :uid AND (deleted_at IS NULL OR deleted_at = '')"
+                " LIMIT 1"
+            ),
+            {"uid": guest_user_id},
+        )
+        guild_id = guild_res.scalar_one_or_none()
+
+        if not guild_id:
+            existing_res = await db.execute(
+                text("SELECT guild_id FROM guilds WHERE deleted_at IS NULL OR deleted_at = ''")
+            )
+            existing_ids = {row[0] for row in existing_res.fetchall()}
+            guild_id = generate_guild_id(name="dev", existing_ids=existing_ids)
+            new_guild = Guild(
+                guild_id=guild_id,
+                created_at=now,
+                name="Dev Workshop",
+                github_user_id=guest_user_id,
+            )
+            db.add(new_guild)
+            await db.flush()
+            db.add(
+                GuildMember(
+                    guild_pk=new_guild.id,
+                    user_id=guest_user_id,
+                    role="owner",
+                    created_at=now,
+                )
+            )
+
+        await db.commit()
+    finally:
+        await db.close()
+
+    return {
+        "login_token": login_token,
+        "guild_id": guild_id,
+        "gh_user_id": guest_user_id,
+        "gh_login": "dev-guest",
+        "gh_name": "Dev Guest",
+        "gh_avatar": "",
+    }
 
 
 @router.delete("/auth/logout")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       # with PIONEER_WORKER_LOG_LEVEL=<this value>, raising worker verbosity.
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       WORKER_LOG_LEVEL: ${WORKER_LOG_LEVEL:-}
+      TEST_MODE: ${TEST_MODE:-}
     volumes:
       - backend-data:/data
       - /var/run/docker.sock:/var/run/docker.sock

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -69,6 +69,25 @@ export const useAuthStore = defineStore('auth', () => {
     return data
   }
 
+  async function loginAsGuest(): Promise<string> {
+    const res = await fetch(`${API_BASE}/auth/guest`, { method: 'POST' })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new Error(body.detail || `Dev login failed: ${res.status}`)
+    }
+    const data = await res.json()
+    loginToken.value = data.login_token
+    user.value = {
+      id: data.gh_user_id,
+      login: data.gh_login,
+      name: data.gh_name || data.gh_login,
+      avatar_url: data.gh_avatar || '',
+    }
+    localStorage.setItem('auth_token', data.login_token)
+    localStorage.setItem('auth_user', JSON.stringify(user.value))
+    return data.guild_id as string
+  }
+
   async function logout() {
     if (loginToken.value) {
       await fetch(`${API_BASE}/auth/logout`, {
@@ -88,6 +107,7 @@ export const useAuthStore = defineStore('auth', () => {
     isLoggedIn,
     authHeaders,
     loginWithGitHub,
+    loginAsGuest,
     restoreFromCallback,
     exchangeCode,
     logout,

--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -28,6 +28,13 @@
           @login="handleLogin"
         />
 
+        <div v-if="!authStore.isLoggedIn && isDev" class="dev-login-bar">
+          <span class="dev-label">DEV MODE</span>
+          <button class="pixel-btn dev-btn" :disabled="loggingIn" @click="handleDevLogin">
+            SKIP LOGIN
+          </button>
+        </div>
+
         <template v-else>
           <div class="sessions-section">
             <div class="section-label">YOUR GUILDS</div>
@@ -80,6 +87,8 @@ const router = useRouter()
 const guildStore = useGuildStore()
 const authStore = useAuthStore()
 const ghStore = useGitHubStore()
+
+const isDev = import.meta.env.DEV
 
 const loading = ref(true)
 const guilds = ref<Guild[]>([])
@@ -139,6 +148,18 @@ onMounted(async () => {
 
 function goToSession(id: string) {
   router.push(`/${id}`)
+}
+
+async function handleDevLogin() {
+  loggingIn.value = true
+  loginError.value = ''
+  try {
+    const guildId = await authStore.loginAsGuest()
+    router.push(`/${guildId}`)
+  } catch (e: unknown) {
+    loginError.value = e instanceof Error ? e.message : String(e)
+    loggingIn.value = false
+  }
 }
 
 async function handleLogin() {
@@ -320,6 +341,35 @@ async function createGuild(name: string) {
   gap: 16px;
   overflow-y: auto;
   padding-bottom: 20px;
+}
+
+.dev-login-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px dashed rgba(0, 187, 170, 0.35);
+  background: rgba(0, 187, 170, 0.04);
+  margin-top: -20px;
+}
+.dev-label {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-teal);
+  letter-spacing: 2px;
+  opacity: 0.7;
+}
+.dev-btn {
+  font-size: 8px;
+  padding: 6px 14px;
+  border-color: var(--color-teal);
+  color: var(--color-teal);
+  background: transparent;
+  box-shadow: none;
+}
+.dev-btn:hover:not(:disabled) {
+  background: rgba(0, 187, 170, 0.1);
+  box-shadow: 0 0 8px rgba(0, 187, 170, 0.3);
 }
 
 @keyframes spin {


### PR DESCRIPTION
## Summary

- Adds `POST /auth/guest` backend endpoint that creates a dev session without GitHub OAuth, gated behind `TEST_MODE=1` environment variable
- Persists a stable dev-guest user and guild across calls (idempotent: new token each call, same user/guild row)
- Adds `loginAsGuest()` to the frontend auth store
- Adds a **SKIP LOGIN / DEV MODE** button on the landing page, visible only in Vite dev mode (`import.meta.env.DEV`)
- Wires `TEST_MODE` through `docker-compose.yml` so it can be set via environment

## Test plan

- [ ] Set `TEST_MODE=1` in the backend environment and `npm run dev` in the frontend
- [ ] Visit the landing page — a teal "DEV MODE / SKIP LOGIN" bar should appear
- [ ] Click "SKIP LOGIN" — should create a session and redirect to the dev guild
- [ ] Confirm the `dev-guest` user is created in the database
- [ ] Confirm the same guild is reused on subsequent logins (not created fresh each time)
- [ ] Without `TEST_MODE=1`, confirm `POST /auth/guest` returns 403
- [ ] Confirm the SKIP LOGIN button is absent in a production build (`npm run build`)

Split out from #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)