### PR TITLE
Patrol robots around the tables with directional lean

### DIFF
--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -3,7 +3,7 @@
     <!-- Pixel-art workshop. The stage keeps the image's aspect ratio and is
          centred; everything inside is positioned as a fraction of it. -->
     <div class="floor-stage" :style="stageStyle">
-      <!-- Coordinate-tuning overlay: walkable polygon + points of interest. -->
+      <!-- Coordinate-tuning overlay: walkable polygon, patrol loop, POIs. -->
       <svg
         v-if="SHOW_FLOOR_DEBUG"
         class="floor-debug"
@@ -11,6 +11,7 @@
         preserveAspectRatio="none"
       >
         <polygon :points="debugPolygon" />
+        <polyline class="patrol" :points="debugPatrol" />
         <circle
           v-for="p in POINTS_OF_INTEREST"
           :key="p.id"
@@ -40,8 +41,8 @@
         </div>
       </div>
 
-      <!-- Agents — walk to their task station, or drift between the
-           points of interest when idle. -->
+      <!-- Agents — walk to their task station, or patrol the loop around
+           the tables when idle, leaning into their direction of travel. -->
       <div
         v-for="agent in agents"
         :key="agent.id"
@@ -50,7 +51,9 @@
           agentPos(agent.id).y * 100
         }%; z-index: ${zIndex(agentPos(agent.id).y)}`"
       >
-        <AgentAvatar :agent="agent" :walking="isWalking(agent.id)" />
+        <div class="agent-tilt" :style="`transform: rotate(${agentTilt(agent.id)}deg)`">
+          <AgentAvatar :agent="agent" :walking="isWalking(agent.id)" />
+        </div>
         <div class="agent-nametag">{{ agent.name }}</div>
       </div>
     </div>
@@ -98,6 +101,13 @@ const STATION_POSITIONS = layout.stationSlots as [number, number][]
 const GRAVITATE_RADIUS = layout.gravitateRadius
 const MAX_STATIONS = STATION_POSITIONS.length
 
+// Ordered loop of waypoints that hugs the open floor around the two tables.
+// Idle robots step along it (bouncing at the ends) so they circle the tables
+// rather than standing on them.
+const PATROL_PATH = layout.patrolPath as [number, number][]
+const PATROL_JITTER = layout.patrolJitter
+const MAX_TILT = 9
+
 const FLOOR_BBOX = {
   minX: Math.min(...FLOOR_POLYGON.map((p) => p[0])),
   maxX: Math.max(...FLOOR_POLYGON.map((p) => p[0])),
@@ -106,6 +116,7 @@ const FLOOR_BBOX = {
 }
 
 const debugPolygon = FLOOR_POLYGON.map(([x, y]) => `${x * 100},${y * 100}`).join(' ')
+const debugPatrol = PATROL_PATH.map(([x, y]) => `${x * 100},${y * 100}`).join(' ')
 
 function pointInFloor(x: number, y: number) {
   let inside = false
@@ -170,10 +181,16 @@ const activeStations = computed<Station[]>(() =>
 
 // ─── Agent positions ───────────────────────────────────────────────────────
 // Positions are fractions of the stage. `walking` is set briefly while an
-// agent moves so RobotWorker runs its walk animation.
+// agent moves so RobotWorker runs its walk animation. `tilt` is a small lean
+// in the agent's current direction of travel.
 const agentPositions = reactive<Record<string, { x: number; y: number }>>({})
 const walking = reactive<Record<string, boolean>>({})
+const tilt = reactive<Record<string, number>>({})
 const walkTimers: Record<string, ReturnType<typeof setTimeout>> = {}
+
+// Each patrolling agent tracks where it is on PATROL_PATH and which way it
+// is heading; it reverses at the ends so the loop never teleports.
+const patrolState = reactive<Record<string, { idx: number; dir: number }>>({})
 
 function agentPos(agentId: string) {
   return agentPositions[agentId] || { x: 0.4, y: 0.64 }
@@ -183,8 +200,33 @@ function isWalking(agentId: string) {
   return !!walking[agentId]
 }
 
+function agentTilt(agentId: string) {
+  return tilt[agentId] || 0
+}
+
 function zIndex(y: number) {
   return Math.round(y * 1000)
+}
+
+function patrolStep(agentId: string) {
+  let st = patrolState[agentId]
+  if (!st) {
+    st = {
+      idx: Math.floor(Math.random() * PATROL_PATH.length),
+      dir: Math.random() < 0.5 ? 1 : -1,
+    }
+    patrolState[agentId] = st
+  }
+  st.idx += st.dir
+  if (st.idx > PATROL_PATH.length - 1) {
+    st.dir = -1
+    st.idx = PATROL_PATH.length - 2
+  } else if (st.idx < 0) {
+    st.dir = 1
+    st.idx = 1
+  }
+  const [x, y] = PATROL_PATH[st.idx]
+  return jitterAround({ x, y }, PATROL_JITTER)
 }
 
 function jitterAround(p: { x: number; y: number }, radius = GRAVITATE_RADIUS) {
@@ -223,6 +265,16 @@ function isAgentAtWork(agent: Agent) {
 function moveTo(agentId: string, pos: { x: number; y: number }) {
   const cur = agentPositions[agentId]
   if (cur && cur.x === pos.x && cur.y === pos.y) return
+  if (cur) {
+    // Lean into the direction of travel, measured in screen pixels so the
+    // stage's portrait aspect ratio doesn't skew the angle.
+    const dx = (pos.x - cur.x) * (stage.w || STAGE_RATIO)
+    const dy = (pos.y - cur.y) * (stage.h || 1)
+    const dist = Math.hypot(dx, dy)
+    if (dist > 0) {
+      tilt[agentId] = Math.max(-MAX_TILT, Math.min(MAX_TILT, (dx / dist) * MAX_TILT))
+    }
+  }
   agentPositions[agentId] = pos
   walking[agentId] = true
   clearTimeout(walkTimers[agentId])
@@ -237,7 +289,7 @@ function syncPositions() {
       const station = stationForAgent(agent)!
       moveTo(agent.id, { x: station.x, y: station.y + 0.07 })
     } else if (!agentPositions[agent.id]) {
-      agentPositions[agent.id] = poiTarget()
+      agentPositions[agent.id] = patrolStep(agent.id)
     }
   })
 }
@@ -251,8 +303,11 @@ function tickWalk() {
   if (idle.length === 0) return
   const agent = idle[walkIdx % idle.length]
   walkIdx++
-  // Mostly drift toward a point of interest; occasionally roam open floor.
-  moveTo(agent.id, Math.random() < 0.8 ? poiTarget() : randomFloorPos())
+  // Mostly patrol the loop around the tables; occasionally drift to a
+  // wall feature or roam the open floor.
+  const roll = Math.random()
+  const target = roll < 0.85 ? patrolStep(agent.id) : roll < 0.95 ? poiTarget() : randomFloorPos()
+  moveTo(agent.id, target)
 }
 
 onMounted(() => {
@@ -340,6 +395,12 @@ function stateLabel(state: string) {
 }
 .floor-debug circle {
   fill: rgba(255, 60, 60, 0.95);
+}
+.floor-debug polyline.patrol {
+  fill: none;
+  stroke: rgba(120, 190, 255, 0.95);
+  stroke-width: 0.6;
+  stroke-dasharray: 1.4 1;
 }
 
 /* ── Work stations ───────────────────────────────────────────────────────── */
@@ -474,6 +535,12 @@ function stateLabel(state: string) {
 .floating-agent :deep(.robot-sprite) {
   width: 9cqw;
   height: auto;
+}
+.agent-tilt {
+  display: flex;
+  justify-content: center;
+  transform-origin: 50% 88%;
+  transition: transform 1.2s ease-in-out;
 }
 .agent-nametag {
   font-size: 1.7cqw;

--- a/frontend/src/components/factory-layout.json
+++ b/frontend/src/components/factory-layout.json
@@ -5,6 +5,7 @@
     "height": 1152
   },
   "gravitateRadius": 0.05,
+  "patrolJitter": 0.022,
   "walkableFloor": [
     [0.14, 0.54],
     [0.42, 0.45],
@@ -20,6 +21,16 @@
     { "id": "table-b", "label": "Workbench B", "x": 0.49, "y": 0.77 },
     { "id": "bulletin", "label": "Bulletin Board", "x": 0.6, "y": 0.5 },
     { "id": "coffee", "label": "Coffee Pot", "x": 0.64, "y": 0.58 }
+  ],
+  "patrolPath": [
+    [0.17, 0.57],
+    [0.21, 0.67],
+    [0.31, 0.76],
+    [0.42, 0.81],
+    [0.52, 0.78],
+    [0.59, 0.69],
+    [0.61, 0.57],
+    [0.55, 0.5]
   ],
   "stationSlots": [
     [0.31, 0.6],

--- a/frontend/src/components/sprites/RobotWorker.vue
+++ b/frontend/src/components/sprites/RobotWorker.vue
@@ -4,6 +4,7 @@
     viewBox="0 0 40 56"
     xmlns="http://www.w3.org/2000/svg"
     overflow="visible"
+    shape-rendering="crispEdges"
   >
     <!-- HEAD GROUP — tilt/shake animations target this whole group -->
     <g class="head-group">
@@ -94,7 +95,7 @@
       rx="0"
       fill="rgba(0,0,0,0.35)"
       stroke="var(--agent-color)"
-      stroke-width="0.5"
+      stroke-width="1"
     />
 
     <!-- Left arm -->

--- a/scripts/preview_factory_layout.py
+++ b/scripts/preview_factory_layout.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Overlay the factory-floor layout on the background image for tuning.
 
-The walkable polygon, points of interest (with their gravitation boxes) and
-work-station slots all come from
-``frontend/src/components/factory-layout.json`` — the same file FactoryFloor.vue
-reads — so editing that JSON and re-running this script previews exactly what
-the app will render.
+The walkable polygon, patrol loop, points of interest and work-station slots
+all come from ``frontend/src/components/factory-layout.json`` — the same file
+FactoryFloor.vue reads — so editing that JSON and re-running this script
+previews exactly what the app will render.
 
 Usage:
     pip install Pillow
@@ -18,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import random
 import sys
 from pathlib import Path
@@ -42,24 +42,20 @@ PALETTE = [
     (238, 119, 34),
     (255, 204, 0),
 ]
+MAX_TILT = 9.0
 
 
-def draw_robot(d: ImageDraw.ImageDraw, cx: float, cy: float, h: float, color):
-    """Draw a simple robot with its feet anchored at (cx, cy)."""
+def robot_shape(d: ImageDraw.ImageDraw, cx: float, cy: float, h: float, color):
+    """Draw a chunky robot with its feet anchored at (cx, cy)."""
     hw = h * 0.42
     top = cy - h
     d.rectangle([cx - hw * 0.5, cy - h * 0.32, cx - hw * 0.08, cy], fill=color)
     d.rectangle([cx + hw * 0.08, cy - h * 0.32, cx + hw * 0.5, cy], fill=color)
-    d.rounded_rectangle(
-        [cx - hw, cy - h * 0.62, cx + hw, cy - h * 0.30],
-        5,
-        fill=(20, 12, 4),
-        outline=color,
-        width=3,
+    d.rectangle(
+        [cx - hw, cy - h * 0.62, cx + hw, cy - h * 0.30], fill=(20, 12, 4), outline=color, width=3
     )
-    d.rounded_rectangle(
+    d.rectangle(
         [cx - hw * 0.78, top, cx + hw * 0.78, cy - h * 0.62],
-        4,
         fill=(20, 12, 4),
         outline=color,
         width=3,
@@ -70,6 +66,16 @@ def draw_robot(d: ImageDraw.ImageDraw, cx: float, cy: float, h: float, color):
     d.rectangle(
         [cx + hw * 0.15, top + h * 0.10, cx + hw * 0.5, top + h * 0.21], fill=(255, 232, 192)
     )
+
+
+def draw_robot(im: Image.Image, cx: float, cy: float, h: float, color, tilt: float = 0.0):
+    """Composite a robot, leaning `tilt` degrees into its direction of travel."""
+    pad = int(h)
+    layer = Image.new("RGBA", (pad * 2, pad + int(h) + 4), (0, 0, 0, 0))
+    robot_shape(ImageDraw.Draw(layer), pad, pad + int(h), h, color)
+    if tilt:
+        layer = layer.rotate(-tilt, center=(pad, pad + int(h)), resample=Image.NEAREST)
+    im.paste(layer, (int(cx - pad), int(cy - pad - h)), layer)
 
 
 def draw_station(d: ImageDraw.ImageDraw, cx: float, cy: float, s: float):
@@ -85,6 +91,19 @@ def draw_station(d: ImageDraw.ImageDraw, cx: float, cy: float, s: float):
     for k, c in enumerate(bars):
         y = cy - s * 0.58 + k * s * 0.25
         d.rectangle([cx - s * 0.74, y, cx + s * 0.74, y + s * 0.12], fill=c)
+
+
+def draw_arrow(d: ImageDraw.ImageDraw, p0, p1, color, width=3):
+    """Draw a line from p0 to p1 with a direction arrowhead at its midpoint."""
+    d.line([p0, p1], fill=color, width=width)
+    ang = math.atan2(p1[1] - p0[1], p1[0] - p0[0])
+    mx, my = (p0[0] + p1[0]) / 2, (p0[1] + p1[1]) / 2
+    for off in (2.6, -2.6):
+        d.line(
+            [(mx, my), (mx + 13 * math.cos(ang + off), my + 13 * math.sin(ang + off))],
+            fill=color,
+            width=width,
+        )
 
 
 def label(d: ImageDraw.ImageDraw, x: float, y: float, text: str, color):
@@ -105,7 +124,7 @@ def main() -> None:
         "--scale", type=float, default=1.0, help="upscale the output image (default: 1.0)"
     )
     ap.add_argument(
-        "--robots", type=int, default=0, help="scatter N sample idle robots across the POIs"
+        "--robots", type=int, default=0, help="scatter N sample robots around the patrol loop"
     )
     args = ap.parse_args()
 
@@ -120,7 +139,9 @@ def main() -> None:
     floor = layout["walkableFloor"]
     pois = layout["pointsOfInterest"]
     slots = layout["stationSlots"]
+    patrol = layout["patrolPath"]
     radius = layout["gravitateRadius"]
+    pjit = layout["patrolJitter"]
 
     # Walkable polygon — robots stay inside this.
     pts = [(fx * W, fy * H) for fx, fy in floor]
@@ -128,6 +149,14 @@ def main() -> None:
     for i, (px, py) in enumerate(pts):
         d.ellipse([px - 6, py - 6, px + 6, py + 6], fill=(0, 255, 130, 255))
         label(d, px + 9, py - 7, f"v{i} ({floor[i][0]:.2f},{floor[i][1]:.2f})", (0, 255, 130))
+
+    # Patrol loop — idle robots step along this, bouncing at the ends.
+    pp = [(fx * W, fy * H) for fx, fy in patrol]
+    for a, b in zip(pp, pp[1:], strict=False):
+        draw_arrow(d, a, b, (120, 190, 255, 235))
+    for i, (px, py) in enumerate(pp):
+        d.ellipse([px - 7, py - 7, px + 7, py + 7], fill=(120, 190, 255, 255))
+        label(d, px + 10, py - 7, f"p{i} ({patrol[i][0]:.2f},{patrol[i][1]:.2f})", (170, 215, 255))
 
     # Work-station slots.
     for i, (fx, fy) in enumerate(slots):
@@ -145,13 +174,20 @@ def main() -> None:
             d, cx + 11, cy - 8, f"{poi['label']} ({poi['x']:.2f},{poi['y']:.2f})", (255, 220, 120)
         )
 
-    # Optional sample robots, gravitating to a random POI like idle agents do.
+    # Sample robots spread around the patrol loop, leaning into their heading.
     rng = random.Random(7)
     for n in range(args.robots):
-        poi = pois[n % len(pois)]
-        fx = poi["x"] + (rng.random() - 0.5) * 2 * radius
-        fy = poi["y"] + (rng.random() - 0.5) * 2 * radius
-        draw_robot(d, fx * W, fy * H, H * 0.07, PALETTE[n % len(PALETTE)])
+        seg = n * (len(patrol) - 1) / max(1, args.robots)
+        i0 = int(seg)
+        i1 = min(i0 + 1, len(patrol) - 1)
+        f = seg - i0
+        fx = patrol[i0][0] * (1 - f) + patrol[i1][0] * f + (rng.random() - 0.5) * 2 * pjit
+        fy = patrol[i0][1] * (1 - f) + patrol[i1][1] * f + (rng.random() - 0.5) * 2 * pjit
+        dx = (patrol[i1][0] - patrol[i0][0]) * W
+        dy = (patrol[i1][1] - patrol[i0][1]) * H
+        dist = math.hypot(dx, dy) or 1.0
+        tilt = max(-MAX_TILT, min(MAX_TILT, dx / dist * MAX_TILT))
+        draw_robot(im, fx * W, fy * H, H * 0.07, PALETTE[n % len(PALETTE)], tilt)
 
     out = Path(args.out)
     im.save(out)
@@ -160,11 +196,10 @@ def main() -> None:
         f"image   : {img_path.relative_to(REPO)} ({layout['image']['width']}x"
         f"{layout['image']['height']})"
     )
-    print(f"polygon : {len(floor)} vertices, gravitate radius {radius}")
+    print(f"polygon : {len(floor)} vertices")
+    print(f"patrol  : {len(patrol)} waypoints, jitter {pjit}")
     for poi in pois:
         print(f"  POI   {poi['id']:<9} ({poi['x']:.2f}, {poi['y']:.2f})  {poi['label']}")
-    for i, (fx, fy) in enumerate(slots):
-        print(f"  slot {i}          ({fx:.2f}, {fy:.2f})")
     print(f"wrote   : {out}")
 
 


### PR DESCRIPTION
## Summary

Follow-up to #427 (merged). Refines how robots move on the pixel-art factory floor.

- **Patrol around the tables** — replaces POI-gravitation with a `patrolPath`: an ordered loop of waypoints hugging the open floor *around* the two tables. Idle robots step waypoint-to-waypoint and bounce back at the ends, so they circle the tables instead of standing on them. ~10% of the time they still drift to a wall feature (bulletin board / coffee pot) or roam the open floor.
- **Walking directions & angles** — each move computes a lean from the travel vector (measured in screen pixels so the portrait stage doesn't skew the angle). The robot tilts up to ±9° into its heading via a new `.agent-tilt` wrapper, easing over 1.2s.
- **More pixelated sprite** — `RobotWorker.vue` renders with `shape-rendering="crispEdges"`, so edges and rounded corners come out hard / stair-stepped instead of anti-aliased. The thinnest stroke was bumped so it survives crisp rendering.
- **Tooling** — `patrolPath` and `patrolJitter` added to `factory-layout.json` (the shared source of truth). `scripts/preview_factory_layout.py` now draws the patrol loop as a direction-arrowed dashed line and places sample robots along it, leaning into their heading. The in-app `SHOW_FLOOR_DEBUG` overlay draws the loop too.

## Test plan

- [x] `npm run type-check`, `npm run lint`, `npm run build` pass
- [x] `ruff check` passes on the updated script
- [x] `python scripts/preview_factory_layout.py --robots 7` renders the patrol loop + leaning robots circling the tables
- [ ] Verify in a running app that idle robots patrol around the tables and lean while walking (no browser available in the authoring environment)

https://claude.ai/code/session_01BqsrYDhGtHRzju4FQYoD8f

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqsrYDhGtHRzju4FQYoD8f)_