### PR TITLE
Review PR #435: Worker join/leave notifies foreman

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -100,6 +100,8 @@ process joins or leaves the guild.
   unexpectedly (crash or network failure). Escalate to the human if no other workers
   are available or if critical tasks were actively running on this worker. Use
   get_task_status to inspect affected tasks before deciding to reassign.
+  A single message may contain multiple `[worker-offline]` lines when several
+  workers disconnect simultaneously — handle each line independently.
 
 ## Issue-first workflow
 **Skip issue creation entirely** for: follow-ups, CI fixes, lint fixes, test fixes, or any

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -138,7 +138,8 @@ async def _trigger_foreman(
 
     ``event`` mirrors the plan's trigger-type vocabulary:
     ``chat``, ``task-complete``, ``followup-done``, ``needs-input``,
-    ``claude-auth``, ``periodic-check``.
+    ``claude-auth``, ``periodic-check``, ``worker-online``,
+    ``worker-offline``.
     """
     ws = foreman_connections.get(guild_id)
     if ws is not None:


### PR DESCRIPTION
## Summary of PR #435

PR #435 (now merged) adds worker lifecycle notifications so the foreman AI learns when workers come online or drop off. This review branch fixes two gaps found during the review.

## What PR #435 does

- **`handle_worker_register`** in `ws_handlers.py` now calls `_trigger_foreman` after updating repos, emitting `[worker-online] worker_id=<id> repos=<...> agent_count=<n>` so the foreman can assign queued tasks to the newly available worker.
- **`handle_worker_disconnect`** emits `[worker-offline] worker_id=<id> reason=shutdown` for clean shutdowns.
- The `finally` cleanup in `routes/websocket.py` batches all stale workers into a single `[worker-offline] reason=disconnect` trigger to avoid stampeding the foreman on mass-disconnect.
- Foreman system prompt updated with a "Reacting to worker lifecycle events" section.
- 3 new tests covering online, graceful offline, and abrupt-disconnect paths.

## Issues found and fixed

### 1. `_trigger_foreman` docstring missing new event types (`ws_handlers.py`)
The docstring enumerated the supported `event` values but `worker-online` and `worker-offline` were absent, making the vocabulary list incorrect for anyone reading it.

**Fix:** Added both to the docstring list.

### 2. Foreman prompt silent on batch-disconnect format (`foreman/prompt.py`)
The mass-disconnect path batches multiple workers into one trigger (one `[worker-offline]` line per worker, newline-separated). The prompt only described the single-worker case, so the foreman had no guidance on how to handle a message containing several lines.

**Fix:** Added a sentence to the `reason=disconnect` bullet explaining that a single message can contain multiple `[worker-offline]` lines and that each should be handled independently.

## Non-blocking observations (not fixed)

- **Re-registration fires `worker-online` again**: Every `worker-register` message triggers a foreman notification, including repo-update re-registrations. This is harmless (the foreman re-checks pending tasks) but slightly noisy. Fixing it would require tracking first-registration state per agent, which isn't worth the complexity.
- **`worker-online`/`worker-offline` not in CLAUDE.md protocol table**: The WS message-type table in CLAUDE.md lists `agent-state`, `task-assigned`, etc., but the new foreman trigger events aren't listed. These are internal trigger names, not wire messages, so this is a documentation judgment call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)