### PR TITLE
fix(lock): task lock service with pg_insert and agent-state ownership guard

### DIFF
--- a/backend/lock_service.py
+++ b/backend/lock_service.py
@@ -21,8 +21,7 @@ from datetime import UTC, datetime, timedelta
 
 from models import Lock
 from sqlalchemy import delete, select
-from sqlalchemy import insert as sa_insert
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -58,27 +57,14 @@ class LockService:
             )
         )
 
-        # Use a savepoint so a primary-key conflict rolls back only this
-        # attempt without aborting the enclosing transaction.  The only
-        # IntegrityError expected here is a UNIQUE/PK violation on ``key``
-        # (meaning another caller holds the lock); all other constraint
-        # errors are re-raised.
-        try:
-            async with self._db.begin_nested():
-                await self._db.execute(
-                    sa_insert(Lock).values(
-                        key=key, owner=owner, acquired_at=now_iso, expires_at=expires_at
-                    )
-                )
-            return True
-        except IntegrityError as exc:
-            # Only swallow primary-key / UNIQUE conflicts.  Any other
-            # constraint violation (e.g. a NULL in a NOT NULL column) is
-            # a programming error and should propagate.
-            orig_msg = str(exc.orig).lower() if exc.orig else ""
-            if "unique" not in orig_msg and "primary key" not in orig_msg:
-                raise
-            return False
+        # INSERT ... ON CONFLICT DO NOTHING returns rowcount=1 when the row is
+        # newly inserted and rowcount=0 when the key already exists (lock held).
+        result = await self._db.execute(
+            pg_insert(Lock)
+            .values(key=key, owner=owner, acquired_at=now_iso, expires_at=expires_at)
+            .on_conflict_do_nothing()
+        )
+        return result.rowcount > 0
 
     async def release(self, key: str) -> None:
         """Release *key*. Safe to call even if the lock is not held (idempotent)."""

--- a/backend/tests/test_agent_state_ws_persistence.py
+++ b/backend/tests/test_agent_state_ws_persistence.py
@@ -18,7 +18,6 @@ per-test guild ids, DB checked while the connections are still open
 from __future__ import annotations
 
 import os
-import sqlite3
 import sys
 from datetime import UTC, datetime, timedelta
 
@@ -305,22 +304,23 @@ def test_guild_get_returns_current_task_id(client):
 def test_agent_idle_releases_task_lock(client):
     """When an agent transitions to idle, the task lock is released and the
     task is moved out of 'working' so a new follow-up can be dispatched."""
-    test_client, db_path = client
+    test_client, db_url = client
     guild_id, worker_id, task_id, agent_id = "gas-5", "w-gas5", "t-gas5", "a-gas5"
