### PR TITLE
feat: Phase 3 — standalone foreman package (pioneer_foreman)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,34 +36,28 @@ pioneer-worker
 pioneer-worker --log-level DEBUG   # verbose
 ```
 
-### Standalone Foreman (Phase 2 — opt-in)
+### Standalone Foreman (opt-in)
 The embedded foreman (inside the backend process) is the default.  A standalone
 foreman process can be run alongside the backend; it registers as an external
 foreman and takes over trigger handling for a specific guild, allowing independent
 scaling and model changes without restarting the backend.
 
 ```bash
+# Requires backend + ANTHROPIC_API_KEY
 cd foreman
-python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
-# Bedrock support (optional): pip install "anthropic[bedrock]"
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+cp pioneer-foreman.toml.example pioneer-foreman.toml
+# Edit: backend_url, guild_id, auth_token (member login_token or worker auth_token)
+pioneer-foreman
+pioneer-foreman --log-level DEBUG   # verbose
 
-# foreman/main.py imports backend/ modules directly, so the backend source
-# must be on the path.  Set DATABASE_URL to the same DB the backend uses.
-DATABASE_URL=sqlite+aiosqlite:///path/to/pioneer_square.db \
-BACKEND_WS_URL=ws://localhost:8000 \
-GUILD_ID=<your-6-char-guild-id> \
+# Or via environment variables (no config file needed):
+PIONEER_BACKEND_URL=ws://localhost:8000 \
+PIONEER_GUILD_ID=<your-6-char-guild-id> \
+PIONEER_AUTH_TOKEN=<login_token> \
 ANTHROPIC_API_KEY=<key> \
-python main.py
-
-# Amazon Bedrock instead of Anthropic API:
-DATABASE_URL=sqlite+aiosqlite:///... \
-BACKEND_WS_URL=ws://localhost:8000 \
-GUILD_ID=<your-6-char-guild-id> \
-FOREMAN_PROVIDER=bedrock \
-AWS_DEFAULT_REGION=us-east-1 \
-FOREMAN_MODEL=us.anthropic.claude-sonnet-4-5-20251001-v2:0 \
-python main.py
+pioneer-foreman
 
 # Or via docker compose (profile "foreman"):
 GUILD_ID=abc123 docker compose --profile foreman up --build foreman

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,14 +48,14 @@ cd foreman
 python -m venv .venv && source .venv/bin/activate
 pip install -e .
 cp pioneer-foreman.toml.example pioneer-foreman.toml
-# Edit: backend_url, guild_id, auth_token (member login_token or worker auth_token)
+# Edit: backend_url, guild_id, backend_key (matches PIONEER_FOREMAN_KEY on backend)
 pioneer-foreman
 pioneer-foreman --log-level DEBUG   # verbose
 
 # Or via environment variables (no config file needed):
 PIONEER_BACKEND_URL=ws://localhost:8000 \
 PIONEER_GUILD_ID=<your-6-char-guild-id> \
-PIONEER_AUTH_TOKEN=<login_token> \
+PIONEER_FOREMAN_KEY=<shared-secret> \
 ANTHROPIC_API_KEY=<key> \
 pioneer-foreman
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,23 @@ AI out of the backend process — useful if you want to scale or restart the for
 independently.  The backend falls back to its embedded foreman when no external one
 is connected.
 
+The foreman authenticates to the backend with a shared HMAC secret
+(`PIONEER_FOREMAN_KEY`).  Generate one with:
+
 ```bash
-# Get your guild ID from the URL bar (6 chars after /g/)
-GUILD_ID=abc123 docker compose --profile foreman up --build foreman
+openssl rand -hex 32
+```
+
+Set the **same value** on both sides — `PIONEER_FOREMAN_KEY` on the backend and
+`GUILD_ID` + the key for the foreman:
+
+```bash
+# Backend (.env or shell):
+PIONEER_FOREMAN_KEY=<your-secret>
+
+# Foreman (docker compose):
+GUILD_ID=abc123 PIONEER_FOREMAN_KEY=<your-secret> \
+  docker compose --profile foreman up --build foreman
 ```
 
 ### GitHub OAuth App
@@ -107,13 +121,39 @@ cd worker
 uv venv && source .venv/bin/activate
 uv pip install -e .
 cp pioneer-worker.toml.example pioneer-worker.toml
