### PR TITLE
Convert date fields in models.py from str to datetime

### DIFF
--- a/backend/alembic/versions/20260526_000000_convert_datetime_columns.py
+++ b/backend/alembic/versions/20260526_000000_convert_datetime_columns.py
@@ -46,6 +46,11 @@ _COLUMNS = [
 
 
 def upgrade() -> None:
+    # IMPORTANT: postgresql_using casts existing text values directly to
+    # timestamptz. This succeeds only when every stored value is a valid
+    # ISO-8601 timestamp string. If any row contains a non-parseable value
+    # the ALTER TABLE will fail mid-migration. Verify clean data beforehand:
+    #   SELECT table, column, value FROM <table> WHERE <column> !~ '^\d{4}-\d{2}-\d{2}'
     for table, column, nullable in _COLUMNS:
         op.alter_column(
             table,
@@ -53,7 +58,7 @@ def upgrade() -> None:
             existing_type=sa.Text(),
             type_=sa.DateTime(timezone=True),
             existing_nullable=nullable,
-            postgresql_using=f"{column}::timestamptz",
+            postgresql_using=f"{column}::timestamptz",  # safe for ISO-8601 text strings
         )
 
 

--- a/backend/alembic/versions/20260526_000000_convert_datetime_columns.py
+++ b/backend/alembic/versions/20260526_000000_convert_datetime_columns.py
@@ -1,0 +1,69 @@
+"""Convert all datetime columns from Text to DateTime(timezone=True).
+
+Revision ID: 20260526_000000_convert_datetime_columns
+Revises: 20260520_000007_merge_rename_with_prior_head
+Create Date: 2026-05-26
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260526_000000_convert_datetime_columns"
+down_revision: str | Sequence[str] | None = "20260520_000007_merge_rename_with_prior_head"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (table, column, nullable)
+_COLUMNS = [
+    ("guilds", "created_at", False),
+    ("guilds", "deleted_at", True),
+    ("agents", "joined_at", False),
+    ("agents", "last_seen", True),
+    ("messages", "created_at", False),
+    ("workers", "created_at", False),
+    ("workers", "last_seen", True),
+    ("tasks", "created_at", False),
+    ("tasks", "finished_at", True),
+    ("tasks", "deleted_at", True),
+    ("github_tokens", "created_at", False),
+    ("github_tokens", "updated_at", False),
+    ("user_sessions", "created_at", False),
+    ("users", "created_at", False),
+    ("users", "updated_at", False),
+    ("guild_members", "created_at", False),
+    ("task_logs", "timestamp", False),
+    ("claude_credentials", "updated_at", False),
+    ("guild_keys", "created_at", False),
+    ("foreman_turns", "created_at", False),
+    ("github_events", "created_at", False),
+    ("task_events", "created_at", False),
+]
+
+
+def upgrade() -> None:
+    for table, column, nullable in _COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.Text(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=nullable,
+            postgresql_using=f"{column}::timestamptz",
+        )
+
+
+def downgrade() -> None:
+    for table, column, nullable in reversed(_COLUMNS):
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.Text(),
+            existing_nullable=nullable,
+            postgresql_using=f"{column}::text",
+        )

--- a/backend/events.py
+++ b/backend/events.py
@@ -85,14 +85,14 @@ async def broadcast(guild_id: str, message: dict, exclude: WebSocket | None = No
 
 async def emit_terminal_line(guild_id: str, agent_id: str, line: str):
     """Broadcast and persist a terminal output line."""
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     await broadcast(
         guild_id,
         {
             "type": "terminal-output",
             "agentId": agent_id,
             "line": line,
-            "timestamp": now,
+            "timestamp": now.isoformat(),
         },
     )
     if line:

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -149,7 +149,7 @@ async def _save_turn(
             content_json=_serialize_content(content),
             is_tool_response=1 if is_tool_response else 0,
             parent_id=parent_id,
-            created_at=datetime.now(UTC).isoformat(),
+            created_at=datetime.now(UTC),
         )
         db.add(turn)
         await db.commit()
@@ -658,7 +658,7 @@ async def run_foreman_ai(
 
         response_text = "\n".join(text_parts).strip()
         if response_text:
-            now = datetime.now(UTC).isoformat()
+            now = datetime.now(UTC)
             db.add(
                 Message(
                     guild_id=guild_pk_val,

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -45,10 +45,10 @@ FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 DEFAULT_FINALIZE_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
 
 
-def _resolve_finalize_deleted_at(inp: dict) -> tuple[str, str | None]:
+def _resolve_finalize_deleted_at(inp: dict) -> tuple[datetime | None, str | None]:
     """Compute the soft-delete instant for a finalize_task tool call.
 
-    Returns ``(deleted_at_iso, error)`` — error is non-None when the inputs
+    Returns ``(deleted_at, error)`` — error is non-None when the inputs
     were malformed. Honours an explicit ``deleted_at`` first, then
     ``expires_in_seconds``, otherwise falls back to the default 3-day window.
     """
@@ -57,21 +57,20 @@ def _resolve_finalize_deleted_at(inp: dict) -> tuple[str, str | None]:
         try:
             parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
         except ValueError as exc:
-            return "", f"Invalid deleted_at: {exc}"
+            return None, f"Invalid deleted_at: {exc}"
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
-        return parsed.astimezone(UTC).isoformat(), None
+        return parsed.astimezone(UTC), None
     seconds = inp.get("expires_in_seconds")
     if seconds is not None:
         try:
             secs = int(seconds)
         except (TypeError, ValueError):
-            return "", f"Invalid expires_in_seconds: {seconds!r}"
+            return None, f"Invalid expires_in_seconds: {seconds!r}"
         if secs < 0:
-            return "", "expires_in_seconds must be >= 0"
-        return (datetime.now(UTC) + timedelta(seconds=secs)).isoformat(), None
-    default = datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS)
-    return default.isoformat(), None
+            return None, "expires_in_seconds must be >= 0"
+        return datetime.now(UTC) + timedelta(seconds=secs), None
+    return datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS), None
 
 
 # ---------------------------------------------------------------------------
@@ -570,7 +569,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 task_id = "t-" + "".join(
                     random.choices(string.ascii_lowercase + string.digits, k=6)
                 )
-                created_at = datetime.now(UTC).isoformat()
+                created_at = datetime.now(UTC)
                 db.add(
                     Task(
                         id=task_id,
@@ -595,7 +594,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         "description": desc,
                         "phase": phase,
                         "state": "pending",
-                        "createdAt": created_at,
+                        "createdAt": created_at.isoformat(),
                     },
                 )
                 result_text = (
@@ -696,7 +695,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     task_id = "t-" + "".join(
                         random.choices(string.ascii_lowercase + string.digits, k=6)
                     )
-                    created_at = datetime.now(UTC).isoformat()
+                    created_at = datetime.now(UTC)
                     db.add(
                         Task(
                             id=task_id,
@@ -805,7 +804,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                             "preferred_worker_id": preferred_worker_id,
                                         }
                                     ),
-                                    created_at=datetime.now(UTC).isoformat(),
+                                    created_at=datetime.now(UTC),
                                 )
                             )
                             await db.commit()
@@ -880,7 +879,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     if not worker_id_val:
                         result_text = f"Task {task_id} not found."
                     else:
-                        finished_at = datetime.now(UTC).isoformat()
+                        finished_at = datetime.now(UTC)
                         await db.execute(
                             update(Task)
                             .where(Task.id == task_id)
@@ -908,11 +907,13 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 "type": "task-update",
                                 "taskId": task_id,
                                 "state": "done",
-                                "finishedAt": finished_at,
-                                "deletedAt": deleted_at,
+                                "finishedAt": finished_at.isoformat(),
+                                "deletedAt": deleted_at.isoformat(),
                             },
                         )
-                        result_text = f"Task {task_id} finalized; soft-delete at {deleted_at}."
+                        result_text = (
+                            f"Task {task_id} finalized; soft-delete at {deleted_at.isoformat()}."
+                        )
 
             elif tu.name == "message_worker":
                 wid = inp["worker_id"]
@@ -983,7 +984,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     if state in ("done", "failed", "cancelled"):
                         result_text = f"Task {task_id} is already {state}."
                     else:
-                        finished_at = datetime.now(UTC).isoformat()
+                        finished_at = datetime.now(UTC)
                         await db.execute(
                             update(Task)
                             .where(Task.id == task_id)
@@ -1008,7 +1009,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 "type": "task-update",
                                 "taskId": task_id,
                                 "state": "cancelled",
-                                "finishedAt": finished_at,
+                                "finishedAt": finished_at.isoformat(),
                             },
                         )
                         result_text = f"Task {task_id} cancelled." + (
@@ -1069,9 +1070,14 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             "agent": agent_info,
                             "branch": task.branch,
                             "pr_url": task.pr_url,
-                            "created_at": task.created_at,
-                            "finished_at": task.finished_at,
-                            "recent_logs": [{"time": r[0], "line": r[1]} for r in log_rows],
+                            "created_at": task.created_at.isoformat(),
+                            "finished_at": task.finished_at.isoformat()
+                            if task.finished_at
+                            else None,
+                            "recent_logs": [
+                                {"time": r[0].isoformat() if r[0] else None, "line": r[1]}
+                                for r in log_rows
+                            ],
                         }
                     )
         finally:

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -908,11 +908,14 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 "taskId": task_id,
                                 "state": "done",
                                 "finishedAt": finished_at.isoformat(),
-                                "deletedAt": deleted_at.isoformat(),
+                                "deletedAt": deleted_at.isoformat()
+                                if deleted_at is not None
+                                else None,
                             },
                         )
                         result_text = (
-                            f"Task {task_id} finalized; soft-delete at {deleted_at.isoformat()}."
+                            f"Task {task_id} finalized; soft-delete at "
+                            f"{deleted_at.isoformat() if deleted_at is not None else 'unknown'}."
                         )
 
             elif tu.name == "message_worker":

--- a/backend/main.py
+++ b/backend/main.py
@@ -84,7 +84,7 @@ async def reset_connection_state() -> None:
 async def _sweep_stale_workers_once() -> int:
     """One pass of the stale-worker sweep. Returns the total number of agents
     and zombie workers marked offline. Extracted for direct testing."""
-    cutoff = (datetime.now(UTC) - timedelta(seconds=WORKER_OFFLINE_AFTER_SECONDS)).isoformat()
+    cutoff = datetime.now(UTC) - timedelta(seconds=WORKER_OFFLINE_AFTER_SECONDS)
     stale_agents: list = []
     zombie_workers: list = []
     agent_cascade_wids: set[str] = set()

--- a/backend/models.py
+++ b/backend/models.py
@@ -4,15 +4,15 @@ from sqlalchemy import Column, DateTime, Index, or_, text
 from sqlmodel import Field, SQLModel
 
 
-def live_tasks_filter(now: str | None = None):
+def live_tasks_filter(now: datetime | None = None):
     """SQL clause matching tasks that have not been soft-deleted.
 
     A task is "live" when ``deleted_at`` is NULL or set to a future timestamp.
-    *now* defaults to the current UTC time as an ISO-8601 string; pass an
-    explicit value to make a query reproducible in tests.
+    *now* defaults to the current UTC time; pass an explicit value to make a
+    query reproducible in tests.
     """
     if now is None:
-        now = datetime.now(UTC).isoformat()
+        now = datetime.now(UTC)
     return or_(Task.deleted_at.is_(None), Task.deleted_at > now)
 
 
@@ -29,86 +29,65 @@ class Guild(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     guild_id: str
-    created_at: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     name: str | None = None
     github_user_id: str | None = None
     primary_repo: str | None = None
-    # HMAC-SHA256 shared secret used to verify GitHub webhook deliveries for
-    # this guild. NULL until an owner first requests one via the
-    # webhook-secret endpoint.
     webhook_secret: str | None = None
-    # A2A AgentCard fields — used to populate /.well-known/agent.json
     description: str | None = None
     url: str | None = None
     version: str | None = None
-    # ISO-8601 UTC timestamp at which this guild is considered soft-deleted.
-    # NULL = active; partial unique index enforces one active row per guild_id.
-    deleted_at: str | None = None
+    deleted_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
 
 
 class Agent(SQLModel, table=True):
     __tablename__ = "agents"
 
     id: str = Field(primary_key=True)
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     worker_id: str | None = Field(default=None, foreign_key="workers.id")
     name: str
     type: str = Field(default="worker", sa_column_kwargs={"server_default": "'worker'"})
     state: str = Field(default="idle", sa_column_kwargs={"server_default": "'idle'"})
     activity: str | None = None
-    # Task this agent is currently executing (NULL when idle/offline). Set
-    # from worker-emitted agent-state messages; lets the UI map a task row
-    # to its agent unambiguously when a worker runs concurrent slots that
-    # share a worker_id.
     current_task_id: str | None = None
-    joined_at: str
-    # ISO-8601 UTC timestamp of the last message received from this agent over
-    # the WebSocket. Refreshed by every inbound frame (incl. application-level
-    # `ping`); the sweeper marks the agent offline when this gets stale.
-    last_seen: str | None = None
+    joined_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    last_seen: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
 
 
 class Message(SQLModel, table=True):
     __tablename__ = "messages"
 
     id: int | None = Field(default=None, primary_key=True)
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     from_agent: str | None = None
     to_agent: str | None = None
     content: str
     message_type: str
-    created_at: str
-    user_id: str | None = None  # github_user_id of the sender; NULL for system/worker messages
-    role: str | None = None  # "tool_use" | "tool_result" | NULL for plain chat
-    meta: str | None = None  # JSON blob with extra WS fields (toolId, toolName, …)
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    user_id: str | None = None
+    role: str | None = None
+    meta: str | None = None
 
 
 class Worker(SQLModel, table=True):
     __tablename__ = "workers"
 
     id: str = Field(primary_key=True)
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     repos: str = Field(default="[]", sa_column_kwargs={"server_default": "'[]'"})
-    # Optional GitHub org; when set the worker accepts any task targeting <org>/*
-    # and clones repos lazily. NULL for workers that use an explicit repos list only.
     org: str | None = None
     state: str = Field(default="idle", sa_column_kwargs={"server_default": "'idle'"})
-    created_at: str
-    last_seen: str | None = None
-    # Identity of the human user this worker process runs on behalf of.
-    # NULL for legacy/unattributed workers.
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    last_seen: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
     user_id: str | None = Field(default=None, foreign_key="users.id")
-    # Bearer token issued at registration; required for fetching guild secrets
-    # (Claude credentials, GitHub token) over REST. NULL on legacy rows that
-    # predate the auth requirement — those workers must re-register to get a
-    # token before they can fetch credentials.
     auth_token: str | None = None
-    # Human-readable label: ``hostname[:3]/worker_id`` (e.g. ``tok/w-g2otus``).
-    # NULL on rows created before this column was added; the API falls back to
-    # worker_id for those legacy rows.
     name: str | None = None
 
 
@@ -116,10 +95,7 @@ class Task(SQLModel, table=True):
     __tablename__ = "tasks"
 
     id: str = Field(primary_key=True)
-    worker_id: str | None = Field(
-        default=None, foreign_key="workers.id"
-    )  # NULL for foreman-owned tasks
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
+    worker_id: str | None = Field(default=None, foreign_key="workers.id")
     guild_id: int = Field(foreign_key="guilds.id")
     description: str
     tool: str = Field(default="claude", sa_column_kwargs={"server_default": "'claude'"})
@@ -129,22 +105,18 @@ class Task(SQLModel, table=True):
     branch: str | None = None
     worktree_path: str | None = None
     pr_url: str | None = None
-    # Explicit PR coordinates extracted from pr_url at PR-creation time, so
-    # github webhook events can be linked back to the task without fragile
-    # URL substring matching. Both NULL until the worker reports a PR.
     pr_number: int | None = None
     pr_repo: str | None = None
-    created_at: str
-    finished_at: str | None = None
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    finished_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
     name: str | None = None
     parent_task_id: str | None = None
     phase: str | None = Field(default="execute", sa_column_kwargs={"server_default": "'execute'"})
-    # ISO-8601 UTC timestamp at which this task is considered soft-deleted.
-    # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
-    deleted_at: str | None = None
-    # github_user_id of the human who initiated this task. Used to route
-    # worker-driven foreman events (task-complete, etc.) back to the originator's
-    # foreman thread in multi-user guilds. NULL on legacy/system tasks.
+    deleted_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
     user_id: str | None = None
 
 
@@ -156,8 +128,8 @@ class GithubToken(SQLModel, table=True):
     access_token: str
     token_type: str = Field(default="bearer", sa_column_kwargs={"server_default": "'bearer'"})
     scope: str | None = None
-    created_at: str
-    updated_at: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
 class UserSession(SQLModel, table=True):
@@ -165,34 +137,29 @@ class UserSession(SQLModel, table=True):
 
     token: str = Field(primary_key=True)
     github_user_id: str = Field(foreign_key="github_tokens.github_user_id")
-    created_at: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
 class User(SQLModel, table=True):
     __tablename__ = "users"
 
-    # Canonical user id == GitHub numeric id, kept as Text for FK compatibility
-    # with the existing github_user_id columns (messages.user_id,
-    # guilds.github_user_id, etc).
     id: str = Field(primary_key=True)
     github_id: str = Field(unique=True)
     github_login: str | None = None
     email: str | None = None
     display_name: str | None = None
     avatar_url: str | None = None
-    created_at: str
-    updated_at: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
 class GuildMember(SQLModel, table=True):
     __tablename__ = "guild_members"
 
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
     user_id: str = Field(foreign_key="users.id", primary_key=True)
-    # owner | member | viewer
     role: str = Field(default="member", sa_column_kwargs={"server_default": "'member'"})
-    created_at: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
 class TaskLog(SQLModel, table=True):
@@ -200,37 +167,32 @@ class TaskLog(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     task_id: str | None = Field(default=None, foreign_key="tasks.id")
-    timestamp: str
+    timestamp: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     line: str
     worker_id: str | None = None
     agent_id: str | None = None
-    data: str | None = None  # JSON: full tool input/output for click-to-expand
+    data: str | None = None
 
 
 class ClaudeCredentials(SQLModel, table=True):
     __tablename__ = "claude_credentials"
 
     id: int | None = Field(default=None, primary_key=True)
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", unique=True)
-    credentials_blob: str  # base64-encoded tar.gz of ~/.claude/
-    updated_at: str
+    credentials_blob: str
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
 class GuildKey(SQLModel, table=True):
     __tablename__ = "guild_keys"
 
     id: int | None = Field(default=None, primary_key=True)
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", unique=True)
-    key_id: str  # "kid" in JWK
+    key_id: str
     public_key_pem: str
     private_key_pem: str
-    created_at: str
-    # When set, served verbatim at /.well-known/jwks.json instead of the
-    # auto-generated key. Stored as JSON text ({"keys": [...]}).
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     custom_jwks: str | None = None
-    # Private key in JWK format for backend signing; never served publicly.
     private_key_jwk: str | None = None
 
 
@@ -238,17 +200,13 @@ class ForemanTurn(SQLModel, table=True):
     __tablename__ = "foreman_turns"
 
     id: int | None = Field(default=None, primary_key=True)
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     user_id: str
-    role: str  # "user" | "assistant" | "system"
-    content_json: str  # JSON-serialized content blocks
-    # 1 if this "user" turn carries tool_results (not human input); 0 otherwise
+    role: str
+    content_json: str
     is_tool_response: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
-    # For tool_result turns: id of the assistant turn whose tool_use blocks this answers
     parent_id: int | None = Field(default=None, foreign_key="foreman_turns.id")
-    created_at: str
-    # Token usage from the API response (assistant turns only; NULL for user/system turns)
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     input_tokens: int | None = None
     output_tokens: int | None = None
 
@@ -257,21 +215,17 @@ class GithubEvent(SQLModel, table=True):
     __tablename__ = "github_events"
 
     id: int | None = Field(default=None, primary_key=True)
-    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
-    # task_id is nullable because an event may arrive before we've linked the
-    # PR to a task (e.g. webhook fires for a manually-opened PR).
     task_id: str | None = Field(default=None, foreign_key="tasks.id")
-    # X-GitHub-Delivery header value; UNIQUE so GitHub redelivery is a no-op.
     delivery_id: str = Field(unique=True)
     event_type: str
     action: str | None = None
-    repo: str  # owner/repo
+    repo: str
     pr_number: int | None = None
     pr_url: str | None = None
     sender_login: str | None = None
     payload_json: str
-    created_at: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
 class Lock(SQLModel, table=True):
@@ -289,19 +243,12 @@ class Lock(SQLModel, table=True):
 
 
 class TaskEvent(SQLModel, table=True):
-    """Queued follow-up triggers that arrived while a task was locked.
-
-    When send_followup is called on a task that already holds a follow-up lock,
-    the call is serialised here instead of spawning a second worker. On lock
-    release (task-followup-done) the foreman is re-triggered with the queued
-    instructions so it can decide whether to dispatch them.
-    """
+    """Queued follow-up triggers that arrived while a task was locked."""
 
     __tablename__ = "task_events"
 
     id: int | None = Field(default=None, primary_key=True)
     task_id: str = Field(foreign_key="tasks.id")
-    # "pending-followup" is the only event_type currently; reserved for future use.
     event_type: str
-    payload_json: str  # JSON: instructions, preferred_worker_id
-    created_at: str
+    payload_json: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))

--- a/backend/models.py
+++ b/backend/models.py
@@ -33,10 +33,16 @@ class Guild(SQLModel, table=True):
     name: str | None = None
     github_user_id: str | None = None
     primary_repo: str | None = None
+    # HMAC-SHA256 shared secret used to verify GitHub webhook deliveries for
+    # this guild. NULL until an owner first requests one via the
+    # webhook-secret endpoint.
     webhook_secret: str | None = None
+    # A2A AgentCard fields — used to populate /.well-known/agent.json
     description: str | None = None
     url: str | None = None
     version: str | None = None
+    # UTC instant at which this guild is considered soft-deleted.
+    # NULL = active; partial unique index enforces one active row per guild_id.
     deleted_at: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
@@ -46,14 +52,22 @@ class Agent(SQLModel, table=True):
     __tablename__ = "agents"
 
     id: str = Field(primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     worker_id: str | None = Field(default=None, foreign_key="workers.id")
     name: str
     type: str = Field(default="worker", sa_column_kwargs={"server_default": "'worker'"})
     state: str = Field(default="idle", sa_column_kwargs={"server_default": "'idle'"})
     activity: str | None = None
+    # Task this agent is currently executing (NULL when idle/offline). Set
+    # from worker-emitted agent-state messages; lets the UI map a task row
+    # to its agent unambiguously when a worker runs concurrent slots that
+    # share a worker_id.
     current_task_id: str | None = None
     joined_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    # UTC instant of the last message received from this agent over the
+    # WebSocket. Refreshed by every inbound frame (incl. application-level
+    # `ping`); the sweeper marks the agent offline when this gets stale.
     last_seen: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
@@ -63,31 +77,44 @@ class Message(SQLModel, table=True):
     __tablename__ = "messages"
 
     id: int | None = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     from_agent: str | None = None
     to_agent: str | None = None
     content: str
     message_type: str
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
-    user_id: str | None = None
-    role: str | None = None
-    meta: str | None = None
+    user_id: str | None = None  # github_user_id of the sender; NULL for system/worker messages
+    role: str | None = None  # "tool_use" | "tool_result" | NULL for plain chat
+    meta: str | None = None  # JSON blob with extra WS fields (toolId, toolName, …)
 
 
 class Worker(SQLModel, table=True):
     __tablename__ = "workers"
 
     id: str = Field(primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     repos: str = Field(default="[]", sa_column_kwargs={"server_default": "'[]'"})
+    # Optional GitHub org; when set the worker accepts any task targeting <org>/*
+    # and clones repos lazily. NULL for workers that use an explicit repos list only.
     org: str | None = None
     state: str = Field(default="idle", sa_column_kwargs={"server_default": "'idle'"})
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     last_seen: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
+    # Identity of the human user this worker process runs on behalf of.
+    # NULL for legacy/unattributed workers.
     user_id: str | None = Field(default=None, foreign_key="users.id")
+    # Bearer token issued at registration; required for fetching guild secrets
+    # (Claude credentials, GitHub token) over REST. NULL on legacy rows that
+    # predate the auth requirement — those workers must re-register to get a
+    # token before they can fetch credentials.
     auth_token: str | None = None
+    # Human-readable label: ``hostname[:3]/worker_id`` (e.g. ``tok/w-g2otus``).
+    # NULL on rows created before this column was added; the API falls back to
+    # worker_id for those legacy rows.
     name: str | None = None
 
 
@@ -95,7 +122,10 @@ class Task(SQLModel, table=True):
     __tablename__ = "tasks"
 
     id: str = Field(primary_key=True)
-    worker_id: str | None = Field(default=None, foreign_key="workers.id")
+    worker_id: str | None = Field(
+        default=None, foreign_key="workers.id"
+    )  # NULL for foreman-owned tasks
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     description: str
     tool: str = Field(default="claude", sa_column_kwargs={"server_default": "'claude'"})
@@ -105,6 +135,9 @@ class Task(SQLModel, table=True):
     branch: str | None = None
     worktree_path: str | None = None
     pr_url: str | None = None
+    # Explicit PR coordinates extracted from pr_url at PR-creation time, so
+    # github webhook events can be linked back to the task without fragile
+    # URL substring matching. Both NULL until the worker reports a PR.
     pr_number: int | None = None
     pr_repo: str | None = None
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
@@ -114,9 +147,14 @@ class Task(SQLModel, table=True):
     name: str | None = None
     parent_task_id: str | None = None
     phase: str | None = Field(default="execute", sa_column_kwargs={"server_default": "'execute'"})
+    # UTC instant at which this task is considered soft-deleted.
+    # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
     deleted_at: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
+    # github_user_id of the human who initiated this task. Used to route
+    # worker-driven foreman events (task-complete, etc.) back to the originator's
+    # foreman thread in multi-user guilds. NULL on legacy/system tasks.
     user_id: str | None = None
 
 
@@ -143,6 +181,9 @@ class UserSession(SQLModel, table=True):
 class User(SQLModel, table=True):
     __tablename__ = "users"
 
+    # Canonical user id == GitHub numeric id, kept as Text for FK compatibility
+    # with the existing github_user_id columns (messages.user_id,
+    # guilds.github_user_id, etc).
     id: str = Field(primary_key=True)
     github_id: str = Field(unique=True)
     github_login: str | None = None
@@ -156,9 +197,12 @@ class User(SQLModel, table=True):
 class GuildMember(SQLModel, table=True):
     __tablename__ = "guild_members"
 
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
     user_id: str = Field(foreign_key="users.id", primary_key=True)
-    role: str = Field(default="member", sa_column_kwargs={"server_default": "'member'"})
+    role: str = Field(
+        default="member", sa_column_kwargs={"server_default": "'member'"}
+    )  # owner | member | viewer
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
@@ -171,15 +215,16 @@ class TaskLog(SQLModel, table=True):
     line: str
     worker_id: str | None = None
     agent_id: str | None = None
-    data: str | None = None
+    data: str | None = None  # JSON: full tool input/output for click-to-expand
 
 
 class ClaudeCredentials(SQLModel, table=True):
     __tablename__ = "claude_credentials"
 
     id: int | None = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", unique=True)
-    credentials_blob: str
+    credentials_blob: str  # base64-encoded tar.gz of ~/.claude/
     updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
@@ -187,12 +232,16 @@ class GuildKey(SQLModel, table=True):
     __tablename__ = "guild_keys"
 
     id: int | None = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", unique=True)
-    key_id: str
+    key_id: str  # "kid" in JWK
     public_key_pem: str
     private_key_pem: str
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    # When set, served verbatim at /.well-known/jwks.json instead of the
+    # auto-generated key. Stored as JSON text ({"keys": [...]}).
     custom_jwks: str | None = None
+    # Private key in JWK format for backend signing; never served publicly.
     private_key_jwk: str | None = None
 
 
@@ -200,13 +249,17 @@ class ForemanTurn(SQLModel, table=True):
     __tablename__ = "foreman_turns"
 
     id: int | None = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     user_id: str
-    role: str
-    content_json: str
+    role: str  # "user" | "assistant" | "system"
+    content_json: str  # JSON-serialized content blocks
+    # 1 if this "user" turn carries tool_results (not human input); 0 otherwise
     is_tool_response: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
+    # For tool_result turns: id of the assistant turn whose tool_use blocks this answers
     parent_id: int | None = Field(default=None, foreign_key="foreman_turns.id")
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    # Token usage from the API response (assistant turns only; NULL for user/system turns)
     input_tokens: int | None = None
     output_tokens: int | None = None
 
@@ -215,12 +268,16 @@ class GithubEvent(SQLModel, table=True):
     __tablename__ = "github_events"
 
     id: int | None = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
+    # task_id is nullable because an event may arrive before we've linked the
+    # PR to a task (e.g. webhook fires for a manually-opened PR).
     task_id: str | None = Field(default=None, foreign_key="tasks.id")
+    # X-GitHub-Delivery header value; UNIQUE so GitHub redelivery is a no-op.
     delivery_id: str = Field(unique=True)
     event_type: str
     action: str | None = None
-    repo: str
+    repo: str  # owner/repo
     pr_number: int | None = None
     pr_url: str | None = None
     sender_login: str | None = None
@@ -243,12 +300,19 @@ class Lock(SQLModel, table=True):
 
 
 class TaskEvent(SQLModel, table=True):
-    """Queued follow-up triggers that arrived while a task was locked."""
+    """Queued follow-up triggers that arrived while a task was locked.
+
+    When send_followup is called on a task that already holds a follow-up lock,
+    the call is serialised here instead of spawning a second worker. On lock
+    release (task-followup-done) the foreman is re-triggered with the queued
+    instructions so it can decide whether to dispatch them.
+    """
 
     __tablename__ = "task_events"
 
     id: int | None = Field(default=None, primary_key=True)
     task_id: str = Field(foreign_key="tasks.id")
+    # "pending-followup" is the only event_type currently; reserved for future use.
     event_type: str
-    payload_json: str
+    payload_json: str  # JSON: instructions, preferred_worker_id
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))

--- a/backend/oauth.py
+++ b/backend/oauth.py
@@ -156,7 +156,7 @@ async def create_session(code: str, state: str) -> dict:
     avatar_url = user_data.get("avatar_url") or ""
     email = user_data.get("email") or None
     login_token = secrets.token_urlsafe(32)
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
 
     db = await get_db()
     try:

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -154,7 +154,7 @@ async def store_claude_credentials(
     Without this check, anyone could overwrite a guild's Claude credentials."""
     token = credentials.credentials if credentials else None
     await authorize_worker_or_member(data.guild_id, token)
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     db = await get_db()
     try:
         guild_pk = await get_guild_pk(db, data.guild_id)
@@ -249,7 +249,7 @@ async def guest_login():
     if not os.environ.get("TEST_MODE"):
         raise HTTPException(status_code=403, detail="Test mode not enabled (set TEST_MODE=1)")
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     guest_user_id = "dev-guest"
     login_token = secrets.token_urlsafe(32)
 

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -343,7 +343,7 @@ async def create_foreman_turn(
         guild_pk = await get_guild_pk(db, guild_id)
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
-        created_at = datetime.now(UTC).isoformat()
+        created_at = datetime.now(UTC)
         turn = ForemanTurn(
             guild_id=guild_pk,
             user_id=body.user_id,
@@ -393,7 +393,7 @@ async def create_foreman_task(
 
         task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
         name = (body.name or "")[:80]
-        created_at = datetime.now(UTC).isoformat()
+        created_at = datetime.now(UTC)
         db.add(
             Task(
                 id=task_id,
@@ -421,7 +421,7 @@ async def create_foreman_task(
             "description": body.description,
             "phase": body.phase,
             "state": "pending",
-            "createdAt": created_at,
+            "createdAt": created_at.isoformat(),
         },
     )
     return {"task_id": task_id, "created_at": created_at}
@@ -556,7 +556,7 @@ async def create_message(
         if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
 
-        created_at = datetime.now(UTC).isoformat()
+        created_at = datetime.now(UTC)
         msg = Message(
             guild_id=guild_pk,
             from_agent=body.from_agent,
@@ -580,7 +580,7 @@ async def create_message(
             "from": body.from_agent,
             "to": body.to_agent,
             "content": body.content,
-            "createdAt": created_at,
+            "createdAt": created_at.isoformat(),
             **({"userId": body.user_id} if body.user_id else {}),
         },
     )

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -71,7 +71,7 @@ async def create_guild(
 ):
     if data is None:
         data = GuildCreate()
-    created_at = datetime.now(UTC).isoformat()
+    created_at = datetime.now(UTC)
     db = await get_db()
     try:
         result = await db.execute(select(Guild.guild_id).where(Guild.deleted_at.is_(None)))
@@ -275,7 +275,7 @@ async def add_guild_member(
                     "before they can be added."
                 ),
             )
-        now = datetime.now(UTC).isoformat()
+        now = datetime.now(UTC)
         stmt = pg_insert(GuildMember).values(
             guild_id=guild_pk,
             user_id=target_id,

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -47,12 +47,8 @@ class RedirectCreate(BaseModel):
     instructions: str
 
 
-def _resolve_finalize_deleted_at(body: FinalizeBody | None) -> str:
-    """Return an ISO-8601 UTC timestamp for the task's soft-delete instant.
-
-    Honours an explicit ``deleted_at`` first, then ``expires_in_seconds``,
-    and otherwise falls back to ``now + DEFAULT_FINALIZE_TTL``.
-    """
+def _resolve_finalize_deleted_at(body: FinalizeBody | None) -> datetime:
+    """Return a UTC datetime for the task's soft-delete instant."""
     if body and body.deleted_at:
         try:
             parsed = datetime.fromisoformat(body.deleted_at.replace("Z", "+00:00"))
@@ -60,12 +56,12 @@ def _resolve_finalize_deleted_at(body: FinalizeBody | None) -> str:
             raise HTTPException(status_code=400, detail=f"Invalid deleted_at: {exc}") from exc
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
-        return parsed.astimezone(UTC).isoformat()
+        return parsed.astimezone(UTC)
     if body and body.expires_in_seconds is not None:
         if body.expires_in_seconds < 0:
             raise HTTPException(status_code=400, detail="expires_in_seconds must be >= 0")
-        return (datetime.now(UTC) + timedelta(seconds=body.expires_in_seconds)).isoformat()
-    return (datetime.now(UTC) + DEFAULT_FINALIZE_TTL).isoformat()
+        return datetime.now(UTC) + timedelta(seconds=body.expires_in_seconds)
+    return datetime.now(UTC) + DEFAULT_FINALIZE_TTL
 
 
 @router.get("/guilds/{guild_id}/tasks")
@@ -268,7 +264,7 @@ async def finalize_task_endpoint(
         worker_id = result.scalar_one_or_none()
         if not worker_id:
             raise HTTPException(status_code=404, detail="Task not found")
-        finished_at = datetime.now(UTC).isoformat()
+        finished_at = datetime.now(UTC)
         deleted_at = _resolve_finalize_deleted_at(body)
         await db.execute(
             update(Task)
@@ -292,11 +288,11 @@ async def finalize_task_endpoint(
             "type": "task-update",
             "taskId": task_id,
             "state": "done",
-            "finishedAt": finished_at,
-            "deletedAt": deleted_at,
+            "finishedAt": finished_at.isoformat(),
+            "deletedAt": deleted_at.isoformat(),
         },
     )
-    return {"status": "finalized", "taskId": task_id, "deletedAt": deleted_at}
+    return {"status": "finalized", "taskId": task_id, "deletedAt": deleted_at.isoformat()}
 
 
 @router.post("/guilds/{guild_id}/tasks/{task_id}/cancel")
@@ -320,7 +316,7 @@ async def cancel_task_endpoint(
         worker_id, state = row
         if state in ("done", "failed", "cancelled"):
             raise HTTPException(status_code=409, detail=f"Task is already {state}")
-        finished_at = datetime.now(UTC).isoformat()
+        finished_at = datetime.now(UTC)
         await db.execute(
             update(Task)
             .where(Task.id == task_id)
@@ -344,7 +340,7 @@ async def cancel_task_endpoint(
             "type": "task-update",
             "taskId": task_id,
             "state": "cancelled",
-            "finishedAt": finished_at,
+            "finishedAt": finished_at.isoformat(),
         },
     )
     return {"status": "cancelled", "taskId": task_id}

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -292,7 +292,8 @@ async def finalize_task_endpoint(
             "deletedAt": deleted_at.isoformat(),
         },
     )
-    return {"status": "finalized", "taskId": task_id, "deletedAt": deleted_at.isoformat()}
+    # Return raw datetime — FastAPI's jsonable_encoder handles ISO-8601 serialisation.
+    return {"status": "finalized", "taskId": task_id, "deletedAt": deleted_at}
 
 
 @router.post("/guilds/{guild_id}/tasks/{task_id}/cancel")

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -530,7 +530,7 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
         if len(body_text) > _MAX_PAYLOAD_BYTES:
             body_text = body_text[:_MAX_PAYLOAD_BYTES] + "\n…[truncated]"
 
-        created_at = datetime.now(UTC).isoformat()
+        created_at = datetime.now(UTC)
         stmt = (
             pg_insert(GithubEvent)
             .values(
@@ -607,7 +607,7 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
     )
 
     chat_line = _build_chat_line(event_type, action, repo, pr_number, payload, task_id)
-    chat_now = datetime.now(UTC).isoformat()
+    chat_now = datetime.now(UTC)
     await broadcast(
         guild_id,
         {
@@ -615,7 +615,7 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
             "from": "github",
             "to": "foreman",
             "content": chat_line,
-            "createdAt": chat_now,
+            "createdAt": chat_now.isoformat(),
         },
     )
     msg_db = await get_db()

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -39,7 +39,7 @@ async def _touch_agent(
         return
     if not agent_id and not worker_id:
         return
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     if agent_id and worker_id is None:
         res = await db.execute(select(Agent.worker_id).where(Agent.id == agent_id))
         worker_id = res.scalar_one_or_none()

--- a/backend/routes/wellknown.py
+++ b/backend/routes/wellknown.py
@@ -103,7 +103,7 @@ async def _get_or_create_guild_key(guild_id: str) -> GuildKey | None:
             key_id=secrets.token_urlsafe(16),
             public_key_pem=pub_pem,
             private_key_pem=priv_pem,
-            created_at=datetime.now(UTC).isoformat(),
+            created_at=datetime.now(UTC),
         )
         db.add(row)
         await db.commit()
@@ -413,7 +413,7 @@ async def set_jwks_config(
                 key_id=secrets.token_urlsafe(16),
                 public_key_pem=pub_pem,
                 private_key_pem=priv_pem,
-                created_at=datetime.now(UTC).isoformat(),
+                created_at=datetime.now(UTC),
             )
             db.add(row)
 

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -75,7 +75,7 @@ async def create_worker(guild_id: str, data: WorkerCreate):
     only returned here — there is no read-after-create endpoint by design, so
     losing it means re-registering."""
     worker_id = "w-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
-    created_at = datetime.now(UTC).isoformat()
+    created_at = datetime.now(UTC)
     worker_name = worker_display_name(worker_id, data.hostname)
     auth_token = secrets.token_urlsafe(32)
 
@@ -233,7 +233,7 @@ async def assign_task(
 ):
     """Persist a task and broadcast a task-assigned event for the worker process."""
     task_id = "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
-    created_at = datetime.now(UTC).isoformat()
+    created_at = datetime.now(UTC)
 
     db = await get_db()
     try:

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -104,7 +104,7 @@ def _sync_session(db_url: str):
 def make_auth_token(db_url: str, user_id: str = "gh-user-test", username: str = "testuser") -> str:
     """Insert a test GitHub user + session into the DB and return the token."""
     token = "test-session-" + secrets.token_hex(8)
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         stmt = (
             pg_insert(GithubToken)
@@ -137,7 +137,7 @@ def insert_guild(
     default ``make_auth_token()`` user satisfies ``require_member`` checks.
     Pass ``owner_user_id=None`` to skip that.
     """
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         stmt = (
             pg_insert(Guild)
@@ -174,7 +174,7 @@ def insert_guild(
 
 def insert_member(db_url: str, guild_id: str, user_id: str, role: str = "member") -> None:
     """Add a user as a member of a guild (creating a users row if needed)."""
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         session.execute(
             pg_insert(User)
@@ -211,7 +211,7 @@ def insert_worker(
     org: str | None = None,
 ) -> None:
     """Insert a worker row for a guild."""
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(Guild.id).where(Guild.guild_id == guild_id, Guild.deleted_at.is_(None))
@@ -235,11 +235,11 @@ def insert_agent(
     worker_id: str | None = None,
     state: str = "idle",
     agent_type: str = "worker",
-    last_seen: str | None = None,
+    last_seen: datetime | None = None,
     current_task_id: str | None = None,
 ) -> None:
     """Insert an agent row for a guild."""
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(Guild.id).where(Guild.guild_id == guild_id, Guild.deleted_at.is_(None))
@@ -282,7 +282,7 @@ def insert_task(
     user_id: str | None = None,
 ) -> None:
     """Insert a task row for a guild."""
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(Guild.id).where(Guild.guild_id == guild_id, Guild.deleted_at.is_(None))

--- a/backend/tests/test_agent_state_ws_persistence.py
+++ b/backend/tests/test_agent_state_ws_persistence.py
@@ -255,7 +255,7 @@ def test_guild_get_returns_current_task_id(client):
     headers = {"Authorization": "Bearer test-token"}
     # Seed the test token & guild membership the way other tests do.
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         session.execute(
             pg_insert(User)

--- a/backend/tests/test_credentials_auth.py
+++ b/backend/tests/test_credentials_auth.py
@@ -30,7 +30,7 @@ def _register_worker(test_client, guild_id: str) -> dict:
 
 def _seed_claude_credentials(db_url: str, guild_id: str, blob: str = "BLOB") -> None:
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(Guild.id).where(Guild.guild_id == guild_id, Guild.deleted_at.is_(None))
@@ -58,7 +58,7 @@ def _seed_github_token(db_url: str, user_id: str = "gh-user-test") -> None:
     """The default test user already has a github_tokens row via make_auth_token —
     this is a no-op that just ensures it's there for clarity."""
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         existing = session.scalar(
             select(GithubToken.github_user_id).where(GithubToken.github_user_id == user_id)
@@ -235,7 +235,7 @@ def test_get_github_token_no_owner_in_guild_members(client):
     from datetime import UTC, datetime
 
     test_client, db_url = client
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     # Insert a guild with github_user_id but no guild_members row
     with _sync_session(db_url) as session:
         stmt = (

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1285,7 +1285,7 @@ class TestExecToolsResultHandling:
         _insert_task(db_session, "t-large1", "g-large-res", "w-large")
         # Insert many log lines
 
-        now = datetime.now(UTC).isoformat()
+        now = datetime.now(UTC)
         with _sync_session(db_session) as session:
             for _i in range(50):
                 session.add(

--- a/backend/tests/test_foreman_context_api.py
+++ b/backend/tests/test_foreman_context_api.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 
 def _insert_foreman_turn(db_url: str, guild_id: str, user_id: str, role: str, content: str) -> None:
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(Guild.id).where(Guild.guild_id == guild_id, Guild.deleted_at.is_(None))

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -21,7 +21,7 @@ def _insert_guild_legacy_only(db_url: str, guild_id: str, user_id: str) -> None:
     Simulates a pre-migration guild to verify the legacy fallback is gone.
     """
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         session.execute(
             pg_insert(Guild)
@@ -207,7 +207,7 @@ def test_guild_partial_unique_index(client):
     test_client, db_url = client  # noqa: F841 — db_url used directly
 
     shared_id = "reuse-me-001"
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
 
     with _sync_session(db_url) as session:
         # Insert the first active guild.

--- a/backend/tests/test_liveness.py
+++ b/backend/tests/test_liveness.py
@@ -64,7 +64,9 @@ def _setup_guild_and_worker(db_url: str, guild_id: str, worker_id: str) -> None:
     insert_worker(db_url, guild_id, worker_id, state="online")
 
 
-def _read_last_seen(db_url: str, agent_id: str, worker_id: str) -> tuple[str | None, str | None]:
+def _read_last_seen(
+    db_url: str, agent_id: str, worker_id: str
+) -> tuple[datetime | None, datetime | None]:
 
     with _sync_session(db_url) as session:
         agent_seen = session.scalar(select(Agent.last_seen).where(Agent.id == agent_id))
@@ -97,8 +99,8 @@ def test_join_initialises_last_seen(client):
     agent_seen, worker_seen = _read_last_seen(db_url, agent_id, worker_id)
     assert agent_seen is not None
     assert worker_seen is not None
-    assert datetime.fromisoformat(str(agent_seen)) >= before - timedelta(seconds=5)
-    assert datetime.fromisoformat(str(worker_seen)) >= before - timedelta(seconds=5)
+    assert agent_seen >= before - timedelta(seconds=5)
+    assert worker_seen >= before - timedelta(seconds=5)
 
 
 def test_ping_message_replies_pong_and_refreshes_last_seen(client):
@@ -123,7 +125,7 @@ def test_ping_message_replies_pong_and_refreshes_last_seen(client):
         ws.receive_json()  # agent-joined
 
         # Force last_seen artificially old so we can detect the refresh.
-        old_ts = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        old_ts = datetime.now(UTC) - timedelta(minutes=5)
 
         with _sync_session(db_url) as session:
             session.execute(update(Agent).where(Agent.id == agent_id).values(last_seen=old_ts))
@@ -166,7 +168,7 @@ def test_any_inbound_frame_touches_sibling_agents(client):
             )
             ws.receive_json()  # broadcast for each join
 
-        old_ts = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        old_ts = datetime.now(UTC) - timedelta(minutes=5)
 
         with _sync_session(db_url) as session:
             session.execute(
@@ -193,8 +195,8 @@ def test_stale_sweeper_marks_silent_workers_offline(client, monkeypatch):
 
     _setup_guild_and_worker(db_url, guild_id, worker_id)
 
-    now = datetime.now(UTC).isoformat()
-    old = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+    now = datetime.now(UTC)
+    old = datetime.now(UTC) - timedelta(seconds=300)
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(Guild.id).where(Guild.guild_id == guild_id, Guild.deleted_at.is_(None))
@@ -267,8 +269,8 @@ def test_sweeper_marks_zombie_worker_offline_when_agents_already_offline(client,
 
     _setup_guild_and_worker(db_url, guild_id, worker_id)
 
-    now = datetime.now(UTC).isoformat()
-    old = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+    now = datetime.now(UTC)
+    old = datetime.now(UTC) - timedelta(seconds=300)
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(Guild.id).where(Guild.guild_id == guild_id, Guild.deleted_at.is_(None))
@@ -319,7 +321,7 @@ def test_sweeper_skips_fresh_workers(client):
 
     _setup_guild_and_worker(db_url, guild_id, worker_id)
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(Guild.id).where(Guild.guild_id == guild_id, Guild.deleted_at.is_(None))
@@ -366,7 +368,7 @@ def test_stale_task_watchdog_releases_lock_when_agent_goes_idle(client, monkeypa
     _setup_guild_and_worker(db_path, guild_id, worker_id)
     from datetime import timezone
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     # Lock acquired long ago — older than WORKER_OFFLINE_AFTER_SECONDS (set to 1s below).
     old_lock_dt = datetime.now(UTC) - timedelta(seconds=300)
     future_exp_dt = datetime.now(UTC) + timedelta(hours=1)

--- a/backend/tests/test_soft_delete_tasks.py
+++ b/backend/tests/test_soft_delete_tasks.py
@@ -41,7 +41,7 @@ def _create_task(test_client, guild_id: str, worker_id: str, desc: str, db_url: 
     return resp.json()["id"]
 
 
-def _set_deleted_at(db_url: str, task_id: str, deleted_at: str | None) -> None:
+def _set_deleted_at(db_url: str, task_id: str, deleted_at: datetime | None) -> None:
 
     with _sync_session(db_url) as session:
         session.execute(update(Task).where(Task.id == task_id).values(deleted_at=deleted_at))
@@ -89,7 +89,7 @@ def test_resolve_finalize_default_window(monkeypatch):
 
     monkeypatch.setattr("routes.tasks.datetime", _FixedDT)
     out = _resolve_finalize_deleted_at(None)
-    assert datetime.fromisoformat(out) == fixed + DEFAULT_FINALIZE_TTL
+    assert out == fixed + DEFAULT_FINALIZE_TTL
 
 
 def test_resolve_finalize_explicit_seconds(monkeypatch):
@@ -104,7 +104,7 @@ def test_resolve_finalize_explicit_seconds(monkeypatch):
 
     monkeypatch.setattr("routes.tasks.datetime", _FixedDT)
     out = _resolve_finalize_deleted_at(FinalizeBody(expires_in_seconds=1200))
-    assert datetime.fromisoformat(out) == fixed + timedelta(seconds=1200)
+    assert out == fixed + timedelta(seconds=1200)
 
 
 def test_resolve_finalize_explicit_deleted_at_iso():
@@ -112,23 +112,22 @@ def test_resolve_finalize_explicit_deleted_at_iso():
 
     target = "2026-06-15T12:00:00+00:00"
     out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at=target))
-    assert datetime.fromisoformat(out) == datetime.fromisoformat(target)
+    assert out == datetime.fromisoformat(target)
 
 
 def test_resolve_finalize_deleted_at_naive_assumed_utc():
     from main import FinalizeBody, _resolve_finalize_deleted_at
 
     out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at="2026-06-15T12:00:00"))
-    parsed = datetime.fromisoformat(out)
-    assert parsed.tzinfo is not None
-    assert parsed == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+    assert out.tzinfo is not None
+    assert out == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
 
 
 def test_resolve_finalize_deleted_at_z_suffix():
     from main import FinalizeBody, _resolve_finalize_deleted_at
 
     out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at="2026-06-15T12:00:00Z"))
-    assert datetime.fromisoformat(out) == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+    assert out == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
 
 
 def test_resolve_finalize_invalid_deleted_at_raises():
@@ -156,7 +155,7 @@ def test_resolve_finalize_deleted_at_wins_over_seconds():
     out = _resolve_finalize_deleted_at(
         FinalizeBody(deleted_at="2026-12-25T00:00:00Z", expires_in_seconds=60)
     )
-    assert datetime.fromisoformat(out) == datetime(2026, 12, 25, tzinfo=UTC)
+    assert out == datetime(2026, 12, 25, tzinfo=UTC)
 
 
 # ---------------------------------------------------------------------------
@@ -172,8 +171,8 @@ def test_list_guild_tasks_hides_past_deleted_at(client):
     t_dead = _create_task(test_client, "gsd01", worker_id, "dead task", db_url)
     t_future = _create_task(test_client, "gsd01", worker_id, "future task", db_url)
 
-    past = (datetime.now(UTC) - timedelta(seconds=5)).isoformat()
-    future = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+    past = datetime.now(UTC) - timedelta(seconds=5)
+    future = datetime.now(UTC) + timedelta(days=1)
     _set_deleted_at(db_url, t_dead, past)
     _set_deleted_at(db_url, t_future, future)
 
@@ -191,7 +190,7 @@ def test_list_worker_tasks_hides_past_deleted_at(client):
     worker_id = _create_worker(test_client, "gsd02")
     t_live = _create_task(test_client, "gsd02", worker_id, "live", db_url)
     t_dead = _create_task(test_client, "gsd02", worker_id, "dead", db_url)
-    _set_deleted_at(db_url, t_dead, (datetime.now(UTC) - timedelta(minutes=1)).isoformat())
+    _set_deleted_at(db_url, t_dead, datetime.now(UTC) - timedelta(minutes=1))
 
     resp = test_client.get(f"/guilds/gsd02/workers/{worker_id}/tasks")
     assert resp.status_code == 200
@@ -204,7 +203,7 @@ def test_get_task_logs_404_on_soft_deleted(client):
     insert_guild(db_url, "gsd03")
     worker_id = _create_worker(test_client, "gsd03")
     task_id = _create_task(test_client, "gsd03", worker_id, "task", db_url)
-    _set_deleted_at(db_url, task_id, (datetime.now(UTC) - timedelta(minutes=1)).isoformat())
+    _set_deleted_at(db_url, task_id, datetime.now(UTC) - timedelta(minutes=1))
 
     resp = test_client.get(f"/guilds/gsd03/tasks/{task_id}/logs", headers=_auth(db_url))
     assert resp.status_code == 404
@@ -228,7 +227,7 @@ def test_finalize_endpoint_default_sets_three_day_window(client):
     parsed = datetime.fromisoformat(deleted_at)
     # Should be roughly 3 days from now (allow ±1 minute slack for slow machines).
     assert timedelta(days=3, minutes=-1) <= parsed - before <= timedelta(days=3, minutes=1)
-    assert _read_task(db_url, task_id)["deleted_at"] == deleted_at
+    assert _read_task(db_url, task_id)["deleted_at"] == datetime.fromisoformat(deleted_at)
 
 
 def test_finalize_endpoint_explicit_expires_in_seconds(client):
@@ -291,7 +290,7 @@ def test_finalize_then_list_hides_after_window_passes(client):
         headers=_auth(db_url),
     )
     # Backdate by 1 second so the strict `>` comparison hides it.
-    past = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+    past = datetime.now(UTC) - timedelta(seconds=1)
     _set_deleted_at(db_url, task_id, past)
     resp = test_client.get("/guilds/gsd08/tasks", headers=_auth(db_url))
     ids = {t["id"] for t in resp.json()}
@@ -309,7 +308,7 @@ def test_foreman_tool_resolver_default():
     before = datetime.now(UTC)
     out, err = _resolve_finalize_deleted_at({})
     assert err is None
-    delta = datetime.fromisoformat(out) - before
+    delta = out - before
     assert (
         timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS - 60)
         <= delta
@@ -323,7 +322,7 @@ def test_foreman_tool_resolver_explicit_seconds():
     before = datetime.now(UTC)
     out, err = _resolve_finalize_deleted_at({"expires_in_seconds": 1200})
     assert err is None
-    delta = datetime.fromisoformat(out) - before
+    delta = out - before
     assert timedelta(seconds=1199) <= delta <= timedelta(seconds=1260)
 
 
@@ -331,7 +330,7 @@ def test_foreman_tool_resolver_invalid_seconds():
     from foreman.tools import _resolve_finalize_deleted_at
 
     out, err = _resolve_finalize_deleted_at({"expires_in_seconds": "not-an-int"})
-    assert out == ""
+    assert out is None
     assert err and "Invalid expires_in_seconds" in err
 
 
@@ -339,7 +338,7 @@ def test_foreman_tool_resolver_negative_seconds():
     from foreman.tools import _resolve_finalize_deleted_at
 
     out, err = _resolve_finalize_deleted_at({"expires_in_seconds": -5})
-    assert out == ""
+    assert out is None
     assert err and ">=" in err
 
 
@@ -349,14 +348,14 @@ def test_foreman_tool_resolver_explicit_deleted_at():
     target = "2026-12-25T00:00:00Z"
     out, err = _resolve_finalize_deleted_at({"deleted_at": target})
     assert err is None
-    assert datetime.fromisoformat(out) == datetime(2026, 12, 25, tzinfo=UTC)
+    assert out == datetime(2026, 12, 25, tzinfo=UTC)
 
 
 def test_foreman_tool_resolver_invalid_deleted_at():
     from foreman.tools import _resolve_finalize_deleted_at
 
     out, err = _resolve_finalize_deleted_at({"deleted_at": "garbage"})
-    assert out == ""
+    assert out is None
     assert err and "Invalid deleted_at" in err
 
 

--- a/backend/tests/test_user_members_api.py
+++ b/backend/tests/test_user_members_api.py
@@ -17,7 +17,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 def _insert_guild_legacy_only(db_url: str, guild_id: str, user_id: str) -> None:
     """Insert a guild with github_user_id but no guild_members row."""
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         session.execute(
             pg_insert(Guild)
@@ -30,7 +30,7 @@ def _insert_guild_legacy_only(db_url: str, guild_id: str, user_id: str) -> None:
 def _seed_user(db_url: str, user_id: str, login: str) -> None:
     """Insert a users row directly so it can be referenced as a member."""
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
     with _sync_session(db_url) as session:
         session.execute(
             pg_insert(User)

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -212,7 +212,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     agent_name = data.get("agentName", "Unknown")
     agent_type = data.get("agentType", "worker")
     worker_id = data.get("workerId")
-    joined_at = datetime.now(UTC).isoformat()
+    joined_at = datetime.now(UTC)
     is_external_foreman = agent_type == "foreman" and data.get("external") is True
     if not is_external_foreman:
         stmt = pg_insert(Agent).values(
@@ -332,7 +332,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         "agentType": agent_type,
         "workerId": worker_id,
         "state": "idle",
-        "joinedAt": joined_at,
+        "joinedAt": joined_at.isoformat(),
     }
     if worker_id:
         r = await ctx.db.execute(
@@ -433,7 +433,7 @@ async def handle_chat(ctx: WSContext, data: dict) -> None:
     from_agent = data.get("from", "user")
     to_agent = data.get("to", "foreman")
     content = data.get("content", "")
-    created_at = datetime.now(UTC).isoformat()
+    created_at = datetime.now(UTC)
     ctx.db.add(
         Message(
             guild_id=ctx.guild_pk,
@@ -453,7 +453,7 @@ async def handle_chat(ctx: WSContext, data: dict) -> None:
             "from": from_agent,
             "to": to_agent,
             "content": content,
-            "createdAt": created_at,
+            "createdAt": created_at.isoformat(),
             **({"userId": ctx.ws_user_id} if ctx.ws_user_id and from_agent == "user" else {}),
         },
     )
@@ -495,7 +495,7 @@ async def handle_terminal_output(ctx: WSContext, data: dict) -> None:
     line = data.get("line", "")
     task_id = data.get("taskId")
     detail = data.get("detail")
-    created_at = datetime.now(UTC).isoformat()
+    created_at = datetime.now(UTC)
     worker_id_for_log = msg_worker_id
     if worker_id_for_log is None and msg_agent_id:
         result = await ctx.db.execute(select(Agent.worker_id).where(Agent.id == msg_agent_id))
@@ -520,7 +520,7 @@ async def handle_terminal_output(ctx: WSContext, data: dict) -> None:
             "workerId": worker_id_for_log,
             "taskId": task_id,
             "line": line,
-            "timestamp": created_at,
+            "timestamp": created_at.isoformat(),
             **({"detail": detail} if detail else {}),
         },
     )
@@ -604,10 +604,21 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
         ("branch", "branch"),
         ("worktreePath", "worktree_path"),
         ("prUrl", "pr_url"),
-        ("finishedAt", "finished_at"),
     ):
         if src in data:
             update_values[col] = data[src]
+    if "finishedAt" in data:
+        raw = data.get("finishedAt")
+        if raw is not None:
+            try:
+                parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=UTC)
+                update_values["finished_at"] = parsed
+            except (ValueError, TypeError):
+                pass
+        else:
+            update_values["finished_at"] = None
     # When the worker reports a PR URL, derive pr_number + pr_repo so github
     # webhook deliveries can be linked back to this task without fragile URL
     # substring matching at receive time.


### PR DESCRIPTION
## Summary

- Replace all `str`-typed date/time columns in `backend/models.py` with `datetime` using `sa_column=Column(DateTime(timezone=True), ...)` — 15 models, 22 columns total
- Add Alembic migration `20260526_000000_convert_datetime_columns` that ALTERs all 22 columns from `Text` to `TIMESTAMPTZ` via `postgresql_using=column::timestamptz` (with full downgrade support)
- Update every caller across 15 application files: DB writes use `datetime.now(UTC)` directly; WebSocket broadcast payloads call `.isoformat()` explicitly (since `json.dumps` can't handle `datetime`); HTTP responses rely on FastAPI's `jsonable_encoder`
- Update 9 test files: helpers and assertions now use `datetime` objects instead of ISO strings for DB operations

## Key design choices

- **DB writes**: raw `datetime` — no `.isoformat()` needed, psycopg2 and asyncpg accept native Python types for `TIMESTAMPTZ` columns
- **WebSocket broadcasts**: explicit `.isoformat()` retained — `json.dumps` does not handle `datetime` objects
- **HTTP responses**: no change — FastAPI's `jsonable_encoder` converts `datetime` → ISO-8601 automatically
- **`live_tasks_filter()`**: parameter changed from `str | None` to `datetime | None`; comparison against the `Task.deleted_at` DateTime column works correctly via SQLAlchemy

## Test plan

- [ ] `docker compose up -d postgres-test && cd backend && python -m pytest` — all 119 tests should pass
- [ ] `ruff check . && ruff format .` — passes (verified locally, 0 issues)
- [ ] Alembic upgrade: `alembic upgrade head` against an existing DB applies migration cleanly
- [ ] Alembic downgrade: `alembic downgrade -1` restores Text columns

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)