### PR TITLE
Fix: clear agent state when task parks awaiting-review

### DIFF
--- a/backend/tests/test_agent_state_ws_persistence.py
+++ b/backend/tests/test_agent_state_ws_persistence.py
@@ -327,6 +327,127 @@ def test_guild_get_returns_current_task_id(client):
             assert agents_by_id[agent_id]["activity"] == "editing"
 
 
+def test_task_complete_clears_agent_state(client):
+    """task-complete with agentId must immediately clear the agent to idle.
+
+    The worker sends agent-state:idle only after task-complete, so there is a
+    window where the foreman can call get_task_status and see agent_state
+    'working' on an already-parked awaiting-review task. Fixes #446.
+    """
+    test_client, db_url = client
+    guild_id, worker_id, task_id, agent_id = "gas-6", "w-gas6", "t-gas6", "a-gas6"
+    _insert_guild_worker_task(db_url, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs6")
+            ws_worker.receive_json()  # drain obs's agent-joined broadcast
+
+            # Set agent to 'working' on the task.
+            ws_worker.send_json(
+                {
+                    "type": "agent-state",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": task_id,
+                    "state": "working",
+                }
+            )
+            ws_obs.receive_json()  # drain agent-state broadcast
+
+            # Worker finishes and sends task-complete (agent-state:idle not sent yet).
+            ws_worker.send_json(
+                {
+                    "type": "task-complete",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": task_id,
+                    "branch": "feature/fix",
+                    "description": "done",
+                    "prUrl": "",
+                    "sessionId": "",
+                    "lastText": "",
+                }
+            )
+
+            # Handler emits agent-state:idle before the task-complete broadcast.
+            msg = ws_obs.receive_json()
+            assert msg["type"] == "agent-state"
+            assert msg["agentId"] == agent_id
+            assert msg["state"] == "idle"
+            assert msg["taskId"] is None
+
+            # DB is already committed at this point.
+            with _sync_session(db_url) as session:
+                row = session.execute(
+                    select(Agent.state, Agent.current_task_id).where(Agent.id == agent_id)
+                ).first()
+
+    assert row.state == "idle"
+    assert row.current_task_id is None
+
+
+def test_task_followup_done_clears_agent_state(client):
+    """task-followup-done with agentId must immediately clear the agent to idle.
+
+    Same race as task-complete: the foreman is triggered right after, so the
+    agent row must be idle before the get_task_status call can arrive. #446.
+    """
+    test_client, db_url = client
+    guild_id, worker_id, task_id, agent_id = "gas-7", "w-gas7", "t-gas7", "a-gas7"
+    _insert_guild_worker_task(db_url, guild_id=guild_id, worker_id=worker_id, task_id=task_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs7")
+            ws_worker.receive_json()  # drain obs's agent-joined broadcast
+
+            # Set agent to 'working' on the task.
+            ws_worker.send_json(
+                {
+                    "type": "agent-state",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": task_id,
+                    "state": "working",
+                }
+            )
+            ws_obs.receive_json()  # drain agent-state broadcast
+
+            # Worker finishes a follow-up iteration (agent-state:idle not sent yet).
+            ws_worker.send_json(
+                {
+                    "type": "task-followup-done",
+                    "workerId": worker_id,
+                    "agentId": agent_id,
+                    "taskId": task_id,
+                    "success": True,
+                    "stopReason": "end_turn",
+                    "branch": "feature/fix",
+                    "sessionId": "",
+                    "prUrl": "",
+                }
+            )
+
+            # Handler emits agent-state:idle before the task-followup-done broadcast.
+            msg = ws_obs.receive_json()
+            assert msg["type"] == "agent-state"
+            assert msg["agentId"] == agent_id
+            assert msg["state"] == "idle"
+            assert msg["taskId"] is None
+
+            # DB is already committed at this point.
+            with _sync_session(db_url) as session:
+                row = session.execute(
+                    select(Agent.state, Agent.current_task_id).where(Agent.id == agent_id)
+                ).first()
+
+    assert row.state == "idle"
+    assert row.current_task_id is None
+
+
 def test_agent_idle_releases_task_lock(client):
     """When an agent transitions to idle, the task lock is released and the
     task is moved out of 'working' so a new follow-up can be dispatched."""

--- a/backend/tests/test_agent_state_ws_persistence.py
+++ b/backend/tests/test_agent_state_ws_persistence.py
@@ -371,12 +371,17 @@ def test_task_complete_clears_agent_state(client):
                 }
             )
 
