### PR TITLE
Fix chat messages reactivity performance (#479 follow-up)

### DIFF
--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -119,7 +119,7 @@ export const useGuildStore = defineStore('guild', () => {
         if (data.type === 'chat') {
           const chatMsg = data as ChatMessage
           if ((chatMsg.from || chatMsg.from_agent) !== 'github') {
-            messages.value = [...messages.value, chatMsg]
+            messages.value.push(chatMsg)
           }
         }
         if (data.type === 'guild-updated') {


### PR DESCRIPTION
## Summary

- Replace `messages.value = [...messages.value, chatMsg]` with `messages.value.push(chatMsg)` in `frontend/src/stores/guild.ts`
- `messages` is already a `ref<ChatMessage[]>([])` — Vue 3 tracks mutations on `.value` arrays, so `.push()` triggers reactivity correctly without copying the entire array
- Existing messages still load on mount via direct assignment in `joinGuild()` (unchanged)

## Why

The spread pattern from PR #479 created an O(n) full array copy on every incoming WebSocket chat message. In a long session with hundreds of messages, this compounds with every new message.

## Test plan

- [ ] Existing messages load correctly when joining a guild
- [ ] New incoming WebSocket `chat` messages appear in real-time
- [ ] Sending your own message still appears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)