### PR TITLE
Worker join/leave notifies foreman

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -84,6 +84,23 @@ Use the body to decide:
 Foreman events from bots on non-CI surfaces are filtered out before reaching you, so
 treat every `[github-event]` you see as something a human likely cares about.
 
+## Reacting to worker lifecycle events
+Messages prefixed `[worker-online]` and `[worker-offline]` notify you when a worker
+process joins or leaves the guild.
+
+- **`[worker-online] worker_id=<id> repos=<repos> agent_count=<n>`**: A worker just
+  registered. Check the current task list for unassigned pending tasks and assign them
+  to the new worker if it covers the relevant repos. If repos is empty the worker can
+  still accept tasks without a repo constraint.
+- **`[worker-offline] worker_id=<id> reason=shutdown`**: The worker shut down cleanly
+  (operator-initiated or via shutdown_worker). No urgent action required; if tasks were
+  assigned to it and are still in-progress, check their status and reassign via
+  send_followup to another idle worker if needed.
+- **`[worker-offline] worker_id=<id> reason=disconnect`**: The worker dropped
+  unexpectedly (crash or network failure). Escalate to the human if no other workers
+  are available or if critical tasks were actively running on this worker. Use
+  get_task_status to inspect affected tasks before deciding to reassign.
+
 ## Issue-first workflow
 **Skip issue creation entirely** for: follow-ups, CI fixes, lint fixes, test fixes, or any
 work continuing on an existing PR/branch — use send_followup instead.

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -204,6 +204,13 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                             "state": "offline",
                         },
                     )
+                for wid in stale_worker_ids:
+                    await ws_handlers._trigger_foreman(
+                        guild_id,
+                        "worker-offline",
+                        f"[worker-offline] worker_id={wid} reason=disconnect",
+                        task_name=f"foreman.worker-offline:{wid}",
+                    )
             finally:
                 # If a cancellation was delivered inside a handler (e.g.
                 # handle_worker_disconnect) the underlying asyncpg connection

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -204,12 +204,19 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                             "state": "offline",
                         },
                     )
-                for wid in stale_worker_ids:
+                # Batch all stale-worker notifications into a single foreman
+                # trigger so a simultaneous mass-disconnect doesn't stampede
+                # the foreman with N concurrent embedded-foreman tasks.
+                if stale_worker_ids:
+                    offline_lines = "\n".join(
+                        f"[worker-offline] worker_id={wid} reason=disconnect"
+                        for wid in sorted(stale_worker_ids)
+                    )
                     await ws_handlers._trigger_foreman(
                         guild_id,
                         "worker-offline",
-                        f"[worker-offline] worker_id={wid} reason=disconnect",
-                        task_name=f"foreman.worker-offline:{wid}",
+                        offline_lines,
+                        task_name="foreman.worker-offline:disconnect-batch",
                     )
             finally:
                 # If a cancellation was delivered inside a handler (e.g.

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -99,10 +99,10 @@ def test_worker_online_notifies_foreman(client):
                     "repos": ["org/repo1", "org/repo2"],
                 }
             )
