### PR TITLE
fix: prevent WS close-race InterfaceError in test_worker_online_notifies_foreman

### DIFF
--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -162,39 +162,55 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                     stale_agents = [
                         aid for aid in joined_agents if agent_owners.get(aid) is websocket
                     ]
+                    # Release ownership first so a racing join/reconnect sees a
+                    # clean slate even if the DB operations below fail.
+                    for agent_id in stale_agents:
+                        agent_owners.pop(agent_id, None)
                     # Look up the worker_ids for all stale agents *before* we
                     # modify their rows, so we can update the Worker table with
                     # the correct IDs (worker IDs are "w-…"; agent IDs are
                     # "a-…" — using agent_id as a Worker.id filter never
                     # matched and left zombie workers stuck in "online").
                     stale_worker_ids: set[str] = set()
-                    if stale_agents:
-                        wid_rows = (
-                            await db.execute(
-                                select(Agent.worker_id).where(
-                                    Agent.id.in_(stale_agents),
-                                    Agent.guild_id == _guild_pk,
-                                    Agent.worker_id.isnot(None),
+                    try:
+                        if stale_agents:
+                            wid_rows = (
+                                await db.execute(
+                                    select(Agent.worker_id).where(
+                                        Agent.id.in_(stale_agents),
+                                        Agent.guild_id == _guild_pk,
+                                        Agent.worker_id.isnot(None),
+                                    )
                                 )
+                            ).all()
+                            stale_worker_ids = {r[0] for r in wid_rows}
+                        for agent_id in stale_agents:
+                            await db.execute(
+                                update(Agent)
+                                .where(Agent.id == agent_id, Agent.guild_id == _guild_pk)
+                                .values(state="offline", activity=None, current_task_id=None)
                             )
-                        ).all()
-                        stale_worker_ids = {r[0] for r in wid_rows}
-                    for agent_id in stale_agents:
-                        agent_owners.pop(agent_id, None)
-                        await db.execute(
-                            update(Agent)
-                            .where(Agent.id == agent_id, Agent.guild_id == _guild_pk)
-                            .values(state="offline", activity=None, current_task_id=None)
+                        # Mirror into workers table using the real worker IDs.
+                        for wid in stale_worker_ids:
+                            await db.execute(
+                                update(Worker)
+                                .where(Worker.id == wid, Worker.guild_id == _guild_pk)
+                                .values(state="offline")
+                            )
+                        if stale_agents:
+                            await db.commit()
+                    except Exception:
+                        # The DB connection may have been closed by a
+                        # CancelledError delivered during a handler (e.g.
+                        # when a close frame races a db.commit() inside the
+                        # message loop).  Log and continue so the broadcast
+                        # and foreman-trigger below still run.
+                        logger.warning(
+                            "WS teardown: DB error for guild %s — stale agents/workers"
+                            " may remain online in DB until sweeper runs",
+                            guild_id,
+                            exc_info=True,
                         )
-                    # Mirror into workers table using the real worker IDs.
-                    for wid in stale_worker_ids:
-                        await db.execute(
-                            update(Worker)
-                            .where(Worker.id == wid, Worker.guild_id == _guild_pk)
-                            .values(state="offline")
-                        )
-                    if stale_agents:
-                        await db.commit()
                 for agent_id in stale_agents:
                     await broadcast(
                         guild_id,

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -99,10 +99,14 @@ def test_worker_online_notifies_foreman(client):
                     "repos": ["org/repo1", "org/repo2"],
                 }
             )
-            # No explicit sync needed: _trigger_foreman is directly awaited
-            # inside handle_worker_register, so triggered is populated before
-            # the handler returns. The WS context exit (close frame) ensures
-            # the server processes worker-register before we reach assertions.
+            # Sync: ping/pong ensures the server has fully processed
+            # worker-register (including db.commit()) before we close the
+            # WebSocket.  Without this, the close frame can arrive while
+            # handle_worker_register is still awaiting inside db.commit(),
+            # which delivers a CancelledError that corrupts the asyncpg
+            # connection and causes InterfaceError in the finally block.
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
 
     online = [(e, m) for e, m in triggered if e == "worker-online"]
     assert online, f"Expected worker-online trigger, got: {triggered}"


### PR DESCRIPTION
## Summary

- `test_worker_online_notifies_foreman` was failing in CI with `sqlalchemy.exc.InterfaceError: connection is closed` (1 failing test, 438 passing)
- Root cause: the test sent `worker-register` then immediately closed the WebSocket. The close frame could race `handle_worker_register`'s `await db.commit()`, delivering a `CancelledError` that corrupted the asyncpg connection. The `finally` block then attempted a `SELECT agents.worker_id` on the closed connection and raised `InterfaceError`.
- Fix 1 (test): add a `ping`/`pong` sync after `worker-register` so the server finishes the handler before the WebSocket closes.
- Fix 2 (production code): wrap the stale-agent DB operations in the `finally` block's teardown in `try/except` so a broken connection yields a warning log rather than an unhandled exception. Also move `agent_owners.pop()` before the DB try-block so ownership is always released even if DB ops fail.

## Test plan

- [ ] `pytest backend/tests/test_worker_foreman_notify.py -v` — all 3 notify tests pass
- [ ] `pytest backend/tests/ -v` — full suite passes (requires postgres-test container)
- [ ] CI should show green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)