-    _insert_guild_worker_task(db_path, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+    _insert_guild_worker_task(db_url, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
 
-    now = datetime.now(UTC).isoformat()
-    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
-    with sqlite3.connect(db_path) as conn:
-        # Set task to 'working' state (as if a follow-up was dispatched).
-        conn.execute("UPDATE tasks SET state='working' WHERE id=?", (task_id,))
-        # Insert the follow-up lock to simulate a dispatch in progress.
-        conn.execute(
-            "INSERT OR REPLACE INTO locks (key, owner, acquired_at, expires_at)"
-            " VALUES (?, ?, ?, ?)",
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")
+    future = (datetime.now(UTC) + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S.%f")
+    with raw_conn(db_url) as (conn, cur):
+        cur.execute("UPDATE tasks SET state = 'working' WHERE id = %s", (task_id,))
+        cur.execute(
+            "INSERT INTO locks (key, owner, acquired_at, expires_at)"
+            " VALUES (%s, %s, %s, %s)"
+            " ON CONFLICT (key) DO UPDATE"
+            " SET owner = EXCLUDED.owner,"
+            " acquired_at = EXCLUDED.acquired_at,"
+            " expires_at = EXCLUDED.expires_at",
             (f"task:{task_id}", "some-lock-holder", now, future),
         )
-        conn.commit()
 
     with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
         _join_ws(ws_worker, agent_id, worker_id)
@@ -353,11 +353,12 @@ def test_agent_idle_releases_task_lock(client):
             msg = ws_obs.receive_json()
             assert msg["state"] == "idle"
 
-    with sqlite3.connect(db_path) as conn:
-        lock_row = conn.execute(
-            "SELECT key FROM locks WHERE key=?", (f"task:{task_id}",)
-        ).fetchone()
-        task_state = conn.execute("SELECT state FROM tasks WHERE id=?", (task_id,)).fetchone()[0]
+    with raw_conn(db_url) as (conn, cur):
+        cur.execute("SELECT key FROM locks WHERE key = %s", (f"task:{task_id}",))
+        lock_row = cur.fetchone()
+        cur.execute("SELECT state FROM tasks WHERE id = %s", (task_id,))
+        task_row = cur.fetchone()
+        task_state = task_row["state"] if task_row else None
 
     assert lock_row is None, "lock should be released when agent goes idle"
     assert task_state == "awaiting-review", (

--- a/backend/tests/test_lock_service.py
+++ b/backend/tests/test_lock_service.py
@@ -19,20 +19,17 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
 import database as database_module
-from helpers import create_db
+from _test_config import TEST_DATABASE_URL
+from helpers import truncate_all
 from lock_service import LockService
 
 
 @pytest.fixture()
-def db_session(tmp_path, monkeypatch):
-    db_path = str(tmp_path / "test_locks.db")
-    db_url = f"sqlite+aiosqlite:///{db_path}"
-    monkeypatch.setenv("DATABASE_URL", db_url)
-    monkeypatch.setenv("DB_PATH", db_path)
-    create_db(db_path)
-    engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+def db_session(_setup_schema):
+    """Fresh PostgreSQL session factory for each test."""
+    truncate_all(TEST_DATABASE_URL)
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False, poolclass=NullPool)
     session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
-    monkeypatch.setattr(database_module, "AsyncSessionLocal", session_factory)
     yield session_factory
 
 

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -373,13 +373,17 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
     # so the task doesn't stay stuck in "working" indefinitely.  We must read
     # current_task_id from the DB *before* the update clears it.
     task_id_to_release: str | None = None
+    agent_worker_id_for_release: str | None = None
     if state in _LOCK_RELEASE_AGENT_STATES and agent_id:
         row = await ctx.db.execute(
-            select(Agent.current_task_id).where(
+            select(Agent.current_task_id, Agent.worker_id).where(
                 Agent.id == agent_id, Agent.guild_pk == ctx.guild_pk
             )
         )
-        task_id_to_release = row.scalar_one_or_none()
+        agent_row = row.one_or_none()
+        if agent_row is not None:
+            task_id_to_release = agent_row[0]
+            agent_worker_id_for_release = agent_row[1]
 
     await ctx.db.execute(
         update(Agent)
@@ -387,14 +391,21 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
         .values(**update_vals)
     )
 
-    if task_id_to_release:
-        # Move the task out of "working" so the foreman can decide next steps.
-        await ctx.db.execute(
+    if task_id_to_release and agent_worker_id_for_release:
+        # Guard: only transition the task when the agent's worker is the one
+        # assigned to it.  Prevents a stale current_task_id from releasing a
+        # lock that belongs to a different worker's active execution.
+        res = await ctx.db.execute(
             update(Task)
-            .where(Task.id == task_id_to_release, Task.state == "working")
+            .where(
+                Task.id == task_id_to_release,
+                Task.state == "working",
+                Task.worker_id == agent_worker_id_for_release,
+            )
             .values(state="awaiting-review")
         )
-        await LockService(ctx.db).release(f"task:{task_id_to_release}")
+        if res.rowcount:
+            await LockService(ctx.db).release(f"task:{task_id_to_release}")
 
     await ctx.db.commit()
     msg: dict = {"type": "agent-state", "agentId": agent_id, "state": state}


### PR DESCRIPTION
## Summary

- Introduces `LockService` backed by a new `locks` table (migrations `000002` + `000003`) to replace the old `tasks.locked_at / lock_holder` columns
- Adds a stale-lock watchdog in `main.py` that auto-releases locks for tasks stuck in `working` with no active agent for ≥90 seconds
- Fixes the root bug: agent going idle now reads its `current_task_id` and releases the matching task lock via `handle_agent_state` in `ws_handlers.py`

**Review fixes applied in this PR:**
- `lock_service`: replaced savepoint+IntegrityError with `pg_insert().on_conflict_do_nothing()` — idiomatic for the PostgreSQL-only deployment
- `ws_handlers handle_agent_state`: guard the task transition and lock release with `Task.worker_id == agent.worker_id` — prevents a stale `current_task_id` on one worker's agent from releasing a lock held by a different worker's active execution
- Tests migrated from SQLite (`sqlite3.connect`, `aiosqlite`) to PostgreSQL (`raw_conn`, `TEST_DATABASE_URL`) to match the rest of the test suite

## Test plan

- [ ] `test_lock_service.py` — acquire/release/TTL/concurrent (PostgreSQL)
- [ ] `test_agent_state_ws_persistence.py::test_agent_idle_releases_task_lock` — agent idle → task moves to awaiting-review, lock removed
- [ ] `test_foreman.py` — send_followup acquires lock, finalize_task releases lock
- [ ] `test_liveness.py` — stale-task watchdog promotes stuck `working` task

🤖 Generated with [Claude Code](https://claude.com/claude-code)