### PR TITLE
fix: foreman-created tasks use worker_id=null, not 'foreman' sentinel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Worker ──WebSocket──────────┘
 - **Guild**: a workspace (was called "session" — DB migration renames the table; the 6-char ID appears in URLs and `pioneer-worker.toml` as `guild_id`).
 - **Worker**: a registered worker entity in the DB (`workers` table, id prefix `w-`). Persisted across restarts.
 - **Agent**: a WebSocket participant (`agents` table, id prefix `a-`). A worker process creates one `agent_id` per process lifetime (stable within a run, not across restarts). The `worker_id` is for DB routing; `agent_id` is the live WebSocket identity.
-- **Task**: a unit of work (`tasks` table, id prefix `t-`). Foreman tasks have `worker_id='foreman'`; worker tasks are owned by a real worker.
+- **Task**: a unit of work (`tasks` table, id prefix `t-`). Foreman-created tasks have `worker_id=NULL` (unassigned) until the foreman's `assign_task` tool sets a real worker; worker tasks are owned by a real worker.
 
 ### Task lifecycle
 

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -365,7 +365,7 @@ async def create_foreman_task(
     body: ForemanTaskCreate,
     _caller: str = Depends(require_worker_or_member_path),
 ):
-    """Create a foreman-owned task (worker_id='foreman').
+    """Create a foreman-owned task (worker_id=None — unassigned until a worker picks it up).
 
     Used by the standalone foreman's ``create_task`` tool in place of the
     direct DB insert currently in ``foreman/tools.py``.

--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -25,7 +25,7 @@ describe('useTasksStore', () => {
         id: 't-1',
         name: 'Fix bug',
         state: 'pending',
-        worker_id: 'foreman',
+        worker_id: null,
       })
     })
 

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -157,7 +157,7 @@ export const useTasksStore = defineStore('tasks', () => {
         description: data.description,
         phase: data.phase,
         state: data.state,
-        worker_id: 'foreman',
+        worker_id: null,
         created_at: data.createdAt,
       })
     } else if (data.type === 'task-assigned') {


### PR DESCRIPTION
## What

The ORM refactor in #429 changed task creation to use `worker_id=None` but the frontend store and test fixture were still expecting the old `'foreman'` string sentinel.

## Changes

- **`frontend/src/stores/tasks.ts`**: `task-created` WS handler now sets `worker_id: null` instead of `'foreman'`
- **`frontend/src/stores/__tests__/tasks.spec.ts`**: update fixture to match
- **`backend/routes/foreman.py`**: fix stale docstring (still said `worker_id='foreman'`)
- **`CLAUDE.md`**: correct architecture note

## Behavior

No functional change — `FactoryFloor.vue` already has `t.worker_id &&` which excludes both `null` and `'foreman'`. The `!== 'foreman'` check is now dead code but kept for any existing DB rows carrying the old sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)