### PR TITLE
Mobile layout polish: viewport, touch targets, tappable floor

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Pioneer Square</title>
   </head>
   <body>

--- a/frontend/src/components/FactoryFloor.vue
+++ b/frontend/src/components/FactoryFloor.vue
@@ -51,9 +51,16 @@
           agentPos(agent.id).y * 100
         }%; z-index: ${zIndex(agentPos(agent.id).y)}`"
       >
-        <div class="agent-tilt" :style="`transform: rotate(${agentTilt(agent.id)}deg)`">
-          <AgentAvatar :agent="agent" :walking="isWalking(agent.id)" />
-        </div>
+        <button
+          class="agent-hit"
+          :title="`Open ${agent.name}`"
+          :aria-label="`Open ${agent.name}`"
+          @click="onAgentTap(agent.id)"
+        >
+          <div class="agent-tilt" :style="`transform: rotate(${agentTilt(agent.id)}deg)`">
+            <AgentAvatar :agent="agent" :walking="isWalking(agent.id)" />
+          </div>
+        </button>
         <div class="agent-nametag">{{ agent.name }}</div>
       </div>
     </div>
@@ -353,6 +360,10 @@ function truncate(str: string | undefined, len: number) {
 function stateLabel(state: string) {
   return tasksStore.stateLabel(state)
 }
+
+function onAgentTap(agentId: string) {
+  agentsStore.selectAgent(agentId)
+}
 </script>
 
 <style scoped>
@@ -535,6 +546,30 @@ function stateLabel(state: string) {
 .floating-agent :deep(.robot-sprite) {
   width: 9cqw;
   height: auto;
+}
+.agent-hit {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  pointer-events: auto;
+  border-radius: 50%;
+  transition: transform 0.12s ease;
+}
+.agent-hit:hover {
+  transform: scale(1.06);
+}
+.agent-hit:focus-visible {
+  outline: 2px solid var(--color-brass);
+  outline-offset: 2px;
+}
+/* Touch: expand the hit area beyond the visible sprite so 9cqw avatars
+   (~35px on a phone) are still comfortable to tap. */
+@media (hover: none) {
+  .agent-hit {
+    padding: 8px;
+    margin: -8px;
+  }
 }
 .agent-tilt {
   display: flex;

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -119,6 +119,13 @@ function onSelectIssue(issue: GitHubIssue) {
     background 0.12s;
 }
 
+@media (max-width: 1024px) {
+  .tab-btn {
+    min-height: 44px;
+    padding: 12px 4px 11px;
+  }
+}
+
 .tab-btn:hover {
   color: var(--color-brass);
   background: rgba(232, 170, 0, 0.06);

--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -230,6 +230,23 @@ function onTabClick(event: MouseEvent, taskId: string) {
   background: rgba(255, 80, 80, 0.12);
 }
 
+/* Touch devices have no :hover — keep the close affordance visible so
+   opened tabs can be closed on mobile. Bump tab + close tap targets to
+   ~44pt while we're at it. */
+@media (hover: none) {
+  .tab {
+    padding: 12px 14px;
+    min-height: 44px;
+  }
+  .worker-tab .tab-close,
+  .task-tab .tab-close {
+    opacity: 1;
+    font-size: 16px;
+    padding: 6px 8px;
+    margin-left: 4px;
+  }
+}
+
 .task-dot {
   width: 8px;
   height: 8px;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -65,7 +65,7 @@ body {
 }
 
 #app {
-  height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -175,7 +175,7 @@ watch(
 .app-layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100dvh;
   width: 100%;
   overflow: hidden;
   background: var(--color-bg);
@@ -200,6 +200,8 @@ watch(
     left: 0;
     right: 0;
     height: 52px;
+    padding-bottom: env(safe-area-inset-bottom);
+    box-sizing: content-box;
     background: var(--color-bg-secondary);
     border-top: 2px solid var(--color-brass-dark);
     z-index: 200;
@@ -252,12 +254,12 @@ watch(
     top: 44px;
     left: 0;
     right: 0;
-    bottom: 52px;
+    bottom: calc(52px + env(safe-area-inset-bottom));
     width: 100% !important;
     min-width: 0 !important;
     max-width: 100% !important;
-    height: calc(100dvh - 96px) !important;
-    max-height: calc(100dvh - 96px) !important;
+    height: calc(100dvh - 96px - env(safe-area-inset-bottom)) !important;
+    max-height: calc(100dvh - 96px - env(safe-area-inset-bottom)) !important;
     display: none !important;
   }
 

--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -194,7 +194,7 @@ async function createGuild(name: string) {
 <style scoped>
 .landing {
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   background: var(--color-bg);
   display: flex;
   align-items: stretch;


### PR DESCRIPTION
## Summary

Groundwork for wrapping the Vue app in an iOS WebView. Three independent fixes to make the existing mobile breakpoint at `AppView.vue:195` actually usable on a phone:

- **iOS viewport + safe areas.** Switch outer containers from `100vh` to `100dvh` so the iOS Safari URL bar no longer hides the bottom of the app, add `viewport-fit=cover` to the meta tag, and reserve `env(safe-area-inset-bottom)` for the mobile tab bar so it clears the iPhone home indicator.
- **Touch targets.** The `MainView` tab-close (`×`) was hover-only via `opacity: 0`, so opened agent/worker/task tabs could not be closed on touch at all. Reveal it under `@media (hover: none)` and bump tab + close tap targets to ~44pt. Also bumps the `GuildSidebar` Tasks/Workers/Issues nested tabs to a 44pt minimum under the mobile breakpoint.
- **Tappable factory floor.** Wraps each agent on the floor in a button that calls `agentsStore.selectAgent`, which opens an agent tab and swaps `MainView` content to that agent's `LogPane` (reusing the existing flow). Adds expanded hit padding under `@media (hover: none)` so the small pixel-art sprites are comfortable to tap on a phone.

Desktop layout is unchanged — every touch-target bump is gated on either the 1024px breakpoint or `@media (hover: none)`.

## Test plan

- [ ] Open on a desktop browser at >1024px — three-pane layout looks identical to `main`
- [ ] Resize below 1024px — bottom tab bar shows Tasks / Work / Chat, clears the home indicator on a real iPhone
- [ ] Open a worker or task tab in MainView, then close it via the `×` on touch
- [ ] Tap a robot on the factory floor — agent's LogPane opens in the same pane
- [ ] On an iOS device, scroll the Chat tab to bottom while the keyboard is open and confirm the input is still visible

## Out of scope (follow-up branches)

- Pinch-zoom / pan on the factory floor (the floor still letterboxes to fit; tapping individual workers compensates for now)
- `WKWebView` iOS shell + APNs bridge for push notifications

---
_Generated by [Claude Code](https://claude.ai/code/session_018Z9YPT87cxeLvPYPv8S5Dz)_