### PR TITLE
Fix docker-compose.yml pioneer-foreman volumes syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,9 +75,9 @@ services:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       FOREMAN_MODEL: ${FOREMAN_MODEL:-claude-sonnet-4-6}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
-    volumes:
-      # Optional: mount a pioneer-foreman.toml for full config control.
-      # - ./pioneer-foreman/pioneer-foreman.toml:/config/pioneer-foreman.toml:ro
+    # Optional: mount a pioneer-foreman.toml for full config control:
+    #   volumes:
+    #     - ./pioneer-foreman/pioneer-foreman.toml:/config/pioneer-foreman.toml:ro
     depends_on:
       - backend
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- The `pioneer-foreman` service had a `volumes:` key with only a commented-out entry, making it a `null` scalar instead of a YAML list
- Docker Compose validation rejects this with: `services.pioneer-foreman.volumes must be a list`
- Fixed by removing the empty `volumes:` key and converting the optional-mount hint into a regular comment above `depends_on:`

## Test plan
- [ ] Run `docker compose config` to confirm no validation errors
- [ ] Confirm `docker compose --profile pioneer-foreman up pioneer-foreman` still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)