-            # Handler emits agent-state:idle before the task-complete broadcast.
-            msg = ws_obs.receive_json()
-            assert msg["type"] == "agent-state"
-            assert msg["agentId"] == agent_id
-            assert msg["state"] == "idle"
-            assert msg["taskId"] is None
+            # Handler synthesizes an agent-state:idle message; scan all
+            # received messages to find it regardless of broadcast order.
+            received = [ws_obs.receive_json(), ws_obs.receive_json()]
+            idle_msgs = [
+                m for m in received
+                if m.get("type") == "agent-state"
+                and m.get("agentId") == agent_id
+                and m.get("state") == "idle"
+                and m.get("taskId") is None
+            ]
+            assert idle_msgs, f"no agent-state:idle found in {received}"
 
             # DB is already committed at this point.
             with _sync_session(db_url) as session:
@@ -431,12 +436,17 @@ def test_task_followup_done_clears_agent_state(client):
                 }
             )
 
-            # Handler emits agent-state:idle before the task-followup-done broadcast.
-            msg = ws_obs.receive_json()
-            assert msg["type"] == "agent-state"
-            assert msg["agentId"] == agent_id
-            assert msg["state"] == "idle"
-            assert msg["taskId"] is None
+            # Handler synthesizes an agent-state:idle message; scan all
+            # received messages to find it regardless of broadcast order.
+            received = [ws_obs.receive_json(), ws_obs.receive_json()]
+            idle_msgs = [
+                m for m in received
+                if m.get("type") == "agent-state"
+                and m.get("agentId") == agent_id
+                and m.get("state") == "idle"
+                and m.get("taskId") is None
+            ]
+            assert idle_msgs, f"no agent-state:idle found in {received}"
 
             # DB is already committed at this point.
             with _sync_session(db_url) as session:

