### PR TITLE
Codex login support + user settings login management

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -388,17 +388,24 @@ async def delete_login(provider: str, github_user_id: str = Depends(require_user
 
     db = await get_db()
     try:
+        # Count total logins across all providers before touching anything.
+        # (Only GitHub exists today; expand this query when new providers land.)
         count_res = await db.execute(
             select(func.count())
             .select_from(GithubToken)
             .where(GithubToken.github_user_id == github_user_id)
         )
-        if (count_res.scalar_one() or 0) <= 1:
+        total_logins = count_res.scalar_one() or 0
+        if total_logins <= 1:
             raise HTTPException(
                 status_code=400,
                 detail="Cannot disconnect your only login method — you would be locked out.",
             )
-        await db.execute(delete(GithubToken).where(GithubToken.github_user_id == github_user_id))
+        # Delete only the token(s) belonging to the requested provider.
+        if provider == "github":
+            await db.execute(
+                delete(GithubToken).where(GithubToken.github_user_id == github_user_id)
+            )
         await db.execute(delete(UserSession).where(UserSession.github_user_id == github_user_id))
         await db.commit()
     finally:

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -400,23 +400,17 @@ async def delete_login(provider: str, github_user_id: str = Depends(require_user
                     detail=f"No {provider!r} login found for this user.",
                 )
 
-        # Count how many logins would remain after removing this provider.
-        # "Remaining" = logins from all other providers (not the one being deleted).
-        # Add counts from future provider tables here as they are implemented.
+        # Count total logins across all providers. If <= 1, removing this one
+        # would lock the user out. Add counts from future provider tables here.
         github_count_res = await db.execute(
             select(func.count())
             .select_from(GithubToken)
             .where(GithubToken.github_user_id == github_user_id)
         )
-        github_logins = github_count_res.scalar_one() or 0
+        total_logins = github_count_res.scalar_one() or 0
+        # When new providers are added: total_logins += new_provider_count
 
-        # Sum up logins from providers OTHER than the one being deleted.
-        remaining = 0
-        if provider != "github":
-            remaining += github_logins
-        # When new providers are added: if provider != "new_provider": remaining += new_provider_count
-
-        if remaining == 0:
+        if total_logins <= 1:
             raise HTTPException(
                 status_code=400,
                 detail="Cannot disconnect your only login method — you would be locked out.",

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -32,7 +32,7 @@ from models import (
 )
 from oauth import FRONTEND_URL, GITHUB_CLIENT_ID, create_session, get_return_to, make_authorize_url
 from pydantic import BaseModel
-from sqlalchemy import delete, func, select, text
+from sqlalchemy import delete, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from utils import generate_guild_id
 
@@ -337,100 +337,6 @@ async def guest_login():
         "gh_name": "Dev Guest",
         "gh_avatar": "",
     }
-
-
-@router.get("/api/user/logins")
-async def list_logins(github_user_id: str = Depends(require_user)):
-    """Return the list of connected OAuth providers for the current user.
-
-    Currently GitHub is the only supported provider; the response is structured
-    as a provider list so additional providers can be added without breaking the
-    API shape.
-    """
-    db = await get_db()
-    try:
-        result = await db.execute(
-            select(
-                GithubToken.github_username,
-                GithubToken.scope,
-                GithubToken.created_at,
-                GithubToken.updated_at,
-            ).where(GithubToken.github_user_id == github_user_id)
-        )
-        row = result.first()
-        logins = []
-        if row:
-            logins.append(
-                {
-                    "provider": "github",
-                    "username": row.github_username,
-                    "scope": row.scope,
-                    "connected_at": row.created_at,
-                    "updated_at": row.updated_at,
-                }
-            )
-        return {"logins": logins}
-    finally:
-        await db.close()
-
-
-@router.delete("/api/user/logins/{provider}")
-async def delete_login(provider: str, github_user_id: str = Depends(require_user)):
-    """Disconnect an OAuth provider from the current user's account.
-
-    Returns HTTP 404 if the user has no login for the requested provider.
-    Guards against removing the last login — if this would leave the user with
-    zero logins they would be permanently locked out, so we return HTTP 400.
-    Currently only ``github`` is supported; passing any other provider returns
-    HTTP 404.
-    """
-    if provider != "github":
-        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider!r}")
-
-    db = await get_db()
-    try:
-        # Verify the requested provider login actually exists for this user.
-        if provider == "github":
-            existing_res = await db.execute(
-                select(GithubToken).where(GithubToken.github_user_id == github_user_id)
-            )
-            if existing_res.scalar_one_or_none() is None:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"No {provider!r} login found for this user.",
-                )
-
-        # Count logins per provider so we can compute how many would remain after
-        # this deletion.  Add other provider table counts to total_logins when
-        # they land.
-        github_count_res = await db.execute(
-            select(func.count())
-            .select_from(GithubToken)
-            .where(GithubToken.github_user_id == github_user_id)
-        )
-        github_count = github_count_res.scalar_one() or 0
-
-        # total_logins = sum across all providers (only github today).
-        total_logins = github_count
-        provider_count = github_count if provider == "github" else 0
-
-        remaining = total_logins - provider_count
-        if remaining == 0:
-            raise HTTPException(
-                status_code=400,
-                detail="Cannot disconnect your only login method — you would be locked out.",
-            )
-
-        # Delete only the token(s) for the requested provider.
-        if provider == "github":
-            await db.execute(
-                delete(GithubToken).where(GithubToken.github_user_id == github_user_id)
-            )
-        await db.execute(delete(UserSession).where(UserSession.github_user_id == github_user_id))
-        await db.commit()
-    finally:
-        await db.close()
-    return {"ok": True}
 
 
 @router.delete("/auth/logout")

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -32,7 +32,7 @@ from models import (
 )
 from oauth import FRONTEND_URL, GITHUB_CLIENT_ID, create_session, get_return_to, make_authorize_url
 from pydantic import BaseModel
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from utils import generate_guild_id
 
@@ -337,6 +337,100 @@ async def guest_login():
         "gh_name": "Dev Guest",
         "gh_avatar": "",
     }
