### PR TITLE
Migrate to SQLModel + rename guild_pk → guild_id

### DIFF
--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -40,7 +40,7 @@ async def set_agent_state(guild_id: str, agent_id: str, state: str) -> None:
         guild_pk = await get_guild_pk(db, guild_id)
         await db.execute(
             update(Agent)
-            .where(Agent.id == agent_id, Agent.guild_pk == guild_pk)
+            .where(Agent.id == agent_id, Agent.guild_id == guild_pk)
             .values(state=state, activity=None)
         )
         await db.commit()

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -13,14 +13,15 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 # Ensure the backend package is importable from this file's location.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from models import Base  # noqa: E402
+import models  # noqa: F401 - registers all SQLModel tables in SQLModel.metadata
+from sqlmodel import SQLModel
 
 config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = Base.metadata
+target_metadata = SQLModel.metadata
 
 # DATABASE_URL env var is required; no hardcoded fallback.
 _db_url = os.environ.get("DATABASE_URL") or config.get_main_option("sqlalchemy.url")

--- a/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
+++ b/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
@@ -16,6 +16,7 @@ Create Date: 2026-05-20 00:00:04.000000
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260520_000004_rename_guild_pk_to_guild_id"
@@ -43,22 +44,63 @@ _UNIQUE_FK_TABLES = [
 ]
 
 
+def _drop_fk(table: str, col: str) -> None:
+    """Drop the FK on *col* from *table*, robust to auto-generated constraint names.
+
+    Migration 20260512_000002 recreated tables as ``{table}_new`` then renamed
+    them.  PostgreSQL keeps the original auto-generated constraint name
+    (e.g. ``agents_new_guild_pk_fkey``) after a table rename, so we cannot
+    assume the conventional ``{table}_{col}_fkey`` pattern.  We query
+    ``pg_constraint`` at migration time to find and drop whatever name exists.
+    """
+    op.execute(
+        sa.text(f"""
+        DO $$ DECLARE cname TEXT; BEGIN
+            SELECT c.conname INTO cname
+              FROM pg_constraint c
+              JOIN pg_class t ON t.oid = c.conrelid
+             WHERE t.relname = '{table}'
+               AND c.contype = 'f'
+               AND c.conname LIKE '%{col}_fkey';
+            IF cname IS NOT NULL THEN
+                EXECUTE format('ALTER TABLE {table} DROP CONSTRAINT %I', cname);
+            END IF;
+        END $$
+        """)
+    )
+
+
+def _drop_unique(table: str, col: str) -> None:
+    """Drop the UNIQUE constraint on *col* from *table*, robust to auto-generated names."""
+    op.execute(
+        sa.text(f"""
+        DO $$ DECLARE cname TEXT; BEGIN
+            SELECT c.conname INTO cname
+              FROM pg_constraint c
+              JOIN pg_class t ON t.oid = c.conrelid
+             WHERE t.relname = '{table}'
+               AND c.contype = 'u'
+               AND c.conname LIKE '%{col}_key';
+            IF cname IS NOT NULL THEN
+                EXECUTE format('ALTER TABLE {table} DROP CONSTRAINT %I', cname);
+            END IF;
+        END $$
+        """)
+    )
+
+
 def upgrade() -> None:
     for table in _SIMPLE_FK_TABLES:
-        op.drop_constraint(f"{table}_guild_pk_fkey", table, type_="foreignkey")
+        _drop_fk(table, "guild_pk")
         op.alter_column(table, "guild_pk", new_column_name="guild_id")
-        op.create_foreign_key(
-            f"{table}_guild_id_fkey", table, "guilds", ["guild_id"], ["id"]
-        )
+        op.create_foreign_key(f"{table}_guild_id_fkey", table, "guilds", ["guild_id"], ["id"])
 
     for table in _UNIQUE_FK_TABLES:
-        op.drop_constraint(f"{table}_guild_pk_fkey", table, type_="foreignkey")
-        op.drop_constraint(f"{table}_guild_pk_key", table, type_="unique")
+        _drop_fk(table, "guild_pk")
+        _drop_unique(table, "guild_pk")
         op.alter_column(table, "guild_pk", new_column_name="guild_id")
         op.create_unique_constraint(f"{table}_guild_id_key", table, ["guild_id"])
-        op.create_foreign_key(
-            f"{table}_guild_id_fkey", table, "guilds", ["guild_id"], ["id"]
-        )
+        op.create_foreign_key(f"{table}_guild_id_fkey", table, "guilds", ["guild_id"], ["id"])
 
 
 def downgrade() -> None:
@@ -67,13 +109,9 @@ def downgrade() -> None:
         op.drop_constraint(f"{table}_guild_id_key", table, type_="unique")
         op.alter_column(table, "guild_id", new_column_name="guild_pk")
         op.create_unique_constraint(f"{table}_guild_pk_key", table, ["guild_pk"])
-        op.create_foreign_key(
-            f"{table}_guild_pk_fkey", table, "guilds", ["guild_pk"], ["id"]
-        )
+        op.create_foreign_key(f"{table}_guild_pk_fkey", table, "guilds", ["guild_pk"], ["id"])
 
     for table in reversed(_SIMPLE_FK_TABLES):
         op.drop_constraint(f"{table}_guild_id_fkey", table, type_="foreignkey")
         op.alter_column(table, "guild_id", new_column_name="guild_pk")
-        op.create_foreign_key(
-            f"{table}_guild_pk_fkey", table, "guilds", ["guild_pk"], ["id"]
-        )
+        op.create_foreign_key(f"{table}_guild_pk_fkey", table, "guilds", ["guild_pk"], ["id"])

