### PR TITLE
fix: PostgreSQL GROUP BY on /guilds and SQLite migration guild_pk lookup

### DIFF
--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -127,7 +127,7 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
                 & (Agent.state != "offline"),
             )
             .where(GuildMember.user_id == github_user_id)
-            .group_by(Guild.guild_id)
+            .group_by(Guild.guild_id, Guild.created_at, Guild.name)
             .order_by(Guild.created_at.desc())
         )
         return [dict(r._mapping) for r in result.fetchall()]

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -222,7 +222,17 @@ def migrate_guilds(sq: sqlite3.Connection, pg: Any) -> dict[str, int]:
         return {gid: pg_id for pg_id, gid in cur.fetchall()}
 
 
-def _lookup_guild_pk(d: dict[str, Any], guild_map: dict[str, int]) -> int | None:
+def _lookup_guild_pk(
+    d: dict[str, Any],
+    guild_map: dict[str, int],
+    sq_int_map: dict[int, int] | None = None,
+) -> int | None:
+    # New SQLite schema: tables carry guild_pk (INTEGER FK to guilds.id).
+    # IDs match between SQLite and PG since guilds were migrated in the same order.
+    sq_pk = d.get("guild_pk")
+    if sq_pk is not None:
+        return sq_pk
+    # Old SQLite schema: tables carry guild_id (TEXT).
     guild_id = d.get("guild_id")
     if guild_id is None:
         return None


### PR DESCRIPTION
- Add created_at and name to GROUP BY in list_guilds — PostgreSQL requires all non-aggregated SELECT columns in GROUP BY (SQLite did not)
- Fix _lookup_guild_pk to handle new SQLite schema where tables use guild_pk (INTEGER FK) instead of guild_id (TEXT); IDs match between SQLite and PG since guilds are migrated in the same order