### PR TITLE
User settings: login management

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -32,7 +32,7 @@ from models import (
 )
 from oauth import FRONTEND_URL, GITHUB_CLIENT_ID, create_session, get_return_to, make_authorize_url
 from pydantic import BaseModel
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from utils import generate_guild_id
 
@@ -337,6 +337,103 @@ async def guest_login():
         "gh_name": "Dev Guest",
         "gh_avatar": "",
     }
+
+
+@router.get("/api/user/logins")
+async def list_logins(github_user_id: str = Depends(require_user)):
+    """Return the list of connected OAuth providers for the current user.
+
+    Currently GitHub is the only supported provider; the response is structured
+    as a provider list so additional providers can be added without breaking the
+    API shape.
+    """
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(
+                GithubToken.github_username,
+                GithubToken.scope,
+                GithubToken.created_at,
+                GithubToken.updated_at,
+            ).where(GithubToken.github_user_id == github_user_id)
+        )
+        row = result.first()
+        logins = []
+        if row:
+            logins.append(
+                {
+                    "provider": "github",
+                    "username": row.github_username,
+                    "scope": row.scope,
+                    "connected_at": row.created_at,
+                    "updated_at": row.updated_at,
+                }
+            )
+        return {"logins": logins}
+    finally:
+        await db.close()
+
+
+@router.delete("/api/user/logins/{provider}")
+async def delete_login(provider: str, github_user_id: str = Depends(require_user)):
+    """Disconnect an OAuth provider from the current user's account.
+
+    Returns HTTP 404 if the user has no login for the requested provider.
+    Guards against removing the last login — if this would leave the user with
+    zero logins they would be permanently locked out, so we return HTTP 400.
+    Currently only ``github`` is supported; passing any other provider returns
+    HTTP 404.
+
+    Session behaviour: this endpoint removes only the provider credential for
+    the named provider.  It does NOT delete ``UserSession`` rows — the frontend
+    is responsible for calling ``DELETE /auth/logout`` immediately after to
+    invalidate the current session.  Other active sessions for this user remain
+    valid until they naturally expire; they will receive 401 on the next GitHub-
+    authenticated API call once the token is gone.
+    """
+    if provider != "github":
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider!r}")
+
+    db = await get_db()
+    try:
+        # Verify the requested provider login actually exists for this user.
+        existing_res = await db.execute(
+            select(GithubToken).where(GithubToken.github_user_id == github_user_id)
+        )
+        if existing_res.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No {provider!r} login found for this user.",
+            )
+
+        # Count total logins across all providers for this user.  If removing
+        # this provider would leave zero logins the user would be permanently
+        # locked out, so we block the operation.
+        # When new providers are added: total_logins += new_provider_count
+        github_count_res = await db.execute(
+            select(func.count())
+            .select_from(GithubToken)
+            .where(GithubToken.github_user_id == github_user_id)
+        )
+        github_count = github_count_res.scalar_one() or 0
+        total_logins = github_count  # add future provider counts here
+
+        if total_logins <= 1:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot disconnect your only login method — you would be locked out.",
+            )
+
+        # Delete only the token row for the specified provider and user.
+        # Other providers (future) are intentionally not touched.
+        if provider == "github":
+            await db.execute(
+                delete(GithubToken).where(GithubToken.github_user_id == github_user_id)
+            )
+        await db.commit()
+    finally:
+        await db.close()
+    return {"ok": True}
 
 
 @router.delete("/auth/logout")

--- a/frontend/src/components/GitHubConfigModal.vue
+++ b/frontend/src/components/GitHubConfigModal.vue
@@ -14,6 +14,58 @@
             <div class="user-label">{{ authStore.user?.name || 'GitHub User' }}</div>
           </div>
         </div>