--- a/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
+++ b/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
@@ -16,7 +16,6 @@ Create Date: 2026-05-20 00:00:04.000000
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260520_000004_rename_guild_pk_to_guild_id"
@@ -24,24 +23,57 @@ down_revision: str | Sequence[str] | None = "20260520_000003_merge_locking_and_m
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-_TABLES = [
+# Tables with a single FK on guild_pk (no extra unique constraints).
+# guild_members also has guild_pk as part of the composite PK; PostgreSQL
+# keeps the PK constraint valid across the rename automatically.
+_SIMPLE_FK_TABLES = [
     "agents",
     "messages",
     "workers",
     "tasks",
     "guild_members",
-    "claude_credentials",
-    "guild_keys",
     "foreman_turns",
     "github_events",
 ]
 
+# Tables where guild_pk carries both a FK and a UNIQUE constraint.
+_UNIQUE_FK_TABLES = [
+    "claude_credentials",
+    "guild_keys",
+]
+
 
 def upgrade() -> None:
-    for table in _TABLES:
-        op.execute(sa.text(f"ALTER TABLE {table} RENAME COLUMN guild_pk TO guild_id"))
+    for table in _SIMPLE_FK_TABLES:
+        op.drop_constraint(f"{table}_guild_pk_fkey", table, type_="foreignkey")
+        op.alter_column(table, "guild_pk", new_column_name="guild_id")
+        op.create_foreign_key(
+            f"{table}_guild_id_fkey", table, "guilds", ["guild_id"], ["id"]
+        )
+
+    for table in _UNIQUE_FK_TABLES:
+        op.drop_constraint(f"{table}_guild_pk_fkey", table, type_="foreignkey")
+        op.drop_constraint(f"{table}_guild_pk_key", table, type_="unique")
+        op.alter_column(table, "guild_pk", new_column_name="guild_id")
+        op.create_unique_constraint(f"{table}_guild_id_key", table, ["guild_id"])
+        op.create_foreign_key(
+            f"{table}_guild_id_fkey", table, "guilds", ["guild_id"], ["id"]
+        )
 
 
 def downgrade() -> None:
-    for table in reversed(_TABLES):
-        op.execute(sa.text(f"ALTER TABLE {table} RENAME COLUMN guild_id TO guild_pk"))
+    for table in reversed(_UNIQUE_FK_TABLES):
+        op.drop_constraint(f"{table}_guild_id_fkey", table, type_="foreignkey")
+        op.drop_constraint(f"{table}_guild_id_key", table, type_="unique")
+        op.alter_column(table, "guild_id", new_column_name="guild_pk")
+        op.create_unique_constraint(f"{table}_guild_pk_key", table, ["guild_pk"])
+        op.create_foreign_key(
+            f"{table}_guild_pk_fkey", table, "guilds", ["guild_pk"], ["id"]
+        )
+
+    for table in reversed(_SIMPLE_FK_TABLES):
+        op.drop_constraint(f"{table}_guild_id_fkey", table, type_="foreignkey")
+        op.alter_column(table, "guild_id", new_column_name="guild_pk")
+        op.create_foreign_key(
+            f"{table}_guild_pk_fkey", table, "guilds", ["guild_pk"], ["id"]
+        )

--- a/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
+++ b/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
@@ -20,7 +20,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260520_000004_rename_guild_pk_to_guild_id"
-down_revision: str | Sequence[str] | None = "20260520_000006_merge_nullable_worker_and_locks_fix"
+down_revision: str | Sequence[str] | None = "20260520_000003_merge_locking_and_messages"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
+++ b/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
@@ -1,0 +1,47 @@
+"""rename_guild_pk_to_guild_id
+
+Rename the ``guild_pk`` FK column to ``guild_id`` in all child tables.
+
+``guild_pk`` was a transitional name introduced in migration
+20260512_000001 to distinguish the new integer FK column from the legacy
+TEXT ``guild_id`` column that was subsequently dropped in 20260512_000002.
+Now that the schema is fully migrated, the conventional FK name
+``guild_id`` (pointing at ``guilds.id``) is used consistently everywhere.
+
+Revision ID: 20260520_000004_rename_guild_pk_to_guild_id
+Revises: 20260520_000003_merge_locking_and_messages
+Create Date: 2026-05-20 00:00:04.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260520_000004_rename_guild_pk_to_guild_id"
+down_revision: str | Sequence[str] | None = "20260520_000003_merge_locking_and_messages"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLES = [
+    "agents",
+    "messages",
+    "workers",
+    "tasks",
+    "guild_members",
+    "claude_credentials",
+    "guild_keys",
+    "foreman_turns",
+    "github_events",
+]
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(sa.text(f"ALTER TABLE {table} RENAME COLUMN guild_pk TO guild_id"))
+
+
+def downgrade() -> None:
+    for table in reversed(_TABLES):
+        op.execute(sa.text(f"ALTER TABLE {table} RENAME COLUMN guild_id TO guild_pk"))

--- a/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
+++ b/backend/alembic/versions/20260520_000004_rename_guild_pk_to_guild_id.py
@@ -20,7 +20,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260520_000004_rename_guild_pk_to_guild_id"
-down_revision: str | Sequence[str] | None = "20260520_000003_merge_locking_and_messages"
+down_revision: str | Sequence[str] | None = "20260520_000006_merge_nullable_worker_and_locks_fix"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/alembic/versions/20260520_000007_merge_rename_with_prior_head.py
+++ b/backend/alembic/versions/20260520_000007_merge_rename_with_prior_head.py
@@ -1,0 +1,37 @@
+"""merge_rename_with_prior_head
+
+Merge the two independent heads that both descend from
+20260520_000003_merge_locking_and_messages:
+
+  - 20260520_000006_merge_nullable_worker_and_locks_fix
+    (nullable worker_id + locks-table fixes)
+  - 20260520_000004_rename_guild_pk_to_guild_id
+    (FK column rename across all child tables)
+
+These migrations touch completely separate columns/tables so the merge
+has no ops.
+
+Revision ID: 20260520_000007_merge_rename_with_prior_head
+Revises: 20260520_000006_merge_nullable_worker_and_locks_fix,
+         20260520_000004_rename_guild_pk_to_guild_id
+Create Date: 2026-05-20 00:00:07.000000
+
+"""
+
+from collections.abc import Sequence
+
+revision: str = "20260520_000007_merge_rename_with_prior_head"
+down_revision: str | Sequence[str] | None = (
+    "20260520_000006_merge_nullable_worker_and_locks_fix",
+    "20260520_000004_rename_guild_pk_to_guild_id",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/auth_deps.py
+++ b/backend/auth_deps.py
@@ -64,7 +64,7 @@ async def ensure_membership(db, guild_id: str, user_id: str) -> str:
 
     res = await db.execute(
         select(GuildMember.role).where(
-            GuildMember.guild_pk == guild_pk, GuildMember.user_id == user_id
+            GuildMember.guild_id == guild_pk, GuildMember.user_id == user_id
         )
     )
     role = res.scalar_one_or_none()
@@ -109,7 +109,7 @@ async def authorize_worker_or_member(guild_id: str, token: str | None) -> str:
             raise HTTPException(status_code=404, detail="Guild not found")
 
         worker_res = await db.execute(
-            select(Worker.id).where(Worker.guild_pk == guild_pk, Worker.auth_token == token)
+            select(Worker.id).where(Worker.guild_id == guild_pk, Worker.auth_token == token)
         )
         worker_id = worker_res.scalar_one_or_none()
         if worker_id:

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -256,7 +256,7 @@ async def _get_guild_user_id(guild_id: str) -> str | None:
             return None
         result = await db.execute(
             select(GuildMember.user_id)
-            .where(GuildMember.guild_pk == guild_pk, GuildMember.role == "owner")
+            .where(GuildMember.guild_id == guild_pk, GuildMember.role == "owner")
             .limit(1)
         )
         return result.scalar_one_or_none()
@@ -277,7 +277,7 @@ async def _load_history(guild_id: str, user_id: str) -> list[dict]:
         guild_pk_val = await get_guild_pk(db, guild_id)
         result = await db.execute(
             select(ForemanTurn)
-            .where(ForemanTurn.guild_pk == guild_pk_val, ForemanTurn.user_id == user_id)
+            .where(ForemanTurn.guild_id == guild_pk_val, ForemanTurn.user_id == user_id)
             .order_by(ForemanTurn.id)
         )
         turns = result.scalars().all()
@@ -338,7 +338,7 @@ async def _save_turn(
     try:
         guild_pk_val = await get_guild_pk(db, guild_id)
         turn = ForemanTurn(
-            guild_pk=guild_pk_val,
+            guild_id=guild_pk_val,
             user_id=user_id,
             role=role,
             content_json=_serialize_content(content),
@@ -411,7 +411,7 @@ async def _poll_loop(guild_id: str) -> None:
                 guild_pk_val = await get_guild_pk(db, guild_id)
                 result = await db.execute(
                     select(Task.id, Task.state, Task.name).where(
-                        Task.guild_pk == guild_pk_val,
+                        Task.guild_id == guild_pk_val,
                         ~Task.state.in_(list(_TERMINAL_STATES)),
                         live_tasks_filter(),
                     )
@@ -481,15 +481,15 @@ async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
             " STRING_AGG(a.id || ':' || a.state, ',') as agents"
             " FROM workers w"
             " LEFT JOIN agents a ON a.worker_id = w.id AND a.state != 'offline'"
-            " WHERE w.guild_pk = :guild_pk AND w.state = 'online'"
+            " WHERE w.guild_id = :guild_id AND w.state = 'online'"
             " GROUP BY w.id"
             " UNION ALL"
             " SELECT a.id, '[]', NULL, a.state, 1, a.id || ':' || a.state"
             " FROM agents a"
-            " WHERE a.guild_pk = :guild_pk AND a.type = 'worker'"
+            " WHERE a.guild_id = :guild_id AND a.type = 'worker'"
             " AND a.worker_id IS NULL AND a.state != 'offline'"
         ),
-        {"guild_pk": guild_pk_val},
+        {"guild_id": guild_pk_val},
     )
     return [dict(r._mapping) for r in result.fetchall()]
 
@@ -543,7 +543,7 @@ async def run_foreman_ai(
                 Task.finished_at,
             )
             .where(
-                Task.guild_pk == guild_pk_val,
+                Task.guild_id == guild_pk_val,
                 ~Task.state.in_(list(_TERMINAL_STATES)),
                 live_tasks_filter(),
             )
@@ -730,7 +730,7 @@ async def run_foreman_ai(
                 for tu in tool_uses:
                     db.add(
                         Message(
-                            guild_pk=guild_pk_val,
+                            guild_id=guild_pk_val,
                             from_agent="foreman",
                             to_agent="user",
                             content=f"▶ {tu.name}",
@@ -749,7 +749,7 @@ async def run_foreman_ai(
                 for result in trimmed:
                     db.add(
                         Message(
-                            guild_pk=guild_pk_val,
+                            guild_id=guild_pk_val,
                             from_agent="foreman",
                             to_agent="user",
                             content=result.get("content", "") or "",
@@ -862,7 +862,7 @@ async def run_foreman_ai(
             now = datetime.now(UTC).isoformat()
             db.add(
                 Message(
-                    guild_pk=guild_pk_val,
+                    guild_id=guild_pk_val,
                     from_agent="foreman",
                     to_agent="user",
                     content=response_text,
@@ -895,7 +895,7 @@ async def clear_foreman_history(guild_id: str, user_id: str) -> int:
         guild_pk_val = await get_guild_pk(db, guild_id)
         result = await db.execute(
             delete(ForemanTurn).where(
-                ForemanTurn.guild_pk == guild_pk_val, ForemanTurn.user_id == user_id
+                ForemanTurn.guild_id == guild_pk_val, ForemanTurn.user_id == user_id
             )
         )
         await db.commit()
@@ -923,7 +923,7 @@ async def get_foreman_history(guild_id: str, user_id: str) -> dict:
         guild_pk_val = await get_guild_pk(db, guild_id)
         result = await db.execute(
             select(ForemanTurn)
-            .where(ForemanTurn.guild_pk == guild_pk_val, ForemanTurn.user_id == user_id)
+            .where(ForemanTurn.guild_id == guild_pk_val, ForemanTurn.user_id == user_id)
             .order_by(ForemanTurn.id)
         )
         turns = result.scalars().all()

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -676,7 +676,7 @@ async def _guild_github_token(guild_id: str) -> tuple[str, str] | None:
         result = await db.execute(
             select(GithubToken.access_token, GithubToken.github_username)
             .join(GuildMember, GuildMember.user_id == GithubToken.github_user_id)
-            .where(GuildMember.guild_pk == guild_pk, GuildMember.role == "owner")
+            .where(GuildMember.guild_id == guild_pk, GuildMember.role == "owner")
             .limit(1)
         )
         row = result.first()
@@ -695,7 +695,7 @@ async def _guild_private_key_pem(guild_id: str) -> str | None:
         if guild_pk is None:
             return None
         result = await db.execute(
-            select(GuildKey.private_key_pem).where(GuildKey.guild_pk == guild_pk)
+            select(GuildKey.private_key_pem).where(GuildKey.guild_id == guild_pk)
         )
         return result.scalar_one_or_none()
     finally:
@@ -743,7 +743,7 @@ async def _select_followup_worker(
     result = await db.execute(
         select(Agent.worker_id)
         .where(
-            Agent.guild_pk == guild_pk,
+            Agent.guild_id == guild_pk,
             Agent.state == "idle",
             Agent.worker_id.is_not(None),
         )
@@ -1077,7 +1077,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     Task(
                         id=task_id,
                         worker_id=None,
-                        guild_pk=guild_pk,
+                        guild_id=guild_pk,
                         name=name,
                         description=desc,
                         tool="claude",
@@ -1117,7 +1117,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 repos: list[str] = inp.get("repos") or ([primary_repo] if primary_repo else [])
                 worker_result = await db.execute(
                     select(Worker.id, Worker.repos, Worker.org).where(
-                        Worker.id == wid, Worker.guild_pk == guild_pk
+                        Worker.id == wid, Worker.guild_id == guild_pk
                     )
                 )
                 worker_row = worker_result.one_or_none()
@@ -1159,7 +1159,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         update_values["issue_repo"] = inp["issue_repo"]
                     await db.execute(
                         update(Task)
-                        .where(Task.id == existing_task_id, Task.guild_pk == guild_pk)
+                        .where(Task.id == existing_task_id, Task.guild_id == guild_pk)
                         .values(**update_values)
                     )
                     await db.commit()
@@ -1195,7 +1195,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         Task(
                             id=task_id,
                             worker_id=wid,
-                            guild_pk=guild_pk,
+                            guild_id=guild_pk,
                             name=name,
                             description=desc,
                             tool=tool,
@@ -1241,7 +1241,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         Task.tool,
                         Task.issue_number,
                         Task.issue_repo,
-                    ).where(Task.id == task_id, Task.guild_pk == guild_pk)
+                    ).where(Task.id == task_id, Task.guild_id == guild_pk)
                 )
                 row = result.one_or_none()
                 if not row:
@@ -1368,7 +1368,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     is_error = True
                 else:
                     result = await db.execute(
-                        select(Task.worker_id).where(Task.id == task_id, Task.guild_pk == guild_pk)
+                        select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_pk)
                     )
                     worker_id_val = result.scalar_one_or_none()
                     if not worker_id_val:
@@ -1427,7 +1427,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 instructions = inp["instructions"]
                 result = await db.execute(
                     select(Task.worker_id, Task.state).where(
-                        Task.id == task_id, Task.guild_pk == guild_pk
+                        Task.id == task_id, Task.guild_id == guild_pk
                     )
                 )
                 row = result.one_or_none()
@@ -1466,7 +1466,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 reason = inp.get("reason", "")
                 result = await db.execute(
                     select(Task.worker_id, Task.state).where(
-                        Task.id == task_id, Task.guild_pk == guild_pk
+                        Task.id == task_id, Task.guild_id == guild_pk
                     )
                 )
                 row = result.one_or_none()
@@ -1513,7 +1513,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 wid = inp["worker_id"]
                 reason = inp.get("reason", "")
                 worker_result = await db.execute(
-                    select(Worker.id).where(Worker.id == wid, Worker.guild_pk == guild_pk)
+                    select(Worker.id).where(Worker.id == wid, Worker.guild_id == guild_pk)
                 )
                 if worker_result.scalar_one_or_none() is None:
                     result_text = f"Worker {wid} not found."
@@ -1530,7 +1530,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 task_id = inp["task_id"]
                 limit = min(int(inp.get("log_lines", 10)), 50)
                 task_result = await db.execute(
-                    select(Task).where(Task.id == task_id, Task.guild_pk == guild_pk)
+                    select(Task).where(Task.id == task_id, Task.guild_id == guild_pk)
                 )
                 task = task_result.scalar_one_or_none()
                 if not task:

--- a/backend/main.py
+++ b/backend/main.py
@@ -97,8 +97,8 @@ async def _sweep_stale_workers_once() -> int:
         # and handled via the agent cascade below.
         zombie_workers = (
             await db.execute(
-                select(Worker.id, Worker.guild_pk, Guild.guild_id)
-                .join(Guild, Guild.id == Worker.guild_pk)
+                select(Worker.id, Worker.guild_id, Guild.guild_id.label("guild_slug"))
+                .join(Guild, Guild.id == Worker.guild_id)
                 .where(Worker.state != "offline")
                 .where(Worker.last_seen.isnot(None))
                 .where(Worker.last_seen < cutoff)
@@ -113,8 +113,8 @@ async def _sweep_stale_workers_once() -> int:
 
         stale_agents = (
             await db.execute(
-                select(Agent.id, Agent.guild_pk, Agent.worker_id, Guild.guild_id)
-                .join(Guild, Guild.id == Agent.guild_pk)
+                select(Agent.id, Agent.guild_id, Agent.worker_id, Guild.guild_id.label("guild_slug"))
+                .join(Guild, Guild.id == Agent.guild_id)
                 .where(Agent.state != "offline")
                 .where(Agent.last_seen.isnot(None))
                 .where(Agent.last_seen < cutoff)
@@ -124,21 +124,21 @@ async def _sweep_stale_workers_once() -> int:
         for row in stale_agents:
             await db.execute(
                 update(Agent)
-                .where(Agent.id == row.id, Agent.guild_pk == row.guild_pk)
+                .where(Agent.id == row.id, Agent.guild_id == row.guild_id)
                 .values(state="offline", activity=None, current_task_id=None)
             )
             if row.worker_id:
-                stale_worker_keys.add((row.worker_id, row.guild_pk))
+                stale_worker_keys.add((row.worker_id, row.guild_id))
                 agent_cascade_wids.add(row.worker_id)
             agent_owners.pop(row.id, None)
 
         for row in zombie_workers:
-            stale_worker_keys.add((row.id, row.guild_pk))
+            stale_worker_keys.add((row.id, row.guild_id))
 
         for worker_id, gpk in stale_worker_keys:
             await db.execute(
                 update(Worker)
-                .where(Worker.id == worker_id, Worker.guild_pk == gpk)
+                .where(Worker.id == worker_id, Worker.guild_id == gpk)
                 .values(state="offline")
             )
         if stale_agents or zombie_workers:
@@ -214,10 +214,10 @@ async def _sweep_stale_workers_once() -> int:
             "Marking %s offline: no ping in over %.0fs (guild=%s)",
             row.id,
             WORKER_OFFLINE_AFTER_SECONDS,
-            row.guild_id,
+            row.guild_slug,
         )
         await broadcast(
-            row.guild_id,
+            row.guild_slug,
             {"type": "agent-state", "agentId": row.id, "state": "offline"},
         )
     # Log zombie workers not already covered by the per-agent log above.
@@ -228,7 +228,7 @@ async def _sweep_stale_workers_once() -> int:
                 " no active agents (guild=%s)",
                 row.id,
                 WORKER_OFFLINE_AFTER_SECONDS,
-                row.guild_id,
+                row.guild_slug,
             )
     return len(stale_agents) + len(zombie_workers)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -113,7 +113,9 @@ async def _sweep_stale_workers_once() -> int:
 
         stale_agents = (
             await db.execute(
-                select(Agent.id, Agent.guild_id, Agent.worker_id, Guild.guild_id.label("guild_slug"))
+                select(
+                    Agent.id, Agent.guild_id, Agent.worker_id, Guild.guild_id.label("guild_slug")
+                )
                 .join(Guild, Guild.id == Agent.guild_id)
                 .where(Agent.state != "offline")
                 .where(Agent.last_seen.isnot(None))

--- a/backend/main.py
+++ b/backend/main.py
@@ -122,6 +122,8 @@ async def _sweep_stale_workers_once() -> int:
                 .where(Agent.last_seen < cutoff)
             )
         ).all()
+        # stale_worker_keys stores (worker_id, guild_id) where guild_id is the
+        # integer FK to guilds.id (not the text slug guild_slug selected above).
         stale_worker_keys: set[tuple[str, int]] = set()
         for row in stale_agents:
             await db.execute(

--- a/backend/models.py
+++ b/backend/models.py
@@ -116,7 +116,9 @@ class Task(SQLModel, table=True):
     __tablename__ = "tasks"
 
     id: str = Field(primary_key=True)
-    worker_id: Optional[str] = Field(default=None, foreign_key="workers.id")  # NULL for foreman-owned tasks
+    worker_id: str | None = Field(
+        default=None, foreign_key="workers.id"
+    )  # NULL for foreman-owned tasks
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     description: str
@@ -277,11 +279,11 @@ class Lock(SQLModel, table=True):
 
     __tablename__ = "locks"
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     key: str = Field(index=True)
-    owner: Optional[str] = None
+    owner: str | None = None
     acquired_at: datetime
-    expires_at: Optional[datetime] = None
+    expires_at: datetime | None = None
 
 
 class TaskEvent(SQLModel, table=True):

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from sqlalchemy import Index, or_, text
+from sqlalchemy import Column, DateTime, Index, or_, text
 from sqlmodel import Field, SQLModel
 
 
@@ -282,8 +282,8 @@ class Lock(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     key: str = Field(index=True)
     owner: str | None = None
-    acquired_at: datetime
-    expires_at: datetime | None = None
+    acquired_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    expires_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
 
 
 class TaskEvent(SQLModel, table=True):

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,11 +1,8 @@
 from datetime import UTC, datetime
+from typing import Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, Text, or_
-from sqlalchemy.orm import DeclarativeBase
-
-
-class Base(DeclarativeBase):
-    pass
+from sqlalchemy import Index, or_, text
+from sqlmodel import Field, SQLModel
 
 
 def live_tasks_filter(now: str | None = None):
@@ -20,262 +17,275 @@ def live_tasks_filter(now: str | None = None):
     return or_(Task.deleted_at.is_(None), Task.deleted_at > now)
 
 
-class Guild(Base):
+class Guild(SQLModel, table=True):
     __tablename__ = "guilds"
+    __table_args__ = (
+        Index(
+            "uq_guilds_guild_id_active",
+            "guild_id",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    guild_id = Column(Text, nullable=False)
-    created_at = Column(Text, nullable=False)
-    name = Column(Text)
-    github_user_id = Column(Text)
-    primary_repo = Column(Text, nullable=True)
+    id: Optional[int] = Field(default=None, primary_key=True)
+    guild_id: str
+    created_at: str
+    name: Optional[str] = None
+    github_user_id: Optional[str] = None
+    primary_repo: Optional[str] = None
     # HMAC-SHA256 shared secret used to verify GitHub webhook deliveries for
     # this guild. NULL until an owner first requests one via the
     # webhook-secret endpoint.
-    webhook_secret = Column(Text, nullable=True)
+    webhook_secret: Optional[str] = None
     # A2A AgentCard fields — used to populate /.well-known/agent.json
-    description = Column(Text, nullable=True)
-    url = Column(Text, nullable=True)
-    version = Column(Text, nullable=True)
+    description: Optional[str] = None
+    url: Optional[str] = None
+    version: Optional[str] = None
     # ISO-8601 UTC timestamp at which this guild is considered soft-deleted.
     # NULL = active; partial unique index enforces one active row per guild_id.
-    deleted_at = Column(Text, nullable=True)
+    deleted_at: Optional[str] = None
 
 
-class Agent(Base):
+class Agent(SQLModel, table=True):
     __tablename__ = "agents"
 
-    id = Column(Text, primary_key=True)
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), nullable=False)
-    worker_id = Column(Text, ForeignKey("workers.id"))
-    name = Column(Text, nullable=False)
-    type = Column(Text, nullable=False, server_default="worker")
-    state = Column(Text, nullable=False, server_default="idle")
-    activity = Column(Text, nullable=True)
+    id: str = Field(primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id")
+    worker_id: Optional[str] = Field(default=None, foreign_key="workers.id")
+    name: str
+    type: str = Field(default="worker")
+    state: str = Field(default="idle")
+    activity: Optional[str] = None
     # Task this agent is currently executing (NULL when idle/offline). Set
     # from worker-emitted agent-state messages; lets the UI map a task row
     # to its agent unambiguously when a worker runs concurrent slots that
     # share a worker_id.
-    current_task_id = Column(Text, nullable=True)
-    joined_at = Column(Text, nullable=False)
+    current_task_id: Optional[str] = None
+    joined_at: str
     # ISO-8601 UTC timestamp of the last message received from this agent over
     # the WebSocket. Refreshed by every inbound frame (incl. application-level
     # `ping`); the sweeper marks the agent offline when this gets stale.
-    last_seen = Column(Text, nullable=True)
+    last_seen: Optional[str] = None
 
 
-class Message(Base):
+class Message(SQLModel, table=True):
     __tablename__ = "messages"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), nullable=False)
-    from_agent = Column(Text)
-    to_agent = Column(Text)
-    content = Column(Text, nullable=False)
-    message_type = Column(Text, nullable=False)
-    created_at = Column(Text, nullable=False)
-    user_id = Column(
-        Text, nullable=True
-    )  # github_user_id of the sender; NULL for system/worker messages
-    role = Column(Text, nullable=True)  # "tool_use" | "tool_result" | NULL for plain chat
-    meta = Column(Text, nullable=True)  # JSON blob with extra WS fields (toolId, toolName, …)
+    id: Optional[int] = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id")
+    from_agent: Optional[str] = None
+    to_agent: Optional[str] = None
+    content: str
+    message_type: str
+    created_at: str
+    user_id: Optional[str] = None  # github_user_id of the sender; NULL for system/worker messages
+    role: Optional[str] = None  # "tool_use" | "tool_result" | NULL for plain chat
+    meta: Optional[str] = None  # JSON blob with extra WS fields (toolId, toolName, …)
 
 
-class Worker(Base):
+class Worker(SQLModel, table=True):
     __tablename__ = "workers"
 
-    id = Column(Text, primary_key=True)
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), nullable=False)
-    repos = Column(Text, nullable=False, server_default="[]")
+    id: str = Field(primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id")
+    repos: str = Field(default="[]")
     # Optional GitHub org; when set the worker accepts any task targeting <org>/*
     # and clones repos lazily. NULL for workers that use an explicit repos list only.
-    org = Column(Text, nullable=True)
-    state = Column(Text, nullable=False, server_default="idle")
-    created_at = Column(Text, nullable=False)
-    last_seen = Column(Text, nullable=True)
+    org: Optional[str] = None
+    state: str = Field(default="idle")
+    created_at: str
+    last_seen: Optional[str] = None
     # Identity of the human user this worker process runs on behalf of.
     # NULL for legacy/unattributed workers.
-    user_id = Column(Text, ForeignKey("users.id"), nullable=True)
+    user_id: Optional[str] = Field(default=None, foreign_key="users.id")
     # Bearer token issued at registration; required for fetching guild secrets
     # (Claude credentials, GitHub token) over REST. NULL on legacy rows that
     # predate the auth requirement — those workers must re-register to get a
     # token before they can fetch credentials.
-    auth_token = Column(Text, nullable=True)
+    auth_token: Optional[str] = None
     # Human-readable label: ``hostname[:3]/worker_id`` (e.g. ``tok/w-g2otus``).
     # NULL on rows created before this column was added; the API falls back to
     # worker_id for those legacy rows.
-    name = Column(Text, nullable=True)
+    name: Optional[str] = None
 
 
-class Task(Base):
+class Task(SQLModel, table=True):
     __tablename__ = "tasks"
 
-    id = Column(Text, primary_key=True)
-    worker_id = Column(
-        Text, ForeignKey("workers.id"), nullable=True
-    )  # NULL for foreman-owned tasks
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), nullable=False)
-    description = Column(Text, nullable=False)
-    tool = Column(Text, nullable=False, server_default="claude")
-    issue_number = Column(Integer)
-    issue_repo = Column(Text)
-    state = Column(Text, nullable=False, server_default="pending")
-    branch = Column(Text)
-    worktree_path = Column(Text)
-    pr_url = Column(Text)
+    id: str = Field(primary_key=True)
+    worker_id: Optional[str] = Field(default=None, foreign_key="workers.id")  # NULL for foreman-owned tasks
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id")
+    description: str
+    tool: str = Field(default="claude")
+    issue_number: Optional[int] = None
+    issue_repo: Optional[str] = None
+    state: str = Field(default="pending")
+    branch: Optional[str] = None
+    worktree_path: Optional[str] = None
+    pr_url: Optional[str] = None
     # Explicit PR coordinates extracted from pr_url at PR-creation time, so
     # github webhook events can be linked back to the task without fragile
     # URL substring matching. Both NULL until the worker reports a PR.
-    pr_number = Column(Integer, nullable=True)
-    pr_repo = Column(Text, nullable=True)
-    created_at = Column(Text, nullable=False)
-    finished_at = Column(Text)
-    name = Column(Text)
-    parent_task_id = Column(Text)
-    phase = Column(Text, server_default="execute")
+    pr_number: Optional[int] = None
+    pr_repo: Optional[str] = None
+    created_at: str
+    finished_at: Optional[str] = None
+    name: Optional[str] = None
+    parent_task_id: Optional[str] = None
+    phase: Optional[str] = Field(default="execute")
     # ISO-8601 UTC timestamp at which this task is considered soft-deleted.
     # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
-    deleted_at = Column(Text, nullable=True)
+    deleted_at: Optional[str] = None
     # github_user_id of the human who initiated this task. Used to route
     # worker-driven foreman events (task-complete, etc.) back to the originator's
     # foreman thread in multi-user guilds. NULL on legacy/system tasks.
-    user_id = Column(Text, nullable=True)
+    user_id: Optional[str] = None
 
 
-class GithubToken(Base):
+class GithubToken(SQLModel, table=True):
     __tablename__ = "github_tokens"
 
-    github_user_id = Column(Text, primary_key=True)
-    github_username = Column(Text)
-    access_token = Column(Text, nullable=False)
-    token_type = Column(Text, nullable=False, server_default="bearer")
-    scope = Column(Text)
-    created_at = Column(Text, nullable=False)
-    updated_at = Column(Text, nullable=False)
+    github_user_id: str = Field(primary_key=True)
+    github_username: Optional[str] = None
+    access_token: str
+    token_type: str = Field(default="bearer")
+    scope: Optional[str] = None
+    created_at: str
+    updated_at: str
 
 
-class UserSession(Base):
+class UserSession(SQLModel, table=True):
     __tablename__ = "user_sessions"
 
-    token = Column(Text, primary_key=True)
-    github_user_id = Column(Text, ForeignKey("github_tokens.github_user_id"), nullable=False)
-    created_at = Column(Text, nullable=False)
+    token: str = Field(primary_key=True)
+    github_user_id: str = Field(foreign_key="github_tokens.github_user_id")
+    created_at: str
 
 
-class User(Base):
+class User(SQLModel, table=True):
     __tablename__ = "users"
 
     # Canonical user id == GitHub numeric id, kept as Text for FK compatibility
     # with the existing github_user_id columns (messages.user_id,
     # guilds.github_user_id, etc).
-    id = Column(Text, primary_key=True)
-    github_id = Column(Text, nullable=False, unique=True)
-    github_login = Column(Text)
-    email = Column(Text)
-    display_name = Column(Text)
-    avatar_url = Column(Text)
-    created_at = Column(Text, nullable=False)
-    updated_at = Column(Text, nullable=False)
+    id: str = Field(primary_key=True)
+    github_id: str = Field(unique=True)
+    github_login: Optional[str] = None
+    email: Optional[str] = None
+    display_name: Optional[str] = None
+    avatar_url: Optional[str] = None
+    created_at: str
+    updated_at: str
 
 
-class GuildMember(Base):
+class GuildMember(SQLModel, table=True):
     __tablename__ = "guild_members"
 
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), primary_key=True)
-    user_id = Column(Text, ForeignKey("users.id"), primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
+    user_id: str = Field(foreign_key="users.id", primary_key=True)
     # owner | member | viewer
-    role = Column(Text, nullable=False, server_default="member")
-    created_at = Column(Text, nullable=False)
+    role: str = Field(default="member")
+    created_at: str
 
 
-class TaskLog(Base):
+class TaskLog(SQLModel, table=True):
     __tablename__ = "task_logs"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    task_id = Column(Text, ForeignKey("tasks.id"), nullable=True)
-    timestamp = Column(Text, nullable=False)
-    line = Column(Text, nullable=False)
-    worker_id = Column(Text)
-    agent_id = Column(Text)
-    data = Column(Text)  # JSON: full tool input/output for click-to-expand
+    id: Optional[int] = Field(default=None, primary_key=True)
+    task_id: Optional[str] = Field(default=None, foreign_key="tasks.id")
+    timestamp: str
+    line: str
+    worker_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    data: Optional[str] = None  # JSON: full tool input/output for click-to-expand
 
 
-class ClaudeCredentials(Base):
+class ClaudeCredentials(SQLModel, table=True):
     __tablename__ = "claude_credentials"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), nullable=False, unique=True)
-    credentials_blob = Column(Text, nullable=False)  # base64-encoded tar.gz of ~/.claude/
-    updated_at = Column(Text, nullable=False)
+    id: Optional[int] = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id", unique=True)
+    credentials_blob: str  # base64-encoded tar.gz of ~/.claude/
+    updated_at: str
 
 
-class GuildKey(Base):
+class GuildKey(SQLModel, table=True):
     __tablename__ = "guild_keys"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), nullable=False, unique=True)
-    key_id = Column(Text, nullable=False)  # "kid" in JWK
-    public_key_pem = Column(Text, nullable=False)
-    private_key_pem = Column(Text, nullable=False)
-    created_at = Column(Text, nullable=False)
+    id: Optional[int] = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id", unique=True)
+    key_id: str  # "kid" in JWK
+    public_key_pem: str
+    private_key_pem: str
+    created_at: str
     # When set, served verbatim at /.well-known/jwks.json instead of the
     # auto-generated key. Stored as JSON text ({"keys": [...]}).
-    custom_jwks = Column(Text, nullable=True)
+    custom_jwks: Optional[str] = None
     # Private key in JWK format for backend signing; never served publicly.
-    private_key_jwk = Column(Text, nullable=True)
+    private_key_jwk: Optional[str] = None
 
 
-class ForemanTurn(Base):
+class ForemanTurn(SQLModel, table=True):
     __tablename__ = "foreman_turns"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), nullable=False)
-    user_id = Column(Text, nullable=False)
-    role = Column(Text, nullable=False)  # "user" | "assistant" | "system"
-    content_json = Column(Text, nullable=False)  # JSON-serialized content blocks
+    id: Optional[int] = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id")
+    user_id: str
+    role: str  # "user" | "assistant" | "system"
+    content_json: str  # JSON-serialized content blocks
     # 1 if this "user" turn carries tool_results (not human input); 0 otherwise
-    is_tool_response = Column(Integer, nullable=False, server_default="0")
+    is_tool_response: int = Field(default=0)
     # For tool_result turns: id of the assistant turn whose tool_use blocks this answers
-    parent_id = Column(Integer, ForeignKey("foreman_turns.id"), nullable=True)
-    created_at = Column(Text, nullable=False)
+    parent_id: Optional[int] = Field(default=None, foreign_key="foreman_turns.id")
+    created_at: str
     # Token usage from the API response (assistant turns only; NULL for user/system turns)
-    input_tokens = Column(Integer, nullable=True)
-    output_tokens = Column(Integer, nullable=True)
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
 
 
-class GithubEvent(Base):
+class GithubEvent(SQLModel, table=True):
     __tablename__ = "github_events"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    guild_pk = Column(Integer, ForeignKey("guilds.id"), nullable=False)
+    id: Optional[int] = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    guild_id: int = Field(foreign_key="guilds.id")
     # task_id is nullable because an event may arrive before we've linked the
     # PR to a task (e.g. webhook fires for a manually-opened PR).
-    task_id = Column(Text, ForeignKey("tasks.id"), nullable=True)
+    task_id: Optional[str] = Field(default=None, foreign_key="tasks.id")
     # X-GitHub-Delivery header value; UNIQUE so GitHub redelivery is a no-op.
-    delivery_id = Column(Text, nullable=False, unique=True)
-    event_type = Column(Text, nullable=False)
-    action = Column(Text, nullable=True)
-    repo = Column(Text, nullable=False)  # owner/repo
-    pr_number = Column(Integer, nullable=True)
-    pr_url = Column(Text, nullable=True)
-    sender_login = Column(Text, nullable=True)
-    payload_json = Column(Text, nullable=False)
-    created_at = Column(Text, nullable=False)
+    delivery_id: str = Field(unique=True)
+    event_type: str
+    action: Optional[str] = None
+    repo: str  # owner/repo
+    pr_number: Optional[int] = None
+    pr_url: Optional[str] = None
+    sender_login: Optional[str] = None
+    payload_json: str
+    created_at: str
 
 
-class Lock(Base):
+class Lock(SQLModel, table=True):
     """Standalone key-value lock table. See lock_service.LockService for usage."""
 
     __tablename__ = "locks"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    key = Column(Text, nullable=False, index=True)
-    owner = Column(Text, nullable=True)
-    acquired_at = Column(DateTime(timezone=True), nullable=False)
-    expires_at = Column(DateTime(timezone=True), nullable=True)
+    id: Optional[int] = Field(default=None, primary_key=True)
+    key: str = Field(index=True)
+    owner: Optional[str] = None
+    acquired_at: datetime
+    expires_at: Optional[datetime] = None
 
 
-class TaskEvent(Base):
+class TaskEvent(SQLModel, table=True):
     """Queued follow-up triggers that arrived while a task was locked.
 
     When send_followup is called on a task that already holds a follow-up lock,
@@ -286,9 +296,9 @@ class TaskEvent(Base):
 
     __tablename__ = "task_events"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    task_id = Column(Text, ForeignKey("tasks.id"), nullable=False)
+    id: Optional[int] = Field(default=None, primary_key=True)
+    task_id: str = Field(foreign_key="tasks.id")
     # "pending-followup" is the only event_type currently; reserved for future use.
-    event_type = Column(Text, nullable=False)
-    payload_json = Column(Text, nullable=False)  # JSON: instructions, preferred_worker_id
-    created_at = Column(Text, nullable=False)
+    event_type: str
+    payload_json: str  # JSON: instructions, preferred_worker_id
+    created_at: str

--- a/backend/models.py
+++ b/backend/models.py
@@ -54,8 +54,8 @@ class Agent(SQLModel, table=True):
     guild_id: int = Field(foreign_key="guilds.id")
     worker_id: str | None = Field(default=None, foreign_key="workers.id")
     name: str
-    type: str = Field(default="worker")
-    state: str = Field(default="idle")
+    type: str = Field(default="worker", sa_column_kwargs={"server_default": "'worker'"})
+    state: str = Field(default="idle", sa_column_kwargs={"server_default": "'idle'"})
     activity: str | None = None
     # Task this agent is currently executing (NULL when idle/offline). Set
     # from worker-emitted agent-state messages; lets the UI map a task row
@@ -91,11 +91,11 @@ class Worker(SQLModel, table=True):
     id: str = Field(primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
-    repos: str = Field(default="[]")
+    repos: str = Field(default="[]", sa_column_kwargs={"server_default": "'[]'"})
     # Optional GitHub org; when set the worker accepts any task targeting <org>/*
     # and clones repos lazily. NULL for workers that use an explicit repos list only.
     org: str | None = None
-    state: str = Field(default="idle")
+    state: str = Field(default="idle", sa_column_kwargs={"server_default": "'idle'"})
     created_at: str
     last_seen: str | None = None
     # Identity of the human user this worker process runs on behalf of.
@@ -122,10 +122,10 @@ class Task(SQLModel, table=True):
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     description: str
-    tool: str = Field(default="claude")
+    tool: str = Field(default="claude", sa_column_kwargs={"server_default": "'claude'"})
     issue_number: int | None = None
     issue_repo: str | None = None
-    state: str = Field(default="pending")
+    state: str = Field(default="pending", sa_column_kwargs={"server_default": "'pending'"})
     branch: str | None = None
     worktree_path: str | None = None
     pr_url: str | None = None
@@ -138,7 +138,7 @@ class Task(SQLModel, table=True):
     finished_at: str | None = None
     name: str | None = None
     parent_task_id: str | None = None
-    phase: str | None = Field(default="execute")
+    phase: str | None = Field(default="execute", sa_column_kwargs={"server_default": "'execute'"})
     # ISO-8601 UTC timestamp at which this task is considered soft-deleted.
     # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
     deleted_at: str | None = None
@@ -154,7 +154,7 @@ class GithubToken(SQLModel, table=True):
     github_user_id: str = Field(primary_key=True)
     github_username: str | None = None
     access_token: str
-    token_type: str = Field(default="bearer")
+    token_type: str = Field(default="bearer", sa_column_kwargs={"server_default": "'bearer'"})
     scope: str | None = None
     created_at: str
     updated_at: str
@@ -191,7 +191,7 @@ class GuildMember(SQLModel, table=True):
     guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
     user_id: str = Field(foreign_key="users.id", primary_key=True)
     # owner | member | viewer
-    role: str = Field(default="member")
+    role: str = Field(default="member", sa_column_kwargs={"server_default": "'member'"})
     created_at: str
 
 
@@ -244,7 +244,7 @@ class ForemanTurn(SQLModel, table=True):
     role: str  # "user" | "assistant" | "system"
     content_json: str  # JSON-serialized content blocks
     # 1 if this "user" turn carries tool_results (not human input); 0 otherwise
-    is_tool_response: int = Field(default=0)
+    is_tool_response: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
     # For tool_result turns: id of the assistant turn whose tool_use blocks this answers
     parent_id: int | None = Field(default=None, foreign_key="foreman_turns.id")
     created_at: str

--- a/backend/models.py
+++ b/backend/models.py
@@ -283,7 +283,9 @@ class Lock(SQLModel, table=True):
     key: str = Field(index=True)
     owner: str | None = None
     acquired_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
-    expires_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+    expires_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
 
 
 class TaskEvent(SQLModel, table=True):

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,4 @@
 from datetime import UTC, datetime
-from typing import Optional
 
 from sqlalchemy import Index, or_, text
 from sqlmodel import Field, SQLModel
@@ -28,23 +27,23 @@ class Guild(SQLModel, table=True):
         ),
     )
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     guild_id: str
     created_at: str
