### PR TITLE
Task locking prevent concurrent t z0u0

### DIFF
--- a/backend/alembic/versions/20260520_000001_add_task_locking.py
+++ b/backend/alembic/versions/20260520_000001_add_task_locking.py
@@ -1,0 +1,44 @@
+"""add_task_locking
+
+Add locked_at / lock_holder to the tasks table and create the task_events
+table to queue follow-up triggers that arrive while a task is locked.
+
+Revision ID: 20260520_000001_add_task_locking
+Revises: 20260520_000000_add_index_worker_last_seen
+Create Date: 2026-05-20 00:00:01.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260520_000001_add_task_locking"
+down_revision: str | Sequence[str] | None = "20260520_000000_add_index_worker_last_seen"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.add_column(sa.Column("locked_at", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("lock_holder", sa.Text(), nullable=True))
+
+    op.create_table(
+        "task_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("task_id", sa.Text(), sa.ForeignKey("tasks.id"), nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("payload_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+    )
+    op.create_index("ix_task_events_task_id", "task_events", ["task_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_events_task_id", "task_events")
+    op.drop_table("task_events")
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.drop_column("lock_holder")
+        batch_op.drop_column("locked_at")

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -14,8 +14,18 @@ from datetime import UTC, datetime, timedelta
 
 from database import get_db
 from events import broadcast, emit_terminal_line
-from models import Agent, GithubToken, Guild, GuildKey, GuildMember, Task, TaskLog, Worker
-from sqlalchemy import select, update
+from models import (
+    Agent,
+    GithubToken,
+    Guild,
+    GuildKey,
+    GuildMember,
+    Task,
+    TaskEvent,
+    TaskLog,
+    Worker,
+)
+from sqlalchemy import delete, or_, select, update
 
 logger = logging.getLogger(__name__)
 
@@ -1266,60 +1276,100 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         )
                         is_error = True
                     else:
-                        update_vals: dict = {
-                            "state": "working",
-                            "phase": "followup",
-                            "worker_id": target_worker_id,
-                        }
-                        if prior_state in ("done", "failed", "cancelled"):
-                            # Re-opening a terminal task: clear soft-delete fields so it
-                            # reappears in the live task list and isn't auto-purged.
-                            update_vals["deleted_at"] = None
-                            update_vals["finished_at"] = None
-                        await db.execute(
-                            update(Task).where(Task.id == task_id).values(**update_vals)
+                        # Atomically acquire the follow-up lock to prevent two
+                        # concurrent foreman runs from both dispatching a worker.
+                        # Locks older than 1 hour are treated as stale/abandoned.
+                        lock_id = "".join(
+                            random.choices(string.ascii_lowercase + string.digits, k=8)
+                        )
+                        now_ts = datetime.now(UTC).isoformat()
+                        stale_cutoff = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+                        lock_result = await db.execute(
+                            update(Task)
+                            .where(
+                                Task.id == task_id,
+                                or_(Task.locked_at.is_(None), Task.locked_at < stale_cutoff),
+                            )
+                            .values(locked_at=now_ts, lock_holder=lock_id)
                         )
                         await db.commit()
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "task-update",
-                                "taskId": task_id,
-                                "state": "working",
-                                "workerId": target_worker_id,
-                                "deletedAt": None,
-                                "finishedAt": None,
-                            },
-                        )
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "task-followup",
-                                "workerId": target_worker_id,
-                                "taskId": task_id,
-                                "name": task_name or "",
-                                "description": task_desc or "",
-                                "tool": task_tool or "claude",
-                                "branch": branch,
-                                "instructions": instructions,
-                                "issueNumber": task_issue_number,
-                                "issueRepo": task_issue_repo,
-                            },
-                        )
-                        if (
-                            target_worker_id != original_worker_id
-                            and original_worker_id
-                            and original_worker_id != "foreman"
-                        ):
+                        if lock_result.rowcount == 0:
+                            # Task already locked by a concurrent follow-up —
+                            # queue this request for replay when the lock releases.
+                            db.add(
+                                TaskEvent(
+                                    task_id=task_id,
+                                    event_type="pending-followup",
+                                    payload_json=json.dumps(
+                                        {
+                                            "instructions": instructions,
+                                            "preferred_worker_id": preferred_worker_id,
+                                        }
+                                    ),
+                                    created_at=datetime.now(UTC).isoformat(),
+                                )
+                            )
+                            await db.commit()
                             result_text = (
-                                f"Follow-up reassigned from {original_worker_id} "
-                                f"to {target_worker_id} (task {task_id} on branch {branch})."
+                                f"Task {task_id} is locked by an in-progress follow-up. "
+                                "Instructions have been queued and will be passed to the "
+                                "foreman when the current follow-up completes."
                             )
                         else:
-                            result_text = (
-                                f"Follow-up sent to {target_worker_id} for task {task_id} "
-                                f"on branch {branch}."
+                            update_vals: dict = {
+                                "state": "working",
+                                "phase": "followup",
+                                "worker_id": target_worker_id,
+                            }
+                            if prior_state in ("done", "failed", "cancelled"):
+                                # Re-opening a terminal task: clear soft-delete fields so it
+                                # reappears in the live task list and isn't auto-purged.
+                                update_vals["deleted_at"] = None
+                                update_vals["finished_at"] = None
+                            await db.execute(
+                                update(Task).where(Task.id == task_id).values(**update_vals)
                             )
+                            await db.commit()
+                            await broadcast(
+                                guild_id,
+                                {
+                                    "type": "task-update",
+                                    "taskId": task_id,
+                                    "state": "working",
+                                    "workerId": target_worker_id,
+                                    "deletedAt": None,
+                                    "finishedAt": None,
+                                },
+                            )
+                            await broadcast(
+                                guild_id,
+                                {
+                                    "type": "task-followup",
+                                    "workerId": target_worker_id,
+                                    "taskId": task_id,
+                                    "name": task_name or "",
+                                    "description": task_desc or "",
+                                    "tool": task_tool or "claude",
+                                    "branch": branch,
+                                    "instructions": instructions,
+                                    "issueNumber": task_issue_number,
+                                    "issueRepo": task_issue_repo,
+                                },
+                            )
+                            if (
+                                target_worker_id != original_worker_id
+                                and original_worker_id
+                                and original_worker_id != "foreman"
+                            ):
+                                result_text = (
+                                    f"Follow-up reassigned from {original_worker_id} "
+                                    f"to {target_worker_id} (task {task_id} on branch {branch})."
+                                )
+                            else:
+                                result_text = (
+                                    f"Follow-up sent to {target_worker_id} for task {task_id} "
+                                    f"on branch {branch}."
+                                )
 
             elif tu.name == "finalize_task":
                 task_id = inp["task_id"]
@@ -1343,8 +1393,12 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 state="done",
                                 finished_at=finished_at,
                                 deleted_at=deleted_at,
+                                locked_at=None,
+                                lock_holder=None,
                             )
                         )
+                        # Discard any queued follow-up events — the task is done.
+                        await db.execute(delete(TaskEvent).where(TaskEvent.task_id == task_id))
                         await db.commit()
                         await broadcast(
                             guild_id,

--- a/backend/models.py
+++ b/backend/models.py
@@ -136,6 +136,13 @@ class Task(Base):
     # worker-driven foreman events (task-complete, etc.) back to the originator's
     # foreman thread in multi-user guilds. NULL on legacy/system tasks.
     user_id = Column(Text, nullable=True)
+    # Follow-up dispatch lock. Set to a UTC ISO-8601 timestamp when a follow-up
+    # is dispatched; cleared when the follow-up worker reports done (or on
+    # finalize). Prevents two concurrent foreman runs from both dispatching a
+    # follow-up for the same task. Locks older than 1 hour are treated as stale
+    # and overridden automatically.
+    locked_at = Column(Text, nullable=True)
+    lock_holder = Column(Text, nullable=True)
 
 
 class GithubToken(Base):
@@ -256,4 +263,23 @@ class GithubEvent(Base):
     pr_url = Column(Text, nullable=True)
     sender_login = Column(Text, nullable=True)
     payload_json = Column(Text, nullable=False)
+    created_at = Column(Text, nullable=False)
+
+
+class TaskEvent(Base):
+    """Queued follow-up triggers that arrived while a task was locked.
+
+    When send_followup is called on a task that already holds a follow-up lock,
+    the call is serialised here instead of spawning a second worker. On lock
+    release (task-followup-done) the foreman is re-triggered with the queued
+    instructions so it can decide whether to dispatch them.
+    """
+
+    __tablename__ = "task_events"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    task_id = Column(Text, ForeignKey("tasks.id"), nullable=False)
+    # "pending-followup" is the only event_type currently; reserved for future use.
+    event_type = Column(Text, nullable=False)
+    payload_json = Column(Text, nullable=False)  # JSON: instructions, preferred_worker_id
     created_at = Column(Text, nullable=False)

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -323,7 +323,7 @@ async def cancel_task_endpoint(
         await db.execute(
             update(Task)
             .where(Task.id == task_id)
-            .values(state="cancelled", finished_at=finished_at)
+            .values(state="cancelled", finished_at=finished_at, locked_at=None, lock_holder=None)
         )
         await db.commit()
     finally:

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -8,11 +8,12 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sqlite3
 import sys
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -827,6 +828,212 @@ class TestExecToolsDispatching:
         assert row[1] == "Specific name"
         assert row[2] == "review"
         assert row[3] == "codex"
+
+    # -----------------------------------------------------------------------
+    # Task locking — prevent concurrent follow-up races
+    # -----------------------------------------------------------------------
+
+    async def test_send_followup_acquires_lock(self, db_session):
+        """Successful send_followup sets locked_at / lock_holder on the task."""
+        insert_guild(db_session, "g-lock-set")
+        _insert_worker(db_session, "g-lock-set", "w-lock1")
+        _insert_agent(db_session, "g-lock-set", "w-lock1", "a-lock1")
+        _insert_task(db_session, "t-lock1", "g-lock-set", "w-lock1")
+
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-lock-set",
+                [
+                    _fake_tool_use(
+                        "send_followup", {"task_id": "t-lock1", "instructions": "Fix tests"}
+                    )
+                ],
+            )
+        assert "t-lock1" in results[0]["content"]
+        with sqlite3.connect(db_session) as conn:
+            row = conn.execute(
+                "SELECT locked_at, lock_holder FROM tasks WHERE id='t-lock1'"
+            ).fetchone()
+        assert row[0] is not None, "locked_at should be set after dispatch"
+        assert row[1] is not None, "lock_holder should be set after dispatch"
+
+    async def test_send_followup_while_locked_queues_event(self, db_session):
+        """A second send_followup on a locked task queues the instructions instead of dispatching."""
+        insert_guild(db_session, "g-lock-queue")
+        _insert_worker(db_session, "g-lock-queue", "w-lq1")
+        _insert_agent(db_session, "g-lock-queue", "w-lq1", "a-lq1")
+        # Pre-lock the task to simulate a concurrent dispatch already in flight.
+        _insert_task(db_session, "t-lq1", "g-lock-queue", "w-lq1")
+        now = datetime.now(UTC).isoformat()
+        with sqlite3.connect(db_session) as conn:
+            conn.execute(
+                "UPDATE tasks SET locked_at=?, lock_holder='existing-holder' WHERE id='t-lq1'",
+                (now,),
+            )
+            conn.commit()
+
+        broadcast_calls = []
+
+        async def capture(gid, msg):
+            broadcast_calls.append(msg)
+
+        with patch("foreman.tools.broadcast", side_effect=capture):
+            results = await exec_tools(
+                "g-lock-queue",
+                [
+                    _fake_tool_use(
+                        "send_followup",
+                        {"task_id": "t-lq1", "instructions": "Add integration tests"},
+                    )
+                ],
+            )
+
+        # No task-followup broadcast — we didn't dispatch
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        assert len(followup_msgs) == 0
+        # The result should mention queued / locked
+        assert (
+            "queued" in results[0]["content"].lower() or "locked" in results[0]["content"].lower()
+        )
+        # A task_event row should exist
+        with sqlite3.connect(db_session) as conn:
+            row = conn.execute(
+                "SELECT event_type, payload_json FROM task_events WHERE task_id='t-lq1'"
+            ).fetchone()
+        assert row is not None, "A task_event row should have been inserted"
+        assert row[0] == "pending-followup"
+        payload = json.loads(row[1])
+        assert payload["instructions"] == "Add integration tests"
+
+    async def test_two_concurrent_followups_only_one_dispatched(self, db_session):
+        """Simulate two simultaneous send_followup calls — exactly one dispatches, one queues."""
+        insert_guild(db_session, "g-race")
+        _insert_worker(db_session, "g-race", "w-race1")
+        _insert_agent(db_session, "g-race", "w-race1", "a-race1")
+        _insert_task(db_session, "t-race1", "g-race", "w-race1")
+
+        broadcast_calls = []
+
+        async def capture(gid, msg):
+            broadcast_calls.append(msg)
+
+        with patch("foreman.tools.broadcast", side_effect=capture):
+            # Fire both concurrently, matching what two async foreman runs would do.
+            results = await asyncio.gather(
+                exec_tools(
+                    "g-race",
+                    [
+                        _fake_tool_use(
+                            "send_followup",
+                            {"task_id": "t-race1", "instructions": "Fix lint"},
+                            "tid-1",
+                        )
+                    ],
+                ),
+                exec_tools(
+                    "g-race",
+                    [
+                        _fake_tool_use(
+                            "send_followup",
+                            {"task_id": "t-race1", "instructions": "Fix tests"},
+                            "tid-2",
+                        )
+                    ],
+                ),
+            )
+
+        all_results = results[0] + results[1]
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        # Exactly one task-followup must have been broadcast
+        assert len(followup_msgs) == 1
+
+        # Exactly one result should indicate queued/locked; the other is success
+        queued = [
+            r
+            for r in all_results
+            if "queued" in r["content"].lower() or "locked" in r["content"].lower()
+        ]
+        dispatched = [
+            r
+            for r in all_results
+            if "follow-up sent" in r["content"].lower() or "reassigned" in r["content"].lower()
+        ]
+        assert len(queued) == 1, f"Expected 1 queued, got: {[r['content'] for r in queued]}"
+        assert len(dispatched) == 1, (
+            f"Expected 1 dispatched, got: {[r['content'] for r in dispatched]}"
+        )
+
+        # One task_event row should exist with the queued instructions
+        with sqlite3.connect(db_session) as conn:
+            rows = conn.execute(
+                "SELECT payload_json FROM task_events WHERE task_id='t-race1'"
+            ).fetchall()
+        assert len(rows) == 1
+
+    async def test_finalize_task_clears_lock_and_queued_events(self, db_session):
+        """finalize_task releases the lock and discards any queued task_events."""
+        insert_guild(db_session, "g-fin-lock")
+        _insert_worker(db_session, "g-fin-lock", "w-fin-lk")
+        _insert_task(db_session, "t-fin-lk", "g-fin-lock", "w-fin-lk")
+        now = datetime.now(UTC).isoformat()
+        with sqlite3.connect(db_session) as conn:
+            conn.execute(
+                "UPDATE tasks SET locked_at=?, lock_holder='h1' WHERE id='t-fin-lk'", (now,)
+            )
+            conn.execute(
+                "INSERT INTO task_events (task_id, event_type, payload_json, created_at) "
+                "VALUES ('t-fin-lk', 'pending-followup', '{\"instructions\": \"stale\"}', ?)",
+                (now,),
+            )
+            conn.commit()
+
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-fin-lock", [_fake_tool_use("finalize_task", {"task_id": "t-fin-lk"})]
+            )
+        assert "finalized" in results[0]["content"].lower()
+        with sqlite3.connect(db_session) as conn:
+            task_row = conn.execute(
+                "SELECT state, locked_at, lock_holder FROM tasks WHERE id='t-fin-lk'"
+            ).fetchone()
+            event_count = conn.execute(
+                "SELECT COUNT(*) FROM task_events WHERE task_id='t-fin-lk'"
+            ).fetchone()[0]
+        assert task_row[0] == "done"
+        assert task_row[1] is None, "locked_at should be cleared on finalize"
+        assert task_row[2] is None, "lock_holder should be cleared on finalize"
+        assert event_count == 0, "Queued events should be deleted on finalize"
+
+    async def test_stale_lock_overridden(self, db_session):
+        """A lock older than 1 hour is treated as stale and can be overridden."""
+        insert_guild(db_session, "g-stale-lock")
+        _insert_worker(db_session, "g-stale-lock", "w-stale")
+        _insert_agent(db_session, "g-stale-lock", "w-stale", "a-stale")
+        _insert_task(db_session, "t-stale", "g-stale-lock", "w-stale")
+        # Set locked_at to 2 hours ago
+        stale_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        with sqlite3.connect(db_session) as conn:
+            conn.execute(
+                "UPDATE tasks SET locked_at=?, lock_holder='old-holder' WHERE id='t-stale'",
+                (stale_ts,),
+            )
+            conn.commit()
+
+        broadcast_calls = []
+
+        async def capture(gid, msg):
+            broadcast_calls.append(msg)
+
+        with patch("foreman.tools.broadcast", side_effect=capture):
+            await exec_tools(
+                "g-stale-lock",
+                [_fake_tool_use("send_followup", {"task_id": "t-stale", "instructions": "Retry"})],
+            )
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        assert len(followup_msgs) == 1, "Stale lock should be overridden and follow-up dispatched"
+        with sqlite3.connect(db_session) as conn:
+            row = conn.execute("SELECT lock_holder FROM tasks WHERE id='t-stale'").fetchone()
+        assert row[0] != "old-holder", "Lock holder should have been replaced"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -26,8 +26,8 @@ from events import (
     pending_claude_auth,
 )
 from fastapi import WebSocket
-from models import Agent, Message, Task, TaskLog, User, Worker
-from sqlalchemy import select, update
+from models import Agent, Message, Task, TaskEvent, TaskLog, User, Worker
+from sqlalchemy import delete, select, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from util.tasks import spawn
 from utils import worker_display_name
@@ -605,7 +605,7 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
     worker_id_msg = data.get("workerId", "")
     if task_id:
         pr_url_fud = data.get("prUrl", "")
-        update_vals: dict = {"state": "awaiting-review"}
+        update_vals: dict = {"state": "awaiting-review", "locked_at": None, "lock_holder": None}
         if pr_url_fud:
             pr_number_val, pr_repo_val = _parse_pr_url(pr_url_fud)
             update_vals.update(
@@ -616,12 +616,46 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
     if not task_id:
         return
+
+    # Collect and drain any follow-up requests that were queued while the task
+    # was locked, then re-trigger the foreman with their instructions so it can
+    # decide whether to dispatch them.
+    queued_payloads: list[dict] = []
+    result = await ctx.db.execute(
+        select(TaskEvent.id, TaskEvent.payload_json)
+        .where(TaskEvent.task_id == task_id, TaskEvent.event_type == "pending-followup")
+        .order_by(TaskEvent.id)
+    )
+    rows = result.all()
+    if rows:
+        event_ids = [r[0] for r in rows]
+        queued_payloads = [json.loads(r[1]) for r in rows]
+        await ctx.db.execute(delete(TaskEvent).where(TaskEvent.id.in_(event_ids)))
+        await ctx.db.commit()
+
     task_uid = await _task_user_id(ctx.db, task_id)
+
+    if queued_payloads:
+        queued_summary = "\n".join(
+            f"  {i + 1}. {p.get('instructions', '')}" for i, p in enumerate(queued_payloads)
+        )
+        human_msg = (
+            f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
+            f"While the task was locked, {len(queued_payloads)} follow-up request(s) were queued:\n"
+            f"{queued_summary}\n"
+            "Review the queued instructions and call send_followup with the relevant ones "
+            "(or a combined version), or call finalize_task if the work is done."
+        )
+    else:
+        human_msg = (
+            f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
+            "Decide: call send_followup for more work, or call finalize_task to mark it done."
+        )
+
     await _trigger_foreman(
         ctx.guild_id,
         "followup-done",
-        f"[followup-done] Worker {worker_id_msg} completed a follow-up for task {task_id}. "
-        "Decide: call send_followup for more work, or call finalize_task to mark it done.",
+        human_msg,
         user_id=task_uid,
         task_id=task_id,
         task_name=f"foreman.followup-done:{task_id}",

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -36,6 +36,8 @@ from foreman import maybe_post_plan_comment, reset_foreman_poll, run_foreman_ai
 
 logger = logging.getLogger(__name__)
 
+_TERMINAL_STATES = ("done", "failed", "cancelled")
+
 
 # ---------------------------------------------------------------------------
 # Helpers (pure DB lookups; live here because main.py + ws_handlers both use
@@ -539,6 +541,9 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
         update_values["pr_number"] = pr_number
         update_values["pr_repo"] = pr_repo
     if update_values:
+        if update_values.get("state") in _TERMINAL_STATES:
+            update_values["locked_at"] = None
+            update_values["lock_holder"] = None
         await ctx.db.execute(update(Task).where(Task.id == task_id).values(**update_values))
         await ctx.db.commit()
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
@@ -605,13 +610,23 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
     worker_id_msg = data.get("workerId", "")
     if task_id:
         pr_url_fud = data.get("prUrl", "")
-        update_vals: dict = {"state": "awaiting-review", "locked_at": None, "lock_holder": None}
+        lock_release: dict = {"locked_at": None, "lock_holder": None}
         if pr_url_fud:
             pr_number_val, pr_repo_val = _parse_pr_url(pr_url_fud)
-            update_vals.update(
+            lock_release.update(
                 {"pr_url": pr_url_fud, "pr_number": pr_number_val, "pr_repo": pr_repo_val}
             )
-        await ctx.db.execute(update(Task).where(Task.id == task_id).values(**update_vals))
+        # Move to awaiting-review and release lock unless task is already terminal.
+        await ctx.db.execute(
+            update(Task)
+            .where(Task.id == task_id, Task.state.not_in(_TERMINAL_STATES))
+            .values(**lock_release, state="awaiting-review")
+        )
+        await ctx.db.execute(
+            update(Task)
+            .where(Task.id == task_id, Task.state.in_(_TERMINAL_STATES))
+            .values(**lock_release)
+        )
         await ctx.db.commit()
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
     if not task_id:


### PR DESCRIPTION
Closes #388

## Summary
- Adds `locked_at` / `lock_holder` columns to the `tasks` table with a migration
- Acquires the lock atomically before dispatching a follow-up
- Releases the lock when the follow-up worker reports done or task moves to `awaiting-review`
- Stores queued triggers in a `task_events` table and replays them on lock release
- Tests cover the race scenario (two simultaneous triggers → one dispatched, second queued and replayed)