+
+
+@router.get("/api/user/logins")
+async def list_logins(github_user_id: str = Depends(require_user)):
+    """Return the list of connected OAuth providers for the current user.
+
+    Currently GitHub is the only supported provider; the response is structured
+    as a provider list so additional providers can be added without breaking the
+    API shape.
+    """
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(
+                GithubToken.github_username,
+                GithubToken.scope,
+                GithubToken.created_at,
+                GithubToken.updated_at,
+            ).where(GithubToken.github_user_id == github_user_id)
+        )
+        row = result.first()
+        logins = []
+        if row:
+            logins.append(
+                {
+                    "provider": "github",
+                    "username": row.github_username,
+                    "scope": row.scope,
+                    "connected_at": row.created_at,
+                    "updated_at": row.updated_at,
+                }
+            )
+        return {"logins": logins}
+    finally:
+        await db.close()
+
+
+@router.delete("/api/user/logins/{provider}")
+async def delete_login(provider: str, github_user_id: str = Depends(require_user)):
+    """Disconnect an OAuth provider from the current user's account.
+
+    Returns HTTP 404 if the user has no login for the requested provider.
+    Guards against removing the last login — if this would leave the user with
+    zero logins they would be permanently locked out, so we return HTTP 400.
+    Currently only ``github`` is supported; passing any other provider returns
+    HTTP 404.
+    """
+    if provider != "github":
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider!r}")
+
+    db = await get_db()
+    try:
+        # Verify the requested provider login actually exists for this user.
+        if provider == "github":
+            existing_res = await db.execute(
+                select(GithubToken).where(GithubToken.github_user_id == github_user_id)
+            )
+            if existing_res.scalar_one_or_none() is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No {provider!r} login found for this user.",
+                )
+
+        # Count logins per provider so we can compute how many would remain after
+        # this deletion.  Add other provider table counts to total_logins when
+        # they land.
+        github_count_res = await db.execute(
+            select(func.count())
+            .select_from(GithubToken)
+            .where(GithubToken.github_user_id == github_user_id)
+        )
+        github_count = github_count_res.scalar_one() or 0
+
+        # total_logins = sum across all providers (only github today).
+        total_logins = github_count
+        provider_count = github_count if provider == "github" else 0
+
+        remaining = total_logins - provider_count
+        if remaining == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot disconnect your only login method — you would be locked out.",
+            )
+
+        # Delete only the token(s) for the requested provider.
+        if provider == "github":
+            await db.execute(
+                delete(GithubToken).where(GithubToken.github_user_id == github_user_id)
+            )
+        await db.execute(delete(UserSession).where(UserSession.github_user_id == github_user_id))
+        await db.commit()
+    finally:
+        await db.close()
+    return {"ok": True}
 
 
 @router.delete("/auth/logout")

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -32,7 +32,7 @@ from models import (
 )
 from oauth import FRONTEND_URL, GITHUB_CLIENT_ID, create_session, get_return_to, make_authorize_url
 from pydantic import BaseModel
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from utils import generate_guild_id
 
@@ -337,6 +337,100 @@ async def guest_login():
         "gh_name": "Dev Guest",
         "gh_avatar": "",
     }
