### PR TITLE
fix(foreman): apply Bedrock support with keyed client cache and optional dependency

### DIFF
--- a/foreman/pioneer-foreman.toml.example
+++ b/foreman/pioneer-foreman.toml.example
@@ -17,6 +17,14 @@ api_key       = ""                     # falls back to ANTHROPIC_API_KEY env var
 max_rounds    = 10
 history_limit = 40
 
+# AI provider: "anthropic" (default) or "bedrock" (Amazon Bedrock).
+# When using Bedrock: set provider = "bedrock", ensure AWS credentials are
+# available (env vars, ~/.aws/credentials, or IAM role), and update model to
+# the Bedrock model ID (e.g. "anthropic.claude-sonnet-4-5").
+# Requires: pip install "anthropic[bedrock]"
+# provider   = "anthropic"
+# aws_region = "us-east-1"             # falls back to AWS_DEFAULT_REGION env var
+
 [poll]
 min_interval = 60     # seconds (doubles each cycle up to max_interval)
 max_interval = 3600

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -27,9 +27,13 @@ class Config:
     # Static token fallback — a member login_token or worker auth_token.
     # Used only when backend_key is not set.
     auth_token: str | None = None
-    # Claude settings
+    # Claude / AI provider settings
     model: str = "claude-sonnet-4-6"
     api_key: str | None = None
+    # "anthropic" (default) or "bedrock" (Amazon Bedrock via AsyncAnthropicBedrock)
+    provider: str = "anthropic"
+    # AWS region for Bedrock; ignored when provider != "bedrock"
+    aws_region: str = "us-east-1"
     max_rounds: int = 10
     history_limit: int = 40
     # Poll settings
@@ -135,6 +139,20 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         or "claude-sonnet-4-6"
     )
 