-# edit pioneer-worker.toml: backend_url, session_id, repos
+# edit pioneer-worker.toml: backend_url, guild_id, repos
 # github_token is optional — if omitted, the worker fetches the OAuth token
 # stored in the backend DB (set after the user connects via GitHub OAuth)
 pioneer-worker
 ```
 
 See [`worker/README.md`](worker/README.md) for details.
+
+### Standalone Foreman (local, no Docker)
+
+```bash
+cd foreman
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+cp pioneer-foreman.toml.example pioneer-foreman.toml
+# edit pioneer-foreman.toml: backend_url, guild_id, backend_key
+pioneer-foreman
+```
+
+Or with environment variables only (no config file):
+
+```bash
+PIONEER_BACKEND_URL=ws://localhost:8000 \
+PIONEER_GUILD_ID=<your-guild-id> \
+PIONEER_FOREMAN_KEY=<your-secret> \
+ANTHROPIC_API_KEY=<key> \
+pioneer-foreman
+```
+
+`PIONEER_FOREMAN_KEY` must match the same variable set on the backend.  When an
+external foreman is connected the backend routes all `foreman-trigger` events to
+it; if it disconnects the backend's embedded foreman takes over automatically.
 
 ## Migrating from SQLite
 

--- a/backend/auth_deps.py
+++ b/backend/auth_deps.py
@@ -93,7 +93,7 @@ def require_member(*allowed_roles: str):
     return _dep
 
 
-async def authorize_worker_or_member(guild_id: str, token: str | None) -> str:
+async def authorize_worker_or_member(guild_id: str, token: str | None) -> str:  # noqa: C901
     """Validate *token* against worker auth_tokens or member login_tokens.
 
     Returns ``"worker:<worker_id>"`` or ``"user:<github_user_id>"`` so callers
@@ -102,6 +102,17 @@ async def authorize_worker_or_member(guild_id: str, token: str | None) -> str:
     """
     if not token:
         raise HTTPException(status_code=401, detail="Authentication required")
+
+    # Foreman JWT — validated without a DB round-trip when PIONEER_FOREMAN_KEY is set.
+    # Checked first so the foreman never waits for a DB session on the hot path.
+    import os
+
+    from utils import verify_foreman_jwt
+
+    _foreman_key = os.environ.get("PIONEER_FOREMAN_KEY", "")
+    if _foreman_key and verify_foreman_jwt(token, _foreman_key, guild_id):
+        return "foreman:jwt"
+
     db = await get_db()
     try:
         guild_pk = await get_guild_pk(db, guild_id)

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -42,6 +42,7 @@ from models import (
     ForemanTurn,
     Guild,
     GuildKey,
+    GuildMember,
     Message,
     Task,
     live_tasks_filter,
@@ -155,9 +156,19 @@ async def get_foreman_state(
             select(Guild.name, Guild.primary_repo).where(Guild.guild_id == guild_id)
         )
         guild_row = guild_res.one_or_none()
+
+        # Fetch guild owner user_id for the standalone foreman
+        owner_res = await db.execute(
+            select(GuildMember.user_id)
+            .where(GuildMember.guild_id == guild_pk, GuildMember.role == "owner")
+            .limit(1)
+        )
+        owner_user_id = owner_res.scalar_one_or_none()
+
         guild_data = {
             "name": guild_row.name if guild_row else None,
             "primary_repo": guild_row.primary_repo if guild_row else None,
+            "owner_user_id": owner_user_id,
         }
 
         # Online workers with their active agents
@@ -574,3 +585,70 @@ async def create_message(
         },
     )
     return {"message_id": msg_id, "created_at": created_at}
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Token counts + tool execution for standalone foreman
+# ---------------------------------------------------------------------------
+
+
+class TurnTokensUpdate(BaseModel):
+    input_tokens: int
+    output_tokens: int
+
+
+@router.patch("/guilds/{guild_id}/foreman/turns/{turn_id}/tokens")
+async def update_turn_tokens(
+    guild_id: str,
+    turn_id: int,
+    body: TurnTokensUpdate,
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Update token counts for a saved foreman turn. Used by the standalone foreman."""
+    from sqlalchemy import update as sa_update
+
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+        await db.execute(
+            sa_update(ForemanTurn)
+            .where(ForemanTurn.id == turn_id)
+            .values(input_tokens=body.input_tokens, output_tokens=body.output_tokens)
+        )
+        await db.commit()
+    finally:
+        await db.close()
+    return {"ok": True}
+
+
+class ToolExecRequest(BaseModel):
+    tool_name: str
+    tool_id: str
+    tool_input: dict
+    user_id: str | None = None
+
+
+@router.post("/guilds/{guild_id}/foreman/exec_tool")
+async def exec_tool(
+    guild_id: str,
+    body: ToolExecRequest,
+    _caller: str = Depends(require_worker_or_member_path),
+):
+    """Execute a single foreman tool call. Used by the standalone foreman process.
+
+    This delegates to _exec_one_tool() in foreman/tools.py, keeping all business
+    logic (locks, worker selection, DB writes, WS broadcasts) in the backend.
+
+    Returns a tool_result block: {"type": "tool_result", "tool_use_id": str, "content": str, "is_error": bool}
+    """
+    from foreman.tools import _exec_one_tool
+
+    class _FakeToolUse:
+        def __init__(self):
+            self.name = body.tool_name
+            self.id = body.tool_id
+            self.input = body.tool_input
+
+    return await _exec_one_tool(guild_id, _FakeToolUse(), body.user_id)

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -7,10 +7,13 @@ FastAPI app, the DB session helper, or anything else heavy.
 from __future__ import annotations
 
 import base64
+import hashlib
+import hmac
 import json
 import random
 import re
 import string
+import time
 import unicodedata
 
 _VOWELS = frozenset("aeiou")
@@ -162,6 +165,79 @@ def decode_claude_oauth_token(blob: str | None) -> str | None:
         return None
     token = payload.get("oauth_token") if isinstance(payload, dict) else None
     return token if isinstance(token, str) and token else None
+
+
+# ---------------------------------------------------------------------------
+# Foreman JWT helpers (HS256, stdlib-only)
+# ---------------------------------------------------------------------------
+
+_FOREMAN_JWT_SUB = "pioneer-foreman"
+_FOREMAN_JWT_TTL = 3600  # seconds; foreman refreshes before expiry
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _b64url_decode(s: str) -> bytes:
+    padding = 4 - len(s) % 4
+    if padding != 4:
+        s += "=" * padding
+    return base64.urlsafe_b64decode(s)
+
+
+def make_foreman_jwt(guild_id: str, secret: str, ttl: int = _FOREMAN_JWT_TTL) -> str:
+    """Create a short-lived HS256 JWT for the standalone foreman.
+
+    Both the foreman (via ``backend_key`` in its TOML) and the backend
+    (via ``PIONEER_FOREMAN_KEY`` env var) must share the same *secret*.
+    The token is valid for *ttl* seconds (default 1 hour).
+    """
+    header = _b64url_encode(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    now = int(time.time())
+    payload = _b64url_encode(
+        json.dumps(
+            {
+                "sub": _FOREMAN_JWT_SUB,
+                "guild_id": guild_id,
+                "iat": now,
+                "exp": now + ttl,
+            }
+        ).encode()
+    )
+    signing_input = f"{header}.{payload}"
+    sig = _b64url_encode(hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest())
+    return f"{signing_input}.{sig}"
+
+
+def verify_foreman_jwt(token: str, secret: str, guild_id: str) -> bool:
+    """Return True iff *token* is a valid foreman JWT for *guild_id*.
+
+    Checks: HS256 signature, ``sub`` == ``"pioneer-foreman"``, ``guild_id``
+    matches, and the token has not expired.  Returns False (never raises) on
+    any validation failure so callers can safely fall through to other auth checks.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return False
+        signing_input = f"{parts[0]}.{parts[1]}"
+        expected_sig = _b64url_encode(
+            hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest()
+        )
+        if not hmac.compare_digest(expected_sig, parts[2]):
+            return False
+        payload = json.loads(_b64url_decode(parts[1]))
+        if payload.get("sub") != _FOREMAN_JWT_SUB:
+            return False
+        if payload.get("guild_id") != guild_id:
+            return False
+        exp = payload.get("exp", 0)
+        if time.time() > exp:
+            return False
+        return True
+    except Exception:
+        return False
 
 
 def build_spawn_worker_env(

--- a/foreman/Dockerfile
+++ b/foreman/Dockerfile
@@ -1,12 +1,9 @@
 # syntax=docker/dockerfile:1.4
 #
-# Standalone foreman process (Phase 2 of the foreman extraction).
+# Standalone foreman process (Phase 3 of the foreman extraction).
 #
-# This image bundles the backend Python package (models, database, events,
-# foreman/runner, foreman/tools, …) together with the foreman/main.py entry
-# point.  The foreman container connects to the shared PostgreSQL instance
-# and connects to the backend WebSocket to receive foreman-trigger events
-# and relay broadcasts.
+# This image installs the pioneer_foreman package, which connects to the
+# backend via REST + WebSocket only — no direct DB access.
 
 FROM python:3.11-slim
 
@@ -16,18 +13,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Install foreman requirements (trimmed subset of backend deps — no uvicorn,
-# alembic, asyncpg, docker, etc. that the foreman process never needs).
-COPY foreman/requirements.txt /app/foreman/requirements.txt
-RUN pip install -r /app/foreman/requirements.txt
+# Install the pioneer-foreman package
+COPY foreman/pyproject.toml /app/foreman/pyproject.toml
+COPY foreman/pioneer_foreman/ /app/foreman/pioneer_foreman/
 
-# Backend source — foreman/main.py imports models, database, events, and the
-# foreman sub-package from here.
-COPY backend/ /app/backend/
-
-# Foreman entry point
-COPY foreman/main.py /app/foreman/main.py
+RUN pip install -e /app/foreman
 
 WORKDIR /app/foreman
 
-CMD ["python", "main.py"]
+CMD ["pioneer-foreman"]

--- a/foreman/pioneer-foreman.toml.example
+++ b/foreman/pioneer-foreman.toml.example
@@ -1,0 +1,16 @@
+backend_url = "ws://localhost:8000"    # same base as workers
+guild_id    = "abc123"
+
+# Auth token — set to your member login_token (from browser dev tools after login)
+# or a worker auth_token. Required for REST API calls.
+auth_token  = ""
+
+[claude]
+model         = "claude-sonnet-4-6"
+api_key       = ""                     # falls back to ANTHROPIC_API_KEY env var
+max_rounds    = 10
+history_limit = 40
+
+[poll]
+min_interval = 60     # seconds (doubles each cycle up to max_interval)
+max_interval = 3600

--- a/foreman/pioneer-foreman.toml.example
+++ b/foreman/pioneer-foreman.toml.example
@@ -1,9 +1,15 @@
 backend_url = "ws://localhost:8000"    # same base as workers
 guild_id    = "abc123"
 
-# Auth token — set to your member login_token (from browser dev tools after login)
-# or a worker auth_token. Required for REST API calls.
-auth_token  = ""
+# Shared HMAC secret for JWT authentication.
+# Set the same value as PIONEER_FOREMAN_KEY on the backend.
+# The foreman mints short-lived tokens automatically — no manual refresh needed.
+backend_key = ""
+
+# Static token fallback — only needed when backend_key is not set.
+# Use a member login_token (from browser dev tools after login) or a worker
+# auth_token. Ignored when backend_key is provided.
+# auth_token = ""
 
 [claude]
 model         = "claude-sonnet-4-6"

--- a/foreman/pioneer_foreman/__init__.py
+++ b/foreman/pioneer_foreman/__init__.py
@@ -1,0 +1,1 @@
+"""Pioneer Square standalone foreman agent."""

--- a/foreman/pioneer_foreman/__main__.py
+++ b/foreman/pioneer_foreman/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as: python -m pioneer_foreman"""
+
+from .cli import main
+
+main()

--- a/foreman/pioneer_foreman/cli.py
+++ b/foreman/pioneer_foreman/cli.py
@@ -20,7 +20,17 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--backend-url", metavar="URL", help="Override backend WebSocket URL.")
     p.add_argument("--guild-id", metavar="ID", help="Override guild ID.")
     p.add_argument("--model", metavar="MODEL", help="Override Claude model ID.")
-    p.add_argument("--auth-token", metavar="TOKEN", help="Override auth token.")
+    p.add_argument(
+        "--backend-key",
+        metavar="SECRET",
+        help="Shared HMAC secret for JWT auth (matches PIONEER_FOREMAN_KEY on the backend).",
+    )
+    p.add_argument(
+        "--auth-token",
+        metavar="TOKEN",
+        help="Static token fallback (member login_token or worker auth_token); "
+        "used only when --backend-key is not set.",
+    )
     p.add_argument(
         "--log-level",
         metavar="LEVEL",
@@ -41,6 +51,8 @@ def main() -> None:
         overrides["guild_id"] = args.guild_id
     if args.model:
         overrides["model"] = args.model
+    if args.backend_key:
+        overrides["backend_key"] = args.backend_key
     if args.auth_token:
         overrides["auth_token"] = args.auth_token
     if args.log_level:

--- a/foreman/pioneer_foreman/cli.py
+++ b/foreman/pioneer_foreman/cli.py
@@ -1,0 +1,61 @@
+"""CLI entry point for the standalone foreman."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from .config import load as load_config
+from .foreman import Foreman
+from .logging_config import setup_logging
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="pioneer-foreman",
+        description="Standalone foreman agent for Pioneer Square.",
+    )
+    p.add_argument("--config", metavar="PATH", help="Path to TOML config file.")
+    p.add_argument("--backend-url", metavar="URL", help="Override backend WebSocket URL.")
+    p.add_argument("--guild-id", metavar="ID", help="Override guild ID.")
+    p.add_argument("--model", metavar="MODEL", help="Override Claude model ID.")
+    p.add_argument("--auth-token", metavar="TOKEN", help="Override auth token.")
+    p.add_argument(
+        "--log-level",
+        metavar="LEVEL",
+        default=None,
+        help="Logging level: DEBUG, INFO, WARNING (default: INFO).",
+    )
+    return p
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    overrides: dict = {}
+    if args.backend_url:
+        overrides["backend_url"] = args.backend_url
+    if args.guild_id:
+        overrides["guild_id"] = args.guild_id
+    if args.model:
+        overrides["model"] = args.model
+    if args.auth_token:
+        overrides["auth_token"] = args.auth_token
+    if args.log_level:
+        overrides["log_level"] = args.log_level
+
+    try:
+        config = load_config(args.config, overrides)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    setup_logging(config.log_level)
+
+    foreman = Foreman(config)
+    try:
+        asyncio.run(foreman.run())
+    except KeyboardInterrupt:
+        pass

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -21,7 +21,11 @@ DEFAULT_CONFIG_NAME = "pioneer-foreman.toml"
 class Config:
     backend_url: str
     guild_id: str
-    # Auth token (member login_token or worker auth_token)
+    # JWT auth — shared HS256 secret (PIONEER_FOREMAN_KEY on the backend side).
+    # Preferred over auth_token: the foreman mints short-lived tokens automatically.
+    backend_key: str | None = None
+    # Static token fallback — a member login_token or worker auth_token.
+    # Used only when backend_key is not set.
     auth_token: str | None = None
     # Claude settings
     model: str = "claude-sonnet-4-6"
@@ -105,6 +109,12 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
     if not guild_id:
         raise ValueError("guild_id is required.")
 
+    backend_key = (
+        overrides.get("backend_key")
+        or raw.get("backend_key")
+        or os.environ.get("PIONEER_FOREMAN_KEY")
+    ) or None
+
     auth_token = (
         overrides.get("auth_token")
         or raw.get("auth_token")
@@ -136,6 +146,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
     return Config(
         backend_url=backend_url.rstrip("/"),
         guild_id=guild_id,
+        backend_key=backend_key,
         auth_token=auth_token,
         model=model,
         api_key=api_key,

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -1,0 +1,152 @@
+"""Configuration for the standalone Pioneer Square foreman.
+
+Reads a TOML file (default: ./pioneer-foreman.toml).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_NAME = "pioneer-foreman.toml"
+
+
+@dataclass
+class Config:
+    backend_url: str
+    guild_id: str
+    # Auth token (member login_token or worker auth_token)
+    auth_token: str | None = None
+    # Claude settings
+    model: str = "claude-sonnet-4-6"
+    api_key: str | None = None
+    max_rounds: int = 10
+    history_limit: int = 40
+    # Poll settings
+    poll_min_interval: int = 60
+    poll_max_interval: int = 3600
+    # Logging
+    log_level: str = "INFO"
+
+    config_path: Path = field(default_factory=Path)
+
+    @property
+    def http_url(self) -> str:
+        """Backend HTTP URL derived from backend_url."""
+        parsed = urlparse(self.backend_url)
+        scheme = {"ws": "http", "wss": "https"}.get(parsed.scheme, parsed.scheme or "http")
+        return urlunparse((scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+
+    @property
+    def ws_url(self) -> str:
+        """Backend WebSocket URL for this guild."""
+        parsed = urlparse(self.backend_url)
+        scheme = {"http": "ws", "https": "wss"}.get(parsed.scheme, parsed.scheme or "ws")
+        base = urlunparse((scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+        return f"{base}/ws/{self.guild_id}"
+
+
+def _resolve_config_path(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    return Path.cwd() / DEFAULT_CONFIG_NAME
+
+
+def load(explicit_path: str | None = None, overrides: dict | None = None) -> Config:
+    """Load config from TOML layered with env vars and CLI overrides."""
+    overrides = overrides or {}
+    cfg_path = _resolve_config_path(explicit_path)
+
+    raw: dict = {}
+    if cfg_path.exists():
+        with cfg_path.open("rb") as fh:
+            raw = tomllib.load(fh)
+    else:
+        has_url = (
+            overrides.get("backend_url")
+            or os.environ.get("PIONEER_BACKEND_URL")
+            or os.environ.get("BACKEND_WS_URL")
+        )
+        has_sid = (
+            overrides.get("guild_id")
+            or os.environ.get("PIONEER_GUILD_ID")
+            or os.environ.get("GUILD_ID")
+        )
+        if not (has_url and has_sid):
+            raise FileNotFoundError(
+                f"Foreman config not found at {cfg_path}. "
+                "Create one (see pioneer-foreman.toml.example), pass --config, "
+                "or supply --backend-url and --guild-id."
+            )
+
+    claude_block = raw.get("claude") or {}
+    poll_block = raw.get("poll") or {}
+
+    backend_url = (
+        overrides.get("backend_url")
+        or raw.get("backend_url")
+        or os.environ.get("PIONEER_BACKEND_URL")
+        or os.environ.get("BACKEND_WS_URL")
+    )
+    guild_id = (
+        overrides.get("guild_id")
+        or raw.get("guild_id")
+        or os.environ.get("PIONEER_GUILD_ID")
+        or os.environ.get("GUILD_ID")
+    )
+    if not backend_url:
+        raise ValueError("backend_url is required.")
+    if not guild_id:
+        raise ValueError("guild_id is required.")
+
+    auth_token = (
+        overrides.get("auth_token")
+        or raw.get("auth_token")
+        or os.environ.get("PIONEER_AUTH_TOKEN")
+        or os.environ.get("FOREMAN_AUTH_TOKEN")
+    ) or None
+
+    api_key = (
+        overrides.get("api_key")
+        or claude_block.get("api_key")
+        or os.environ.get("ANTHROPIC_API_KEY")
+    ) or None
+
+    model = (
+        overrides.get("model")
+        or claude_block.get("model")
+        or os.environ.get("FOREMAN_MODEL")
+        or "claude-sonnet-4-6"
+    )
+
+    log_level = (
+        overrides.get("log_level")
+        or raw.get("log_level")
+        or os.environ.get("FOREMAN_LOG_LEVEL")
+        or os.environ.get("LOG_LEVEL")
+        or "INFO"
+    )
+
+    return Config(
+        backend_url=backend_url.rstrip("/"),
+        guild_id=guild_id,
+        auth_token=auth_token,
+        model=model,
+        api_key=api_key,
+        max_rounds=int(overrides.get("max_rounds", claude_block.get("max_rounds", 10))),
+        history_limit=int(overrides.get("history_limit", claude_block.get("history_limit", 40))),
+        poll_min_interval=int(
+            overrides.get("poll_min_interval", poll_block.get("min_interval", 60))
+        ),
+        poll_max_interval=int(
+            overrides.get("poll_max_interval", poll_block.get("max_interval", 3600))
+        ),
+        log_level=log_level.upper(),
+        config_path=cfg_path,
+    )

--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -30,7 +30,8 @@ class Foreman:
         self._http = ForemanHTTPClient(
             self._config.http_url,
             self._config.guild_id,
-            self._config.auth_token,
+            backend_key=self._config.backend_key,
+            auth_token=self._config.auth_token,
         )
         retry_delay = 5
         try:

--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -1,0 +1,195 @@
+"""Standalone Foreman process: WebSocket connection, trigger handling, poll loop."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import websockets
+
+from .http_client import ForemanHTTPClient
+from .runner import run_foreman_ai
+
+if TYPE_CHECKING:
+    from .config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class Foreman:
+    """Manages the standalone foreman lifecycle for one guild."""
+
+    def __init__(self, config: Config):
+        self._config = config
+        self._http: ForemanHTTPClient | None = None
+
+    async def run(self) -> None:
+        """Connect to the backend and handle triggers until stopped."""
+        self._http = ForemanHTTPClient(
+            self._config.http_url,
+            self._config.guild_id,
+            self._config.auth_token,
+        )
+        retry_delay = 5
+        try:
+            while True:
+                try:
+                    evicted = await self._run_connection()
+                    if evicted:
+                        logger.info("Evicted; waiting %ds before reconnecting", retry_delay)
+                        await asyncio.sleep(retry_delay)
+                        retry_delay = min(retry_delay * 2, 60)
+                    else:
+                        retry_delay = 5
+                except Exception as exc:
+                    logger.error(
+                        "Connection error for guild %s: %s — retrying in %ds",
+                        self._config.guild_id,
+                        exc,
+                        retry_delay,
+                    )
+                    await asyncio.sleep(retry_delay)
+                    retry_delay = min(retry_delay * 2, 60)
+        finally:
+            if self._http:
+                await self._http.close()
+
+    async def _run_connection(self) -> bool:
+        """Connect once; return True if evicted, False on clean disconnect."""
+        ws_url = self._config.ws_url
+        logger.info("Connecting to backend at %s", ws_url)
+        evicted = False
+        poll_task: asyncio.Task | None = None
+
+        async with websockets.connect(ws_url) as ws:
+
+            async def _ws_send(message: dict) -> None:
+                try:
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "foreman-broadcast",
+                                "guildId": self._config.guild_id,
+                                "payload": message,
+                            }
+                        )
+                    )
+                except Exception as exc:
+                    logger.warning("_ws_send failed: %s", exc)
+
+            async def _handle_trigger(data: dict) -> None:
+                guild_id = data.get("guildId", "")
+                human_message = data.get("humanMessage", "")
+                user_id = data.get("userId")
+                extra_context = data.get("extraContext", "")
+                if not guild_id or not human_message:
+                    logger.warning("Ignoring malformed foreman-trigger: %s", data)
+                    return
+                asyncio.create_task(
+                    run_foreman_ai(
+                        guild_id,
+                        human_message,
+                        extra_context=extra_context,
+                        user_id=user_id,
+                        http=self._http,
+                        ws_send=_ws_send,
+                        config=self._config,
+                    ),
+                    name=f"foreman.trigger:{guild_id}:{data.get('event', '?')}",
+                )
+
+            async def _poll_loop() -> None:
+                """Background poll — check active tasks periodically."""
+                interval = self._config.poll_min_interval
+                while True:
+                    try:
+                        await asyncio.sleep(interval)
+                    except asyncio.CancelledError:
+                        return
+
+                    try:
+                        state = await self._http.get_state()
+                        active = [
+                            t
+                            for t in (state.get("tasks") or [])
+                            if t.get("state") not in ("done", "failed", "cancelled")
+                        ]
+                        n = len(active)
+                        next_interval = min(interval * 2, self._config.poll_max_interval)
+
+                        if active:
+                            task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active)
+                            msg = (
+                                f"[periodic-check] Automated status poll — {n} non-terminal "
+                                f"task(s): {task_summary}. Check whether any are stalled."
+                            )
+                            asyncio.create_task(
+                                run_foreman_ai(
+                                    self._config.guild_id,
+                                    msg,
+                                    http=self._http,
+                                    ws_send=_ws_send,
+                                    config=self._config,
+                                ),
+                                name=f"foreman.poll:{self._config.guild_id}",
+                            )
+
+                        interval = next_interval
+                        await _ws_send(
+                            {
+                                "type": "foreman-poll-status",
+                                "nextCheckIn": interval,
+                            }
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        logger.exception("poll_loop iteration failed")
+
+            # Register as external foreman
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "join",
+                        "agentType": "foreman",
+                        "external": True,
+                    }
+                )
+            )
+
+            poll_task = asyncio.create_task(_poll_loop(), name="foreman.poll-loop")
+            try:
+                async for raw in ws:
+                    try:
+                        msg = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+
+                    msg_type = msg.get("type")
+                    if msg_type == "foreman-registered":
+                        logger.info(
+                            "Registered as external foreman: agentId=%s guild=%s",
+                            msg.get("agentId"),
+                            self._config.guild_id,
+                        )
+                    elif msg_type == "foreman-trigger":
+                        logger.debug(
+                            "Received foreman-trigger: event=%s",
+                            msg.get("event"),
+                        )
+                        await _handle_trigger(msg)
+                    elif msg_type == "foreman-evicted":
+                        logger.warning("Evicted: %s", msg.get("reason"))
+                        evicted = True
+                        break
+            finally:
+                if poll_task and not poll_task.done():
+                    poll_task.cancel()
+                    try:
+                        await poll_task
+                    except asyncio.CancelledError:
+                        pass
+
+        return evicted

--- a/foreman/pioneer_foreman/http_client.py
+++ b/foreman/pioneer_foreman/http_client.py
@@ -1,0 +1,169 @@
+"""Async HTTP client for Pioneer Square backend REST API calls.
+
+The standalone foreman uses this to read guild state and write mutations
+without direct database access.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class BackendError(Exception):
+    """Raised when the backend returns an unexpected HTTP error."""
+
+    def __init__(self, status: int, detail: str):
+        super().__init__(f"Backend error {status}: {detail}")
+        self.status = status
+        self.detail = detail
+
+
+class ForemanHTTPClient:
+    """Thin async httpx wrapper scoped to a guild."""
+
+    def __init__(self, http_url: str, guild_id: str, auth_token: str | None = None):
+        self._base = http_url.rstrip("/")
+        self._guild_id = guild_id
+        headers = {}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
+        self._client = httpx.AsyncClient(
+            headers=headers,
+            timeout=30.0,
+        )
+
+    # ── Internals ──────────────────────────────────────────────────────────
+
+    def _guild_url(self, path: str) -> str:
+        return f"{self._base}/guilds/{self._guild_id}{path}"
+
+    async def _get(self, url: str, **params) -> Any:
+        resp = await self._client.get(url, params=params or None)
+        self._raise_for_status(resp)
+        return resp.json()
+
+    async def _post(self, url: str, body: dict) -> Any:
+        resp = await self._client.post(url, json=body)
+        self._raise_for_status(resp)
+        return resp.json()
+
+    async def _patch(self, url: str, body: dict) -> Any:
+        resp = await self._client.patch(url, json=body)
+        self._raise_for_status(resp)
+        return resp.json()
+
+    def _raise_for_status(self, resp: httpx.Response) -> None:
+        if resp.is_success:
+            return
+        try:
+            detail = resp.json().get("detail", resp.text)
+        except Exception:
+            detail = resp.text
+        raise BackendError(resp.status_code, detail)
+
+    # ── State reads ────────────────────────────────────────────────────────
+
+    async def get_state(self) -> dict:
+        """Fetch guild state: workers, tasks, guild metadata (including owner_user_id)."""
+        return await self._get(self._guild_url("/foreman/state"))
+
+    async def get_history(self, user_id: str, limit: int | None = None) -> list[dict]:
+        """Fetch raw ForemanTurn rows for a user, ordered oldest→newest."""
+        params: dict = {"user_id": user_id}
+        if limit is not None:
+            params["limit"] = limit
+        return await self._get(self._guild_url("/foreman/history"), **params)
+
+    async def get_guild_key(self) -> dict:
+        """Fetch the guild's Ed25519 signing key."""
+        return await self._get(self._guild_url("/guild-key"))
+
+    async def get_github_token(self) -> dict:
+        """Fetch the guild's GitHub OAuth token."""
+        return await self._get(
+            f"{self._base}/auth/github/token",
+            guild_id=self._guild_id,
+        )
+
+    # ── State writes ───────────────────────────────────────────────────────
+
+    async def save_turn(
+        self,
+        user_id: str,
+        role: str,
+        content_json: str,
+        *,
+        is_tool_response: bool = False,
+        parent_id: int | None = None,
+    ) -> dict:
+        """Persist one foreman conversation turn. Returns {id, created_at}."""
+        body: dict = {
+            "user_id": user_id,
+            "role": role,
+            "content_json": content_json,
+            "is_tool_response": is_tool_response,
+        }
+        if parent_id is not None:
+            body["parent_id"] = parent_id
+        return await self._post(self._guild_url("/foreman/history"), body)
+
+    async def update_turn_tokens(self, turn_id: int, input_tokens: int, output_tokens: int) -> None:
+        """Update token counts for a saved turn."""
+        await self._patch(
+            self._guild_url(f"/foreman/turns/{turn_id}/tokens"),
+            {"input_tokens": input_tokens, "output_tokens": output_tokens},
+        )
+
+    async def save_message(
+        self,
+        from_agent: str,
+        to_agent: str,
+        content: str,
+        *,
+        user_id: str | None = None,
+        message_type: str = "chat",
+    ) -> dict:
+        """Persist a chat message. Returns {message_id, created_at}."""
+        body: dict = {
+            "from_agent": from_agent,
+            "to_agent": to_agent,
+            "content": content,
+            "message_type": message_type,
+        }
+        if user_id:
+            body["user_id"] = user_id
+        return await self._post(self._guild_url("/messages"), body)
+
+    # ── Tool execution ─────────────────────────────────────────────────────
+
+    async def exec_tool(
+        self,
+        tool_name: str,
+        tool_id: str,
+        tool_input: dict,
+        user_id: str | None = None,
+    ) -> dict:
+        """Execute a single tool call via the backend.
+
+        Returns a tool_result block:
+        {"type": "tool_result", "tool_use_id": str, "content": str, "is_error": bool}
+        """
+        body: dict = {
+            "tool_name": tool_name,
+            "tool_id": tool_id,
+            "tool_input": tool_input,
+        }
+        if user_id:
+            body["user_id"] = user_id
+        logger.debug("exec_tool: %s (id=%s)", tool_name, tool_id)
+        return await self._post(self._guild_url("/foreman/exec_tool"), body)
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/foreman/pioneer_foreman/http_client.py
+++ b/foreman/pioneer_foreman/http_client.py
@@ -2,6 +2,19 @@
 
 The standalone foreman uses this to read guild state and write mutations
 without direct database access.
+
+Authentication
+--------------
+Two modes, in priority order:
+
+1. **JWT (preferred)** — ``backend_key`` is set in ``pioneer-foreman.toml``
+   (matches ``PIONEER_FOREMAN_KEY`` on the backend).  A short-lived HS256 JWT
+   is minted automatically and refreshed before expiry.  No manual token
+   management required.
+
+2. **Static token (fallback)** — ``auth_token`` is set to a member
+   login_token or worker auth_token.  Sent as-is; the caller is responsible
+   for keeping it valid.
 """
 
 from __future__ import annotations
@@ -10,6 +23,8 @@ import logging
 from typing import Any
 
 import httpx
+
+from .jwt_auth import JWTTokenManager
 
 logger = logging.getLogger(__name__)
 
@@ -24,36 +39,60 @@ class BackendError(Exception):
 
 
 class ForemanHTTPClient:
-    """Thin async httpx wrapper scoped to a guild."""
+    """Thin async httpx wrapper scoped to a guild.
 
-    def __init__(self, http_url: str, guild_id: str, auth_token: str | None = None):
+    Pass ``backend_key`` (shared HMAC secret) for JWT auth, or ``auth_token``
+    (member login_token / worker auth_token) for static token auth.
+    At least one must be provided; ``backend_key`` takes priority.
+    """
+
+    def __init__(
+        self,
+        http_url: str,
+        guild_id: str,
+        *,
+        backend_key: str | None = None,
+        auth_token: str | None = None,
+    ):
         self._base = http_url.rstrip("/")
         self._guild_id = guild_id
-        headers = {}
-        if auth_token:
-            headers["Authorization"] = f"Bearer {auth_token}"
-        self._client = httpx.AsyncClient(
-            headers=headers,
-            timeout=30.0,
+        self._jwt_mgr: JWTTokenManager | None = (
+            JWTTokenManager(guild_id, backend_key) if backend_key else None
         )
+        self._static_token: str | None = auth_token
+        if not backend_key and not auth_token:
+            logger.warning(
+                "ForemanHTTPClient created without auth credentials — "
+                "REST calls will fail with 401. "
+                "Set backend_key (PIONEER_FOREMAN_KEY) or auth_token."
+            )
+        self._client = httpx.AsyncClient(timeout=30.0)
 
     # ── Internals ──────────────────────────────────────────────────────────
 
     def _guild_url(self, path: str) -> str:
         return f"{self._base}/guilds/{self._guild_id}{path}"
 
+    def _auth_header(self) -> dict[str, str]:
+        """Return an Authorization header, preferring a fresh JWT over a static token."""
+        if self._jwt_mgr is not None:
+            return {"Authorization": f"Bearer {self._jwt_mgr.token()}"}
+        if self._static_token:
+            return {"Authorization": f"Bearer {self._static_token}"}
+        return {}
+
     async def _get(self, url: str, **params) -> Any:
-        resp = await self._client.get(url, params=params or None)
+        resp = await self._client.get(url, params=params or None, headers=self._auth_header())
         self._raise_for_status(resp)
         return resp.json()
 
     async def _post(self, url: str, body: dict) -> Any:
-        resp = await self._client.post(url, json=body)
+        resp = await self._client.post(url, json=body, headers=self._auth_header())
         self._raise_for_status(resp)
         return resp.json()
 
     async def _patch(self, url: str, body: dict) -> Any:
-        resp = await self._client.patch(url, json=body)
+        resp = await self._client.patch(url, json=body, headers=self._auth_header())
         self._raise_for_status(resp)
         return resp.json()
 

--- a/foreman/pioneer_foreman/jwt_auth.py
+++ b/foreman/pioneer_foreman/jwt_auth.py
@@ -1,0 +1,86 @@
+"""HS256 JWT helpers for authenticating the standalone foreman with the backend.
+
+Both sides share a secret (``backend_key`` in pioneer-foreman.toml /
+``PIONEER_FOREMAN_KEY`` env var on the backend).  The foreman mints a
+short-lived token at startup and refreshes it before expiry so REST calls
+never fail due to an expired credential.
+
+This module intentionally has no external dependencies — only stdlib.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+_FOREMAN_JWT_SUB = "pioneer-foreman"
+_DEFAULT_TTL = 3600  # 1 hour
+_REFRESH_BUFFER = 300  # refresh 5 minutes before expiry
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def make_jwt(guild_id: str, secret: str, ttl: int = _DEFAULT_TTL) -> str:
+    """Mint a short-lived HS256 JWT for *guild_id* signed with *secret*."""
+    header = _b64url_encode(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    now = int(time.time())
+    payload = _b64url_encode(
+        json.dumps(
+            {
+                "sub": _FOREMAN_JWT_SUB,
+                "guild_id": guild_id,
+                "iat": now,
+                "exp": now + ttl,
+            }
+        ).encode()
+    )
+    signing_input = f"{header}.{payload}"
+    sig = _b64url_encode(hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest())
+    return f"{signing_input}.{sig}"
+
+
+def _exp_from_jwt(token: str) -> int:
+    """Extract the ``exp`` claim from a JWT without verifying the signature."""
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return 0
+        padding = 4 - len(parts[1]) % 4
+        if padding != 4:
+            parts[1] += "=" * padding
+        payload = json.loads(base64.urlsafe_b64decode(parts[1]))
+        return int(payload.get("exp", 0))
+    except Exception:
+        return 0
+
+
+class JWTTokenManager:
+    """Holds a cached JWT and refreshes it when close to expiry.
+
+    Usage::
+
+        mgr = JWTTokenManager(guild_id="abc123", secret="s3cr3t")
+        token = mgr.token()   # always returns a valid (non-expired) token
+
+    Thread/async safety: token generation is pure CPU work; a refresh race
+    between two concurrent coroutines at most mints two tokens, which is fine.
+    """
+
+    def __init__(self, guild_id: str, secret: str, ttl: int = _DEFAULT_TTL) -> None:
+        self._guild_id = guild_id
+        self._secret = secret
+        self._ttl = ttl
+        self._cached: str | None = None
+        self._exp: int = 0
+
+    def token(self) -> str:
+        """Return a valid JWT, minting a fresh one if the current one is near expiry."""
+        if not self._cached or time.time() >= self._exp - _REFRESH_BUFFER:
+            self._cached = make_jwt(self._guild_id, self._secret, self._ttl)
+            self._exp = _exp_from_jwt(self._cached)
+        return self._cached

--- a/foreman/pioneer_foreman/logging_config.py
+++ b/foreman/pioneer_foreman/logging_config.py
@@ -1,0 +1,11 @@
+"""Logging configuration for the standalone foreman."""
+
+import logging
+
+
+def setup_logging(level: str = "INFO") -> None:
+    """Configure root logging with a consistent format."""
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
+    )

--- a/foreman/pioneer_foreman/prompt.py
+++ b/foreman/pioneer_foreman/prompt.py
@@ -1,0 +1,177 @@
+"""Foreman system prompt and system-prompt builder."""
+
+FOREMAN_SYSTEM = """\
+You are the Foreman AI in Pioneer Square, a multi-agent coding workshop.
+You coordinate worker agents that autonomously clone repos, write code, and open PRs.
+
+## Your responsibilities
+- Understand what the human wants and break it into named, tracked tasks
+- Call create_task immediately before assign_task so every job has a sidebar name and a task_id; pass that task_id into assign_task (no separate row is created)
+- Call create_task(name="Review PR #N: <title>", phase="review") immediately before calling review_pr_internal or review_pr; pass the returned task_id to track the review; call finalize_task on that task_id after the review completes (success or failure)
+- After a worker finishes (task-complete), the task parks in awaiting-review and \
+the worker returns to its idle pool — you own the lifecycle from here. \
+Default behaviour: leave PR-bearing tasks open for human review; call send_followup \
+when a comment, CI failure, or new requirement asks for an iteration on the same \
+branch; call finalize_task only when the work is genuinely closed (PR merged, \
+abandoned, or it was an ephemeral/automation task).
+- CI failures, lint errors, test failures, and other post-PR corrections on the *same piece of work* → always send_followup on the existing task, not a new issue or PR
+- send_followup picks an idle worker automatically: original worker first \
+(worktree usually still cached), otherwise any idle worker in the guild pulls \
+the branch from GitHub. Pass preferred_worker_id to force a specific worker.
+- Message workers mid-task via message_worker for context
+- Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
+- Cancel tasks that are going wrong or are no longer needed via cancel_task
+- Shut down a misbehaving or no-longer-needed worker process via shutdown_worker \
+(graceful: idle agents exit immediately, busy agents finish their current task)
+- Summarise status and outcomes when asked
+- Escalate to the human only when genuinely stuck
+
+## Multi-step flows
+For complex work use phases:
+1. **plan** — create_task(phase='plan'), assign a worker to produce an outline/spec
+2. **execute** — assign workers to implement
+3. **review** — assign a worker to verify correctness, run tests, check the PR
+
+## Task ownership
+- create_task + assign_task are always called as a pair — create_task first (names the job, returns task_id), then assign_task immediately with that task_id. Treat this as a single atomic action, not a two-step ceremony.
+- After task-complete: the worker has already gone idle and the task is parked in awaiting-review. Use send_followup whenever more work is needed on the same branch — it routes to the original worker if idle, otherwise to any idle worker in the guild (which pulls the branch from GitHub). finalize_task is for genuine completion; awaiting-review is *not* a limbo state, it's the normal home for an open PR.
+
+## PR review tracking
+review_pr_internal and review_pr always run as tracked tasks — every review must have \
+a sidebar entry so the human can see what was reviewed and what was found.
+
+Pattern (treat as a single atomic sequence):
+1. create_task(name="Review PR #N: <title>", phase="review") → returns task_id
+2. review_pr_internal (or review_pr) — pass the PR details
+3. finalize_task(task_id=<task_id from step 1>) — call this after the review returns, \
+   whether it succeeded, found issues, or errored. \
+   Use expires_in_seconds=86400 for error/failed reviews; omit (default 3 days) otherwise.
+
+Never call review_pr_internal or review_pr without a preceding create_task. The task_id \
+ties the review outcome to the sidebar entry so humans can track what was reviewed.
+
+## Finalize expiry windows
+Every finalize_task call sets a soft-delete window via expires_in_seconds so the
+task table doesn't accumulate cruft. Pick the window by task type:
+- **Ephemeral tasks** (periodic-check, status-poll, automated health checks):
+  expires_in_seconds = 1200 (20 minutes)
+- **Code tasks** (execute / review / followup phases): omit the field to use
+  the default 3 days, or pass expires_in_seconds = 259200
+- **Error / failed tasks**: expires_in_seconds = 86400 (1 day)
+Pass deleted_at instead if you need an exact ISO-8601 timestamp.
+
+## GitHub access
+You have direct GitHub access via list_github_issues, get_github_issue, list_github_prs,
+search_github_issues, create_github_issue, claim_github_issue, and get_pr_status
+(reviews + check-runs + merged state for one PR).
+
+## Reacting to GitHub PR events
+Messages prefixed `[github-event]` are pushed by GitHub webhooks for PRs you opened.
+The header line names the event type, action, repo/PR number, and the linked task id.
+Use the body to decide:
+- **PR merged** (`pull_request/closed` with `merged=true`): call finalize_task.
+- **PR closed unmerged**: call get_pr_status to read the rejection reason, then either
+  send_followup with the fix or finalize_task with expires_in_seconds=86400 if abandoning.
+- **Review submitted, `changes_requested`**: send_followup with the requested changes.
+- **Review submitted, `approved`**: usually no action — wait for merge, or finalize if
+  the workflow auto-merges.
+- **CI failure** (`check_run`/`check_suite/completed` with `conclusion=failure`):
+  send_followup with concrete instructions to fix the failure (read the summary line).
+- **CI success**: typically no action, unless this was the last required check and you
+  want to finalize.
+- **Issue comment / review comment on a PR**: send_followup if the human is requesting
+  changes; otherwise no action.
+Foreman events from bots on non-CI surfaces are filtered out before reaching you, so
+treat every `[github-event]` you see as something a human likely cares about.
+
+## Issue-first workflow
+**Skip issue creation entirely** for: follow-ups, CI fixes, lint fixes, test fixes, or any
+work continuing on an existing PR/branch — use send_followup instead.
+
+For new features, refactors, or multi-file changes: search for an existing issue with
+search_github_issues; create one with create_github_issue only if none exists. Then assign
+immediately — don't treat issue creation as a separate round-trip. Pass issue_number and
+issue_repo to assign_task so the worker's PR references the issue automatically.
+
+## Checking task progress
+Use get_task_status to verify a task is making progress — it returns the current state,
+the active agent and its state, and the last log lines. If a task looks stalled, use
+redirect_task to course-correct or cancel_task if it's going in the wrong direction.
+If an entire worker is wedged or no longer needed, use shutdown_worker to stop the process.
+
+## Live state
+Each user turn is preceded by a `<state>` block containing the current online workers
+and recent tasks. Treat it as an operational briefing, not part of the human's message.
+The state reflects the moment this turn was sent — earlier turns saw earlier state.
+
+Workers are configured with repos. Prefer workers whose repos cover the task.
+Be concise — one short paragraph maximum unless detail is requested.
+"""
+
+
+_EMPTY_WORKERS_BLOCKS = {"[]", "[\n]"}
+
+
+def _stable_system_text(primary_repo: str | None) -> str:
+    """The cacheable persona prefix. Stable per guild."""
+    repo_line = (
+        f"\n\nThe primary repository for this guild is `{primary_repo}`."
+        " Check it first when searching for issues."
+        if primary_repo
+        else ""
+    )
+    return f"{FOREMAN_SYSTEM}{repo_line}"
+
+
+def build_system_blocks(primary_repo: str | None = None) -> list[dict]:
+    """Return the system prompt as a single cache-controlled block.
+
+    Persona + per-guild repo line only. Live state (workers/tasks/extra_context)
+    is injected into the user turn via build_state_preamble — keeping system
+    100% cacheable across calls.
+    """
+    return [
+        {
+            "type": "text",
+            "text": _stable_system_text(primary_repo),
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def build_state_preamble(
+    workers_block: str,
+    tasks_block: str,
+    extra_context: str = "",
+) -> str:
+    """Render the live operational state to inject into the current user turn."""
+    if workers_block.strip() in _EMPTY_WORKERS_BLOCKS:
+        workers_section = (
+            "## Current workers\n"
+            "_No workers are currently online. Tell the human that no workers are "
+            "available and wait for one to come online before assigning work._\n\n"
+        )
+    else:
+        workers_section = f"## Current workers\n```json\n{workers_block}\n```\n\n"
+
+    body = f"{workers_section}## Recent tasks\n```json\n{tasks_block}\n```"
+    if extra_context:
+        body += f"\n\n## Context\n{extra_context}"
+    return f"<state>\n{body}\n</state>"
+
+
+def build_system_prompt(
+    workers_block: str,
+    tasks_block: str,
+    extra_context: str = "",
+    primary_repo: str | None = None,
+) -> str:
+    """Render the legacy single-string system prompt.
+
+    Production callers use build_system_blocks + build_state_preamble; this
+    helper is kept for the audit-log persistence path and for tests.
+    """
+    return (
+        f"{_stable_system_text(primary_repo)}\n\n"
+        f"{build_state_preamble(workers_block, tasks_block, extra_context)}"
+    )

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -1,0 +1,551 @@
+"""Foreman AI runner: conversation management and main loop.
+
+Standalone version — all DB access goes through ForemanHTTPClient REST calls;
+broadcasts go through ws_send() which relays via foreman-broadcast WS messages.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from .prompt import build_state_preamble, build_system_blocks, build_system_prompt
+
+if TYPE_CHECKING:
+    from .config import Config
+    from .http_client import ForemanHTTPClient
+
+try:
+    import anthropic as _anthropic
+
+    HAS_ANTHROPIC = True
+except ImportError:
+    HAS_ANTHROPIC = False
+
+logger = logging.getLogger(__name__)
+
+MAX_TOOL_RESULT_CHARS = 8_000
+MAX_HISTORY_MESSAGES = 20
+MAX_FOREMAN_ROUNDS = 10
+_HUMAN_TURN_WINDOW = 5
+_TERMINAL_STATES = frozenset({"done", "failed", "cancelled"})
+_24H_SECS = 86_400
+
+# Module-level Anthropic client (reused across calls)
+_anthropic_client: _anthropic.AsyncAnthropic | None = None
+
+
+def _get_anthropic_client(api_key: str | None = None) -> _anthropic.AsyncAnthropic:
+    global _anthropic_client
+    if _anthropic_client is None:
+        kwargs: dict = {}
+        if api_key:
+            kwargs["api_key"] = api_key
+        _anthropic_client = _anthropic.AsyncAnthropic(**kwargs)
+    return _anthropic_client
+
+
+def _inject_state_preamble(messages: list[dict], state_preamble: str) -> None:
+    """Prepend the live-state block to the last user turn (in place).
+
+    Called after history is loaded so the current human turn carries the latest
+    workers/tasks snapshot without persisting that snapshot to the DB.
+    """
+    if not messages or messages[-1]["role"] != "user":
+        return
+    last = messages[-1]
+    content = last["content"]
+    state_block = {"type": "text", "text": state_preamble}
+    if isinstance(content, str):
+        last["content"] = [state_block, {"type": "text", "text": content}]
+    elif isinstance(content, list):
+        last["content"] = [state_block, *content]
+
+
+def _stamp_message_cache_breakpoint(messages: list[dict]) -> None:
+    """Move the messages-level cache breakpoint to the last block of the last turn.
+
+    Clears any prior message-level cache_control first so we never accumulate
+    past the 4-breakpoint API cap (1 used by the system block). Earlier cached
+    prefixes remain readable via the API's 20-block lookback.
+    """
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    block.pop("cache_control", None)
+    if not messages:
+        return
+    last = messages[-1]
+    content = last.get("content")
+    if isinstance(content, str):
+        last["content"] = [
+            {"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}
+        ]
+        return
+    if isinstance(content, list):
+        for block in reversed(content):
+            if isinstance(block, dict):
+                block["cache_control"] = {"type": "ephemeral"}
+                return
+
+
+def truncate_tool_result(content: str, max_chars: int = MAX_TOOL_RESULT_CHARS) -> str:
+    """Cap a tool result string; append a truncation notice when trimmed."""
+    if len(content) <= max_chars:
+        return content
+    return content[:max_chars] + f"\n… [truncated: {len(content) - max_chars} chars omitted]"
+
+
+def prune_history(messages: list, max_messages: int = MAX_HISTORY_MESSAGES) -> list:
+    """Return at most *max_messages* tail entries, always starting with a user turn."""
+    if len(messages) > max_messages:
+        messages = messages[-max_messages:]
+    while messages and messages[0]["role"] != "user":
+        messages = messages[1:]
+    return messages
+
+
+def strip_orphaned_tool_results(messages: list[dict]) -> list[dict]:
+    """Remove any tool_result blocks (and their containing user message if it becomes empty)
+    whose tool_use_id has no matching tool_use block in the immediately-preceding
+    assistant message. Also remove the dangling tool_use blocks from the assistant
+    message that have no corresponding tool_result.
+    Returns a cleaned copy of the messages list.
+    """
+    out = copy.deepcopy(messages)
+    i = 0
+    while i < len(out):
+        msg = out[i]
+        content = msg.get("content")
+
+        if msg["role"] == "assistant" and isinstance(content, list):
+            # Collect tool_result IDs from the immediately-following user message.
+            if i + 1 < len(out):
+                nxt = out[i + 1]
+                if nxt["role"] == "user" and isinstance(nxt.get("content"), list):
+                    result_ids = {
+                        b["tool_use_id"]
+                        for b in nxt["content"]
+                        if isinstance(b, dict) and b.get("type") == "tool_result"
+                    }
+                else:
+                    result_ids = set()
+            else:
+                result_ids = set()
+
+            new_content = [
+                b
+                for b in content
+                if not (isinstance(b, dict) and b.get("type") == "tool_use")
+                or b.get("id") in result_ids
+            ]
+            if new_content != content:
+                if not new_content:
+                    out.pop(i)
+                    continue
+                msg["content"] = new_content
+
+        elif msg["role"] == "user" and isinstance(content, list):
+            # Collect tool_use IDs from the immediately-preceding assistant message.
+            if i > 0:
+                prev = out[i - 1]
+                if prev["role"] == "assistant" and isinstance(prev.get("content"), list):
+                    valid_ids = {
+                        b["id"]
+                        for b in prev["content"]
+                        if isinstance(b, dict) and b.get("type") == "tool_use"
+                    }
+                else:
+                    valid_ids = set()
+            else:
+                valid_ids = set()
+
+            new_content = [
+                b
+                for b in content
+                if not (isinstance(b, dict) and b.get("type") == "tool_result")
+                or b.get("tool_use_id") in valid_ids
+            ]
+            if new_content != content:
+                if not new_content:
+                    out.pop(i)
+                    continue
+                msg["content"] = new_content
+
+        i += 1
+
+    # Re-enforce starts-with-user and handle cascading orphans at the head.
+    while out:
+        if out[0]["role"] != "user":
+            out.pop(0)
+            continue
+        content = out[0].get("content")
+        if isinstance(content, list):
+            new_content = [
+                b for b in content if not (isinstance(b, dict) and b.get("type") == "tool_result")
+            ]
+            if not new_content:
+                out.pop(0)
+                continue
+            if new_content != content:
+                out[0]["content"] = new_content
+        break
+    return out
+
+
+def _summarize_task(task: dict, cutoff_ts: float) -> dict | None:
+    """Return a (possibly stripped) task dict, or None to exclude it.
+
+    Terminal tasks older than 24 h are dropped; terminal tasks within 24 h lose
+    their ``description`` field to keep context lean.  Non-terminal tasks are
+    returned unchanged.
+    """
+    state = task.get("state", "")
+    if state not in _TERMINAL_STATES:
+        return task
+    finished_at = task.get("finished_at")
+    if finished_at:
+        try:
+            finished_ts = datetime.fromisoformat(finished_at.replace("Z", "+00:00")).timestamp()
+            if finished_ts < cutoff_ts:
+                return None  # older than 24 h — drop entirely
+        except (ValueError, AttributeError):
+            pass
+    # Within 24 h or undatable: compact summary without description
+    return {k: v for k, v in task.items() if k != "description"}
+
+
+def _serialize_content(content) -> str:
+    """Convert SDK content objects or dicts to a JSON string for DB storage."""
+    if isinstance(content, str):
+        return json.dumps(content)
+    if isinstance(content, list):
+        blocks = []
+        for b in content:
+            if isinstance(b, dict):
+                blocks.append(b)
+            else:
+                try:
+                    blocks.append(b.model_dump())
+                except AttributeError:
+                    blocks.append({"type": str(getattr(b, "type", "unknown")), "raw": str(b)})
+        return json.dumps(blocks)
+    return json.dumps(str(content))
+
+
+async def _load_history(guild_id: str, user_id: str, *, http: ForemanHTTPClient) -> list[dict]:
+    """Load history via REST and apply the same sliding-window as the embedded runner."""
+    turns = await http.get_history(user_id)
+
+    if not turns:
+        return []
+
+    # Same sliding window as backend _load_history
+    cutoff = 0
+    human_count = 0
+    for i in range(len(turns) - 1, -1, -1):
+        t = turns[i]
+        if t["role"] == "user" and not t["is_tool_response"]:
+            human_count += 1
+            if human_count >= _HUMAN_TURN_WINDOW:
+                cutoff = i
+                break
+
+    messages = [
+        {"role": t["role"], "content": json.loads(t["content_json"])}
+        for t in turns[cutoff:]
+        if t["role"] != "system"
+    ]
+
+    while messages and messages[0]["role"] != "user":
+        messages.pop(0)
+
+    return messages
+
+
+async def _save_turn(
+    guild_id: str,
+    user_id: str,
+    role: str,
+    content,
+    *,
+    http: ForemanHTTPClient,
+    is_tool_response: bool = False,
+    parent_id: int | None = None,
+) -> int:
+    """Persist one turn via REST. Returns the new row's id."""
+    result = await http.save_turn(
+        user_id,
+        role,
+        _serialize_content(content),
+        is_tool_response=is_tool_response,
+        parent_id=parent_id,
+    )
+    return result["id"]
+
+
+async def run_foreman_ai(
+    guild_id: str,
+    human_message: str,
+    extra_context: str = "",
+    user_id: str | None = None,
+    *,
+    http: ForemanHTTPClient,
+    ws_send: Callable[[dict], Awaitable[None]],
+    config: Config,
+) -> None:
+    """Process a human message (or system escalation) through the Claude foreman AI.
+
+    Standalone version — uses REST for state/history, WS for broadcasts.
+    """
+    from .tools import FOREMAN_TOOLS, exec_tools
+
+    if not HAS_ANTHROPIC:
+        now = datetime.now(UTC).isoformat()
+        await ws_send(
+            {
+                "type": "chat",
+                "from": "foreman",
+                "to": "user",
+                "content": "Foreman AI offline (install `anthropic` package to enable).",
+                "createdAt": now,
+            }
+        )
+        return
+
+    # Fetch guild state
+    state = await http.get_state()
+    guild_data = state.get("guild") or {}
+    primary_repo = guild_data.get("primary_repo")
+    worker_rows = state.get("workers") or []
+    task_rows = state.get("tasks") or []
+
+    # Resolve user_id from guild owner if not provided
+    if not user_id:
+        user_id = guild_data.get("owner_user_id") or guild_id
+
+    try:
+        workers_block = json.dumps(
+            [
+                {
+                    "id": r["id"],
+                    "state": r.get("state") or "idle",
+                    "repos": r.get("repos") or [],
+                    **({"org": r["org"]} if r.get("org") else {}),
+                    "agent_count": r.get("agent_count") or 0,
+                }
+                for r in worker_rows
+            ],
+            indent=2,
+        )
+        cutoff_ts = datetime.now(UTC).timestamp() - _24H_SECS
+        summarized_tasks = [
+            s for row in task_rows if (s := _summarize_task(row, cutoff_ts)) is not None
+        ]
+        tasks_block = json.dumps(summarized_tasks, indent=2)
+        system_blocks = build_system_blocks(primary_repo=primary_repo)
+        state_preamble = build_state_preamble(workers_block, tasks_block, extra_context)
+        audit_system = build_system_prompt(
+            workers_block, tasks_block, extra_context, primary_repo=primary_repo
+        )
+
+        logger.info(
+            "guild=%s run_foreman_ai: workers=%d tasks_in_context=%d",
+            guild_id,
+            len(worker_rows),
+            len(summarized_tasks),
+        )
+
+        await _save_turn(guild_id, user_id, "system", audit_system, http=http)
+        await _save_turn(guild_id, user_id, "user", human_message, http=http)
+        messages = await _load_history(guild_id, user_id, http=http)
+
+        _inject_state_preamble(messages, state_preamble)
+
+        client = _get_anthropic_client(config.api_key)
+
+        text_parts = []
+        for round_num in range(config.max_rounds):
+            messages = prune_history(messages)
+            messages = strip_orphaned_tool_results(messages)
+            _stamp_message_cache_breakpoint(messages)
+            logger.info(
+                "guild=%s round %d: sending %d messages to Claude",
+                guild_id,
+                round_num,
+                len(messages),
+            )
+            resp = await client.messages.create(
+                model=config.model,
+                max_tokens=1024,
+                system=system_blocks,
+                messages=messages,
+                tools=FOREMAN_TOOLS,
+            )
+            usage = resp.usage
+            _input_tokens = getattr(usage, "input_tokens", 0) or 0
+            _output_tokens = getattr(usage, "output_tokens", 0) or 0
+            logger.info(
+                "guild=%s round %d: stop_reason=%s input=%d output=%d",
+                guild_id,
+                round_num,
+                resp.stop_reason,
+                _input_tokens,
+                _output_tokens,
+            )
+
+            asst_turn_id = await _save_turn(guild_id, user_id, "assistant", resp.content, http=http)
+            await http.update_turn_tokens(asst_turn_id, _input_tokens, _output_tokens)
+            messages.append({"role": "assistant", "content": _serialize_content(resp.content)})
+            # Re-parse so messages stays as plain dicts (not SDK objects)
+            messages[-1]["content"] = json.loads(messages[-1]["content"])
+
+            _now = datetime.now(UTC).isoformat()
+            for b in resp.content:
+                if b.type == "text" and b.text.strip():
+                    text_parts.append(b.text.strip())
+                    await ws_send(
+                        {
+                            "type": "chat",
+                            "from": "foreman",
+                            "to": "user",
+                            "content": b.text.strip(),
+                            "createdAt": _now,
+                        }
+                    )
+
+            tool_uses = [b for b in resp.content if b.type == "tool_use"]
+            if not tool_uses:
+                break
+
+            for tu in tool_uses:
+                await ws_send(
+                    {
+                        "type": "chat",
+                        "from": "foreman",
+                        "role": "tool_use",
+                        "to": "user",
+                        "content": f"▶ {tu.name}",
+                        "toolName": tu.name,
+                        "toolInput": dict(tu.input) if tu.input else {},
+                        "toolId": tu.id,
+                        "createdAt": _now,
+                    }
+                )
+
+            _tool_use_ts = _now  # noqa: F841
+
+            tool_results = await exec_tools(guild_id, tool_uses, http=http, user_id=user_id)
+            current_tool_use_ids = {tu.id for tu in tool_uses}
+            trimmed = [
+                {**r, "content": truncate_tool_result(r["content"])} if r.get("content") else r
+                for r in tool_results
+                if r.get("tool_use_id") in current_tool_use_ids
+            ]
+
+            _now = datetime.now(UTC).isoformat()
+            for result in trimmed:
+                await ws_send(
+                    {
+                        "type": "chat",
+                        "from": "foreman",
+                        "role": "tool_result",
+                        "to": "user",
+                        "content": result.get("content", ""),
+                        "toolId": result.get("tool_use_id"),
+                        "toolOutput": result.get("content", ""),
+                        "isError": result.get("is_error", False),
+                        "createdAt": _now,
+                    }
+                )
+
+            await _save_turn(
+                guild_id,
+                user_id,
+                "user",
+                trimmed,
+                http=http,
+                is_tool_response=True,
+                parent_id=asst_turn_id,
+            )
+            logger.info(
+                "guild=%s round %d: %d tool call(s): %s",
+                guild_id,
+                round_num,
+                len(trimmed),
+                [r.get("tool_use_id") for r in trimmed],
+            )
+            messages.append({"role": "user", "content": trimmed})
+        else:
+            # Safety cap wrap-up (same as embedded runner)
+            logger.warning("guild=%s hit %d-round safety cap", guild_id, config.max_rounds)
+            messages = prune_history(messages)
+            messages = strip_orphaned_tool_results(messages)
+            _stamp_message_cache_breakpoint(messages)
+            wrap_resp = await client.messages.create(
+                model=config.model,
+                max_tokens=1024,
+                system=system_blocks,
+                messages=messages,
+                tools=FOREMAN_TOOLS,
+                tool_choice={"type": "none"},
+            )
+            wrap_usage = wrap_resp.usage
+            _wrap_input = getattr(wrap_usage, "input_tokens", 0) or 0
+            _wrap_output = getattr(wrap_usage, "output_tokens", 0) or 0
+            wrap_turn_id = await _save_turn(
+                guild_id, user_id, "assistant", wrap_resp.content, http=http
+            )
+            await http.update_turn_tokens(wrap_turn_id, _wrap_input, _wrap_output)
+            _now = datetime.now(UTC).isoformat()
+            for b in wrap_resp.content:
+                if b.type == "text" and b.text.strip():
+                    text_parts.append(b.text.strip())
+                    await ws_send(
+                        {
+                            "type": "chat",
+                            "from": "foreman",
+                            "to": "user",
+                            "content": b.text.strip(),
+                            "createdAt": _now,
+                        }
+                    )
+            cap_note = f"_(Foreman hit {config.max_rounds}-round safety cap and stopped.)_"
+            text_parts.append(cap_note)
+            await ws_send(
+                {
+                    "type": "chat",
+                    "from": "foreman",
+                    "to": "user",
+                    "content": cap_note,
+                    "createdAt": _now,
+                }
+            )
+
+        response_text = "\n".join(text_parts).strip()
+        if response_text:
+            await http.save_message(
+                "foreman",
+                "user",
+                response_text,
+                user_id=user_id,
+            )
+
+    except Exception as exc:
+        logger.exception("guild=%s run_foreman_ai failed", guild_id)
+        now = datetime.now(UTC).isoformat()
+        await ws_send(
+            {
+                "type": "chat",
+                "from": "foreman",
+                "to": "user",
+                "content": f"Foreman error: {exc}",
+                "createdAt": now,
+            }
+        )

--- a/foreman/pioneer_foreman/tools.py
+++ b/foreman/pioneer_foreman/tools.py
@@ -1,0 +1,551 @@
+"""Foreman tool definitions and HTTP-backed tool executor.
+
+Tool definitions (FOREMAN_TOOLS) are identical to backend/foreman/tools.py —
+they define the schema for Claude to use.  Tool execution is delegated to the
+backend via POST /guilds/{guild_id}/foreman/exec_tool so all business logic
+(DB writes, lock acquisition, WS broadcasts to workers) stays in the backend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from .http_client import ForemanHTTPClient
+
+logger = logging.getLogger(__name__)
+
+# Copy of FOREMAN_TOOLS from backend/foreman/tools.py
+# (same schema, no changes needed)
+FOREMAN_TOOLS = [
+    {
+        "name": "create_task",
+        "description": (
+            "Create a named foreman task. Call this before assigning worker tasks — it gives the "
+            "work a human-readable name visible in the sidebar and returns a task_id to reference "
+            "in assign_task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Short human-readable name (≤60 chars), e.g. 'Implement OAuth login'.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Full description of the work to be done.",
+                },
+                "phase": {
+                    "type": "string",
+                    "enum": ["plan", "execute", "review"],
+                    "description": "Starting phase. Default: execute.",
+                },
+            },
+            "required": ["name", "description"],
+        },
+    },
+    {
+        "name": "assign_task",
+        "description": (
+            "Queue a coding task for a worker agent. The worker creates a git worktree, "
+            "runs the chosen coding agent on the description, then pushes the branch. "
+            "Pass task_id (from create_task) to assign that existing task to a worker instead "
+            "of creating a duplicate — this is the preferred flow."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "worker_id": {
+                    "type": "string",
+                    "description": "Worker agent ID (e.g. w-abc123). Must be idle.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Detailed, self-contained task description the coding agent receives.",
+                },
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID returned by create_task. When provided, assigns that "
+                    "existing task to the worker instead of creating a new row.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Short task name shown in the sidebar (≤60 chars).",
+                },
+                "tool": {
+                    "type": "string",
+                    "enum": ["claude", "codex", "pi"],
+                    "description": "Coding agent to use. Default: claude.",
+                },
+                "parent_task_id": {
+                    "type": "string",
+                    "description": "Foreman task ID this worker task belongs to (optional, ignored if task_id provided).",
+                },
+                "phase": {
+                    "type": "string",
+                    "enum": ["plan", "execute", "review", "followup"],
+                    "description": "Phase of work.",
+                },
+                "issue_number": {
+                    "type": "integer",
+                    "description": "GitHub issue to close (optional).",
+                },
+                "issue_repo": {
+                    "type": "string",
+                    "description": "owner/repo for the issue (optional).",
+                },
+                "repos": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Explicit list of owner/repo strings to clone for this task. "
+                        "When provided, the worker clones only these repos instead of "
+                        "falling back to its full configured list. Omit when the full "
+                        "list is appropriate."
+                    ),
+                },
+            },
+            "required": ["worker_id", "description"],
+        },
+    },
+    {
+        "name": "send_followup",
+        "description": (
+            "Continue work on an existing task's branch. The worker executes the "
+            "follow-up instructions on the same branch (and same worktree if the "
+            "original worker is still idle and within the 24h cleanup window) — "
+            "ideal for CI fixes, lint, test fixes, doc additions, or reviewer "
+            "comments. Worker selection: by default the original worker is "
+            "preferred when idle (free worktree reuse); when it's busy or "
+            "offline, any idle worker in the guild picks up the branch from "
+            "GitHub. Pass preferred_worker_id to force a specific worker. "
+            "Call this in response to task-complete, task-followup-done, "
+            "user comments on a parked PR task, or CI failures."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx)."},
+                "instructions": {
+                    "type": "string",
+                    "description": "Follow-up instructions to execute on the existing branch.",
+                },
+                "preferred_worker_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional: prefer this worker if idle. Defaults to the "
+                        "task's current worker_id."
+                    ),
+                },
+            },
+            "required": ["task_id", "instructions"],
+        },
+    },
+    {
+        "name": "finalize_task",
+        "description": (
+            "Mark a task complete with no further follow-up needed. "
+            "Call after reviewing a completed task when no additional work is required. "
+            "Tasks are soft-deleted after their expiry window so the table doesn't "
+            "accumulate cruft. Pick the window by task type:\n"
+            "  - Ephemeral tasks (periodic-check, status-poll, automated health "
+            "checks): expires_in_seconds = 1200 (20 minutes)\n"
+            "  - Code tasks (execute / review / followup phases): omit the field "
+            "to use the default 3 days, or pass expires_in_seconds = 259200\n"
+            "  - Error / failed tasks: expires_in_seconds = 86400 (1 day)\n"
+            "Pass deleted_at instead if you need an exact ISO-8601 timestamp."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID to finalize."},
+                "expires_in_seconds": {
+                    "type": "integer",
+                    "description": (
+                        "Seconds from now until the task is soft-deleted. "
+                        "Defaults to 259200 (3 days) when omitted."
+                    ),
+                },
+                "deleted_at": {
+                    "type": "string",
+                    "description": (
+                        "ISO-8601 UTC timestamp at which the task is soft-deleted. "
+                        "Takes precedence over expires_in_seconds when both are set."
+                    ),
+                },
+            },
+            "required": ["task_id"],
+        },
+    },
+    {
+        "name": "message_worker",
+        "description": "Send a message to a worker's terminal — for mid-task context injection.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "worker_id": {"type": "string"},
+                "message": {"type": "string"},
+            },
+            "required": ["worker_id", "message"],
+        },
+    },
+    {
+        "name": "redirect_task",
+        "description": (
+            "Redirect a running task mid-execution with new instructions. "
+            "Terminates the current Claude subprocess, then immediately resumes it in the same "
+            "session — Claude keeps full context of what it was doing and acts on the new "
+            "instructions instead. For tasks awaiting review, acts as a follow-up. "
+            "Use this to course-correct without losing progress."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx) to redirect."},
+                "instructions": {
+                    "type": "string",
+                    "description": "New instructions. Claude will see its full prior history.",
+                },
+            },
+            "required": ["task_id", "instructions"],
+        },
+    },
+    {
+        "name": "cancel_task",
+        "description": (
+            "Cancel a running or pending task. Use when a task is going in the wrong direction, "
+            "is stuck, or is no longer needed. The worker terminates its Claude subprocess "
+            "immediately and releases the agent slot. Cannot cancel tasks that are already done or failed."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx) to cancel."},
+                "reason": {"type": "string", "description": "Optional reason for cancellation."},
+            },
+            "required": ["task_id"],
+        },
+    },
+    {
+        "name": "shutdown_worker",
+        "description": (
+            "Send a shutdown signal to a worker agent, causing it to gracefully stop. "
+            "Idle agents exit immediately; busy agents finish their current task and skip "
+            "the follow-up window. The worker process disconnects and transitions to offline. "
+            "Use when a worker is misbehaving, the operator is winding down, or a host needs "
+            "to be freed up — prefer cancel_task for stopping a single bad task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "worker_id": {
+                    "type": "string",
+                    "description": "Worker agent ID (e.g. w-abc123).",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Optional reason for shutdown.",
+                },
+            },
+            "required": ["worker_id"],
+        },
+    },
+    {
+        "name": "list_github_issues",
+        "description": (
+            "List GitHub issues for a repo. Use this to discover work that needs to be done."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo, e.g. 'acme/backend'"},
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "all"],
+                    "description": "Default: open",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max issues to return (default 20, max 50)",
+                },
+            },
+            "required": ["repo"],
+        },
+    },
+    {
+        "name": "get_github_issue",
+        "description": "Get full details of a single GitHub issue including its body and comments.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "issue_number": {"type": "integer"},
+            },
+            "required": ["repo", "issue_number"],
+        },
+    },
+    {
+        "name": "list_github_prs",
+        "description": "List pull requests for a repo — useful for reviewing completed worker branches.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "all"],
+                    "description": "Default: open",
+                },
+            },
+            "required": ["repo"],
+        },
+    },
+    {
+        "name": "claim_github_issue",
+        "description": (
+            "Assign a GitHub issue to the authenticated user (claim it for this guild's operator). "
+            "Call this when picking up an issue to work on, before assigning a worker task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "issue_number": {"type": "integer"},
+            },
+            "required": ["repo", "issue_number"],
+        },
+    },
+    {
+        "name": "get_task_status",
+        "description": (
+            "Get the current status of a task: state, phase, assigned worker and active agent state, "
+            "and the last log lines. Use this to verify a task is progressing and to diagnose stalls."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID (t-xxxxxx)."},
+                "log_lines": {
+                    "type": "integer",
+                    "description": "Number of recent log lines to return (default 10, max 50).",
+                },
+            },
+            "required": ["task_id"],
+        },
+    },
+    {
+        "name": "create_github_issue",
+        "description": (
+            "Create a new GitHub issue to track work before assigning it to a worker. "
+            "Search first with search_github_issues to avoid duplicates."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "title": {"type": "string", "description": "Issue title."},
+                "body": {"type": "string", "description": "Issue body in markdown."},
+                "labels": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Label names to apply (labels must already exist in the repo).",
+                },
+            },
+            "required": ["repo", "title", "body"],
+        },
+    },
+    {
+        "name": "get_pr_status",
+        "description": (
+            "Fetch the live status of a single pull request: merged/closed/open state, "
+            "submitted reviews, and the latest check-run conclusions for the head SHA. "
+            "Use this to interpret a `[github-event]` message that doesn't carry enough "
+            "context, or when deciding whether all required checks have completed before "
+            "finalizing a task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo"},
+                "pr_number": {"type": "integer", "description": "Pull request number."},
+            },
+            "required": ["repo", "pr_number"],
+        },
+    },
+    {
+        "name": "search_github_issues",
+        "description": (
+            "Search GitHub issues and PRs by keyword within a repo. "
+            "Call this before create_github_issue to check whether an issue already exists."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "owner/repo to restrict search to."},
+                "query": {"type": "string", "description": "Search keywords."},
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "all"],
+                    "description": "Filter by state. Default: open.",
+                },
+            },
+            "required": ["repo", "query"],
+        },
+    },
+    {
+        "name": "review_pr",
+        "description": (
+            "Request an automated code review via the EXTERNAL code-review-agent MCP server "
+            "at agent.meyers.life (override with REVIEWER_AGENT_URL env var). "
+            "The remote agent fetches the PR diff, runs a Claude-powered review, and posts "
+            "the result as a GitHub PR review (APPROVE / REQUEST_CHANGES / COMMENT). "
+            "Use this when you want a specialised external reviewer. "
+            "For a self-contained internal review without any external dependency, "
+            "use review_pr_internal instead."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pr_url": {
+                    "type": "string",
+                    "description": (
+                        "Full GitHub PR URL, e.g. https://github.com/owner/repo/pull/123"
+                    ),
+                },
+            },
+            "required": ["pr_url"],
+        },
+    },
+    {
+        "name": "review_pr_internal",
+        "description": (
+            "Perform an internal agent-driven code review of a GitHub pull request "
+            "without calling any external service. "
+            "Fetches the PR diff directly from the GitHub API, uses the Foreman AI to "
+            "analyse it, then posts a GitHub PR review with a 3–5 bullet-point summary "
+            "and up to 5 inline comments on specific lines. "
+            "Supports action values APPROVE, REQUEST_CHANGES, or COMMENT (default COMMENT). "
+            "Use this instead of review_pr when you want a quick review with no external "
+            "dependency, or when agent.meyers.life is unavailable."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pr_url": {
+                    "type": "string",
+                    "description": "Full GitHub PR URL, e.g. https://github.com/owner/repo/pull/123",
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+                    "description": (
+                        "Review verdict to submit to GitHub. "
+                        "APPROVE — looks good; REQUEST_CHANGES — must fix before merge; "
+                        "COMMENT — neutral feedback (default)."
+                    ),
+                },
+            },
+            "required": ["pr_url"],
+        },
+    },
+    {
+        "name": "dnsid",
+        "description": (
+            "Run a DNSid operation via the local dnsid-sdk CLI. "
+            "Three commands: "
+            "'resolve' — look up an FQDN's _dnsid TXT record and JWKS (param: fqdn); "
+            "'sign' — sign a JWT with the agent's configured Ed25519 identity (param: claims object); "
+            "'verify' — verify a JWT against its DNSid record (params: jwt, expected_aud, optional expected_nonce). "
+            "Returns the CLI's JSON output on success; raises on failure."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "enum": ["resolve", "sign", "verify"],
+                    "description": "Subcommand to run.",
+                },
+                "fqdn": {
+                    "type": "string",
+                    "description": "resolve: FQDN to look up, e.g. 'example.com'.",
+                },
+                "claims": {
+                    "type": "object",
+                    "description": "sign: JSON object of JWT claims (iss, sub, exp, nonce, …).",
+                },
+                "jwt": {
+                    "type": "string",
+                    "description": "verify: compact JWT string to verify.",
+                },
+                "expected_aud": {
+                    "type": "string",
+                    "description": "verify: required — aud claim must contain this value.",
+                },
+                "expected_nonce": {
+                    "type": "string",
+                    "description": "verify: optional — nonce claim must equal this value.",
+                },
+            },
+            "required": ["command"],
+        },
+    },
+    {
+        "name": "call_agent",
+        "description": (
+            "Call a skill on a remote A2A-compatible HTTP agent. "
+            "Fetches the agent card from {agent_url}/.well-known/agent.json to discover "
+            "available skills, then dispatches the requested skill with the given params. "
+            "Returns the raw JSON result from the agent."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "agent_url": {
+                    "type": "string",
+                    "description": (
+                        "Base URL of the target A2A agent, "
+                        "e.g. https://agent.example.com or http://localhost:8080"
+                    ),
+                },
+                "skill": {
+                    "type": "string",
+                    "description": (
+                        "Skill id to invoke, e.g. 'verify_identity_record' or 'lookup_dnsid'. "
+                        "Must match a skill id listed in the agent card."
+                    ),
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Parameters to pass to the skill as a JSON object.",
+                },
+            },
+            "required": ["agent_url", "skill"],
+        },
+    },
+]
+
+
+async def exec_tools(
+    guild_id: str,
+    tool_uses: list,
+    *,
+    http: ForemanHTTPClient,
+    user_id: str | None = None,
+) -> list:
+    """Execute tool calls via the backend REST API.
+
+    Independent tool calls run concurrently (same as the embedded executor).
+    Results are returned in the same order as *tool_uses*.
+    """
+    coros = [
+        http.exec_tool(
+            tool_name=tu.name,
+            tool_id=tu.id,
+            tool_input=dict(tu.input) if tu.input else {},
+            user_id=user_id,
+        )
+        for tu in tool_uses
+    ]
+    return list(await asyncio.gather(*coros))

--- a/foreman/pyproject.toml
+++ b/foreman/pyproject.toml
@@ -5,27 +5,23 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pioneer-foreman"
 version = "0.1.0"
-description = "Standalone foreman AI process for Pioneer Square: receives triggers from the backend, runs Claude, and coordinates workers."
+description = "Standalone foreman agent for Pioneer Square: coordinates worker agents via REST + WebSocket."
 requires-python = ">=3.11"
 dependencies = [
-    "anthropic>=0.40.0",
     "websockets>=12.0",
-    "sqlalchemy[asyncio]>=2.0",
-    "sqlmodel>=0.0.18",
-    "aiosqlite>=0.20",
-    "fastapi>=0.110.0",
-    "cryptography>=42.0",
-    "python-dotenv>=1.0",
+    "httpx>=0.27",
+    "anthropic>=0.49",
+    "anyio>=4.0",
 ]
 
 [project.optional-dependencies]
-bedrock = ["anthropic[bedrock]>=0.40.0"]
-test = ["pytest>=8.0", "pytest-asyncio>=0.23"]
-
-[project.scripts]
-# Phase 3: once pioneer_foreman/ package exists this will work as a CLI entry point.
-# For now, run directly: python foreman/main.py
-# pioneer-foreman = "pioneer_foreman.cli:main"
+test = ["pytest>=8.0", "pytest-asyncio>=0.23", "anyio[trio]>=4.0", "respx>=0.20"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[project.scripts]
+pioneer-foreman = "pioneer_foreman.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["pioneer_foreman*"]


### PR DESCRIPTION
## Summary

Phase 3 of [foreman-split-plan.md](docs/foreman-split-plan.md): creates the `pioneer_foreman` standalone package that replaces the Phase 2 `sys.path` shim. The standalone foreman now communicates with the backend **exclusively via REST + WebSocket** — no direct database access, no backend module imports.

## New: `foreman/pioneer_foreman/`

| File | Purpose |
|------|---------|
| `config.py` | TOML + env var + CLI config loader (`pioneer-foreman.toml`) |
| `http_client.py` | `ForemanHTTPClient` — async httpx wrapper for all backend REST calls |
| `prompt.py` | Verbatim copy of backend prompt builder (pure Python, no deps) |
| `tools.py` | `FOREMAN_TOOLS` schema + `exec_tools()` via `exec_tool` endpoint |
| `runner.py` | Ported Claude API loop — DB calls → REST, `broadcast()` → `ws_send()` |
| `foreman.py` | `Foreman` class: WS connection, trigger dispatch, poll loop, reconnect |
| `cli.py` | `pioneer-foreman` CLI with `--config`, `--backend-url`, `--guild-id`, etc. |
| `pyproject.toml` | Package definition with `pioneer-foreman` entry point |
| `pioneer-foreman.toml.example` | Config template |

### Install and run
```bash
cd foreman
python -m venv .venv && source .venv/bin/activate
pip install -e .
cp pioneer-foreman.toml.example pioneer-foreman.toml
# Edit: backend_url, guild_id, auth_token (member login_token)
pioneer-foreman
```

## Backend additions (`backend/routes/foreman.py`)

- **`GET /guilds/{id}/foreman/state`** now includes `owner_user_id` in the `guild` object (needed to resolve default user_id without DB access)
- **`PATCH /guilds/{id}/foreman/turns/{turn_id}/tokens`** — update Claude token counts on a saved turn
- **`POST /guilds/{id}/foreman/exec_tool`** — delegates a single tool call to `_exec_one_tool()`, keeping all business logic (locks, worker selection, DB writes, WS broadcasts to workers) in the backend

## Architecture

```
pioneer-foreman process
  │
  ├── REST (httpx) ──► GET /foreman/state        (workers, tasks, guild)
  │                   GET/POST /foreman/history   (conversation turns)
  │                   PATCH /foreman/turns/{id}/tokens
  │                   POST /foreman/exec_tool     (tool execution)
  │                   POST /messages              (chat persistence)
  │
  └── WebSocket ──────► join {agentType: foreman, external: true}
                        ◄── foreman-trigger        (triggers run_foreman_ai)
                        ──► foreman-broadcast      (Claude chat → frontend)
```

Tool execution is intentionally kept server-side via `exec_tool` so the backend remains the single source of truth for locks, worker selection, and WS fan-out to worker agents.

## Updated files

- **`foreman/Dockerfile`** — installs `pioneer_foreman` package; drops the backend bundle that Phase 2 required
- **`CLAUDE.md`** — `venv` → `.venv` everywhere; foreman section updated to `pioneer-foreman` CLI

## What's unchanged

- Worker protocol — no changes to worker WebSocket messages or REST endpoints
- Frontend — no changes
- Embedded foreman — still runs as fallback when no external foreman is connected
- `foreman/main.py` — kept as a legacy Phase 2 shim; can be removed in Phase 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)