-            # handler runs synchronously; give the event loop a tick so the
-            # awaited fake_trigger coroutine completes before we exit
-            ws.send_json({"type": "ping"})
-            ws.receive_json()  # pong
+            # No explicit sync needed: _trigger_foreman is directly awaited
+            # inside handle_worker_register, so triggered is populated before
+            # the handler returns. The WS context exit (close frame) ensures
+            # the server processes worker-register before we reach assertions.
 
     online = [(e, m) for e, m in triggered if e == "worker-online"]
     assert online, f"Expected worker-online trigger, got: {triggered}"

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -1,0 +1,180 @@
+"""Tests that worker join/leave events trigger foreman notifications.
+
+Verifies that:
+- handle_worker_register triggers [worker-online] to the foreman
+- handle_worker_disconnect triggers [worker-offline] reason=shutdown
+- abrupt WebSocket disconnect triggers [worker-offline] reason=disconnect
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+from starlette.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module  # noqa: E402
+import main as main_module  # noqa: E402
+import ws_handlers  # noqa: E402
+from _test_config import TEST_DATABASE_URL  # noqa: E402
+from helpers import insert_guild, insert_worker  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client(_setup_schema):
+    """Module-scoped TestClient shared by all notify tests."""
+    db_url = TEST_DATABASE_URL
+    new_engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+    new_session = async_sessionmaker(new_engine, expire_on_commit=False, class_=AsyncSession)
+    mp = pytest.MonkeyPatch()
+    mp.setattr(database_module, "AsyncSessionLocal", new_session)
+    mp.setattr(main_module, "AsyncSessionLocal", new_session)
+
+    async def _stubbed_reset_connection_state() -> None:
+        pass
+
+    mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
+    mp.setenv("DATABASE_URL", db_url)
+
+    with TestClient(main_module.app) as c:
+        yield c, db_url
+
+    mp.undo()
+
+
+def _make_trigger_spy():
+    """Return (spy_list, async_fake) where spy_list accumulates (event, msg) calls."""
+    triggered: list[tuple[str, str]] = []
+
+    async def fake_trigger(
+        guild_id: str,
+        event: str,
+        msg: str,
+        *,
+        user_id: str | None = None,
+        task_id: str | None = None,
+        task_name: str = "",
+    ) -> None:
+        triggered.append((event, msg))
+
+    return triggered, fake_trigger
+
+
+def test_worker_online_notifies_foreman(client):
+    """worker-register triggers [worker-online] with worker_id, repos, and agent_count."""
+    test_client, db_url = client
+    guild_id = "nfy001"
+    worker_id = "w-nfy001"
+    agent_id = "a-nfy001"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json(
+                {
+                    "type": "worker-register",
+                    "workerId": worker_id,
+                    "repos": ["org/repo1", "org/repo2"],
+                }
+            )
+            # handler runs synchronously; give the event loop a tick so the
+            # awaited fake_trigger coroutine completes before we exit
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+    online = [(e, m) for e, m in triggered if e == "worker-online"]
+    assert online, f"Expected worker-online trigger, got: {triggered}"
+    _event, msg = online[0]
+    assert f"worker_id={worker_id}" in msg, msg
+    assert "repos=org/repo1,org/repo2" in msg, msg
+    assert "agent_count=1" in msg, msg
+
+
+def test_worker_graceful_offline_notifies_foreman(client):
+    """worker-disconnect triggers [worker-offline] reason=shutdown."""
+    test_client, db_url = client
+    guild_id = "nfy002"
+    worker_id = "w-nfy002"
+    agent_id = "a-nfy002"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json({"type": "worker-disconnect", "workerId": worker_id})
+            ws.receive_json()  # agent-state offline broadcast
+
+    offline = [(e, m) for e, m in triggered if e == "worker-offline"]
+    assert offline, f"Expected worker-offline trigger, got: {triggered}"
+    _event, msg = offline[0]
+    assert f"worker_id={worker_id}" in msg, msg
+    assert "reason=shutdown" in msg, msg
+
+
+def test_abrupt_disconnect_notifies_foreman(client):
+    """Abrupt WebSocket close (no worker-disconnect) triggers [worker-offline] reason=disconnect."""
+    test_client, db_url = client
+    guild_id = "nfy003"
+    worker_id = "w-nfy003"
+    agent_id = "a-nfy003"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+            # Close without sending worker-disconnect — simulates container crash.
+
+    offline = [(e, m) for e, m in triggered if e == "worker-offline"]
+    assert offline, f"Expected worker-offline trigger on abrupt disconnect, got: {triggered}"
+    _event, msg = offline[0]
+    assert f"worker_id={worker_id}" in msg, msg
+    assert "reason=disconnect" in msg, msg

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -540,6 +540,14 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
         .values(**update_vals)
     )
     await ctx.db.commit()
+    repos_str = ",".join(repos) if repos else ""
+    agent_count = len(ctx.joined_agents)
+    await _trigger_foreman(
+        ctx.guild_id,
+        "worker-online",
+        f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}",
+        task_name=f"foreman.worker-online:{worker_id}",
+    )
 
 
 async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
@@ -564,6 +572,13 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
             {"type": "agent-state", "agentId": agent_id, "state": "offline"},
         )
     reset_foreman_poll(ctx.guild_id)
+    if worker_id:
+        await _trigger_foreman(
+            ctx.guild_id,
+            "worker-offline",
+            f"[worker-offline] worker_id={worker_id} reason=shutdown",
+            task_name=f"foreman.worker-offline:{worker_id}",
+        )
 
 
 async def handle_task_update(ctx: WSContext, data: dict) -> None:

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -28,7 +28,7 @@ from events import (
 from fastapi import WebSocket
 from lock_service import LockService
 from models import Agent, Message, Task, TaskEvent, TaskLog, User, Worker
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from util.tasks import spawn
 from utils import worker_display_name
@@ -541,7 +541,17 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
     )
     await ctx.db.commit()
     repos_str = ",".join(repos) if repos else ""
-    agent_count = len(ctx.joined_agents)
+    # Query the DB for agents belonging to this specific worker so the count
+    # is accurate even when multiple workers share the same WS connection or
+    # agents from previous sessions are still tracked in joined_agents.
+    count_res = await ctx.db.execute(
+        select(func.count(Agent.id)).where(
+            Agent.worker_id == worker_id,
+            Agent.guild_id == ctx.guild_pk,
+            Agent.state != "offline",
+        )
+    )
+    agent_count = count_res.scalar_one()
     await _trigger_foreman(
         ctx.guild_id,
         "worker-online",
@@ -571,7 +581,6 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
             ctx.guild_id,
             {"type": "agent-state", "agentId": agent_id, "state": "offline"},
         )
-    reset_foreman_poll(ctx.guild_id)
     if worker_id:
         await _trigger_foreman(
             ctx.guild_id,
@@ -579,6 +588,7 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
             f"[worker-offline] worker_id={worker_id} reason=shutdown",
             task_name=f"foreman.worker-offline:{worker_id}",
         )
+    reset_foreman_poll(ctx.guild_id)
 
 
 async def handle_task_update(ctx: WSContext, data: dict) -> None:


### PR DESCRIPTION
## Summary

- **`[worker-online]`** — `handle_worker_register` in `ws_handlers.py` now calls `_trigger_foreman` after updating the worker's repo list. Emits `[worker-online] worker_id=<id> repos=<comma-separated> agent_count=<n>` so the foreman can assign queued tasks to the newly available worker.
- **`[worker-offline] reason=shutdown`** — `handle_worker_disconnect` in `ws_handlers.py` calls `_trigger_foreman` after broadcasting the offline state, emitting `[worker-offline] worker_id=<id> reason=shutdown` for clean shutdowns.
- **`[worker-offline] reason=disconnect`** — the `finally` block in `routes/websocket.py` calls `ws_handlers._trigger_foreman` for each stale worker ID after marking agents offline, emitting `[worker-offline] worker_id=<id> reason=disconnect` for abrupt drops.
- **Foreman system prompt** (`foreman/prompt.py`) — new "Reacting to worker lifecycle events" section tells the foreman to check pending tasks on `worker-online`, ignore clean shutdowns unless tasks are affected, and escalate unexpected `disconnect` events to the human.

Both call sites use the existing `_trigger_foreman` helper, which routes to an external foreman if one is connected and falls back to the embedded loop—no new infrastructure required.

## Test plan

- [ ] `test_worker_online_notifies_foreman` — join + worker-register → `[worker-online]` with correct `worker_id`, `repos`, and `agent_count`
- [ ] `test_worker_graceful_offline_notifies_foreman` — worker-disconnect → `[worker-offline] reason=shutdown`
- [ ] `test_abrupt_disconnect_notifies_foreman` — close WS without worker-disconnect → `[worker-offline] reason=disconnect`
- [ ] All existing disconnect and liveness tests continue to pass (foreman trigger is patched in new tests; existing tests are unaffected because `spawn(run_foreman_ai(...))` schedules a task that completes after the test WS closes)

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)