### PR TITLE
Fix: chat messages not showing in real-time (#477)

### DIFF
--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -119,7 +119,7 @@ export const useGuildStore = defineStore('guild', () => {
         if (data.type === 'chat') {
           const chatMsg = data as ChatMessage
           if ((chatMsg.from || chatMsg.from_agent) !== 'github') {
-            messages.value.push(chatMsg)
+            messages.value = [...messages.value, chatMsg]
           }
         }
         if (data.type === 'guild-updated') {


### PR DESCRIPTION
## Summary

- `computed(() => guildStore.messages)` in `ChatTab.vue` only tracks changes to the ref's **identity** — it is not invalidated when the underlying array is mutated in-place via `.push()`
- The WebSocket handler in `guild.ts` was calling `messages.value.push(chatMsg)`, which mutated the reactive array but never replaced the ref's value
- Because the outer computed was never invalidated, the `watch(messages, …)` scroll handler never fired, and the `groupedMessages` computed's dependency chain was broken — the chat pane silently received other users' messages but the UI never re-rendered
- Changing to `messages.value = [...messages.value, chatMsg]` replaces the array reference, triggers the ref's setter, and propagates the update through the full computed/watch dependency chain so incoming messages render immediately

## Test plan

- [ ] Confirm all 86 existing unit tests pass (`npm test`)
- [ ] Confirm TypeScript type-check is clean (`npm run type-check`)
- [ ] Open two browser tabs connected to the same guild; verify a message sent in one tab appears immediately in the other without a refresh
- [ ] Verify own sent messages continue to appear normally (echo path unchanged)
- [ ] Verify system messages (task-assigned, task-complete, etc.) still render correctly

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)