--- a/backend/tests/test_agent_state_ws_persistence.py
+++ b/backend/tests/test_agent_state_ws_persistence.py
@@ -375,7 +375,8 @@ def test_task_complete_clears_agent_state(client):
             # received messages to find it regardless of broadcast order.
             received = [ws_obs.receive_json(), ws_obs.receive_json()]
             idle_msgs = [
-                m for m in received
+                m
+                for m in received
                 if m.get("type") == "agent-state"
                 and m.get("agentId") == agent_id
                 and m.get("state") == "idle"
@@ -440,7 +441,8 @@ def test_task_followup_done_clears_agent_state(client):
             # received messages to find it regardless of broadcast order.
             received = [ws_obs.receive_json(), ws_obs.receive_json()]
             idle_msgs = [
-                m for m in received
+                m
+                for m in received
                 if m.get("type") == "agent-state"
                 and m.get("agentId") == agent_id
                 and m.get("state") == "idle"

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -628,6 +628,7 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
 async def handle_task_complete(ctx: WSContext, data: dict) -> None:
     task_id = data.get("taskId")
     worker_id_msg = data.get("workerId", "")
+    agent_id_msg = data.get("agentId", "")
     desc = data.get("description", "")
     branch = data.get("branch", "")
     pr_url = data.get("prUrl", "")
@@ -648,8 +649,30 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
             .where(Task.id == task_id, Task.state == "working")
             .values(state="awaiting-review")
         )
+        # Clear the agent that ran this task so get_task_status doesn't return
+        # agent_state:"working" after the task has parked in awaiting-review.
+        # The worker will also send agent-state:idle shortly after, but the
+        # foreman may call get_task_status before that message arrives.
+        if agent_id_msg:
+            await ctx.db.execute(
+                update(Agent)
+                .where(Agent.id == agent_id_msg, Agent.guild_id == ctx.guild_pk)
+                .values(state="idle", current_task_id=None, activity=None)
+            )
         await LockService(ctx.db).release(f"task:{task_id}")
         await ctx.db.commit()
+        if agent_id_msg:
+            await broadcast(
+                ctx.guild_id,
+                {
+                    "type": "agent-state",
+                    "agentId": agent_id_msg,
+                    "workerId": worker_id_msg,
+                    "state": "idle",
+                    "taskId": None,
+                    "activity": None,
+                },
+            )
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
     if task_id:
         spawn(
@@ -683,6 +706,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
 async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
     task_id = data.get("taskId")
     worker_id_msg = data.get("workerId", "")
+    agent_id_msg = data.get("agentId", "")
     if task_id:
         pr_url_fud = data.get("prUrl", "")
         pr_update: dict = {}
@@ -701,8 +725,28 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
                 .where(Task.id == task_id, Task.state.in_(_TERMINAL_STATES))
                 .values(**pr_update)
             )
+        # Clear the agent that ran this follow-up so get_task_status returns
+        # the correct idle state while the task parks in awaiting-review.
+        if agent_id_msg:
+            await ctx.db.execute(
+                update(Agent)
+                .where(Agent.id == agent_id_msg, Agent.guild_id == ctx.guild_pk)
+                .values(state="idle", current_task_id=None, activity=None)
+            )
         await LockService(ctx.db).release(f"task:{task_id}")
         await ctx.db.commit()
+        if agent_id_msg:
+            await broadcast(
+                ctx.guild_id,
+                {
+                    "type": "agent-state",
+                    "agentId": agent_id_msg,
+                    "workerId": worker_id_msg,
+                    "state": "idle",
+                    "taskId": None,
+                    "activity": None,
+                },
+            )
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
     if not task_id:
         return

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -656,23 +656,33 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
         if agent_id_msg:
             await ctx.db.execute(
                 update(Agent)
-                .where(Agent.id == agent_id_msg, Agent.guild_id == ctx.guild_pk)
+                .where(
+                    Agent.id == agent_id_msg,
+                    Agent.guild_id == ctx.guild_pk,
+                    Agent.worker_id == worker_id_msg,
+                )
                 .values(state="idle", current_task_id=None, activity=None)
             )
         await LockService(ctx.db).release(f"task:{task_id}")
         await ctx.db.commit()
         if agent_id_msg:
-            await broadcast(
-                ctx.guild_id,
-                {
-                    "type": "agent-state",
-                    "agentId": agent_id_msg,
-                    "workerId": worker_id_msg,
-                    "state": "idle",
-                    "taskId": None,
-                    "activity": None,
-                },
-            )
+            try:
+                await broadcast(
+                    ctx.guild_id,
+                    {
+                        "type": "agent-state",
+                        "agentId": agent_id_msg,
+                        "workerId": worker_id_msg,
+                        "state": "idle",
+                        "taskId": None,
+                        "activity": None,
+                    },
+                )
+            except Exception:
+                logger.warning(
+                    "synthesized agent-state:idle broadcast failed after commit",
+                    exc_info=True,
+                )
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
     if task_id:
         spawn(
@@ -730,23 +740,33 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
         if agent_id_msg:
             await ctx.db.execute(
                 update(Agent)
-                .where(Agent.id == agent_id_msg, Agent.guild_id == ctx.guild_pk)
+                .where(
+                    Agent.id == agent_id_msg,
+                    Agent.guild_id == ctx.guild_pk,
+                    Agent.worker_id == worker_id_msg,
+                )
                 .values(state="idle", current_task_id=None, activity=None)
             )
         await LockService(ctx.db).release(f"task:{task_id}")
         await ctx.db.commit()
         if agent_id_msg:
-            await broadcast(
-                ctx.guild_id,
-                {
-                    "type": "agent-state",
-                    "agentId": agent_id_msg,
-                    "workerId": worker_id_msg,
-                    "state": "idle",
-                    "taskId": None,
-                    "activity": None,
-                },
-            )
+            try:
+                await broadcast(
+                    ctx.guild_id,
+                    {
+                        "type": "agent-state",
+                        "agentId": agent_id_msg,
+                        "workerId": worker_id_msg,
+                        "state": "idle",
+                        "taskId": None,
+                        "activity": None,
+                    },
+                )
+            except Exception:
+                logger.warning(
+                    "synthesized agent-state:idle broadcast failed after commit",
+                    exc_info=True,
+                )
     await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
     if not task_id:
         return


### PR DESCRIPTION
## Summary

- `handle_task_complete` and `handle_task_followup_done` now immediately set the agent to `idle` (clearing `current_task_id` and `activity`) in the same DB transaction that moves the task to `awaiting-review`
- A synthesized `agent-state: idle` broadcast is emitted right after the commit so the frontend updates without waiting for the worker's duplicate message
- Previously, the agent stayed in `working` state until the worker's own `agent-state: idle` message arrived; the foreman's `get_task_status` call (triggered immediately after) would see stale `agent_state: "working"` on an already-parked task

## Root cause

The worker message sequence is:
1. `task-update` (state=awaiting-review) → task parked
2. `task-complete` / `task-followup-done` → foreman triggered
3. `agent-state: idle` → agent cleared

The foreman fires at step 2 and calls `get_task_status` before step 3 completes, hitting the race window.

## Test plan

- [ ] `test_task_complete_clears_agent_state` — verifies agent row is idle and `current_task_id=None` before the worker's `agent-state:idle` arrives
- [ ] `test_task_followup_done_clears_agent_state` — same for the follow-up path
- [ ] Existing `test_agent_state_ws_persistence.py` tests continue to pass (idempotent: the subsequent `agent-state:idle` from the worker is a no-op)

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)