+
+        <div class="section">
+          <div class="section-title">Connected Accounts</div>
+
+          <div v-if="loading" class="loading-row">Loading…</div>
+
+          <div v-else-if="logins.length === 0" class="empty-row">No connected accounts found.</div>
+
+          <div v-else class="login-list">
+            <div v-for="login in logins" :key="login.provider" class="login-row">
+              <div class="login-icon">
+                <span v-if="login.provider === 'github'" class="provider-icon">⬡</span>
+                <span v-else class="provider-icon">◈</span>
+              </div>
+              <div class="login-info">
+                <div class="login-provider">{{ providerLabel(login.provider) }}</div>
+                <div class="login-username">{{ login.username }}</div>
+              </div>
+              <div class="login-actions">
+                <button
+                  class="disconnect-btn"
+                  :disabled="logins.length <= 1 || disconnecting === login.provider"
+                  :title="
+                    logins.length <= 1
+                      ? 'Cannot disconnect your only login method'
+                      : `Disconnect ${providerLabel(login.provider)}`
+                  "
+                  @click="confirmDisconnect(login.provider)"
+                >
+                  {{ disconnecting === login.provider ? '…' : 'Disconnect' }}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="statusMsg" class="status-row" :class="statusClass">{{ statusMsg }}</div>
+        </div>
+      </div>
+
+      <!-- Confirmation dialog -->
+      <div v-if="confirmProvider" class="confirm-overlay">
+        <div class="confirm-box">
+          <div class="confirm-title">Disconnect {{ providerLabel(confirmProvider) }}?</div>
+          <div class="confirm-body">
+            This will remove your {{ providerLabel(confirmProvider) }} login. You will be signed
+            out of this session.
+          </div>
+          <div class="confirm-actions">
+            <button class="pixel-btn confirm-cancel" @click="confirmProvider = null">Cancel</button>
+            <button class="pixel-btn confirm-ok" @click="doDisconnect">Disconnect</button>
+          </div>
+        </div>
       </div>
 
       <div class="modal-footer">
@@ -24,10 +76,78 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
+import { api } from '../utils/api'
 
 defineEmits<{ close: [] }>()
 const authStore = useAuthStore()
