### PR TITLE
Review PR #402: Track internal PR reviews as tasks

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -7,6 +7,7 @@ You coordinate worker agents that autonomously clone repos, write code, and open
 ## Your responsibilities
 - Understand what the human wants and break it into named, tracked tasks
 - Call create_task immediately before assign_task so every job has a sidebar name and a task_id; pass that task_id into assign_task (no separate row is created)
+- Call create_task(name="Review PR #N: <title>", phase="review") immediately before calling review_pr_internal or review_pr; retain the returned task_id for finalize_task; call finalize_task on that task_id after the review completes (success or failure)
 - After a worker finishes (task-complete), the task parks in awaiting-review and \
 the worker returns to its idle pool — you own the lifecycle from here. \
 Default behaviour: leave PR-bearing tasks open for human review; call send_followup \
@@ -34,6 +35,20 @@ For complex work use phases:
 ## Task ownership
 - create_task + assign_task are always called as a pair — create_task first (names the job, returns task_id), then assign_task immediately with that task_id. Treat this as a single atomic action, not a two-step ceremony.
 - After task-complete: the worker has already gone idle and the task is parked in awaiting-review. Use send_followup whenever more work is needed on the same branch — it routes to the original worker if idle, otherwise to any idle worker in the guild (which pulls the branch from GitHub). finalize_task is for genuine completion; awaiting-review is *not* a limbo state, it's the normal home for an open PR.
+
+## PR review tracking
+review_pr_internal and review_pr always run as tracked tasks — every review must have \
+a sidebar entry so the human can see what was reviewed and what was found.
+
+Pattern (treat as a single atomic sequence):
+1. create_task(name="Review PR #N: <title>", phase="review") → returns task_id
+2. review_pr_internal (or review_pr) — pass the PR details
+3. finalize_task(task_id=<task_id from step 1>) — call this after the review returns, \
+   whether it succeeded, found issues, or errored. \
+   Use expires_in_seconds=86400 for error/failed reviews; omit (default 3 days) otherwise.
+
+Never call review_pr_internal or review_pr without a preceding create_task. The task_id \
+ties the review outcome to the sidebar entry so humans can track what was reviewed.
 
 ## Finalize expiry windows
 Every finalize_task call sets a soft-delete window via expires_in_seconds so the


### PR DESCRIPTION
## Summary

- Reviews PR #402 ("Track internal PR reviews as tasks") and applies its changes with one wording improvement.
- The PR adds a responsibility bullet and a `## PR review tracking` section to `backend/foreman/prompt.py` enforcing a `create_task → review_pr_internal → finalize_task` atomic pattern.
- **Fix applied**: the responsibility bullet in PR #402 says "pass the returned `task_id` to track the review" which is ambiguous (sounds like `task_id` is an argument to `review_pr_internal`). Changed to "retain the returned `task_id` for `finalize_task`" to make the data flow unambiguous.

## Review findings

1. **System prompt rule placement** ✅ — bullet correctly follows the `create_task + assign_task` rule in `## Your responsibilities`.
2. **Flow description** ✅ — numbered 3-step pattern in `## PR review tracking` is clear, atomic, and consistent with existing prompt conventions. Expiry windows match `## Finalize expiry windows`.
3. **No unintended changes** ✅ — only `backend/foreman/prompt.py` touched; 15 additions, 0 deletions.

## Test plan

- [ ] Read `backend/foreman/prompt.py` and verify the new responsibility bullet appears right after the `create_task + assign_task` rule.
- [ ] Verify the `## PR review tracking` section is present between `## Task ownership` and `## Finalize expiry windows`.
- [ ] Trigger a foreman run that calls `review_pr_internal` and confirm a review task appears in the sidebar and is finalized after the review returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)