### PR TITLE
foreman: add own requirements, pyproject.toml, and Bedrock support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,27 @@ foreman and takes over trigger handling for a specific guild, allowing independe
 scaling and model changes without restarting the backend.
 
 ```bash
-# Requires backend + ANTHROPIC_API_KEY
-# Install backend deps (foreman/main.py imports backend modules directly):
-cd backend && pip install -r requirements.txt && cd ..
+cd foreman
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+# Bedrock support (optional): pip install "anthropic[bedrock]"
 
+# foreman/main.py imports backend/ modules directly, so the backend source
+# must be on the path.  Set DATABASE_URL to the same DB the backend uses.
+DATABASE_URL=sqlite+aiosqlite:///path/to/pioneer_square.db \
 BACKEND_WS_URL=ws://localhost:8000 \
 GUILD_ID=<your-6-char-guild-id> \
 ANTHROPIC_API_KEY=<key> \
-python foreman/main.py
+python main.py
+
+# Amazon Bedrock instead of Anthropic API:
+DATABASE_URL=sqlite+aiosqlite:///... \
+BACKEND_WS_URL=ws://localhost:8000 \
+GUILD_ID=<your-6-char-guild-id> \
+FOREMAN_PROVIDER=bedrock \
+AWS_DEFAULT_REGION=us-east-1 \
+FOREMAN_MODEL=us.anthropic.claude-sonnet-4-5-20251001-v2:0 \
+python main.py
 
 # Or via docker compose (profile "foreman"):
 GUILD_ID=abc123 docker compose --profile foreman up --build foreman

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -27,6 +27,15 @@ logger = logging.getLogger(__name__)
 
 FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 
+# Set FOREMAN_PROVIDER=bedrock to use Amazon Bedrock instead of the Anthropic API.
+# Requires: pip install "anthropic[bedrock]"  +  AWS credentials in env / IAM role.
+# On Bedrock, model IDs use the "anthropic." prefix, e.g.:
+#   anthropic.claude-sonnet-4-5   (Sonnet 4.x on Bedrock)
+#   anthropic.claude-opus-4-5     (Opus 4.x on Bedrock)
+# Check your Bedrock console for exact IDs available in your region.
+FOREMAN_PROVIDER = os.environ.get("FOREMAN_PROVIDER", "anthropic").lower()
+_BEDROCK_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
 MAX_TOOL_RESULT_CHARS = 8_000  # ~2 k tokens; cap per-result content before storing/sending
 MAX_HISTORY_MESSAGES = 20  # sliding window cap on messages sent to Anthropic
 MAX_FOREMAN_ROUNDS = 10  # safety cap on tool-call rounds per invocation
@@ -42,14 +51,22 @@ _poll_tasks: dict[str, "asyncio.Task[None]"] = {}
 
 # Module-level client — reused across calls so the underlying httpx connection
 # pool isn't thrown away every invocation. Lazily initialised so import works
-# without an API key.
-_anthropic_client: "_anthropic.AsyncAnthropic | None" = None
+# without an API key (Anthropic) or AWS credentials (Bedrock).
+_anthropic_client: "_anthropic.AsyncAnthropic | _anthropic.AsyncAnthropicBedrock | None" = None
 
 
-def _get_anthropic_client() -> "_anthropic.AsyncAnthropic":
+def _get_anthropic_client() -> "_anthropic.AsyncAnthropic | _anthropic.AsyncAnthropicBedrock":
     global _anthropic_client
     if _anthropic_client is None:
-        _anthropic_client = _anthropic.AsyncAnthropic()
+        if FOREMAN_PROVIDER == "bedrock":
+            _anthropic_client = _anthropic.AsyncAnthropicBedrock(
+                aws_region=_BEDROCK_REGION,
+            )
+            logger.info(
+                "Foreman using Amazon Bedrock (region=%s, model=%s)", _BEDROCK_REGION, FOREMAN_MODEL
+            )
+        else:
+            _anthropic_client = _anthropic.AsyncAnthropic()
     return _anthropic_client
 
 

--- a/foreman/Dockerfile
+++ b/foreman/Dockerfile
@@ -16,9 +16,10 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Install backend requirements (includes anthropic, sqlalchemy, websockets, …)
-COPY backend/requirements.txt /app/backend/requirements.txt
-RUN pip install -r /app/backend/requirements.txt
+# Install foreman requirements (trimmed subset of backend deps — no uvicorn,
+# alembic, asyncpg, docker, etc. that the foreman process never needs).
+COPY foreman/requirements.txt /app/foreman/requirements.txt
+RUN pip install -r /app/foreman/requirements.txt
 
 # Backend source — foreman/main.py imports models, database, events, and the
 # foreman sub-package from here.

--- a/foreman/pyproject.toml
+++ b/foreman/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pioneer-foreman"
+version = "0.1.0"
+description = "Standalone foreman AI process for Pioneer Square: receives triggers from the backend, runs Claude, and coordinates workers."
+requires-python = ">=3.11"
+dependencies = [
+    "anthropic>=0.40.0",
+    "websockets>=12.0",
+    "sqlalchemy[asyncio]>=2.0",
+    "sqlmodel>=0.0.18",
+    "aiosqlite>=0.20",
+    "fastapi>=0.110.0",
+    "cryptography>=42.0",
+    "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+bedrock = ["anthropic[bedrock]>=0.40.0"]
+test = ["pytest>=8.0", "pytest-asyncio>=0.23"]
+
+[project.scripts]
+# Phase 3: once pioneer_foreman/ package exists this will work as a CLI entry point.
+# For now, run directly: python foreman/main.py
+# pioneer-foreman = "pioneer_foreman.cli:main"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -1,0 +1,40 @@
+# Foreman runtime dependencies
+#
+# The standalone foreman process imports backend/ source directly (via a
+# sys.path insert in main.py). These packages cover that full dependency
+# chain without pulling in backend-only extras like uvicorn, alembic, or
+# asyncpg that the foreman process never uses.
+#
+# Note: Phase 3 will replace the sys.path import with a proper REST client,
+# after which sqlmodel/fastapi/aiosqlite/sqlalchemy can be dropped here.
+
+# Claude API
+anthropic>=0.40.0
+
+# WebSocket client (foreman/main.py WS connection to backend)
+websockets>=12.0
+
+# ORM + async SQLite driver (backend modules: database.py, models.py, runner.py)
+sqlalchemy[asyncio]>=2.0
+sqlmodel>=0.0.18
+aiosqlite>=0.20
+
+# FastAPI is needed at import time (events.py uses `from fastapi import WebSocket`)
+# — only the core package, no uvicorn or extras required
+fastapi>=0.110.0
+
+# Ed25519 signing for dnsid tool (foreman/oidc.py)
+cryptography>=42.0
+
+# .env file loading (optional; convenient for local dev)
+python-dotenv>=1.0
+
+# ── Optional: Amazon Bedrock ──────────────────────────────────────────────────
+# Uncomment (or install separately) to use FOREMAN_PROVIDER=bedrock.
+# Requires AWS credentials in env / IAM role and Bedrock model access enabled.
+#
+# anthropic[bedrock]>=0.40.0
+
+# ── Development / testing ─────────────────────────────────────────────────────
+# pytest>=8.0
+# pytest-asyncio>=0.23


### PR DESCRIPTION
## What

Gives the standalone foreman its own dependency manifest (like the worker has), and adds opt-in Amazon Bedrock support.

## Changes

### `foreman/requirements.txt` (new)
Trimmed runtime deps — only what `foreman/main.py` and its `backend/` import chain actually need. Drops ~10 packages the foreman never uses (uvicorn, alembic, asyncpg, psycopg2, docker, python-multipart, pytest, ruff).

### `foreman/pyproject.toml` (new)
Follows the worker pattern. The `pioneer-foreman` CLI entry point is commented out until Phase 3 creates the `pioneer_foreman/` package. Includes a `bedrock` optional extra.

### `foreman/Dockerfile`
Now installs from `foreman/requirements.txt` instead of `backend/requirements.txt`.

### `backend/foreman/runner.py`
Adds `FOREMAN_PROVIDER=bedrock` support via `anthropic.AsyncAnthropicBedrock`. Default is unchanged (`FOREMAN_PROVIDER=anthropic`). Requires `pip install "anthropic[bedrock]"` and AWS credentials/IAM role.

```bash
FOREMAN_PROVIDER=bedrock \
AWS_DEFAULT_REGION=us-east-1 \
FOREMAN_MODEL=us.anthropic.claude-sonnet-4-5-20251001-v2:0 \
GUILD_ID=abc123 python foreman/main.py
```

### `CLAUDE.md`
Foreman setup section now matches the worker format (venv + pip), includes `DATABASE_URL` note, and adds a Bedrock invocation example.

## Notes

- Prompt caching works as-is on Bedrock — the runner uses `cache_control` blocks (GA), no beta header needed
- Before Phase 3, the foreman still needs `DATABASE_URL` and the `backend/` source on disk (the sys.path import isn't gone yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)