### PR TITLE
Review PR #461: Fix agent stays active after task completes

### DIFF
--- a/docs/reviews/pr-461-agent-stays-active.md
+++ b/docs/reviews/pr-461-agent-stays-active.md
@@ -1,0 +1,28 @@
+# PR #461 Review: Fix agent stays active after task completes
+
+**PR:** https://github.com/jmelloy/pioneer-square/pull/461  
+**Date:** 2026-05-26  
+**Verdict:** Approve with minor suggestions
+
+## What the PR Does
+
+Fixes a race condition where short-lived tasks complete before the worker's `agent-state: idle` WebSocket frame arrives, leaving the sidebar showing the agent as permanently working. The fix adds handlers for `task-complete` and `task-followup-done` in `agents.ts` to proactively reset agent state, with a fallback from `agentId` to `taskId` lookup for resilience.
+
+## Key Findings
+
+### Multi-round followup flicker
+When a task has multiple followup rounds, the agent will briefly flash idle between rounds:
+`working → idle (task-followup-done) → working (task-followup arrives) → idle...`
+
+This trades the "stuck working" bug for a transient flicker. Acceptable tradeoff, worth documenting.
+
+### `updateAgentState` return value
+Returning `boolean` from `updateAgentState` slightly muddles its responsibility (now doubles as a lookup predicate). Not a blocker.
+
+### Test coverage
+7 tests (PR says 5) — double-update idempotency and deregistration-race tests are strong regression guards. Missing: multi-round followup flicker test.
+
+## Suggestions (non-blocking)
+1. Add a comment or follow-up issue about the `working → idle → working` flicker on multi-round followups.
+2. Consider a dedicated `findAgentById` helper to keep `updateAgentState` single-responsibility.
+3. Add a test for the multi-round followup scenario to prevent silent regressions.


### PR DESCRIPTION
## Summary

- Posted a code review on PR #461 (https://github.com/jmelloy/pioneer-square/pull/461)
- Added review notes document at `docs/reviews/pr-461-agent-stays-active.md`

## Review Verdict: Approve with minor suggestions

### Key findings

- **Fix is correct**: proactively resetting agent state on `task-complete` and `task-followup-done` correctly addresses the race condition where short-lived tasks complete before `agent-state: idle` arrives
- **Multi-round followup flicker**: when a task has multiple followup rounds, setting idle on `task-followup-done` causes a brief `working → idle → working` flicker before the next `task-followup` arrives — a visual tradeoff vs the "stuck working" bug, worth documenting
- **`updateAgentState` return value**: returning `boolean` slightly muddles the function's responsibility; a dedicated `findAgentById` helper would be cleaner (non-blocking)
- **Test coverage is solid**: 7 tests (PR says 5) including strong double-update idempotency and deregistration-race regression guards; missing a multi-round followup flicker test

🤖 Generated with [Claude Code](https://claude.com/claude-code)