-    name: Optional[str] = None
-    github_user_id: Optional[str] = None
-    primary_repo: Optional[str] = None
+    name: str | None = None
+    github_user_id: str | None = None
+    primary_repo: str | None = None
     # HMAC-SHA256 shared secret used to verify GitHub webhook deliveries for
     # this guild. NULL until an owner first requests one via the
     # webhook-secret endpoint.
-    webhook_secret: Optional[str] = None
+    webhook_secret: str | None = None
     # A2A AgentCard fields — used to populate /.well-known/agent.json
-    description: Optional[str] = None
-    url: Optional[str] = None
-    version: Optional[str] = None
+    description: str | None = None
+    url: str | None = None
+    version: str | None = None
     # ISO-8601 UTC timestamp at which this guild is considered soft-deleted.
     # NULL = active; partial unique index enforces one active row per guild_id.
-    deleted_at: Optional[str] = None
+    deleted_at: str | None = None
 
 
 class Agent(SQLModel, table=True):
@@ -53,37 +52,37 @@ class Agent(SQLModel, table=True):
     id: str = Field(primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
-    worker_id: Optional[str] = Field(default=None, foreign_key="workers.id")
+    worker_id: str | None = Field(default=None, foreign_key="workers.id")
     name: str
     type: str = Field(default="worker")
     state: str = Field(default="idle")
-    activity: Optional[str] = None
+    activity: str | None = None
     # Task this agent is currently executing (NULL when idle/offline). Set
     # from worker-emitted agent-state messages; lets the UI map a task row
     # to its agent unambiguously when a worker runs concurrent slots that
     # share a worker_id.
-    current_task_id: Optional[str] = None
+    current_task_id: str | None = None
     joined_at: str
     # ISO-8601 UTC timestamp of the last message received from this agent over
     # the WebSocket. Refreshed by every inbound frame (incl. application-level
     # `ping`); the sweeper marks the agent offline when this gets stale.
-    last_seen: Optional[str] = None
+    last_seen: str | None = None
 
 
 class Message(SQLModel, table=True):
     __tablename__ = "messages"
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
-    from_agent: Optional[str] = None
-    to_agent: Optional[str] = None
+    from_agent: str | None = None
+    to_agent: str | None = None
     content: str
     message_type: str
     created_at: str
-    user_id: Optional[str] = None  # github_user_id of the sender; NULL for system/worker messages
-    role: Optional[str] = None  # "tool_use" | "tool_result" | NULL for plain chat
-    meta: Optional[str] = None  # JSON blob with extra WS fields (toolId, toolName, …)
+    user_id: str | None = None  # github_user_id of the sender; NULL for system/worker messages
+    role: str | None = None  # "tool_use" | "tool_result" | NULL for plain chat
+    meta: str | None = None  # JSON blob with extra WS fields (toolId, toolName, …)
 
 
 class Worker(SQLModel, table=True):
@@ -95,22 +94,22 @@ class Worker(SQLModel, table=True):
     repos: str = Field(default="[]")
     # Optional GitHub org; when set the worker accepts any task targeting <org>/*
     # and clones repos lazily. NULL for workers that use an explicit repos list only.
-    org: Optional[str] = None
+    org: str | None = None
     state: str = Field(default="idle")
     created_at: str
-    last_seen: Optional[str] = None
+    last_seen: str | None = None
     # Identity of the human user this worker process runs on behalf of.
     # NULL for legacy/unattributed workers.
-    user_id: Optional[str] = Field(default=None, foreign_key="users.id")
+    user_id: str | None = Field(default=None, foreign_key="users.id")
     # Bearer token issued at registration; required for fetching guild secrets
     # (Claude credentials, GitHub token) over REST. NULL on legacy rows that
     # predate the auth requirement — those workers must re-register to get a
     # token before they can fetch credentials.
-    auth_token: Optional[str] = None
+    auth_token: str | None = None
     # Human-readable label: ``hostname[:3]/worker_id`` (e.g. ``tok/w-g2otus``).
     # NULL on rows created before this column was added; the API falls back to
     # worker_id for those legacy rows.
-    name: Optional[str] = None
+    name: str | None = None
 
 
 class Task(SQLModel, table=True):
@@ -122,39 +121,39 @@ class Task(SQLModel, table=True):
     guild_id: int = Field(foreign_key="guilds.id")
     description: str
     tool: str = Field(default="claude")
-    issue_number: Optional[int] = None
-    issue_repo: Optional[str] = None
+    issue_number: int | None = None
+    issue_repo: str | None = None
     state: str = Field(default="pending")
-    branch: Optional[str] = None
-    worktree_path: Optional[str] = None
-    pr_url: Optional[str] = None
+    branch: str | None = None
+    worktree_path: str | None = None
+    pr_url: str | None = None
     # Explicit PR coordinates extracted from pr_url at PR-creation time, so
     # github webhook events can be linked back to the task without fragile
     # URL substring matching. Both NULL until the worker reports a PR.
-    pr_number: Optional[int] = None
-    pr_repo: Optional[str] = None
+    pr_number: int | None = None
+    pr_repo: str | None = None
     created_at: str
-    finished_at: Optional[str] = None
-    name: Optional[str] = None
-    parent_task_id: Optional[str] = None
-    phase: Optional[str] = Field(default="execute")
+    finished_at: str | None = None
+    name: str | None = None
+    parent_task_id: str | None = None
+    phase: str | None = Field(default="execute")
     # ISO-8601 UTC timestamp at which this task is considered soft-deleted.
     # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
-    deleted_at: Optional[str] = None
+    deleted_at: str | None = None
     # github_user_id of the human who initiated this task. Used to route
     # worker-driven foreman events (task-complete, etc.) back to the originator's
     # foreman thread in multi-user guilds. NULL on legacy/system tasks.
-    user_id: Optional[str] = None
+    user_id: str | None = None
 
 
 class GithubToken(SQLModel, table=True):
     __tablename__ = "github_tokens"
 
     github_user_id: str = Field(primary_key=True)
-    github_username: Optional[str] = None
+    github_username: str | None = None
     access_token: str
     token_type: str = Field(default="bearer")
-    scope: Optional[str] = None
+    scope: str | None = None
     created_at: str
     updated_at: str
 
@@ -175,10 +174,10 @@ class User(SQLModel, table=True):
     # guilds.github_user_id, etc).
     id: str = Field(primary_key=True)
     github_id: str = Field(unique=True)
-    github_login: Optional[str] = None
-    email: Optional[str] = None
-    display_name: Optional[str] = None
-    avatar_url: Optional[str] = None
+    github_login: str | None = None
+    email: str | None = None
+    display_name: str | None = None
+    avatar_url: str | None = None
     created_at: str
     updated_at: str
 
@@ -197,19 +196,19 @@ class GuildMember(SQLModel, table=True):
 class TaskLog(SQLModel, table=True):
     __tablename__ = "task_logs"
 
-    id: Optional[int] = Field(default=None, primary_key=True)
-    task_id: Optional[str] = Field(default=None, foreign_key="tasks.id")
+    id: int | None = Field(default=None, primary_key=True)
+    task_id: str | None = Field(default=None, foreign_key="tasks.id")
     timestamp: str
     line: str
-    worker_id: Optional[str] = None
-    agent_id: Optional[str] = None
-    data: Optional[str] = None  # JSON: full tool input/output for click-to-expand
+    worker_id: str | None = None
+    agent_id: str | None = None
+    data: str | None = None  # JSON: full tool input/output for click-to-expand
 
 
 class ClaudeCredentials(SQLModel, table=True):
     __tablename__ = "claude_credentials"
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", unique=True)
     credentials_blob: str  # base64-encoded tar.gz of ~/.claude/
@@ -219,7 +218,7 @@ class ClaudeCredentials(SQLModel, table=True):
 class GuildKey(SQLModel, table=True):
     __tablename__ = "guild_keys"
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", unique=True)
     key_id: str  # "kid" in JWK
@@ -228,15 +227,15 @@ class GuildKey(SQLModel, table=True):
     created_at: str
     # When set, served verbatim at /.well-known/jwks.json instead of the
     # auto-generated key. Stored as JSON text ({"keys": [...]}).
-    custom_jwks: Optional[str] = None
+    custom_jwks: str | None = None
     # Private key in JWK format for backend signing; never served publicly.
-    private_key_jwk: Optional[str] = None
+    private_key_jwk: str | None = None
 
 
 class ForemanTurn(SQLModel, table=True):
     __tablename__ = "foreman_turns"
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     user_id: str
@@ -245,30 +244,30 @@ class ForemanTurn(SQLModel, table=True):
     # 1 if this "user" turn carries tool_results (not human input); 0 otherwise
     is_tool_response: int = Field(default=0)
     # For tool_result turns: id of the assistant turn whose tool_use blocks this answers
-    parent_id: Optional[int] = Field(default=None, foreign_key="foreman_turns.id")
+    parent_id: int | None = Field(default=None, foreign_key="foreman_turns.id")
     created_at: str
     # Token usage from the API response (assistant turns only; NULL for user/system turns)
-    input_tokens: Optional[int] = None
-    output_tokens: Optional[int] = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
 
 class GithubEvent(SQLModel, table=True):
     __tablename__ = "github_events"
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     # task_id is nullable because an event may arrive before we've linked the
     # PR to a task (e.g. webhook fires for a manually-opened PR).
-    task_id: Optional[str] = Field(default=None, foreign_key="tasks.id")
+    task_id: str | None = Field(default=None, foreign_key="tasks.id")
     # X-GitHub-Delivery header value; UNIQUE so GitHub redelivery is a no-op.
     delivery_id: str = Field(unique=True)
     event_type: str
-    action: Optional[str] = None
+    action: str | None = None
     repo: str  # owner/repo
-    pr_number: Optional[int] = None
-    pr_url: Optional[str] = None
-    sender_login: Optional[str] = None
+    pr_number: int | None = None
+    pr_url: str | None = None
+    sender_login: str | None = None
     payload_json: str
     created_at: str
 
@@ -296,7 +295,7 @@ class TaskEvent(SQLModel, table=True):
 
     __tablename__ = "task_events"
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     task_id: str = Field(foreign_key="tasks.id")
     # "pending-followup" is the only event_type currently; reserved for future use.
     event_type: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ websockets
 asyncpg
 psycopg2-binary
 sqlalchemy[asyncio]
+sqlmodel
 alembic
 python-multipart
 anthropic

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -95,7 +95,7 @@ async def get_github_token(
             raise HTTPException(status_code=404, detail="No GitHub account linked to this guild")
         owner_res = await db.execute(
             select(GuildMember.user_id)
-            .where(GuildMember.guild_pk == guild_pk, GuildMember.role == "owner")
+            .where(GuildMember.guild_id == guild_pk, GuildMember.role == "owner")
             .limit(1)
         )
         owner_user_id = owner_res.scalar_one_or_none()
@@ -131,7 +131,7 @@ async def get_claude_credentials(
                 status_code=404, detail="No Claude credentials stored for this guild"
             )
         result = await db.execute(
-            select(ClaudeCredentials).where(ClaudeCredentials.guild_pk == guild_pk)
+            select(ClaudeCredentials).where(ClaudeCredentials.guild_id == guild_pk)
         )
         row = result.scalar_one_or_none()
         if not row:
@@ -161,7 +161,7 @@ async def store_claude_credentials(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
-            select(ClaudeCredentials).where(ClaudeCredentials.guild_pk == guild_pk)
+            select(ClaudeCredentials).where(ClaudeCredentials.guild_id == guild_pk)
         )
         row = result.scalar_one_or_none()
         if row:
@@ -170,7 +170,7 @@ async def store_claude_credentials(
         else:
             db.add(
                 ClaudeCredentials(
-                    guild_pk=guild_pk,
+                    guild_id=guild_pk,
                     credentials_blob=data.credentials_blob,
                     updated_at=now,
                 )
@@ -217,7 +217,7 @@ async def api_me(github_user_id: str = Depends(require_user)):
 
         members_res = await db.execute(
             select(Guild.guild_id, GuildMember.role, Guild.name)
-            .join(Guild, Guild.id == GuildMember.guild_pk)
+            .join(Guild, Guild.id == GuildMember.guild_id)
             .where(GuildMember.user_id == github_user_id)
         )
         memberships = [
@@ -318,7 +318,7 @@ async def guest_login():
             await db.flush()
             db.add(
                 GuildMember(
-                    guild_pk=new_guild.id,
+                    guild_id=new_guild.id,
                     user_id=guest_user_id,
                     role="owner",
                     created_at=now,

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -167,15 +167,15 @@ async def get_foreman_state(
                 " STRING_AGG(a.id || ':' || a.state, ',') as agents"
                 " FROM workers w"
                 " LEFT JOIN agents a ON a.worker_id = w.id AND a.state != 'offline'"
-                " WHERE w.guild_pk = :guild_pk AND w.state = 'online'"
+                " WHERE w.guild_id = :guild_id AND w.state = 'online'"
                 " GROUP BY w.id"
                 " UNION ALL"
                 " SELECT a.id, '[]', NULL, a.state, 1, a.id || ':' || a.state"
                 " FROM agents a"
-                " WHERE a.guild_pk = :guild_pk AND a.type = 'worker'"
+                " WHERE a.guild_id = :guild_id AND a.type = 'worker'"
                 " AND a.worker_id IS NULL AND a.state != 'offline'"
             ),
-            {"guild_pk": guild_pk},
+            {"guild_id": guild_pk},
         )
         worker_rows = [dict(r._mapping) for r in workers_res.fetchall()]
         workers_data = [
@@ -207,7 +207,7 @@ async def get_foreman_state(
                 Task.user_id,
             )
             .where(
-                Task.guild_pk == guild_pk,
+                Task.guild_id == guild_pk,
                 ~Task.state.in_(list(_TERMINAL)),
                 live_tasks_filter(),
             )
@@ -261,7 +261,7 @@ async def get_foreman_history_for_user(
                 ForemanTurn.parent_id,
                 ForemanTurn.created_at,
             )
-            .where(ForemanTurn.guild_pk == guild_pk, ForemanTurn.user_id == user_id)
+            .where(ForemanTurn.guild_id == guild_pk, ForemanTurn.user_id == user_id)
             .order_by(ForemanTurn.id)
         )
         if limit is not None and limit > 0:
@@ -304,7 +304,7 @@ async def get_guild_key(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
-            select(GuildKey.key_id, GuildKey.private_key_pem).where(GuildKey.guild_pk == guild_pk)
+            select(GuildKey.key_id, GuildKey.private_key_pem).where(GuildKey.guild_id == guild_pk)
         )
         row = result.one_or_none()
     finally:
@@ -350,7 +350,7 @@ async def create_foreman_turn(
             raise HTTPException(status_code=404, detail="Guild not found")
         created_at = datetime.now(UTC).isoformat()
         turn = ForemanTurn(
-            guild_pk=guild_pk,
+            guild_id=guild_pk,
             user_id=body.user_id,
             role=body.role,
             content_json=body.content_json,
@@ -403,7 +403,7 @@ async def create_foreman_task(
             Task(
                 id=task_id,
                 worker_id=None,
-                guild_pk=guild_pk,
+                guild_id=guild_pk,
                 name=name,
                 description=body.description,
                 tool="claude",
@@ -500,7 +500,7 @@ async def patch_task(
 
         # Verify task exists in this guild
         exists = await db.execute(
-            select(Task.id).where(Task.id == task_id, Task.guild_pk == guild_pk)
+            select(Task.id).where(Task.id == task_id, Task.guild_id == guild_pk)
         )
         if exists.scalar_one_or_none() is None:
             raise HTTPException(status_code=404, detail="Task not found")
@@ -563,7 +563,7 @@ async def create_message(
 
         created_at = datetime.now(UTC).isoformat()
         msg = Message(
-            guild_pk=guild_pk,
+            guild_id=guild_pk,
             from_agent=body.from_agent,
             to_agent=body.to_agent,
             content=body.content,

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -89,7 +89,7 @@ async def create_guild(
             await db.flush()
             db.add(
                 GuildMember(
-                    guild_pk=new_guild.id,
+                    guild_id=new_guild.id,
                     user_id=github_user_id,
                     role="owner",
                     created_at=created_at,
@@ -118,11 +118,11 @@ async def list_guilds(github_user_id: str = Depends(require_user)):
             .select_from(Guild)
             .join(
                 GuildMember,
-                (GuildMember.guild_pk == Guild.id) & (GuildMember.user_id == github_user_id),
+                (GuildMember.guild_id == Guild.id) & (GuildMember.user_id == github_user_id),
             )
             .outerjoin(
                 Agent,
-                (Agent.guild_pk == Guild.id)
+                (Agent.guild_id == Guild.id)
                 & (Agent.type != "foreman")
                 & (Agent.state != "offline"),
             )
@@ -195,7 +195,7 @@ async def get_guild(guild_id: str, github_user_id: str = Depends(require_member(
             select(Agent, Worker.name.label("worker_name"))
             .outerjoin(Worker, Worker.id == Agent.worker_id)
             .where(
-                Agent.guild_pk == guild_pk,
+                Agent.guild_id == guild_pk,
                 Agent.state != "offline",
                 Agent.type != "foreman",
             )
@@ -203,7 +203,7 @@ async def get_guild(guild_id: str, github_user_id: str = Depends(require_member(
         agent_rows = result.all()
         result = await db.execute(
             select(Message)
-            .where(Message.guild_pk == guild_pk)
+            .where(Message.guild_id == guild_pk)
             # .id.desc() is a stable tiebreaker because message IDs are auto-increment integers.
             .order_by(Message.created_at.desc(), Message.id.desc())
             .limit(100)
@@ -242,7 +242,7 @@ async def list_guild_members(
                 User.avatar_url,
             )
             .outerjoin(User, User.id == GuildMember.user_id)
-            .where(GuildMember.guild_pk == guild_pk)
+            .where(GuildMember.guild_id == guild_pk)
             .order_by(GuildMember.created_at.asc())
         )
         return [dict(r._mapping) for r in result.fetchall()]
@@ -277,13 +277,13 @@ async def add_guild_member(
             )
         now = datetime.now(UTC).isoformat()
         stmt = pg_insert(GuildMember).values(
-            guild_pk=guild_pk,
+            guild_id=guild_pk,
             user_id=target_id,
             role=data.role,
             created_at=now,
         )
         stmt = stmt.on_conflict_do_update(
-            index_elements=["guild_pk", "user_id"],
+            index_elements=["guild_id", "user_id"],
             set_={"role": stmt.excluded.role},
         )
         await db.execute(stmt)
@@ -312,7 +312,7 @@ async def update_guild_member(
             raise HTTPException(status_code=404, detail="Guild not found")
         res = await db.execute(
             select(GuildMember).where(
-                GuildMember.guild_pk == guild_pk, GuildMember.user_id == user_id
+                GuildMember.guild_id == guild_pk, GuildMember.user_id == user_id
             )
         )
         member = res.scalar_one_or_none()
@@ -323,7 +323,7 @@ async def update_guild_member(
             owner_count = await db.execute(
                 select(func.count())
                 .select_from(GuildMember)
-                .where(GuildMember.guild_pk == guild_pk, GuildMember.role == "owner")
+                .where(GuildMember.guild_id == guild_pk, GuildMember.role == "owner")
             )
             if (owner_count.scalar() or 0) <= 1:
                 raise HTTPException(
@@ -403,7 +403,7 @@ async def remove_guild_member(
             raise HTTPException(status_code=404, detail="Guild not found")
         res = await db.execute(
             select(GuildMember).where(
-                GuildMember.guild_pk == guild_pk, GuildMember.user_id == user_id
+                GuildMember.guild_id == guild_pk, GuildMember.user_id == user_id
             )
         )
         member = res.scalar_one_or_none()
@@ -413,7 +413,7 @@ async def remove_guild_member(
             owner_count = await db.execute(
                 select(func.count())
                 .select_from(GuildMember)
-                .where(GuildMember.guild_pk == guild_pk, GuildMember.role == "owner")
+                .where(GuildMember.guild_id == guild_pk, GuildMember.role == "owner")
             )
             if (owner_count.scalar() or 0) <= 1:
                 raise HTTPException(
@@ -421,7 +421,7 @@ async def remove_guild_member(
                 )
         await db.execute(
             delete(GuildMember).where(
-                GuildMember.guild_pk == guild_pk, GuildMember.user_id == user_id
+                GuildMember.guild_id == guild_pk, GuildMember.user_id == user_id
             )
         )
         await db.commit()

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -97,7 +97,7 @@ async def list_guild_tasks(
                 Task.finished_at,
                 Task.deleted_at,
             )
-            .where(Task.guild_pk == guild_pk, live_tasks_filter())
+            .where(Task.guild_id == guild_pk, live_tasks_filter())
             .order_by(Task.created_at.desc())
             .limit(100)
         )
@@ -121,7 +121,7 @@ async def get_task_logs(
         result = await db.execute(
             select(Task.id).where(
                 Task.id == task_id,
-                Task.guild_pk == guild_pk,
+                Task.guild_id == guild_pk,
                 live_tasks_filter(),
             )
         )
@@ -218,7 +218,7 @@ async def create_task_followup(
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
             select(Task.worker_id, Task.state, Task.branch).where(
-                Task.id == task_id, Task.guild_pk == guild_pk
+                Task.id == task_id, Task.guild_id == guild_pk
             )
         )
         row = result.one_or_none()
@@ -263,7 +263,7 @@ async def finalize_task_endpoint(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
-            select(Task.worker_id).where(Task.id == task_id, Task.guild_pk == guild_pk)
+            select(Task.worker_id).where(Task.id == task_id, Task.guild_id == guild_pk)
         )
         worker_id = result.scalar_one_or_none()
         if not worker_id:
@@ -312,7 +312,7 @@ async def cancel_task_endpoint(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
-            select(Task.worker_id, Task.state).where(Task.id == task_id, Task.guild_pk == guild_pk)
+            select(Task.worker_id, Task.state).where(Task.id == task_id, Task.guild_id == guild_pk)
         )
         row = result.one_or_none()
         if not row:
@@ -367,7 +367,7 @@ async def redirect_task_endpoint(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
-            select(Task.worker_id, Task.state).where(Task.id == task_id, Task.guild_pk == guild_pk)
+            select(Task.worker_id, Task.state).where(Task.id == task_id, Task.guild_id == guild_pk)
         )
         row = result.one_or_none()
         if not row:

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -275,7 +275,7 @@ async def _find_task(db, guild_pk: int, repo: str | None, pr_number: int | None)
     res = await db.execute(
         select(Task.id, Task.user_id)
         .where(
-            Task.guild_pk == guild_pk,
+            Task.guild_id == guild_pk,
             Task.pr_repo == repo,
             Task.pr_number == pr_number,
         )
@@ -534,7 +534,7 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
         stmt = (
             pg_insert(GithubEvent)
             .values(
-                guild_pk=guild_pk,
+                guild_id=guild_pk,
                 task_id=task_id,
                 delivery_id=delivery_id,
                 event_type=event_type,
@@ -622,7 +622,7 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
     try:
         msg_db.add(
             Message(
-                guild_pk=guild_pk,
+                guild_id=guild_pk,
                 from_agent="github",
                 to_agent="foreman",
                 content=chat_line,

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -46,18 +46,18 @@ async def _touch_agent(
     if worker_id:
         await db.execute(
             update(Worker)
-            .where(Worker.id == worker_id, Worker.guild_pk == guild_pk)
+            .where(Worker.id == worker_id, Worker.guild_id == guild_pk)
             .values(last_seen=now)
         )
         await db.execute(
             update(Agent)
-            .where(Agent.worker_id == worker_id, Agent.guild_pk == guild_pk)
+            .where(Agent.worker_id == worker_id, Agent.guild_id == guild_pk)
             .values(last_seen=now)
         )
     elif agent_id:
         await db.execute(
             update(Agent)
-            .where(Agent.id == agent_id, Agent.guild_pk == guild_pk)
+            .where(Agent.id == agent_id, Agent.guild_id == guild_pk)
             .values(last_seen=now)
         )
     await db.commit()
@@ -81,12 +81,12 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
             _gp_res = await _gp_db.execute(select(Guild.id).where(Guild.guild_id == guild_id))
             _guild_pk = _gp_res.scalar_one_or_none()
         except Exception:
-            logger.exception("WS guild_pk lookup failed for guild %s", guild_id)
+            logger.exception("WS guild id lookup failed for guild %s", guild_id)
         finally:
             try:
                 await _gp_db.close()
             except Exception:
-                logger.debug("WS _gp_db close error during guild_pk lookup", exc_info=True)
+                logger.debug("WS _gp_db close error during guild id lookup", exc_info=True)
 
         # Identify the browser user from the optional ?token= query param.
         # Workers don't pass a token; ws_user_id stays None for them.
@@ -173,7 +173,7 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                             await db.execute(
                                 select(Agent.worker_id).where(
                                     Agent.id.in_(stale_agents),
-                                    Agent.guild_pk == _guild_pk,
+                                    Agent.guild_id == _guild_pk,
                                     Agent.worker_id.isnot(None),
                                 )
                             )
@@ -183,14 +183,14 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                         agent_owners.pop(agent_id, None)
                         await db.execute(
                             update(Agent)
-                            .where(Agent.id == agent_id, Agent.guild_pk == _guild_pk)
+                            .where(Agent.id == agent_id, Agent.guild_id == _guild_pk)
                             .values(state="offline", activity=None, current_task_id=None)
                         )
                     # Mirror into workers table using the real worker IDs.
                     for wid in stale_worker_ids:
                         await db.execute(
                             update(Worker)
-                            .where(Worker.id == wid, Worker.guild_pk == _guild_pk)
+                            .where(Worker.id == wid, Worker.guild_id == _guild_pk)
                             .values(state="offline")
                         )
                     if stale_agents:

--- a/backend/routes/wellknown.py
+++ b/backend/routes/wellknown.py
@@ -85,7 +85,7 @@ async def _get_or_create_guild_key(guild_id: str) -> GuildKey | None:
             return None
 
         row = (
-            await db.execute(select(GuildKey).where(GuildKey.guild_pk == guild_pk))
+            await db.execute(select(GuildKey).where(GuildKey.guild_id == guild_pk))
         ).scalar_one_or_none()
 
         if row:
@@ -99,7 +99,7 @@ async def _get_or_create_guild_key(guild_id: str) -> GuildKey | None:
 
         pub_pem, priv_pem = _generate_ed25519_pems()
         row = GuildKey(
-            guild_pk=guild_pk,
+            guild_id=guild_pk,
             key_id=secrets.token_urlsafe(16),
             public_key_pem=pub_pem,
             private_key_pem=priv_pem,
@@ -155,7 +155,7 @@ async def get_jwks_config(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         row = (
-            await db.execute(select(GuildKey).where(GuildKey.guild_pk == guild_pk))
+            await db.execute(select(GuildKey).where(GuildKey.guild_id == guild_pk))
         ).scalar_one_or_none()
     finally:
         await db.close()
@@ -341,7 +341,7 @@ async def agent_card(request: Request) -> JSONResponse:
                 await db.execute(select(Guild).where(Guild.guild_id == guild_id))
             ).scalar_one_or_none()
             if guild:
-                rows = await db.execute(select(Worker).where(Worker.guild_pk == guild.id))
+                rows = await db.execute(select(Worker).where(Worker.guild_id == guild.id))
                 workers = list(rows.scalars().all())
         finally:
             await db.close()
@@ -371,7 +371,7 @@ async def guild_agent_card(
         ).scalar_one_or_none()
         if not guild:
             raise HTTPException(404, detail="Guild not found")
-        rows = await db.execute(select(Worker).where(Worker.guild_pk == guild.id))
+        rows = await db.execute(select(Worker).where(Worker.guild_id == guild.id))
         workers = list(rows.scalars().all())
     finally:
         await db.close()
@@ -403,7 +403,7 @@ async def set_jwks_config(
             raise HTTPException(404, detail="Guild not found")
 
         row = (
-            await db.execute(select(GuildKey).where(GuildKey.guild_pk == guild_pk))
+            await db.execute(select(GuildKey).where(GuildKey.guild_id == guild_pk))
         ).scalar_one_or_none()
 
         if not row:

--- a/backend/routes/wellknown.py
+++ b/backend/routes/wellknown.py
@@ -409,7 +409,7 @@ async def set_jwks_config(
         if not row:
             pub_pem, priv_pem = _generate_ed25519_pems()
             row = GuildKey(
-                guild_pk=guild_pk,
+                guild_id=guild_pk,
                 key_id=secrets.token_urlsafe(16),
                 public_key_pem=pub_pem,
                 private_key_pem=priv_pem,

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -88,7 +88,7 @@ async def create_worker(guild_id: str, data: WorkerCreate):
         db.add(
             Worker(
                 id=worker_id,
-                guild_pk=guild_pk,
+                guild_id=guild_pk,
                 repos=json.dumps(data.repos),
                 org=data.org,
                 state="offline",
@@ -137,7 +137,7 @@ async def spawn_worker_container(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
-            select(ClaudeCredentials.credentials_blob).where(ClaudeCredentials.guild_pk == guild_pk)
+            select(ClaudeCredentials.credentials_blob).where(ClaudeCredentials.guild_id == guild_pk)
         )
         stored_blob = result.scalar_one_or_none()
     finally:
@@ -217,7 +217,7 @@ async def list_workers(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
-            select(Worker).where(Worker.guild_pk == guild_pk).order_by(Worker.created_at.desc())
+            select(Worker).where(Worker.guild_id == guild_pk).order_by(Worker.created_at.desc())
         )
         return [row_to_dict(w) for w in result.scalars().all()]
     finally:
@@ -241,7 +241,7 @@ async def assign_task(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
         result = await db.execute(
-            select(Worker.id).where(Worker.id == worker_id, Worker.guild_pk == guild_pk)
+            select(Worker.id).where(Worker.id == worker_id, Worker.guild_id == guild_pk)
         )
         if not result.scalar_one_or_none():
             raise HTTPException(status_code=404, detail="Worker not found")
@@ -250,7 +250,7 @@ async def assign_task(
             Task(
                 id=task_id,
                 worker_id=worker_id,
-                guild_pk=guild_pk,
+                guild_id=guild_pk,
                 name=name,
                 description=data.description,
                 tool=data.tool,
@@ -297,7 +297,7 @@ async def list_tasks(guild_id: str, worker_id: str):
             select(Task)
             .where(
                 Task.worker_id == worker_id,
-                Task.guild_pk == guild_pk,
+                Task.guild_id == guild_pk,
                 live_tasks_filter(),
             )
             .order_by(Task.created_at.desc())

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -136,8 +136,8 @@ def insert_guild(
                 (owner_user_id, owner_user_id, owner_user_id, now, now),
             )
             cur.execute(
-                "INSERT INTO guild_members (guild_pk, user_id, role, created_at) "
-                "VALUES (%s, %s, %s, %s) ON CONFLICT (guild_pk, user_id) DO NOTHING",
+                "INSERT INTO guild_members (guild_id, user_id, role, created_at) "
+                "VALUES (%s, %s, %s, %s) ON CONFLICT (guild_id, user_id) DO NOTHING",
                 (guild_pk, owner_user_id, "owner", now),
             )
 
@@ -156,7 +156,7 @@ def insert_member(db_url: str, guild_id: str, user_id: str, role: str = "member"
         guild_pk = row["id"] if row else None
         if guild_pk:
             cur.execute(
-                "INSERT INTO guild_members (guild_pk, user_id, role, created_at) "
-                "VALUES (%s, %s, %s, %s) ON CONFLICT (guild_pk, user_id) DO UPDATE SET role = EXCLUDED.role",
+                "INSERT INTO guild_members (guild_id, user_id, role, created_at) "
+                "VALUES (%s, %s, %s, %s) ON CONFLICT (guild_id, user_id) DO UPDATE SET role = EXCLUDED.role",
                 (guild_pk, user_id, role, now),
             )

--- a/backend/tests/test_agent_state_ws_persistence.py
+++ b/backend/tests/test_agent_state_ws_persistence.py
@@ -73,7 +73,7 @@ def _insert_guild_worker_task(
         )
         guild_pk = cur.fetchone()["id"]
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at)"
+            "INSERT INTO workers (id, guild_id, repos, state, created_at)"
             " VALUES (%s, %s, '[]', 'online', %s)",
             (worker_id, guild_pk, now),
         )
@@ -82,7 +82,7 @@ def _insert_guild_worker_task(
         # these tests the task state is incidental — we're checking the
         # agent-state path, not the task lifecycle.
         cur.execute(
-            "INSERT INTO tasks (id, worker_id, guild_pk, description, tool, state, created_at)"
+            "INSERT INTO tasks (id, worker_id, guild_id, description, tool, state, created_at)"
             " VALUES (%s, %s, %s, %s, %s, %s, %s)",
             (task_id, worker_id, guild_pk, "test task", "claude", "awaiting-review", now),
         )
@@ -279,8 +279,8 @@ def test_guild_get_returns_current_task_id(client):
         cur.execute("SELECT id FROM guilds WHERE guild_id = %s", (guild_id,))
         guild_pk = cur.fetchone()["id"]
         cur.execute(
-            "INSERT INTO guild_members (guild_pk, user_id, role, created_at)"
-            " VALUES (%s, %s, 'member', %s) ON CONFLICT (guild_pk, user_id) DO NOTHING",
+            "INSERT INTO guild_members (guild_id, user_id, role, created_at)"
+            " VALUES (%s, %s, 'member', %s) ON CONFLICT (guild_id, user_id) DO NOTHING",
             (guild_pk, "u-gas4", now),
         )
 

--- a/backend/tests/test_credentials_auth.py
+++ b/backend/tests/test_credentials_auth.py
@@ -32,9 +32,9 @@ def _seed_claude_credentials(db_url: str, guild_id: str, blob: str = "BLOB") -> 
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO claude_credentials (guild_pk, credentials_blob, updated_at) "
+            "INSERT INTO claude_credentials (guild_id, credentials_blob, updated_at) "
             "VALUES (%s, %s, %s) "
-            "ON CONFLICT (guild_pk) DO UPDATE"
+            "ON CONFLICT (guild_id) DO UPDATE"
             " SET credentials_blob = EXCLUDED.credentials_blob,"
             " updated_at = EXCLUDED.updated_at",
             (guild_pk, blob, now),
@@ -154,7 +154,7 @@ def test_post_claude_credentials_accepts_worker_token(client):
     with raw_conn(db_url) as (conn, cur):
         cur.execute(
             "SELECT cc.credentials_blob FROM claude_credentials cc "
-            "JOIN guilds g ON g.id = cc.guild_pk "
+            "JOIN guilds g ON g.id = cc.guild_id "
             "WHERE g.guild_id = %s AND g.deleted_at IS NULL",
             ("g-write",),
         )

--- a/backend/tests/test_disconnect.py
+++ b/backend/tests/test_disconnect.py
@@ -66,7 +66,7 @@ def _setup_guild_and_worker(db_url: str, guild_id: str, worker_id: str) -> None:
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at)"
+            "INSERT INTO workers (id, guild_id, repos, state, created_at)"
             " VALUES (%s, %s, '[]', 'online', %s) ON CONFLICT DO NOTHING",
             (worker_id, guild_pk, now),
         )

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -76,11 +76,11 @@ def _insert_worker(db_url: str, guild_id: str, worker_id: str) -> None:
     with raw_conn(db_url) as (conn, cur):
         cur.execute("SELECT id FROM guilds WHERE guild_id = %s AND deleted_at IS NULL", (guild_id,))
         row = cur.fetchone()
-        guild_pk = row["id"]
+        guild_id = row["id"]
         cur.execute(
             "INSERT INTO workers (id, guild_id, repos, state, created_at) "
             "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
-            (worker_id, guild_pk, "[]", "idle", now),
+            (worker_id, guild_id, "[]", "idle", now),
         )
 
 
@@ -99,16 +99,16 @@ def _insert_task(
     with raw_conn(db_url) as (conn, cur):
         cur.execute("SELECT id FROM guilds WHERE guild_id = %s AND deleted_at IS NULL", (guild_id,))
         row = cur.fetchone()
-        guild_pk = row["id"]
+        guild_id = row["id"]
         cur.execute(
             "INSERT INTO tasks "
-            "(id, worker_id, guild_pk, description, tool, state, phase, created_at, "
+            "(id, worker_id, guild_id, description, tool, state, phase, created_at, "
             " issue_number, issue_repo, branch) "
             "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
             (
                 task_id,
                 worker_id,
-                guild_pk,
+                guild_id,
                 "do the thing",
                 "claude",
                 state,
@@ -133,12 +133,12 @@ def _insert_agent(
     with raw_conn(db_url) as (conn, cur):
         cur.execute("SELECT id FROM guilds WHERE guild_id = %s AND deleted_at IS NULL", (guild_id,))
         row = cur.fetchone()
-        guild_pk = row["id"]
+        guild_id = row["id"]
         cur.execute(
             "INSERT INTO agents "
-            "(id, guild_pk, worker_id, name, type, state, joined_at) "
+            "(id, guild_id, worker_id, name, type, state, joined_at) "
             "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
-            (agent_id, guild_pk, worker_id, agent_id.upper(), "worker", state, now),
+            (agent_id, guild_id, worker_id, agent_id.upper(), "worker", state, now),
         )
 
 
@@ -226,11 +226,11 @@ def _insert_worker_with_state(db_url: str, guild_id: str, worker_id: str, state:
     with raw_conn(db_url) as (conn, cur):
         cur.execute("SELECT id FROM guilds WHERE guild_id = %s AND deleted_at IS NULL", (guild_id,))
         row = cur.fetchone()
-        guild_pk = row["id"]
+        guild_id = row["id"]
         cur.execute(
             "INSERT INTO workers (id, guild_id, repos, state, created_at) "
             "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
-            (worker_id, guild_pk, "[]", state, now),
+            (worker_id, guild_id, "[]", state, now),
         )
 
 

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -78,7 +78,7 @@ def _insert_worker(db_url: str, guild_id: str, worker_id: str) -> None:
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at) "
+            "INSERT INTO workers (id, guild_id, repos, state, created_at) "
             "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
             (worker_id, guild_pk, "[]", "idle", now),
         )
@@ -228,7 +228,7 @@ def _insert_worker_with_state(db_url: str, guild_id: str, worker_id: str, state:
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at) "
+            "INSERT INTO workers (id, guild_id, repos, state, created_at) "
             "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
             (worker_id, guild_pk, "[]", state, now),
         )

--- a/backend/tests/test_foreman_context_api.py
+++ b/backend/tests/test_foreman_context_api.py
@@ -19,7 +19,7 @@ def _insert_foreman_turn(db_url: str, guild_id: str, user_id: str, role: str, co
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO foreman_turns (guild_pk, user_id, role, content_json, is_tool_response, created_at) "
+            "INSERT INTO foreman_turns (guild_id, user_id, role, content_json, is_tool_response, created_at) "
             "VALUES (%s, %s, %s, %s, %s, %s)",
             (guild_pk, user_id, role, f'"{content}"', 0, now),
         )

--- a/backend/tests/test_github_webhooks.py
+++ b/backend/tests/test_github_webhooks.py
@@ -37,12 +37,12 @@ def _insert_task(
         guild_pk = row["id"]
         # Workers FK is NOT NULL; insert a placeholder worker row first.
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at) "
+            "INSERT INTO workers (id, guild_id, repos, state, created_at) "
             "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
             (f"w-{task_id}", guild_pk, "[]", "online", now),
         )
         cur.execute(
-            "INSERT INTO tasks (id, worker_id, guild_pk, description, tool, state, "
+            "INSERT INTO tasks (id, worker_id, guild_id, description, tool, state, "
             "pr_url, pr_number, pr_repo, created_at) "
             "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
             (

--- a/backend/tests/test_github_webhooks.py
+++ b/backend/tests/test_github_webhooks.py
@@ -34,12 +34,12 @@ def _insert_task(
     with raw_conn(db_url) as (conn, cur):
         cur.execute("SELECT id FROM guilds WHERE guild_id = %s AND deleted_at IS NULL", (guild_id,))
         row = cur.fetchone()
-        guild_pk = row["id"]
+        guild_id = row["id"]
         # Workers FK is NOT NULL; insert a placeholder worker row first.
         cur.execute(
             "INSERT INTO workers (id, guild_id, repos, state, created_at) "
             "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
-            (f"w-{task_id}", guild_pk, "[]", "online", now),
+            (f"w-{task_id}", guild_id, "[]", "online", now),
         )
         cur.execute(
             "INSERT INTO tasks (id, worker_id, guild_id, description, tool, state, "
@@ -48,7 +48,7 @@ def _insert_task(
             (
                 task_id,
                 f"w-{task_id}",
-                guild_pk,
+                guild_id,
                 "test task",
                 "claude",
                 "awaiting-review",
@@ -169,7 +169,7 @@ def test_webhook_accepts_ping(client):
     with raw_conn(db_url) as (conn, cur):
         cur.execute(
             "SELECT COUNT(*) FROM github_events"
-            " WHERE guild_pk = (SELECT id FROM guilds WHERE guild_id = 'g4' AND deleted_at IS NULL)"
+            " WHERE guild_id = (SELECT id FROM guilds WHERE guild_id = 'g4' AND deleted_at IS NULL)"
         )
         rows = cur.fetchone()
     assert rows["count"] == 0
@@ -323,7 +323,7 @@ def test_webhook_emits_foreman_chat_message(client):
     with raw_conn(db_url) as (conn, cur):
         cur.execute(
             "SELECT from_agent, to_agent, content, message_type FROM messages"
-            " WHERE guild_pk = (SELECT id FROM guilds WHERE guild_id = 'gchat1' AND deleted_at IS NULL)"
+            " WHERE guild_id = (SELECT id FROM guilds WHERE guild_id = 'gchat1' AND deleted_at IS NULL)"
         )
         row = cur.fetchone()
     assert row is not None
@@ -357,7 +357,7 @@ def test_webhook_chat_line_includes_merged_status(client):
     with raw_conn(db_url) as (conn, cur):
         cur.execute(
             "SELECT content FROM messages"
-            " WHERE guild_pk = (SELECT id FROM guilds WHERE guild_id = 'gchat2' AND deleted_at IS NULL)"
+            " WHERE guild_id = (SELECT id FROM guilds WHERE guild_id = 'gchat2' AND deleted_at IS NULL)"
         )
         row = cur.fetchone()
     assert row is not None
@@ -377,7 +377,7 @@ def test_webhook_chat_line_not_emitted_for_duplicate(client):
     with raw_conn(db_url) as (conn, cur):
         cur.execute(
             "SELECT COUNT(*) FROM messages"
-            " WHERE guild_pk = (SELECT id FROM guilds WHERE guild_id = 'gchat3' AND deleted_at IS NULL)"
+            " WHERE guild_id = (SELECT id FROM guilds WHERE guild_id = 'gchat3' AND deleted_at IS NULL)"
         )
         count = cur.fetchone()["count"]
     assert count == 1  # second delivery is a duplicate; no second message

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -67,12 +67,12 @@ def _insert_task(
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at) "
+            "INSERT INTO workers (id, guild_id, repos, state, created_at) "
             "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
             (f"w-{task_id}", guild_pk, "[]", "online", now),
         )
         cur.execute(
-            "INSERT INTO tasks (id, worker_id, guild_pk, description, tool, state, "
+            "INSERT INTO tasks (id, worker_id, guild_id, description, tool, state, "
             "pr_url, pr_number, pr_repo, user_id, created_at) "
             "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
             (

--- a/backend/tests/test_liveness.py
+++ b/backend/tests/test_liveness.py
@@ -68,7 +68,7 @@ def _setup_guild_and_worker(db_url: str, guild_id: str, worker_id: str) -> None:
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at)"
+            "INSERT INTO workers (id, guild_id, repos, state, created_at)"
             " VALUES (%s, %s, '[]', 'online', %s) ON CONFLICT DO NOTHING",
             (worker_id, guild_pk, now),
         )
@@ -206,7 +206,7 @@ def test_stale_sweeper_marks_silent_workers_offline(client, monkeypatch):
         guild_pk = row["id"]
         cur.execute(
             "INSERT INTO agents "
-            "(id, guild_pk, worker_id, name, type, state, joined_at, last_seen) "
+            "(id, guild_id, worker_id, name, type, state, joined_at, last_seen) "
             "VALUES (%s, %s, %s, 'Test', 'worker', 'idle', %s, %s)",
             (agent_id, guild_pk, worker_id, now, now),
         )
@@ -279,7 +279,7 @@ def test_sweeper_marks_zombie_worker_offline_when_agents_already_offline(client,
         # the buggy WS close handler ran: agent marked offline, worker not.
         cur.execute(
             "INSERT INTO agents "
-            "(id, guild_pk, worker_id, name, type, state, joined_at, last_seen) "
+            "(id, guild_id, worker_id, name, type, state, joined_at, last_seen) "
             "VALUES (%s, %s, %s, 'Test', 'worker', 'offline', %s, %s)",
             (agent_id, guild_pk, worker_id, now, old),
         )
@@ -322,7 +322,7 @@ def test_sweeper_skips_fresh_workers(client):
         guild_pk = row["id"]
         cur.execute(
             "INSERT INTO agents "
-            "(id, guild_pk, worker_id, name, type, state, joined_at, last_seen) "
+            "(id, guild_id, worker_id, name, type, state, joined_at, last_seen) "
             "VALUES (%s, %s, %s, 'Test', 'worker', 'idle', %s, %s)",
             (agent_id, guild_pk, worker_id, now, now),
         )
@@ -367,7 +367,7 @@ def test_stale_task_watchdog_releases_lock_when_agent_goes_idle(client, monkeypa
         # Task stuck in "working".
         cur.execute(
             "INSERT INTO tasks "
-            "(id, worker_id, guild_pk, description, tool, state, created_at)"
+            "(id, worker_id, guild_id, description, tool, state, created_at)"
             " VALUES (%s, %s, %s, 'stuck task', 'claude', 'working', %s)"
             " ON CONFLICT DO NOTHING",
             (task_id, worker_id, guild_pk, now),
@@ -375,7 +375,7 @@ def test_stale_task_watchdog_releases_lock_when_agent_goes_idle(client, monkeypa
         # Agent is idle (finished), not actively running anything.
         cur.execute(
             "INSERT INTO agents "
-            "(id, guild_pk, worker_id, name, type, state, joined_at, last_seen, current_task_id)"
+            "(id, guild_id, worker_id, name, type, state, joined_at, last_seen, current_task_id)"
             " VALUES (%s, %s, %s, 'Test', 'worker', 'idle', %s, %s, NULL)"
             " ON CONFLICT DO NOTHING",
             (agent_id, guild_pk, worker_id, now, now),

--- a/backend/tests/test_pr_url_ws_persistence.py
+++ b/backend/tests/test_pr_url_ws_persistence.py
@@ -75,14 +75,14 @@ def _insert_guild_worker_task(
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at)"
+            "INSERT INTO workers (id, guild_id, repos, state, created_at)"
             " VALUES (%s, %s, '[]', 'online', %s) ON CONFLICT DO NOTHING",
             (worker_id, guild_pk, now),
         )
         # Use "awaiting-review" so the join handler does not replay the task as
         # task-assigned (it only replays "pending" and "working" tasks).
         cur.execute(
-            "INSERT INTO tasks (id, worker_id, guild_pk, description, tool, state, created_at)"
+            "INSERT INTO tasks (id, worker_id, guild_id, description, tool, state, created_at)"
             " VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
             (task_id, worker_id, guild_pk, "test task", "claude", "awaiting-review", now),
         )

--- a/backend/tests/test_terminal_output_ws_routing.py
+++ b/backend/tests/test_terminal_output_ws_routing.py
@@ -61,7 +61,7 @@ def _insert_guild_worker(db_url: str, *, guild_id: str, worker_id: str) -> None:
         row = cur.fetchone()
         guild_pk = row["id"]
         cur.execute(
-            "INSERT INTO workers (id, guild_pk, repos, state, created_at)"
+            "INSERT INTO workers (id, guild_id, repos, state, created_at)"
             " VALUES (%s, %s, '[]', 'online', %s) ON CONFLICT DO NOTHING",
             (worker_id, guild_pk, now),
         )

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -49,7 +49,7 @@ def test_create_worker_appears_in_list(client):
     assert resp.status_code == 200
     workers = resp.json()
     assert len(workers) == 1
-    assert isinstance(workers[0]["guild_pk"], int)
+    assert isinstance(workers[0]["guild_id"], int)
 
 
 def test_create_worker_does_not_insert_agent_row(client):

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -214,7 +214,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     joined_at = datetime.now(UTC).isoformat()
     stmt = pg_insert(Agent).values(
         id=agent_id,
-        guild_pk=ctx.guild_pk,
+        guild_id=ctx.guild_pk,
         worker_id=worker_id,
         name=agent_name,
         type=agent_type,
@@ -226,7 +226,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     stmt = stmt.on_conflict_do_update(
         index_elements=["id"],
         set_={
-            "guild_pk": stmt.excluded.guild_pk,
+            "guild_id": stmt.excluded.guild_id,
             "worker_id": stmt.excluded.worker_id,
             "name": stmt.excluded.name,
             "type": stmt.excluded.type,
@@ -240,7 +240,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     if agent_type == "worker" and worker_id:
         await ctx.db.execute(
             update(Worker)
-            .where(Worker.id == worker_id, Worker.guild_pk == ctx.guild_pk)
+            .where(Worker.id == worker_id, Worker.guild_id == ctx.guild_pk)
             .values(state="online", last_seen=joined_at)
         )
     await ctx.db.commit()
@@ -298,7 +298,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         if worker_id:
             result = await ctx.db.execute(
                 select(Task).where(
-                    Task.guild_pk == ctx.guild_pk,
+                    Task.guild_id == ctx.guild_pk,
                     Task.worker_id == worker_id,
                     Task.state.in_(["pending", "working"]),
                 )
@@ -333,7 +333,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     }
     if worker_id:
         r = await ctx.db.execute(
-            select(Worker.name).where(Worker.id == worker_id, Worker.guild_pk == ctx.guild_pk)
+            select(Worker.name).where(Worker.id == worker_id, Worker.guild_id == ctx.guild_pk)
         )
         stored_name = r.scalar_one_or_none()
         broadcast_payload["workerName"] = stored_name or worker_display_name(worker_id)
@@ -377,7 +377,7 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
     if state in _LOCK_RELEASE_AGENT_STATES and agent_id:
         row = await ctx.db.execute(
             select(Agent.current_task_id, Agent.worker_id).where(
-                Agent.id == agent_id, Agent.guild_pk == ctx.guild_pk
+                Agent.id == agent_id, Agent.guild_id == ctx.guild_pk
             )
         )
         agent_row = row.one_or_none()
@@ -387,7 +387,7 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
 
     await ctx.db.execute(
         update(Agent)
-        .where(Agent.id == agent_id, Agent.guild_pk == ctx.guild_pk)
+        .where(Agent.id == agent_id, Agent.guild_id == ctx.guild_pk)
         .values(**update_vals)
     )
 
@@ -433,7 +433,7 @@ async def handle_chat(ctx: WSContext, data: dict) -> None:
     created_at = datetime.now(UTC).isoformat()
     ctx.db.add(
         Message(
-            guild_pk=ctx.guild_pk,
+            guild_id=ctx.guild_pk,
             from_agent=from_agent,
             to_agent=to_agent,
             content=content,
@@ -536,7 +536,7 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
             update_vals["user_id"] = resolved
     await ctx.db.execute(
         update(Worker)
-        .where(Worker.id == worker_id, Worker.guild_pk == ctx.guild_pk)
+        .where(Worker.id == worker_id, Worker.guild_id == ctx.guild_pk)
         .values(**update_vals)
     )
     await ctx.db.commit()
@@ -547,13 +547,13 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
     for agent_id in ctx.joined_agents:
         await ctx.db.execute(
             update(Agent)
-            .where(Agent.id == agent_id, Agent.guild_pk == ctx.guild_pk)
+            .where(Agent.id == agent_id, Agent.guild_id == ctx.guild_pk)
             .values(state="offline", activity=None, current_task_id=None)
         )
     if worker_id:
         await ctx.db.execute(
             update(Worker)
-            .where(Worker.id == worker_id, Worker.guild_pk == ctx.guild_pk)
+            .where(Worker.id == worker_id, Worker.guild_id == ctx.guild_pk)
             .values(state="offline")
         )
     if ctx.joined_agents or worker_id:


### PR DESCRIPTION
## Summary

- Replaces all `DeclarativeBase`/`Column(...)` model definitions with `SQLModel` table classes using `Field(...)`
- Renames the `guild_pk` FK column to `guild_id` across all child tables via Alembic migration `20260520_000004`
- Fixes all `Model.guild_pk` ORM field accesses → `Model.guild_id` throughout routes, foreman, ws_handlers, and agent_runner
- Fixes all model instantiation kwargs (`guild_pk=value` → `guild_id=value`)
- Updates raw SQL strings in foreman context queries to use the renamed column
- Fixes raw SQL INSERT column names in all 10 affected test files

## Test plan

- [ ] Models import cleanly (`python -c "from models import *"` → OK)
- [ ] `ruff check . --fix && ruff format .` passes with zero remaining errors
- [ ] All existing backend tests pass against a PostgreSQL test DB (`pytest backend/`)
- [ ] `alembic upgrade head` runs without errors on a fresh DB
- [ ] No `DeclarativeBase` or bare `Column(...)` imports remain in model files
- [ ] Zero `guild_pk` SQL column references remain (only Python local variable names)

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)