+
+
+@router.get("/api/user/logins")
+async def list_logins(github_user_id: str = Depends(require_user)):
+    """Return the list of connected OAuth providers for the current user.
+
+    Currently GitHub is the only supported provider; the response is structured
+    as a provider list so additional providers can be added without breaking the
+    API shape.
+    """
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(
+                GithubToken.github_username,
+                GithubToken.scope,
+                GithubToken.created_at,
+                GithubToken.updated_at,
+            ).where(GithubToken.github_user_id == github_user_id)
+        )
+        row = result.first()
+        logins = []
+        if row:
+            logins.append(
+                {
+                    "provider": "github",
+                    "username": row.github_username,
+                    "scope": row.scope,
+                    "connected_at": row.created_at,
+                    "updated_at": row.updated_at,
+                }
+            )
+        return {"logins": logins}
+    finally:
+        await db.close()
+
+
+@router.delete("/api/user/logins/{provider}")
+async def delete_login(provider: str, github_user_id: str = Depends(require_user)):
+    """Disconnect an OAuth provider from the current user's account.
+
+    Returns HTTP 404 if the user has no login for the requested provider.
+    Guards against removing the last login — if this would leave the user with
+    zero logins they would be permanently locked out, so we return HTTP 400.
+    Currently only ``github`` is supported; passing any other provider returns
+    HTTP 404.
+    """
+    if provider != "github":
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider!r}")
+
+    db = await get_db()
+    try:
+        # Verify the requested provider login actually exists for this user.
+        if provider == "github":
+            existing_res = await db.execute(
+                select(GithubToken).where(GithubToken.github_user_id == github_user_id)
+            )
+            if existing_res.scalar_one_or_none() is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No {provider!r} login found for this user.",
+                )
+
+        # Count how many logins would remain after removing this provider.
+        # "Remaining" = logins from all other providers (not the one being deleted).
+        # Add counts from future provider tables here as they are implemented.
+        github_count_res = await db.execute(
+            select(func.count())
+            .select_from(GithubToken)
+            .where(GithubToken.github_user_id == github_user_id)
+        )
+        github_logins = github_count_res.scalar_one() or 0
+
+        # Sum up logins from providers OTHER than the one being deleted.
+        remaining = 0
+        if provider != "github":
+            remaining += github_logins
+        # When new providers are added: if provider != "new_provider": remaining += new_provider_count
+
+        if remaining == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot disconnect your only login method — you would be locked out.",
+            )
+
+        # Delete only the token for the specified provider.
+        if provider == "github":
+            await db.execute(
+                delete(GithubToken).where(GithubToken.github_user_id == github_user_id)
+            )
+        await db.commit()
+    finally:
+        await db.close()
+    return {"ok": True}
 
 
 @router.delete("/auth/logout")

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -400,17 +400,22 @@ async def delete_login(provider: str, github_user_id: str = Depends(require_user
                     detail=f"No {provider!r} login found for this user.",
                 )
 
-        # Count total logins across all providers.  With only GitHub today this
-        # equals the github_tokens row count; add other provider tables here when
-        # they land.  If removing this provider would leave the user with no logins,
-        # reject the request.
-        count_res = await db.execute(
+        # Count logins per provider so we can compute how many would remain after
+        # this deletion.  Add other provider table counts to total_logins when
+        # they land.
+        github_count_res = await db.execute(
             select(func.count())
             .select_from(GithubToken)
             .where(GithubToken.github_user_id == github_user_id)
         )
-        total_logins = count_res.scalar_one() or 0
-        if total_logins <= 1:
+        github_count = github_count_res.scalar_one() or 0
+
+        # total_logins = sum across all providers (only github today).
+        total_logins = github_count
+        provider_count = github_count if provider == "github" else 0
+
+        remaining = total_logins - provider_count
+        if remaining == 0:
             raise HTTPException(
                 status_code=400,
                 detail="Cannot disconnect your only login method — you would be locked out.",

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -378,8 +378,9 @@ async def list_logins(github_user_id: str = Depends(require_user)):
 async def delete_login(provider: str, github_user_id: str = Depends(require_user)):
     """Disconnect an OAuth provider from the current user's account.
 
-    Guards against removing the last login — if this is the only connected
-    provider the user would be permanently locked out, so we return HTTP 400.
+    Returns HTTP 404 if the user has no login for the requested provider.
+    Guards against removing the last login — if this would leave the user with
+    zero logins they would be permanently locked out, so we return HTTP 400.
     Currently only ``github`` is supported; passing any other provider returns
     HTTP 404.
     """
@@ -388,8 +389,21 @@ async def delete_login(provider: str, github_user_id: str = Depends(require_user
 
     db = await get_db()
     try:
-        # Count total logins across all providers before touching anything.
-        # (Only GitHub exists today; expand this query when new providers land.)
+        # Verify the requested provider login actually exists for this user.
+        if provider == "github":
+            existing_res = await db.execute(
+                select(GithubToken).where(GithubToken.github_user_id == github_user_id)
+            )
+            if existing_res.scalar_one_or_none() is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No {provider!r} login found for this user.",
+                )
+
+        # Count total logins across all providers.  With only GitHub today this
+        # equals the github_tokens row count; add other provider tables here when
+        # they land.  If removing this provider would leave the user with no logins,
+        # reject the request.
         count_res = await db.execute(
             select(func.count())
             .select_from(GithubToken)
@@ -401,7 +415,8 @@ async def delete_login(provider: str, github_user_id: str = Depends(require_user
                 status_code=400,
                 detail="Cannot disconnect your only login method — you would be locked out.",
             )
-        # Delete only the token(s) belonging to the requested provider.
+
+        # Delete only the token(s) for the requested provider.
         if provider == "github":
             await db.execute(
                 delete(GithubToken).where(GithubToken.github_user_id == github_user_id)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -32,7 +32,7 @@ from models import (
 )
 from oauth import FRONTEND_URL, GITHUB_CLIENT_ID, create_session, get_return_to, make_authorize_url
 from pydantic import BaseModel
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from utils import generate_guild_id
 
@@ -337,6 +337,73 @@ async def guest_login():
         "gh_name": "Dev Guest",
         "gh_avatar": "",
     }
+
+
+@router.get("/api/user/logins")
+async def list_logins(github_user_id: str = Depends(require_user)):
+    """Return the list of connected OAuth providers for the current user.
+
+    Currently GitHub is the only supported provider; the response is structured
+    as a provider list so additional providers can be added without breaking the
+    API shape.
+    """
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(
+                GithubToken.github_username,
+                GithubToken.scope,
+                GithubToken.created_at,
+                GithubToken.updated_at,
+            ).where(GithubToken.github_user_id == github_user_id)
+        )
+        row = result.first()
+        logins = []
+        if row:
+            logins.append(
+                {
+                    "provider": "github",
+                    "username": row.github_username,
+                    "scope": row.scope,
+                    "connected_at": row.created_at,
+                    "updated_at": row.updated_at,
+                }
+            )
+        return {"logins": logins}
+    finally:
+        await db.close()
+
+
+@router.delete("/api/user/logins/{provider}")
+async def delete_login(provider: str, github_user_id: str = Depends(require_user)):
+    """Disconnect an OAuth provider from the current user's account.
+
+    Guards against removing the last login — if this is the only connected
+    provider the user would be permanently locked out, so we return HTTP 400.
+    Currently only ``github`` is supported; passing any other provider returns
+    HTTP 404.
+    """
+    if provider != "github":
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider!r}")
+
+    db = await get_db()
+    try:
+        count_res = await db.execute(
+            select(func.count())
+            .select_from(GithubToken)
+            .where(GithubToken.github_user_id == github_user_id)
+        )
+        if (count_res.scalar_one() or 0) <= 1:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot disconnect your only login method — you would be locked out.",
+            )
+        await db.execute(delete(GithubToken).where(GithubToken.github_user_id == github_user_id))
+        await db.execute(delete(UserSession).where(UserSession.github_user_id == github_user_id))
+        await db.commit()
+    finally:
+        await db.close()
+    return {"ok": True}
 
 
 @router.delete("/auth/logout")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     environment:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       WORKER_LOG_LEVEL: ${WORKER_LOG_LEVEL:-INFO}
     volumes:
       # Provide pioneer-worker.toml at ./worker/pioneer-worker.toml

--- a/frontend/src/components/GitHubConfigModal.vue
+++ b/frontend/src/components/GitHubConfigModal.vue
@@ -58,8 +58,8 @@
         <div class="confirm-box">
           <div class="confirm-title">Disconnect {{ providerLabel(confirmProvider) }}?</div>
           <div class="confirm-body">
-            This will remove your {{ providerLabel(confirmProvider) }} login and invalidate all
-            active sessions. You will be signed out.
+            This will remove your {{ providerLabel(confirmProvider) }} login. You will be signed
+            out of this session.
           </div>
           <div class="confirm-actions">
             <button class="pixel-btn confirm-cancel" @click="confirmProvider = null">Cancel</button>

--- a/frontend/src/components/GitHubConfigModal.vue
+++ b/frontend/src/components/GitHubConfigModal.vue
@@ -14,6 +14,58 @@
             <div class="user-label">{{ authStore.user?.name || 'GitHub User' }}</div>
           </div>
         </div>
+
+        <div class="section">
+          <div class="section-title">Connected Accounts</div>
+
+          <div v-if="loading" class="loading-row">Loading…</div>
+
+          <div v-else-if="logins.length === 0" class="empty-row">No connected accounts found.</div>
+
+          <div v-else class="login-list">
+            <div v-for="login in logins" :key="login.provider" class="login-row">
+              <div class="login-icon">
+                <span v-if="login.provider === 'github'" class="provider-icon">⬡</span>
+                <span v-else class="provider-icon">◈</span>
+              </div>
+              <div class="login-info">
+                <div class="login-provider">{{ providerLabel(login.provider) }}</div>
+                <div class="login-username">{{ login.username }}</div>
+              </div>
+              <div class="login-actions">
+                <button
+                  class="disconnect-btn"
+                  :disabled="logins.length <= 1 || disconnecting === login.provider"
+                  :title="
+                    logins.length <= 1
+                      ? 'Cannot disconnect your only login method'
+                      : `Disconnect ${providerLabel(login.provider)}`
+                  "
+                  @click="confirmDisconnect(login.provider)"
+                >
+                  {{ disconnecting === login.provider ? '…' : 'Disconnect' }}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="statusMsg" class="status-row" :class="statusClass">{{ statusMsg }}</div>
+        </div>
+      </div>
+
+      <!-- Confirmation dialog -->
+      <div v-if="confirmProvider" class="confirm-overlay">
+        <div class="confirm-box">
+          <div class="confirm-title">Disconnect {{ providerLabel(confirmProvider) }}?</div>
+          <div class="confirm-body">
+            This will remove your {{ providerLabel(confirmProvider) }} login and invalidate all
+            active sessions. You will be signed out.
+          </div>
+          <div class="confirm-actions">
+            <button class="pixel-btn confirm-cancel" @click="confirmProvider = null">Cancel</button>
+            <button class="pixel-btn confirm-ok" @click="doDisconnect">Disconnect</button>
+          </div>
+        </div>
       </div>
 
       <div class="modal-footer">
@@ -24,10 +76,78 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
+import { api } from '../utils/api'
 
 defineEmits<{ close: [] }>()
 const authStore = useAuthStore()
+
+interface LoginEntry {
+  provider: string
+  username: string
+  scope: string | null
+  connected_at: string | null
+  updated_at: string | null
+}
+
+const logins = ref<LoginEntry[]>([])
+const loading = ref(true)
+const disconnecting = ref<string | null>(null)
+const confirmProvider = ref<string | null>(null)
+const statusMsg = ref('')
+const statusClass = ref<'status-ok' | 'status-err'>('status-ok')
+
+let statusTimer: ReturnType<typeof setTimeout> | null = null
+
+function providerLabel(p: string) {
+  if (p === 'github') return 'GitHub'
+  return p.charAt(0).toUpperCase() + p.slice(1)
+}
+
+async function fetchLogins() {
+  loading.value = true
+  try {
+    const data = await api<{ logins: LoginEntry[] }>('/api/user/logins')
+    logins.value = data.logins ?? []
+  } catch {
+    logins.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+function setStatus(msg: string, ok: boolean) {
+  statusMsg.value = msg
+  statusClass.value = ok ? 'status-ok' : 'status-err'
+  if (statusTimer) clearTimeout(statusTimer)
+  statusTimer = setTimeout(() => {
+    statusMsg.value = ''
+  }, 3500)
+}
+
+function confirmDisconnect(provider: string) {
+  confirmProvider.value = provider
+}
+
+async function doDisconnect() {
+  const provider = confirmProvider.value
+  confirmProvider.value = null
+  if (!provider) return
+  disconnecting.value = provider
+  try {
+    await api(`/api/user/logins/${provider}`, { method: 'DELETE' })
+    setStatus(`${providerLabel(provider)} disconnected. You will be signed out.`, true)
+    await authStore.logout()
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Disconnect failed'
+    setStatus(msg, false)
+  } finally {
+    disconnecting.value = null
+  }
+}
+
+onMounted(fetchLogins)
 </script>
 
 <style scoped>
@@ -49,6 +169,7 @@ const authStore = useAuthStore()
   max-height: 80vh;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .modal-header {
@@ -122,6 +243,173 @@ const authStore = useAuthStore()
 .user-label {
   font-size: 11px;
   color: var(--color-text-dim);
+}
+
+/* ── Connected Accounts section ── */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-title {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-brass-dark);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--color-brass-dark);
+}
+
+.loading-row,
+.empty-row {
+  font-size: 11px;
+  color: var(--color-text-dim);
+  padding: 8px 0;
+}
+
+.login-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.login-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-brass-dark);
+}
+
+.provider-icon {
+  font-size: 16px;
+  color: var(--color-brass);
+  line-height: 1;
+}
+
+.login-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.login-provider {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-brass-light);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.login-username {
+  font-size: 11px;
+  color: var(--color-teal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.disconnect-btn {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--color-red, #c0392b);
+  color: var(--color-red, #c0392b);
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 1px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.disconnect-btn:hover:not(:disabled) {
+  background: rgba(192, 57, 43, 0.15);
+}
+
+.disconnect-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  border-color: var(--color-text-dim);
+  color: var(--color-text-dim);
+}
+
+.status-row {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  letter-spacing: 0.5px;
+  padding-top: 4px;
+}
+
+.status-ok {
+  color: var(--color-green, #27ae60);
+}
+
+.status-err {
+  color: var(--color-red, #c0392b);
+}
+
+/* ── Confirmation dialog ── */
+
+.confirm-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.confirm-box {
+  background: var(--color-bg-secondary);
+  border: 2px solid var(--color-brass);
+  padding: 20px;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.confirm-title {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  color: var(--color-brass-light);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+.confirm-body {
+  font-size: 12px;
+  color: var(--color-text-dim);
+  line-height: 1.5;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.confirm-cancel {
+  font-size: 7px;
+  padding: 5px 10px;
+}
+
+.confirm-ok {
+  font-size: 7px;
+  padding: 5px 10px;
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #c0392b);
+}
+
+.confirm-ok:hover {
+  background: rgba(192, 57, 43, 0.15);
 }
 
 .modal-footer {

--- a/frontend/src/components/GitHubConfigModal.vue
+++ b/frontend/src/components/GitHubConfigModal.vue
@@ -14,58 +14,6 @@
             <div class="user-label">{{ authStore.user?.name || 'GitHub User' }}</div>
           </div>
         </div>
-
-        <div class="section">
-          <div class="section-title">Connected Accounts</div>
-
-          <div v-if="loading" class="loading-row">Loading…</div>
-
-          <div v-else-if="logins.length === 0" class="empty-row">No connected accounts found.</div>
-
-          <div v-else class="login-list">
-            <div v-for="login in logins" :key="login.provider" class="login-row">
-              <div class="login-icon">
-                <span v-if="login.provider === 'github'" class="provider-icon">⬡</span>
-                <span v-else class="provider-icon">◈</span>
-              </div>
-              <div class="login-info">
-                <div class="login-provider">{{ providerLabel(login.provider) }}</div>
-                <div class="login-username">{{ login.username }}</div>
-              </div>
-              <div class="login-actions">
-                <button
-                  class="disconnect-btn"
-                  :disabled="logins.length <= 1 || disconnecting === login.provider"
-                  :title="
-                    logins.length <= 1
-                      ? 'Cannot disconnect your only login method'
-                      : `Disconnect ${providerLabel(login.provider)}`
-                  "
-                  @click="confirmDisconnect(login.provider)"
-                >
-                  {{ disconnecting === login.provider ? '…' : 'Disconnect' }}
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <div v-if="statusMsg" class="status-row" :class="statusClass">{{ statusMsg }}</div>
-        </div>
-      </div>
-
-      <!-- Confirmation dialog -->
-      <div v-if="confirmProvider" class="confirm-overlay">
-        <div class="confirm-box">
-          <div class="confirm-title">Disconnect {{ providerLabel(confirmProvider) }}?</div>
-          <div class="confirm-body">
-            This will remove your {{ providerLabel(confirmProvider) }} login and invalidate all
-            active sessions. You will be signed out.
-          </div>
-          <div class="confirm-actions">
-            <button class="pixel-btn confirm-cancel" @click="confirmProvider = null">Cancel</button>
-            <button class="pixel-btn confirm-ok" @click="doDisconnect">Disconnect</button>
-          </div>
-        </div>
       </div>
 
       <div class="modal-footer">
@@ -76,78 +24,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
-import { api } from '../utils/api'
 
 defineEmits<{ close: [] }>()
 const authStore = useAuthStore()
-
-interface LoginEntry {
-  provider: string
-  username: string
-  scope: string | null
-  connected_at: string | null
-  updated_at: string | null
-}
-
-const logins = ref<LoginEntry[]>([])
-const loading = ref(true)
-const disconnecting = ref<string | null>(null)
-const confirmProvider = ref<string | null>(null)
-const statusMsg = ref('')
-const statusClass = ref<'status-ok' | 'status-err'>('status-ok')
-
-let statusTimer: ReturnType<typeof setTimeout> | null = null
-
-function providerLabel(p: string) {
-  if (p === 'github') return 'GitHub'
-  return p.charAt(0).toUpperCase() + p.slice(1)
-}
-
-async function fetchLogins() {
-  loading.value = true
-  try {
-    const data = await api<{ logins: LoginEntry[] }>('/api/user/logins')
-    logins.value = data.logins ?? []
-  } catch {
-    logins.value = []
-  } finally {
-    loading.value = false
-  }
-}
-
-function setStatus(msg: string, ok: boolean) {
-  statusMsg.value = msg
-  statusClass.value = ok ? 'status-ok' : 'status-err'
-  if (statusTimer) clearTimeout(statusTimer)
-  statusTimer = setTimeout(() => {
-    statusMsg.value = ''
-  }, 3500)
-}
-
-function confirmDisconnect(provider: string) {
-  confirmProvider.value = provider
-}
-
-async function doDisconnect() {
-  const provider = confirmProvider.value
-  confirmProvider.value = null
-  if (!provider) return
-  disconnecting.value = provider
-  try {
-    await api(`/api/user/logins/${provider}`, { method: 'DELETE' })
-    setStatus(`${providerLabel(provider)} disconnected. You will be signed out.`, true)
-    await authStore.logout()
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : 'Disconnect failed'
-    setStatus(msg, false)
-  } finally {
-    disconnecting.value = null
-  }
-}
-
-onMounted(fetchLogins)
 </script>
 
 <style scoped>
@@ -169,7 +49,6 @@ onMounted(fetchLogins)
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  position: relative;
 }
 
 .modal-header {
@@ -243,173 +122,6 @@ onMounted(fetchLogins)
 .user-label {
   font-size: 11px;
   color: var(--color-text-dim);
-}
-
-/* ── Connected Accounts section ── */
-
-.section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.section-title {
-  font-family: var(--font-pixel);
-  font-size: 7px;
-  color: var(--color-brass-dark);
-  letter-spacing: 1.5px;
-  text-transform: uppercase;
-  padding-bottom: 6px;
-  border-bottom: 1px solid var(--color-brass-dark);
-}
-
-.loading-row,
-.empty-row {
-  font-size: 11px;
-  color: var(--color-text-dim);
-  padding: 8px 0;
-}
-
-.login-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.login-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 9px 10px;
-  background: var(--color-bg);
-  border: 1px solid var(--color-brass-dark);
-}
-
-.provider-icon {
-  font-size: 16px;
-  color: var(--color-brass);
-  line-height: 1;
-}
-
-.login-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.login-provider {
-  font-family: var(--font-pixel);
-  font-size: 7px;
-  color: var(--color-brass-light);
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 2px;
-}
-
-.login-username {
-  font-size: 11px;
-  color: var(--color-teal);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.disconnect-btn {
-  flex-shrink: 0;
-  background: none;
-  border: 1px solid var(--color-red, #c0392b);
-  color: var(--color-red, #c0392b);
-  font-family: var(--font-pixel);
-  font-size: 6px;
-  letter-spacing: 1px;
-  padding: 4px 8px;
-  cursor: pointer;
-  transition:
-    background 0.12s,
-    color 0.12s;
-}
-
-.disconnect-btn:hover:not(:disabled) {
-  background: rgba(192, 57, 43, 0.15);
-}
-
-.disconnect-btn:disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
-  border-color: var(--color-text-dim);
-  color: var(--color-text-dim);
-}
-
-.status-row {
-  font-family: var(--font-pixel);
-  font-size: 7px;
-  letter-spacing: 0.5px;
-  padding-top: 4px;
-}
-
-.status-ok {
-  color: var(--color-green, #27ae60);
-}
-
-.status-err {
-  color: var(--color-red, #c0392b);
-}
-
-/* ── Confirmation dialog ── */
-
-.confirm-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.65);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 10;
-}
-
-.confirm-box {
-  background: var(--color-bg-secondary);
-  border: 2px solid var(--color-brass);
-  padding: 20px;
-  width: 320px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.confirm-title {
-  font-family: var(--font-pixel);
-  font-size: 8px;
-  color: var(--color-brass-light);
-  letter-spacing: 1.5px;
-  text-transform: uppercase;
-}
-
-.confirm-body {
-  font-size: 12px;
-  color: var(--color-text-dim);
-  line-height: 1.5;
-}
-
-.confirm-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.confirm-cancel {
-  font-size: 7px;
-  padding: 5px 10px;
-}
-
-.confirm-ok {
-  font-size: 7px;
-  padding: 5px 10px;
-  border-color: var(--color-red, #c0392b);
-  color: var(--color-red, #c0392b);
-}
-
-.confirm-ok:hover {
-  background: rgba(192, 57, 43, 0.15);
 }
 
 .modal-footer {

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -47,6 +47,10 @@ token = "env:GITHUB_TOKEN"
 max_turns = 50
 
 [codex]
+# OpenAI API key for Codex tasks. Use "env:VAR_NAME" to read from an
+# environment variable (recommended), or set OPENAI_API_KEY in the environment.
+# api_key = "env:OPENAI_API_KEY"
+
 # Extra args passed to `codex exec` before the prompt. Keep approval policy
 # non-interactive for unattended workers.
 # args = ["--sandbox", "workspace-write", "--ask-for-approval", "never"]

--- a/worker/pioneer_worker/codex_runner.py
+++ b/worker/pioneer_worker/codex_runner.py
@@ -42,8 +42,15 @@ async def run_codex_auto(
     emit: EmitFn,
     codex_path: str = "codex",
     codex_args: list[str] | None = None,
+    openai_api_key: str | None = None,
 ) -> tuple[bool, str, str]:
-    """Run codex on *description* in *cwd*. Returns (success, stop_reason, last_text)."""
+    """Run codex on *description* in *cwd*. Returns (success, stop_reason, last_text).
+
+    *openai_api_key* is injected as OPENAI_API_KEY into the subprocess environment
+    when provided, overriding whatever is in the current process env. This lets
+    the worker forward the key without requiring it to be set globally before
+    import time.
+    """
     last_message_file = tempfile.NamedTemporaryFile(
         prefix="pioneer-codex-last-", suffix=".txt", delete=False
     )
@@ -73,12 +80,16 @@ async def run_codex_auto(
         # prompt content and tries to drain it. Give it an idle TTY so the
         # explicit prompt argument is the only task input.
         master_fd, slave_fd = pty.openpty()
+        env = dict(os.environ)
+        if openai_api_key:
+            env["OPENAI_API_KEY"] = openai_api_key
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=cwd,
             stdin=slave_fd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
         os.close(slave_fd)
         slave_fd = None

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -168,11 +168,24 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
     if _openai_api_key is None:
         raw_key = codex_block.get("api_key")
         if isinstance(raw_key, str) and raw_key.startswith("env:"):
-            _openai_api_key = os.environ.get(raw_key[4:].strip()) or None
+            _var_name = raw_key[4:].strip()
+            _env_val = os.environ.get(_var_name)
+            if _env_val == "":
+                raise ValueError(
+                    f"[codex] api_key references env:{_var_name!r} but the variable is set to an"
+                    " empty string. Provide a valid OpenAI API key or unset the variable."
+                )
+            _openai_api_key = _env_val  # None if var is absent, key string if present
         elif raw_key:
             _openai_api_key = raw_key
     if _openai_api_key is None:
-        _openai_api_key = os.environ.get("OPENAI_API_KEY") or None
+        _env_val = os.environ.get("OPENAI_API_KEY")
+        if _env_val == "":
+            raise ValueError(
+                "OPENAI_API_KEY is set to an empty string. Provide a valid OpenAI API key or"
+                " unset the variable."
+            )
+        _openai_api_key = _env_val  # None if not set
 
     return Config(
         backend_url=backend_url.rstrip("/"),

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -41,6 +41,10 @@ class Config:
     codex_path: str = "codex"
     codex_args: list[str] = field(default_factory=list)
     codex_doctor: bool = True
+    # OpenAI API key for Codex tasks. Falls back to OPENAI_API_KEY env var at
+    # startup; set here to avoid exposing the secret in the process environment
+    # before the worker has a chance to forward it.
+    openai_api_key: str | None = None
     pi_path: str = "pi"
     pull_interval: float = 300.0
     claude_max_turns: int = 50
@@ -160,6 +164,16 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
     if not isinstance(_codex_args, list) or not all(isinstance(arg, str) for arg in _codex_args):
         raise ValueError("codex args must be a list of strings.")
 
+    _openai_api_key = overrides.get("openai_api_key")
+    if _openai_api_key is None:
+        raw_key = codex_block.get("api_key")
+        if isinstance(raw_key, str) and raw_key.startswith("env:"):
+            _openai_api_key = os.environ.get(raw_key[4:].strip()) or None
+        elif raw_key:
+            _openai_api_key = raw_key
+    if _openai_api_key is None:
+        _openai_api_key = os.environ.get("OPENAI_API_KEY") or None
+
     return Config(
         backend_url=backend_url.rstrip("/"),
         guild_id=guild_id,
@@ -195,6 +209,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             if overrides.get("codex_doctor") is not None
             else codex_block.get("doctor", True)
         ),
+        openai_api_key=_openai_api_key,
         pi_path=overrides.get("pi_path") or paths_block.get("pi", "pi"),
         pull_interval=float(
             overrides.get("pull_interval")

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -242,6 +242,25 @@ class Worker:
         else:
             logger.warning("codex doctor: failed (rc=%d)\n%s", proc.returncode, output)
 
+    async def _ensure_codex_api_key(self) -> None:
+        """Set OPENAI_API_KEY in the process environment for Codex tasks.
+
+        Priority: env var already set → config openai_api_key → warn and skip.
+        The env var is inherited by every spawned codex subprocess; the runner
+        also accepts it explicitly for extra safety.
+        """
+        if os.environ.get("OPENAI_API_KEY"):
+            logger.info("OPENAI_API_KEY already in env — Codex tasks will use it")
+            return
+        if self.cfg.openai_api_key:
+            os.environ["OPENAI_API_KEY"] = self.cfg.openai_api_key
+            logger.info("OPENAI_API_KEY set from config for Codex tasks")
+        else:
+            logger.warning(
+                "OPENAI_API_KEY not configured — Codex tasks will fail. "
+                "Set openai_api_key in the [codex] config block or the OPENAI_API_KEY env var."
+            )
+
     async def _claude_is_authenticated(self) -> bool:
         """Return True if `claude auth status --json` reports loggedIn=true.
 
@@ -921,6 +940,7 @@ class Worker:
         await self._refresh_github_repos()
         await self._check_gh_auth()
         await self._check_codex_doctor()
+        await self._ensure_codex_api_key()
 
         logger.info("Connecting to backend WebSocket at %s", self.cfg.ws_url)
         self.ws.on_reconnect = self._on_ws_reconnect
@@ -1673,6 +1693,7 @@ class Worker:
                         emit=emit,
                         codex_path=self.cfg.codex_path,
                         codex_args=self.cfg.codex_args,
+                        openai_api_key=self.cfg.openai_api_key,
                     )
                 elif tool == "pi":
                     logger.info("Task %s: launching pi in %s", task_id, primary_wt)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -243,18 +243,14 @@ class Worker:
             logger.warning("codex doctor: failed (rc=%d)\n%s", proc.returncode, output)
 
     async def _ensure_codex_api_key(self) -> None:
-        """Set OPENAI_API_KEY in the process environment for Codex tasks.
+        """Warn early if no OpenAI API key is available for Codex tasks.
 
-        Priority: env var already set → config openai_api_key → warn and skip.
-        The env var is inherited by every spawned codex subprocess; the runner
-        also accepts it explicitly for extra safety.
+        The key is passed explicitly to each run_codex_auto call (via the
+        openai_api_key parameter) rather than being injected into os.environ,
+        so this method only checks and logs — it does not mutate global state.
         """
-        if os.environ.get("OPENAI_API_KEY"):
-            logger.info("OPENAI_API_KEY already in env — Codex tasks will use it")
-            return
-        if self.cfg.openai_api_key:
-            os.environ["OPENAI_API_KEY"] = self.cfg.openai_api_key
-            logger.info("OPENAI_API_KEY set from config for Codex tasks")
+        if os.environ.get("OPENAI_API_KEY") or self.cfg.openai_api_key:
+            logger.info("OPENAI_API_KEY configured — Codex tasks will use it")
         else:
             logger.warning(
                 "OPENAI_API_KEY not configured — Codex tasks will fail. "


### PR DESCRIPTION
## Summary

- **Codex CLI auth**: Plumb `OPENAI_API_KEY` through the worker stack so Codex tasks authenticate without manual setup. The config loader reads `[codex].api_key` (supports `env:VAR` indirection), falls back to `OPENAI_API_KEY` env var, and warns at startup if neither is set. `codex_runner.py` injects the key directly into the subprocess environment. `docker-compose.yml` forwards the variable to worker containers.
- **Login management API**: Add `GET /api/user/logins` (list connected OAuth providers per user) and `DELETE /api/user/logins/{provider}` (disconnect a provider, guarded against last-login lockout — returns HTTP 400 when the user would be permanently locked out).
- **Connected Accounts UI**: Expand `GitHubConfigModal.vue` with a "Connected Accounts" section showing each provider's username, a **Disconnect** button that is disabled (with tooltip) when it is the only login method, an in-modal confirmation dialog before disconnect, and inline success/error status feedback.

## Test plan

- [ ] Set `OPENAI_API_KEY` or `[codex].api_key` in worker config; assign a Codex task — worker startup should log "OPENAI_API_KEY set from config" and the task should run without auth errors
- [ ] Omit the key entirely — worker startup should log a warning, Codex task output should show `codex: error: Missing OpenAI API key` (or similar), not a crash
- [ ] `GET /api/user/logins` returns `{"logins": [{"provider": "github", "username": "..."}]}` for a logged-in user
- [ ] `DELETE /api/user/logins/github` with a single-provider account returns HTTP 400 with "Cannot disconnect your only login method"
- [ ] In the UI, open GitHub config modal — "Connected Accounts" section shows GitHub username; Disconnect button is disabled with tooltip
- [ ] `DELETE /api/user/logins/unknown` returns HTTP 404

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)