### PR TITLE
User settings: view & clear Claude/Codex tokens (#475)

### DIFF
--- a/backend/alembic/versions/20260527_000000_add_api_keys_to_users.py
+++ b/backend/alembic/versions/20260527_000000_add_api_keys_to_users.py
@@ -1,0 +1,34 @@
+"""add_api_keys_to_users
+
+Adds ``claude_api_key`` and ``openai_api_key`` nullable columns to the
+``users`` table to support per-user API key storage for the user-settings UI.
+
+Revision ID: 20260527_000000_add_api_keys_to_users
+Revises: 20260526_000000_convert_datetime_columns
+Create Date: 2026-05-27
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260527_000000_add_api_keys_to_users"
+down_revision: str | Sequence[str] | None = "20260526_000000_convert_datetime_columns"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(sa.Column("claude_api_key", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("openai_api_key", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("openai_api_key")
+        batch_op.drop_column("claude_api_key")

--- a/backend/models.py
+++ b/backend/models.py
@@ -192,6 +192,10 @@ class User(SQLModel, table=True):
     avatar_url: str | None = None
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    # Per-user API keys set from the user-settings UI; stored in plaintext,
+    # never returned raw — always masked at the API layer.
+    claude_api_key: str | None = None
+    openai_api_key: str | None = None
 
 
 class GuildMember(SQLModel, table=True):

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -39,6 +39,20 @@ from utils import generate_guild_id
 router = APIRouter()
 
 
+def _mask_token(token: str | None) -> str | None:
+    """Return a masked representation of *token*, or None when not set.
+
+    Shows the first 7 characters (the recognizable prefix) and the last 4,
+    with ``****`` in between — e.g. ``sk-ant-****1234``.
+    """
+    if not token:
+        return None
+    if len(token) <= 8:
+        return "****"
+    prefix_len = min(7, len(token) - 4)
+    return token[:prefix_len] + "****" + token[-4:]
+
+
 class CodeExchangeRequest(BaseModel):
     code: str
     state: str
@@ -333,6 +347,51 @@ async def guest_login():
         "gh_name": "Dev Guest",
         "gh_avatar": "",
     }
+
+
+@router.get("/api/users/me/tokens")
+async def get_my_tokens(github_user_id: str = Depends(require_user)):
+    """Return which API tokens the current user has configured, masked.
+
+    Never returns raw token values — each present token is shown as e.g.
+    ``sk-ant-****1234``.
+    """
+    db = await get_db()
+    try:
+        u_res = await db.execute(select(User).where(User.id == github_user_id))
+        user = u_res.scalar_one_or_none()
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        return {
+            "claude": _mask_token(user.claude_api_key),
+            "codex": _mask_token(user.openai_api_key),
+        }
+    finally:
+        await db.close()
+
+
+@router.delete("/api/users/me/tokens/{provider}")
+async def clear_my_token(provider: str, github_user_id: str = Depends(require_user)):
+    """Clear the stored API token for *provider* (``claude`` or ``codex``).
+
+    Sets the column to NULL in the database; the raw value is never returned.
+    """
+    if provider not in ("claude", "codex"):
+        raise HTTPException(status_code=400, detail="provider must be 'claude' or 'codex'")
+    db = await get_db()
+    try:
+        u_res = await db.execute(select(User).where(User.id == github_user_id))
+        user = u_res.scalar_one_or_none()
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        if provider == "claude":
+            user.claude_api_key = None
+        else:
+            user.openai_api_key = None
+        await db.commit()
+    finally:
+        await db.close()
+    return {"ok": True}
 
 
 @router.delete("/auth/logout")

--- a/frontend/src/components/GitHubConfigModal.vue
+++ b/frontend/src/components/GitHubConfigModal.vue
@@ -2,7 +2,7 @@
   <div class="modal-overlay" @click.self="$emit('close')">
     <div class="modal">
       <div class="modal-header">
-        <span class="modal-title">⚙ GITHUB CONFIGURATION</span>
+        <span class="modal-title">⚙ USER SETTINGS</span>
         <button class="close-btn" @click="$emit('close')">✕</button>
       </div>
 
@@ -14,6 +14,41 @@
             <div class="user-label">{{ authStore.user?.name || 'GitHub User' }}</div>
           </div>
         </div>
+
+        <div class="section">
+          <div class="section-title">API TOKENS</div>
+          <div class="token-row">
+            <div class="token-info">
+              <span class="token-label">Claude</span>
+              <span class="token-value" :class="{ unset: !tokens.claude }">
+                {{ tokens.claude ?? 'Not set' }}
+              </span>
+            </div>
+            <button
+              class="pixel-btn danger-btn"
+              :disabled="!tokens.claude || clearing === 'claude'"
+              @click="clearToken('claude')"
+            >
+              {{ clearing === 'claude' ? '…' : 'CLEAR' }}
+            </button>
+          </div>
+          <div class="token-row">
+            <div class="token-info">
+              <span class="token-label">Codex</span>
+              <span class="token-value" :class="{ unset: !tokens.codex }">
+                {{ tokens.codex ?? 'Not set' }}
+              </span>
+            </div>
+            <button
+              class="pixel-btn danger-btn"
+              :disabled="!tokens.codex || clearing === 'codex'"
+              @click="clearToken('codex')"
+            >
+              {{ clearing === 'codex' ? '…' : 'CLEAR' }}
+            </button>
+          </div>
+          <div v-if="tokenError" class="token-error">{{ tokenError }}</div>
+        </div>
       </div>
 
       <div class="modal-footer">
@@ -24,10 +59,45 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
+import { api } from '../utils/api'
 
 defineEmits<{ close: [] }>()
 const authStore = useAuthStore()
+
+const tokens = ref<{ claude: string | null; codex: string | null }>({
+  claude: null,
+  codex: null,
+})
+const clearing = ref<'claude' | 'codex' | null>(null)
+const tokenError = ref<string | null>(null)
+
+async function loadTokens() {
+  try {
+    const data = await api<{ claude: string | null; codex: string | null }>(
+      '/api/users/me/tokens',
+    )
+    tokens.value = data
+  } catch {
+    // Not fatal — just leave tokens as null
+  }
+}
+
+async function clearToken(provider: 'claude' | 'codex') {
+  clearing.value = provider
+  tokenError.value = null
+  try {
+    await api(`/api/users/me/tokens/${provider}`, { method: 'DELETE' })
+    tokens.value = { ...tokens.value, [provider]: null }
+  } catch (err) {
+    tokenError.value = err instanceof Error ? err.message : 'Failed to clear token'
+  } finally {
+    clearing.value = null
+  }
+}
+
+onMounted(loadTokens)
 </script>
 
 <style scoped>
@@ -122,6 +192,81 @@ const authStore = useAuthStore()
 .user-label {
   font-size: 11px;
   color: var(--color-text-dim);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-title {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass-light);
+  letter-spacing: 2px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--color-brass-dark);
+}
+
+.token-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  background: var(--color-bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.token-info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.token-label {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-text-dim);
+  letter-spacing: 1px;
+}
+
+.token-value {
+  font-size: 11px;
+  color: var(--color-text);
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.token-value.unset {
+  color: var(--color-text-dim);
+  font-style: italic;
+  font-family: inherit;
+}
+
+.danger-btn {
+  flex-shrink: 0;
+  border-color: rgba(255, 80, 80, 0.6) !important;
+  color: rgba(255, 130, 130, 1) !important;
+}
+
+.danger-btn:not(:disabled):hover {
+  background: rgba(255, 80, 80, 0.15) !important;
+}
+
+.danger-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.token-error {
+  font-size: 11px;
+  color: rgba(255, 130, 130, 1);
+  padding: 4px 0;
 }
 
 .modal-footer {


### PR DESCRIPTION
## Summary

- **DB migration** (`20260527_000000`): adds `claude_api_key` and `openai_api_key` nullable `TEXT` columns to the `users` table.
- **`GET /api/users/me/tokens`**: returns which tokens the caller has set, masked (`sk-ant-****1234` style) — raw values are never returned.
- **`DELETE /api/users/me/tokens/{provider}`**: clears (`NULL`s) the stored token for `claude` or `codex`; returns `400` for unknown providers.
- **`GitHubConfigModal.vue`**: renamed to "User Settings", adds an **API Tokens** section with a row per provider showing the masked value or "Not set", and a **Clear** button (disabled when not set or while clearing).

## Security

- `_mask_token()` helper in `auth.py` shows at most the first 7 chars + last 4; the raw key never leaves the server.
- Both new endpoints are gated behind `require_user` (login token required).

## Test plan

- [ ] Log in, open the user settings modal — API Tokens section loads showing "Not set" for both rows.
- [ ] Manually set a value in the DB (`UPDATE users SET claude_api_key = 'sk-ant-api03-test1234' WHERE id = ...`), reload modal — shows `sk-ant-****1234`.
- [ ] Click **Clear** — token row reverts to "Not set"; DB column is NULL.
- [ ] `GET /api/users/me/tokens` without auth returns 401.
- [ ] `DELETE /api/users/me/tokens/github` returns 400.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)