+    provider = (
+        overrides.get("provider")
+        or claude_block.get("provider")
+        or os.environ.get("FOREMAN_PROVIDER")
+        or "anthropic"
+    ).lower()
+
+    aws_region = (
+        overrides.get("aws_region")
+        or claude_block.get("aws_region")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or "us-east-1"
+    )
+
     log_level = (
         overrides.get("log_level")
         or raw.get("log_level")
@@ -150,6 +168,8 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         auth_token=auth_token,
         model=model,
         api_key=api_key,
+        provider=provider,
+        aws_region=aws_region,
         max_rounds=int(overrides.get("max_rounds", claude_block.get("max_rounds", 10))),
         history_limit=int(overrides.get("history_limit", claude_block.get("history_limit", 40))),
         poll_min_interval=int(

--- a/foreman/pioneer_foreman/prompt.py
+++ b/foreman/pioneer_foreman/prompt.py
@@ -84,6 +84,25 @@ Use the body to decide:
 Foreman events from bots on non-CI surfaces are filtered out before reaching you, so
 treat every `[github-event]` you see as something a human likely cares about.
 
+## Reacting to worker lifecycle events
+Messages prefixed `[worker-online]` and `[worker-offline]` notify you when a worker
+process joins or leaves the guild.
+
+- **`[worker-online] worker_id=<id> repos=<repos> agent_count=<n>`**: A worker just
+  registered. Check the current task list for unassigned pending tasks and assign them
+  to the new worker if it covers the relevant repos. If repos is empty the worker can
+  still accept tasks without a repo constraint.
+- **`[worker-offline] worker_id=<id> reason=shutdown`**: The worker shut down cleanly
+  (operator-initiated or via shutdown_worker). No urgent action required; if tasks were
+  assigned to it and are still in-progress, check their status and reassign via
+  send_followup to another idle worker if needed.
+- **`[worker-offline] worker_id=<id> reason=disconnect`**: The worker dropped
+  unexpectedly (crash or network failure). Escalate to the human if no other workers
+  are available or if critical tasks were actively running on this worker. Use
+  get_task_status to inspect affected tasks before deciding to reassign.
+  A single message may contain multiple `[worker-offline]` lines when several
+  workers disconnect simultaneously — handle each line independently.
+
 ## Issue-first workflow
 **Skip issue creation entirely** for: follow-ups, CI fixes, lint fixes, test fixes, or any
 work continuing on an existing PR/branch — use send_followup instead.

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -35,18 +35,28 @@ _HUMAN_TURN_WINDOW = 5
 _TERMINAL_STATES = frozenset({"done", "failed", "cancelled"})
 _24H_SECS = 86_400
 
-# Module-level Anthropic client (reused across calls)
-_anthropic_client: _anthropic.AsyncAnthropic | None = None
+# Client cache keyed on (provider, region, api_key) so different configs
+# get different clients instead of silently reusing the first one created.
+_anthropic_clients: dict[tuple, _anthropic.AsyncAnthropic | _anthropic.AsyncAnthropicBedrock] = {}
 
 
-def _get_anthropic_client(api_key: str | None = None) -> _anthropic.AsyncAnthropic:
-    global _anthropic_client
-    if _anthropic_client is None:
-        kwargs: dict = {}
-        if api_key:
-            kwargs["api_key"] = api_key
-        _anthropic_client = _anthropic.AsyncAnthropic(**kwargs)
-    return _anthropic_client
+def _get_anthropic_client(
+    config: Config,
+) -> _anthropic.AsyncAnthropic | _anthropic.AsyncAnthropicBedrock:
+    provider = config.provider.lower()
+    region = config.aws_region
+    api_key = config.api_key or ""
+    cache_key = (provider, region, api_key)
+    if cache_key not in _anthropic_clients:
+        if provider == "bedrock":
+            _anthropic_clients[cache_key] = _anthropic.AsyncAnthropicBedrock(aws_region=region)
+            logger.info("Foreman using Amazon Bedrock (region=%s, model=%s)", region, config.model)
+        else:
+            kwargs: dict = {}
+            if api_key:
+                kwargs["api_key"] = api_key
+            _anthropic_clients[cache_key] = _anthropic.AsyncAnthropic(**kwargs)
+    return _anthropic_clients[cache_key]
 
 
 def _inject_state_preamble(messages: list[dict], state_preamble: str) -> None:
@@ -355,11 +365,16 @@ async def run_foreman_ai(
             workers_block, tasks_block, extra_context, primary_repo=primary_repo
         )
 
+        _system_chars = next((len(b["text"]) for b in system_blocks if b.get("type") == "text"), 0)
         logger.info(
-            "guild=%s run_foreman_ai: workers=%d tasks_in_context=%d",
+            "guild=%s run_foreman_ai: workers=%d tasks_in_context=%d "
+            "system_chars=%d state_chars=%d extra_context_chars=%d",
             guild_id,
             len(worker_rows),
             len(summarized_tasks),
+            _system_chars,
+            len(state_preamble),
+            len(extra_context),
         )
 
         await _save_turn(guild_id, user_id, "system", audit_system, http=http)
@@ -368,7 +383,7 @@ async def run_foreman_ai(
 
         _inject_state_preamble(messages, state_preamble)
 
-        client = _get_anthropic_client(config.api_key)
+        client = _get_anthropic_client(config)
 
         text_parts = []
         for round_num in range(config.max_rounds):
@@ -392,11 +407,15 @@ async def run_foreman_ai(
             _input_tokens = getattr(usage, "input_tokens", 0) or 0
             _output_tokens = getattr(usage, "output_tokens", 0) or 0
             logger.info(
-                "guild=%s round %d: stop_reason=%s input=%d output=%d",
+                "guild=%s round %d: stop_reason=%s content_blocks=%d "
+                "input=%d cache_read=%d cache_write=%d output=%d",
                 guild_id,
                 round_num,
                 resp.stop_reason,
+                len(resp.content),
                 _input_tokens,
+                getattr(usage, "cache_read_input_tokens", 0) or 0,
+                getattr(usage, "cache_creation_input_tokens", 0) or 0,
                 _output_tokens,
             )
 
@@ -499,6 +518,15 @@ async def run_foreman_ai(
             wrap_usage = wrap_resp.usage
             _wrap_input = getattr(wrap_usage, "input_tokens", 0) or 0
             _wrap_output = getattr(wrap_usage, "output_tokens", 0) or 0
+            logger.info(
+                "guild=%s wrap-up: stop_reason=%s input=%d cache_read=%d cache_write=%d output=%d",
+                guild_id,
+                wrap_resp.stop_reason,
+                _wrap_input,
+                getattr(wrap_usage, "cache_read_input_tokens", 0) or 0,
+                getattr(wrap_usage, "cache_creation_input_tokens", 0) or 0,
+                _wrap_output,
+            )
             wrap_turn_id = await _save_turn(
                 guild_id, user_id, "assistant", wrap_resp.content, http=http
             )

--- a/foreman/pyproject.toml
+++ b/foreman/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+bedrock = ["anthropic[bedrock]>=0.49"]
 test = ["pytest>=8.0", "pytest-asyncio>=0.23", "anyio[trio]>=4.0", "respx>=0.20"]
 
 [tool.pytest.ini_options]

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -1,12 +1,10 @@
-# Foreman runtime dependencies
+# Legacy foreman runtime dependencies (for foreman/main.py)
 #
-# The standalone foreman process imports backend/ source directly (via a
-# sys.path insert in main.py). These packages cover that full dependency
-# chain without pulling in backend-only extras like uvicorn, alembic, or
-# asyncpg that the foreman process never uses.
+# foreman/main.py imports backend/ source directly (via a sys.path insert).
+# These packages cover that full dependency chain.
 #
-# Note: Phase 3 will replace the sys.path import with a proper REST client,
-# after which sqlmodel/fastapi/aiosqlite/sqlalchemy can be dropped here.
+# For the standalone Phase 3 package (pioneer_foreman), use pyproject.toml
+# instead: pip install -e foreman/  (much lighter — no ORM or FastAPI needed).
 
 # Claude API (bedrock extra adds boto3 for FOREMAN_PROVIDER=bedrock support)
 anthropic[bedrock]>=0.40.0


### PR DESCRIPTION
## Summary

Review and corrected implementation of the Bedrock support proposed in PR #442. Three bugs from the review are fixed here:

- **Keyed client cache** (`runner.py`): replaces the single `_anthropic_client` global with a `dict` keyed on `(provider, region, api_key)`. The original singleton would silently return the wrong client if a second `Config` with a different provider or region was passed — e.g., a test reconfiguring from `bedrock` back to `anthropic` would keep using the Bedrock client. The dict ensures each distinct configuration gets its own client while still reusing the connection pool across calls with the same settings.
- **Optional Bedrock dependency** (`pyproject.toml`): keeps `anthropic>=0.49` as the base install and adds `bedrock = ["anthropic[bedrock]>=0.49"]` as an optional extra. PR #442 promoted `bedrock` to a hard dependency, forcing `boto3`/`botocore` (~30–50 MB) on every user regardless of whether they use Bedrock.
- **Bounds-checked `system_blocks` access** (`runner.py`): `system_blocks[0]["text"]` raises `IndexError`/`KeyError` on unexpected prompt shapes; replaced with `next((len(b["text"]) for b in system_blocks if b.get("type") == "text"), 0)`.

All other changes from PR #442 are included as-is: prompt parity (`[worker-online]`/`[worker-offline]` lifecycle section), cache-token logging per round and wrap-up, `pioneer-foreman.toml.example` Bedrock docs, and `requirements.txt` comment cleanup.

## Test plan

- [ ] `pioneer-foreman` starts with default config (provider=anthropic) — existing behaviour unchanged
- [ ] `FOREMAN_PROVIDER=bedrock AWS_DEFAULT_REGION=us-east-1` creates `AsyncAnthropicBedrock`; confirmed by startup log line
- [ ] `provider = "bedrock"` in `pioneer-foreman.toml` also triggers Bedrock path
- [ ] `pip install -e foreman/` does **not** install boto3; `pip install -e "foreman/[bedrock]"` does
- [ ] Worker join/leave events routed to the standalone foreman trigger the correct lifecycle instructions
- [ ] Two `run_foreman_ai` calls with different `config.provider` values each get the correct client type

🤖 Generated with [Claude Code](https://claude.com/claude-code)