### PR TITLE
fix: fall back to create_worktree when attach_worktree fails (branch not on origin)

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1647,6 +1647,20 @@ class Worker:
             if is_followup:
                 logger.info("Task %s: attaching worktree %s to branch %s", task_id, wt_path, branch)
                 ok = await git_ops.attach_worktree(repo_path, wt_path, branch)
+                if not ok:
+                    # Branch never reached origin (e.g. original task failed before push).
+                    # Fall back to creating a fresh branch so the follow-up can still run.
+                    logger.warning(
+                        "Task %s: attach failed for %s — branch %s not found on origin; "
+                        "falling back to create_worktree",
+                        task_id,
+                        repo_full,
+                        branch,
+                    )
+                    await emit(
+                        f"[worker] Branch not found on origin; creating fresh branch {branch[:50]}"
+                    )
+                    ok = await git_ops.create_worktree(repo_path, wt_path, branch)
             else:
                 logger.info("Task %s: creating worktree %s on branch %s", task_id, wt_path, branch)
                 ok = await git_ops.create_worktree(repo_path, wt_path, branch)


### PR DESCRIPTION
## Problem

When a follow-up task runs and the original branch never made it to `origin` (e.g. the original task timed out or errored before pushing), `attach_worktree` fails at all three strategies:

1. `git fetch origin <branch>` — rc=128, branch not a remote ref
2. `git worktree add <path> <branch>` — rc=128, no local ref either
3. `git worktree add -B <branch> <path> origin/<branch>` — rc=128, same

The task then aborts with `worktree failed`, even though the work could still proceed on a fresh branch.

**Seen in the wild:**
```
fatal: couldn't find remote ref claude/integrate-dnsid-ts-into-dnsid-portal-frontend-t-xsk4
fatal: invalid reference: claude/integrate-dnsid-ts-into-dnsid-portal-frontend-t-xsk4
fatal: invalid reference: origin/claude/integrate-dnsid-ts-into-dnsid-portal-frontend-t-xsk4
```

## Fix

After `attach_worktree` returns `False`, fall back to `create_worktree`, which creates a fresh branch from `origin/HEAD` under the same branch name (`-b`). The follow-up task proceeds and can push a PR as intended.

## Files changed

- `worker/pioneer_worker/worker.py` — add fallback in the follow-up worktree setup path

🤖 Generated with [Claude Code](https://claude.com/claude-code)