### PR TITLE
Clean up Worker/Agent pane buttons (#469)

### DIFF
--- a/frontend/src/components/LogPane.vue
+++ b/frontend/src/components/LogPane.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="log-pane" :class="'kind-' + kind">
-    <PaneHeader :icon="icon" :title-text="titleText" :entity-state="entityState">
+    <PaneHeader :icon="icon" :title-text="titleText" :entity-state="entityState" :entity-id="entityIdBadge">
       <template v-if="kind === 'task'" #meta>
         <span v-if="taskPhase" class="phase-badge" :class="taskPhase">{{ taskPhase }}</span>
         <span v-if="taskStateLabel" class="state-badge" :class="stateBadgeClass">
@@ -28,6 +28,12 @@
     <LogList ref="logListRef" :logs="logs" />
 
     <AgentActions v-if="kind === 'agent'" :agent-id="id" :agent-state="entityState" />
+    <TaskActions
+      v-if="kind === 'agent' && agentTask"
+      :task-id="agentTask.id"
+      :task-state="agentTask.state"
+      :worker-id="agentTask.worker_id"
+    />
     <WorkerActions v-if="kind === 'worker'" :worker-id="id" :worker-state="entityState" />
     <TaskActions
       v-if="kind === 'task'"
@@ -106,6 +112,18 @@ const entityState = computed(() => {
   if (props.kind === 'agent') return agent.value?.state
   if (props.kind === 'worker') return worker.value?.state
   return undefined
+})
+
+const agentTask = computed(() => {
+  if (props.kind !== 'agent' || !agent.value?.taskId) return null
+  return tasksStore.tasks.find((t) => t.id === agent.value!.taskId) ?? null
+})
+
+const entityIdBadge = computed(() => {
+  if (props.kind !== 'worker') return undefined
+  const w = worker.value
+  if (!w) return undefined
+  return w.name && w.name !== w.id ? w.id : undefined
 })
 
 const taskPhase = computed(() =>

--- a/frontend/src/components/log-pane/PaneHeader.vue
+++ b/frontend/src/components/log-pane/PaneHeader.vue
@@ -3,6 +3,7 @@
     <div class="pane-title">
       <span class="title-icon">{{ icon }}</span>
       <span class="title-text">{{ titleText }}</span>
+      <code v-if="entityId" class="entity-id-chip">{{ entityId }}</code>
     </div>
     <div class="pane-meta">
       <slot name="meta">
@@ -22,6 +23,7 @@ const props = defineProps<{
   icon: string
   titleText: string
   entityState?: string
+  entityId?: string
 }>()
 
 const isLive = computed(() => {
@@ -50,6 +52,17 @@ const isLive = computed(() => {
 
 .title-icon {
   color: var(--color-green);
+}
+
+.entity-id-chip {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-dim);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-brass-dark);
+  padding: 1px 5px;
+  border-radius: 2px;
+  letter-spacing: 0.5px;
 }
 
 .pane-meta {

--- a/frontend/src/components/log-pane/WorkerActions.vue
+++ b/frontend/src/components/log-pane/WorkerActions.vue
@@ -27,9 +27,9 @@
         class="pixel-btn shutdown-btn"
         :disabled="workerState === 'offline' || shuttingDown"
         @click="handleShutdown"
-        title="Ask the worker to shut down"
+        title="Sends a graceful shutdown request via the foreman message API. The worker finishes current work before exiting."
       >
-        {{ shuttingDown ? '…' : '⏻ Shut down' }}
+        {{ shuttingDown ? '…' : '⏻ Send Shutdown Signal' }}
       </button>
     </div>
     <div v-if="actionError" class="action-error">{{ actionError }}</div>


### PR DESCRIPTION
## Summary

- **Worker ID badge**: The worker pane header now shows the worker's short ID (e.g. `w-1it5l7`) as a compact monospace chip alongside the worker name, matching the style of task IDs in the task header.
- **Shutdown button**: Renamed from "Shut down" to "Send Shutdown Signal" with an updated tooltip making clear it sends a graceful shutdown request via the foreman message API — not a direct process kill.
- **Task actions on Agent tab**: The Agent tab now surfaces `redirect_task` and `cancel_task` when the agent has an active (working) task, and `send_followup` when the task is `awaiting-review`. These buttons only appear when there is an active task on the agent — idle agents show no task actions.
- **Worker tab unchanged**: `message_worker` and `shutdown_worker` remain on the Worker tab at all times.

## Files changed

- `frontend/src/components/log-pane/PaneHeader.vue` — new `entityId` prop renders as a monospace badge in the title
- `frontend/src/components/LogPane.vue` — passes worker ID badge to PaneHeader; adds `TaskActions` below `AgentActions` for agent panes when `agent.taskId` resolves to a task
- `frontend/src/components/log-pane/WorkerActions.vue` — shutdown button label and tooltip updated

## Test plan

- [ ] Open a Worker tab for a named worker — confirm the worker ID chip (e.g. `w-xxxx`) appears next to the name in the header
- [ ] Open an Agent tab while the agent is idle — confirm no task action buttons appear
- [ ] Open an Agent tab while the agent is executing a task (state `working`) — confirm Redirect and Cancel buttons appear
- [ ] Open an Agent tab while the agent's task is `awaiting-review` — confirm Follow-up and Finalize buttons appear
- [ ] Hover the shutdown button on a Worker tab — confirm tooltip reads "Sends a graceful shutdown request via the foreman message API…"

Closes #469

🤖 Generated with [Claude Code](https://claude.ai/claude-code)