### PR TITLE
Fix Workers tab: click should activate detail tab (#395)

### DIFF
--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -36,9 +36,9 @@
       <!-- Task tabs — only shown when explicitly opened -->
       <button
         v-for="task in visibleTaskTabs"
-        :key="'task-' + task.id"
+        :key="taskTabId(task.id)"
         class="tab task-tab"
-        :class="{ active: agentsStore.activeTab === 'task-' + task.id }"
+        :class="{ active: agentsStore.activeTab === taskTabId(task.id) }"
         @click="onTabClick($event, task.id)"
       >
         <span class="task-dot" :class="'task-dot-' + task.state.replace(/[^a-z]/g, '-')"></span>
@@ -58,7 +58,7 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useAgentsStore } from '../stores/agents'
-import { useTasksStore } from '../stores/tasks'
+import { useTasksStore, taskTabId } from '../stores/tasks'
 import FactoryFloor from './FactoryFloor.vue'
 import LogPane from './LogPane.vue'
 
@@ -107,7 +107,7 @@ function onAgentTabClick(event: MouseEvent, agentId: string) {
 function onTabClick(event: MouseEvent, taskId: string) {
   if ((event.target as HTMLElement).closest('.tab-close')) {
     tasksStore.closeTask(taskId)
-    if (agentsStore.activeTab === 'task-' + taskId) agentsStore.activeTab = 'factory'
+    if (agentsStore.activeTab === taskTabId(taskId)) agentsStore.activeTab = 'factory'
   } else {
     agentsStore.openTaskTab(taskId)
   }

--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -84,7 +84,7 @@ const visibleTaskTabs = computed(() =>
 watch(
   () => tasksStore.selectedTaskId,
   (id) => {
-    if (id) agentsStore.activeTab = 'task-' + id
+    if (id) agentsStore.openTaskTab(id)
   },
 )
 
@@ -109,7 +109,7 @@ function onTabClick(event: MouseEvent, taskId: string) {
     tasksStore.closeTask(taskId)
     if (agentsStore.activeTab === 'task-' + taskId) agentsStore.activeTab = 'factory'
   } else {
-    agentsStore.activeTab = 'task-' + taskId
+    agentsStore.openTaskTab(taskId)
   }
 }
 </script>

--- a/frontend/src/components/sidebar/WorkerList.vue
+++ b/frontend/src/components/sidebar/WorkerList.vue
@@ -75,7 +75,10 @@ function currentTaskForWorker(workerId: string) {
 
 function openAgentTask(workerId: string) {
   const task = currentTaskForWorker(workerId)
-  if (task) tasksStore.selectTask(task.id)
+  if (task) {
+    tasksStore.selectTask(task.id)
+    agentsStore.activeTab = 'task-' + task.id
+  }
 }
 </script>
 

--- a/frontend/src/components/sidebar/WorkerList.vue
+++ b/frontend/src/components/sidebar/WorkerList.vue
@@ -77,7 +77,7 @@ function openAgentTask(workerId: string) {
   const task = currentTaskForWorker(workerId)
   if (task) {
     tasksStore.selectTask(task.id)
-    agentsStore.activeTab = 'task-' + task.id
+    agentsStore.openTaskTab(task.id)
   }
 }
 </script>

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useGuildStore } from './guild'
 import { api } from '../utils/api'
 import { formatWorkerId } from '../utils/format'
+import { taskTabId } from './tasks'
 import type { Agent, AgentActivity, AgentState, LogDetail, LogEntry, Worker, WSInbound } from '../types'
 
 const STATE_RANK: Record<string, number> = {
@@ -158,7 +159,7 @@ export const useAgentsStore = defineStore('agents', () => {
   }
 
   function openTaskTab(taskId: string) {
-    activeTab.value = 'task-' + taskId
+    activeTab.value = taskTabId(taskId)
   }
 
   function sendMessage(agentId: string, content: string) {

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -157,6 +157,10 @@ export const useAgentsStore = defineStore('agents', () => {
     if (activeTab.value === 'agent-' + agentId) activeTab.value = 'factory'
   }
 
+  function openTaskTab(taskId: string) {
+    activeTab.value = 'task-' + taskId
+  }
+
   function sendMessage(agentId: string, content: string) {
     const guildStore = useGuildStore()
     guildStore.sendMessage({
@@ -304,6 +308,7 @@ export const useAgentsStore = defineStore('agents', () => {
     closeWorker,
     selectAgent,
     closeAgent,
+    openTaskTab,
     sendMessage,
     runAgent,
     stopAgent,

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -3,6 +3,10 @@ import { computed, ref } from 'vue'
 import { api } from '../utils/api'
 import type { LogEntry, Task, TaskState, WSInbound } from '../types'
 
+export function taskTabId(id: string): string {
+  return 'task-' + id
+}
+
 // Cap on setTimeout delay to avoid the 32-bit overflow that fires the timer
 // immediately on long horizons (e.g. a 3-day finalize window).
 const MAX_TIMEOUT_MS = 2_147_483_647


### PR DESCRIPTION
## Summary

- Clicking the task button (📋) on a worker row in the Workers tab called `tasksStore.selectTask()` but never set `agentsStore.activeTab`, so the task tab would appear in the tab bar but remain unselected.
- Added `agentsStore.activeTab = 'task-' + task.id` immediately after `selectTask()` in `WorkerList.vue`'s `openAgentTask` handler, matching the same activation pattern used by the Tasks tab's watcher in `MainView.vue`.
- Worker row clicks already worked correctly via `agentsStore.selectWorker()` which sets `activeTab` directly.

## Test plan

- [ ] Open the Workers tab in the sidebar
- [ ] Click the 📋 task button on a worker that has an active task — the task tab should open **and** become the selected (highlighted) tab
- [ ] Verify the Tasks tab still works correctly (click a task → tab opens and is selected)
- [ ] Verify clicking a worker row still opens and selects the worker detail tab

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)