### PR TITLE
Add steampunk character reference guide for pixel art sprites

### DIFF
--- a/docs/steampunk-characters.md
+++ b/docs/steampunk-characters.md
@@ -1,0 +1,102 @@
+# Steampunk Factory Workers — 16-bit Pixel Art Reference
+
+A roster of 25 characters for the Pioneer Square factory floor. Each entry describes a 16-bit pixel art sprite (roughly 32×32 to 48×48 px), suitable for a steampunk-themed multi-agent workspace. Palette leans on brass, copper, oxidized verdigris, soot black, oil-stain umber, ember orange, and gaslamp yellow, with the occasional bright accent.
+
+---
+
+## 1. The Foreman
+A barrel-chested human in a soot-streaked waistcoat, brass-buckled belt, and a stovepipe hat dented from years of falling rivets. Holds a clipboard in one hand and a brass speaking-trumpet in the other. Bushy mustache; one eye covered by a monocle wired to a tiny ticker-tape readout. Palette: deep maroon coat, brass fittings, charcoal trousers.
+
+## 2. The Boilerplate Robot
+A blocky automaton built from riveted iron plates with a domed copper head and two glowing amber porthole eyes. Steam vents on its shoulders huff white puffs every few frames. Articulated claw hands; chest hatch reveals a softly pulsing furnace. Walks with a heavy two-frame stomp.
+
+## 3. The Tinker Elf
+A slender, pointy-eared figure in a leather apron stuffed with screwdrivers, calipers, and tiny gears. Wears half-moon goggles pushed up onto a mop of moss-green hair. Soft boots, fingerless gloves. Sprite animates with a quick, twitchy hand-fidget — perpetually adjusting something invisible.
+
+## 4. The Ogre Stoker
+Hulking green-grey brute in a scorched leather smock, hauling a coal shovel twice the size of any human's. Tusks chipped; one ear pierced with a brass bolt. A pair of safety goggles sits absurdly small on a forehead the size of a manhole cover. Sweat-shine animates on his bald crown.
+
+## 5. The Dwarf Riveter
+Stout, red-bearded, knee-high to most of the crew. Wears a horned welding mask flipped up, hobnailed boots, and carries a pneumatic rivet gun connected by coiled brass hose to a back-mounted air tank. Idle frame: he flicks a spent rivet into the air and catches it.
+
+## 6. The Chemist
+A gaunt figure in a stained lab coat over a high-collared shirt, wearing a gas mask with two round filter canisters. Hands hold a bubbling Erlenmeyer flask whose contents cycle through sickly green, violet, and pink. Bandolier of vials across the chest. Faint heat-shimmer animates above the flask.
+
+## 7. The Time Traveler
+Disheveled gentleman in a dust-coated frock coat, wild silver hair, and a pocket watch the size of a saucer chained to his vest. Carries a brass-and-mahogany lever-device that crackles with blue arcs. Sprite occasionally "stutters" — a one-frame ghost-image trailing his movement.
+
+## 8. The Frogfolk Diver
+A bipedal bullfrog in a riveted copper diving helmet with a single round porthole. Webbed hands grip a wrench; webbed feet flap audibly. Belly pouch holds spare hoses. Skin is mottled olive and ochre; eyes blink sideways. Bubble emoticons rise from the helmet vent when idle.
+
+## 9. The Steam Knight
+Walking suit of articulated plate armor with copper piping along every joint. A vent slit visor glows ember-red; a tabard of oil-stained crimson hangs over the cuirass. Carries a wrench-hammer hybrid as long as he is tall. Stomps leave faint dust puffs.
+
+## 10. The Aetheric Witch
+A tall woman in a high-collared black coat embroidered with brass thread constellations. Pointed hat slightly askew, brim hung with tiny clock-gears. Floats two inches above the floor; in one hand a glass orb crackles with violet aether. Cat familiar — a brass clockwork tabby — circles her ankles.
+
+## 11. The Aviator
+Goggled pilot in a sheepskin-lined leather jacket, long white scarf trailing behind even when standing still (small wind-loop animation). Jodhpurs, knee-high boots, and a leather helmet. Holds a folded map and a sextant. A tiny brass airship pin glints on the collar.
+
+## 12. The Engineer Cat
+A ginger tabby standing upright on hind legs, wearing a tiny conductor's cap and red neckerchief. Holds an oversized monkey wrench in both paws. Tail flicks in the idle animation. Goggles sit on the cap, never worn. The unofficial mascot of the boiler room.
+
+## 13. The Pneumatic Postwoman
+Wiry courier in a slate-blue uniform with brass buttons, a satchel bulging with pneumatic-tube canisters. Cap with a winged-envelope badge. One arm is a sleek brass prosthetic ending in a tube-launcher. Sprite has a running animation that's faster than everyone else's.
+
+## 14. The Cog Goblin
+A wiry, sharp-eared green imp the size of a toddler, wearing a leather pilot's cap three sizes too big. Pockets overflow with stolen gears and bolts. Cackles silently — mouth animates open without sound. Best left unsupervised near the supply crates.
+
+## 15. The Cyborg Surgeon
+Half-flesh, half-clockwork woman in a long apron over surgical scrubs. Right eye replaced by a magnifying ocular array of three nested lenses. Holds delicate forceps and a tiny soldering iron. A row of glass-stoppered syringes lines a chest bandolier. Calm, unblinking sprite.
+
+## 16. The Orc Welder
+Broad-shouldered green-skinned welder in a heavy apron and a full-face welding hood with a slit visor. Acetylene torch hisses a steady blue flame (animated flicker). Pauldron of riveted scrap metal on one shoulder; the other bare and tattooed with factory marks.
+
+## 17. The Skeleton Clerk
+A neatly dressed skeleton in a brown suit with sleeve garters, green eyeshade, and round spectacles perched on bone. Sits behind a tiny rolltop desk piled with ledgers. Quill pen scratches in a continuous loop. Occasionally a moth flutters out of his ribcage.
+
+## 18. The Mermaid Machinist
+A finned figure in a brass-and-glass aquatic harness — a water-filled torso tank that lets her work topside. Long copper hair floats inside the tank. Operates a lathe with webbed, ring-bedecked hands. Trail of condensation drips from the tank rim.
+
+## 19. The Crow-Mask Inspector
+A tall, narrow figure in a long oxblood coat and a plague-doctor-style brass crow mask with green glass eye-lenses. Carries a brass-bound inspection ledger and a stamp that hisses steam when pressed. Walks slowly; every footstep echoes longer than it should.
+
+## 20. The Coal Imp
+Tiny soot-black creature with glowing orange cracks across its skin, like a walking ember. Curling horns; rides on the back of a shovel like a surfboard when moving fast. Leaves a faint trail of glowing motes. Mischievous grin in every frame.
+
+## 21. The Brass Bard
+A flamboyant figure in a velvet doublet and feathered tricorn, strapped into a one-man-band rig of pipes, accordion, and clockwork drum. Plays a tune nobody asked for but everyone secretly hums. Sprite has a foot-tap idle and a full strumming animation when active.
+
+## 22. The Wizard Programmer
+Long-bearded mage in star-spangled robes — except the stars are circuit traces and the staff's gemstone is a glowing vacuum tube. Reading from a scroll that's actually a long perforated punch-card. Hat tip animates when he "compiles" a spell.
+
+## 23. The Centaur Hauler
+Half-human, half-draft-horse, with a steam-powered cart fused to the equine half — pistons drive the rear legs. Human torso wears a teamster's vest and a flat cap; holds reins to himself. Hauls crates of supplies across the factory floor in a clopping eight-frame cycle.
+
+## 24. The Vampire Accountant
+Pale, slicked-back-hair gentleman in an immaculate pinstripe waistcoat, sleeve garters, and rose-tinted pince-nez (sunlight precaution). Operates a hand-cranked brass calculator faster than the eye can follow. Sprite never breathes — completely still between actions, then a blur of motion.
+
+## 25. The Apprentice
+The newest hire: a wide-eyed teenager in oversized coveralls cinched with twine, soot smudge on one cheek, oil-stained newsboy cap. Carries a clipboard and a toolbox almost too heavy to lift. Idle animation: she keeps glancing around to see what everyone else is doing.
+
+---
+
+## Palette reference
+
+| Swatch | Hex | Use |
+|--------|------|-----|
+| Brass | `#b08d57` | Fittings, buckles, instruments |
+| Copper | `#b87333` | Pipes, helmets, kettles |
+| Verdigris | `#43b3ae` | Oxidized accents, aetheric glow |
+| Soot | `#1a1a1a` | Outlines, shadows |
+| Umber | `#5a3a1b` | Leather, wood, oil stains |
+| Ember | `#ff6a1f` | Furnaces, hot metal, coal imp |
+| Gaslamp | `#ffd166` | Lighting, glow halos |
+| Bone | `#e8e0c8` | Highlights, paper, skin tones |
+
+## Animation notes
+
+- Idle loop: 2–4 frames, ~6–10 fps.
+- Working loop: 4–8 frames, ~12 fps.
+- Steam puffs: separate 3-frame overlay sprite for any character with a vent.
+- Lighting: side-lit from the right (workshop windows); rim-light in ember on furnace-adjacent sprites.