+
+interface LoginEntry {
+  provider: string
+  username: string
+  scope: string | null
+  connected_at: string | null
+  updated_at: string | null
+}
+
+const logins = ref<LoginEntry[]>([])
+const loading = ref(true)
+const disconnecting = ref<string | null>(null)
+const confirmProvider = ref<string | null>(null)
+const statusMsg = ref('')
+const statusClass = ref<'status-ok' | 'status-err'>('status-ok')
+
+let statusTimer: ReturnType<typeof setTimeout> | null = null
+
+function providerLabel(p: string) {
+  if (p === 'github') return 'GitHub'
+  return p.charAt(0).toUpperCase() + p.slice(1)
+}
+
+async function fetchLogins() {
+  loading.value = true
+  try {
+    const data = await api<{ logins: LoginEntry[] }>('/api/user/logins')
+    logins.value = data.logins ?? []
+  } catch {
+    logins.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+function setStatus(msg: string, ok: boolean) {
+  statusMsg.value = msg
+  statusClass.value = ok ? 'status-ok' : 'status-err'
+  if (statusTimer) clearTimeout(statusTimer)
+  statusTimer = setTimeout(() => {
+    statusMsg.value = ''
+  }, 3500)
+}
+
+function confirmDisconnect(provider: string) {
+  confirmProvider.value = provider
+}
+
+async function doDisconnect() {
+  const provider = confirmProvider.value
+  confirmProvider.value = null
+  if (!provider) return
+  disconnecting.value = provider
+  try {
+    await api(`/api/user/logins/${provider}`, { method: 'DELETE' })
+    setStatus(`${providerLabel(provider)} disconnected. You will be signed out.`, true)
+    await authStore.logout()
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Disconnect failed'
+    setStatus(msg, false)
+  } finally {
+    disconnecting.value = null
+  }
+}
+
+onMounted(fetchLogins)
 </script>
 
 <style scoped>
@@ -49,6 +169,7 @@ const authStore = useAuthStore()
   max-height: 80vh;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .modal-header {
@@ -122,6 +243,173 @@ const authStore = useAuthStore()
 .user-label {
   font-size: 11px;
   color: var(--color-text-dim);
+}
+
+/* ── Connected Accounts section ── */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-title {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-brass-dark);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--color-brass-dark);
+}
+
+.loading-row,
+.empty-row {
+  font-size: 11px;
+  color: var(--color-text-dim);
+  padding: 8px 0;
+}
+
+.login-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.login-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-brass-dark);
+}
+
+.provider-icon {
+  font-size: 16px;
+  color: var(--color-brass);
+  line-height: 1;
+}
+
+.login-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.login-provider {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-brass-light);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.login-username {
+  font-size: 11px;
+  color: var(--color-teal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.disconnect-btn {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--color-red, #c0392b);
+  color: var(--color-red, #c0392b);
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 1px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.disconnect-btn:hover:not(:disabled) {
+  background: rgba(192, 57, 43, 0.15);
+}
+
+.disconnect-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  border-color: var(--color-text-dim);
+  color: var(--color-text-dim);
+}
+
+.status-row {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  letter-spacing: 0.5px;
+  padding-top: 4px;
+}
+
+.status-ok {
+  color: var(--color-green, #27ae60);
+}
+
+.status-err {
+  color: var(--color-red, #c0392b);
+}
+
+/* ── Confirmation dialog ── */
+
+.confirm-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.confirm-box {
+  background: var(--color-bg-secondary);
+  border: 2px solid var(--color-brass);
+  padding: 20px;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.confirm-title {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  color: var(--color-brass-light);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+.confirm-body {
+  font-size: 12px;
+  color: var(--color-text-dim);
+  line-height: 1.5;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.confirm-cancel {
+  font-size: 7px;
+  padding: 5px 10px;
+}
+
+.confirm-ok {
+  font-size: 7px;
+  padding: 5px 10px;
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #c0392b);
+}
+
+.confirm-ok:hover {
+  background: rgba(192, 57, 43, 0.15);
 }
 
 .modal-footer {


### PR DESCRIPTION
## Summary

Splits the user settings / login-management portion of #381 into a standalone PR — no Codex API key changes included.

- **`GET /api/user/logins`** — list connected OAuth providers for the current user (GitHub only for now; response shape supports future providers)
- **`DELETE /api/user/logins/{provider}`** — disconnect a provider with a lockout guard (HTTP 400 if it would be the last login)
- **Frontend** — "Connected Accounts" section in `GitHubConfigModal` with a per-provider Disconnect button and an in-modal confirmation dialog

## Reviewer concerns addressed from #381

**(a) Token scope** — `delete_login` deletes only the `GithubToken` row for the requesting user and the specified provider; other providers (future) are not touched.

**(b) Session behaviour** — the endpoint no longer deletes any `UserSession` rows. The docstring now explicitly documents that: only the current session is invalidated (the frontend calls `DELETE /auth/logout` immediately after); other active sessions remain valid until they naturally expire.

**(c) Lockout guard** — the guard counts logins for this specific user across all providers; both the count query and the deletion query are scoped to the same `github_user_id`, so the `<= 1` check correctly prevents the user from locking themselves out.

## Test plan

- [ ] Open GitHubConfigModal while logged in — Connected Accounts section loads and shows the GitHub entry
- [ ] Disconnect button is disabled (greyed out) when only 1 login exists — tooltip explains why
- [ ] Clicking Disconnect shows confirmation dialog; Cancel dismisses without action
- [ ] Confirm Disconnect calls `DELETE /api/user/logins/github`, shows success message, then signs out
- [ ] `GET /api/user/logins` returns 401 without a valid session
- [ ] `DELETE /api/user/logins/github` returns 400 when the user has only one login method
- [ ] `DELETE /api/user/logins/unknown` returns 404
- [ ] `DELETE /api/user/logins/github` returns 404 when no GitHub token exists for the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)