### PR TITLE
Fix codex_runner readline buffer overflow (#453)

### DIFF
--- a/worker/pioneer_worker/codex_runner.py
+++ b/worker/pioneer_worker/codex_runner.py
@@ -90,6 +90,7 @@ async def run_codex_auto(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            limit=8 * 1024 * 1024,  # raise readline limit to 8 MB
         )
         os.close(slave_fd)
         slave_fd = None


### PR DESCRIPTION
## Summary

- Added `limit=8 * 1024 * 1024` to the `asyncio.create_subprocess_exec` call in `run_codex_auto` (`codex_runner.py`)
- This raises the `StreamReader` buffer from asyncio's default 64 KB to 8 MB, matching the limit already used in `claude_runner.py`
- Without this fix, any stdout line emitted by Codex longer than 64 KB causes `ValueError: Separator is not found, and chunk exceed the limit`

Closes #453