### PR DESCRIPTION
## Summary
Add a comprehensive reference document for 25 steampunk factory worker characters designed as 16-bit pixel art sprites for the Pioneer Square UI. This serves as a visual and design specification for the worker character roster.

## Changes
- **New file**: `docs/steampunk-characters.md`
  - 25 detailed character descriptions covering diverse archetypes (humans, robots, fantasy races, hybrids, supernatural beings)
  - Each entry includes visual details, personality traits, and animation notes suitable for 32×32 to 48×48 pixel sprites
  - Comprehensive color palette reference with 8 core steampunk colors (brass, copper, verdigris, soot, umber, ember, gaslamp yellow, bone) and their hex values
  - Animation guidelines covering idle loops, working loops, steam effects, and lighting direction
  - Characters range from traditional roles (Foreman, Engineer, Welder) to whimsical additions (Brass Bard, Vampire Accountant, Coal Imp)

## Notable details
- Palette is carefully curated for steampunk aesthetic with oxidized metals, industrial tones, and warm accent colors
- Animation notes provide consistent frame rates and timing guidance (2–4 frames at 6–10 fps for idle, 4–8 frames at 12 fps for working)
- Character diversity includes different body types, species, and mechanical augmentations to support varied visual representation in the factory floor UI
- Document is structured for easy reference during sprite asset creation and implementation

https://claude.ai/code/session_01WWuPXUeZ4emBAoXXXd9gTj