### PR TITLE
Notify foreman on max-turns (#484)

### DIFF
--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -4,6 +4,7 @@ Verifies that:
 - handle_worker_register triggers [worker-online] to the foreman
 - handle_worker_disconnect triggers [worker-offline] reason=shutdown
 - abrupt WebSocket disconnect triggers [worker-offline] reason=disconnect
+- task-complete with stopReason=max_turns triggers a max-turns foreman message
 """
 
 from __future__ import annotations
@@ -24,7 +25,7 @@ import database as database_module  # noqa: E402
 import main as main_module  # noqa: E402
 import ws_handlers  # noqa: E402
 from _test_config import TEST_DATABASE_URL  # noqa: E402
-from helpers import insert_guild, insert_worker  # noqa: E402
+from helpers import insert_guild, insert_task, insert_worker  # noqa: E402
 
 
 @pytest.fixture(scope="module")
@@ -182,3 +183,73 @@ def test_abrupt_disconnect_notifies_foreman(client):
     _event, msg = offline[0]
     assert f"worker_id={worker_id}" in msg, msg
     assert "reason=disconnect" in msg, msg
+
+
+def test_task_complete_max_turns_notifies_foreman(client):
+    """task-complete with stopReason=max_turns sends a truncation-aware foreman trigger."""
+    test_client, db_url = client
+    guild_id = "nfy004"
+    worker_id = "w-nfy004"
+    task_id = "t-nfy004"
+    agent_id = "a-nfy004"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+    insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="working")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+            ws_worker.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws_worker.receive_json()  # agent-joined broadcast
+
+            with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+                ws_obs.send_json(
+                    {
+                        "type": "join",
+                        "agentId": "a-nfy004-obs",
+                        "agentName": "Observer",
+                        "agentType": "browser",
+                    }
+                )
+                ws_obs.receive_json()  # agent-joined for observer
+                ws_worker.receive_json()  # observer's agent-joined broadcast to worker
+
+                ws_worker.send_json(
+                    {
+                        "type": "task-complete",
+                        "workerId": worker_id,
+                        "taskId": task_id,
+                        "branch": "feature/partial-work",
+                        "stopReason": "max_turns",
+                        "lastText": "I was working on the migration when I ran out of turns.",
+                        "prUrl": "",
+                        "sessionId": "",
+                    }
+                )
+                ws_obs.receive_json()  # task-complete broadcast
+
+                ws_worker.send_json({"type": "ping"})
+                ws_worker.receive_json()  # pong — ensures handler is done
+
+    complete_triggers = [(e, m) for e, m in triggered if e == "task-complete"]
+    assert complete_triggers, f"Expected task-complete trigger, got: {triggered}"
+    _event, msg = complete_triggers[0]
+    assert "max-turns" in msg, f"Expected 'max-turns' in message, got: {msg}"
+    assert "max_turns" not in msg.split("max-turns")[0].replace("max_turns", ""), True
+    assert task_id in msg, f"Expected task_id in message, got: {msg}"
+    assert "continuation" in msg.lower() or "resume" in msg.lower() or "send_followup" in msg, (
+        f"Expected continuation/resume/send_followup hint, got: {msg}"
+    )
+    assert "I was working on the migration" in msg, (
+        f"Expected lastText snippet in message, got: {msg}"
+    )

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -643,6 +643,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
     branch = data.get("branch", "")
     pr_url = data.get("prUrl", "")
     last_text = data.get("lastText", "")
+    stop_reason = data.get("stopReason", "success")
     if task_id:
         # Persist pr_url regardless of current state — the prior task-update may
         # have already moved the task to awaiting-review, so the state guard below
@@ -672,18 +673,33 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
 
     task_uid = await _task_user_id(ctx.db, task_id)
     pr_line = f" PR: {pr_url}." if pr_url else ""
+    if stop_reason == "max_turns":
+        last_text_snippet = f' Last output: "{last_text[:200]}".' if last_text else ""
+        foreman_message = (
+            f"[task-complete/max-turns] Worker {worker_id_msg} task {task_id}: "
+            f'"{desc[:80]}" — branch: {branch}.{pr_line} '
+            f"IMPORTANT: Claude hit its max-turns limit and stopped before finishing. "
+            f"Partial work has been committed and the branch pushed.{last_text_snippet} "
+            "Call send_followup with a continuation prompt so the worker can resume on the "
+            "same branch/worktree. Only call finalize_task if the partial work is sufficient "
+            "or the task should be abandoned."
+        )
+    else:
+        foreman_message = (
+            f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
+            f'"{desc[:80]}" — branch: {branch}.{pr_line} '
+            "The worker has returned to its idle pool; the task is parked in "
+            "awaiting-review for human review. "
+            "Default behaviour: leave PR-bearing tasks open so reviewers can "
+            "comment — call send_followup if a comment or CI failure asks for "
+            "an iteration on the same branch (any idle worker can pick it up). "
+            "Only call finalize_task when the work is genuinely closed (PR "
+            "merged, task abandoned, or it was an ephemeral/automation task)."
+        )
     await _trigger_foreman(
         ctx.guild_id,
         "task-complete",
-        f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
-        f'"{desc[:80]}" — branch: {branch}.{pr_line} '
-        "The worker has returned to its idle pool; the task is parked in "
-        "awaiting-review for human review. "
-        "Default behaviour: leave PR-bearing tasks open so reviewers can "
-        "comment — call send_followup if a comment or CI failure asks for "
-        "an iteration on the same branch (any idle worker can pick it up). "
-        "Only call finalize_task when the work is genuinely closed (PR "
-        "merged, task abandoned, or it was an ephemeral/automation task).",
+        foreman_message,
         user_id=task_uid,
         task_id=task_id,
         task_name=f"foreman.task-complete:{task_id}",
@@ -694,6 +710,8 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
 async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
     task_id = data.get("taskId")
     worker_id_msg = data.get("workerId", "")
+    stop_reason = data.get("stopReason", "success")
+    last_text_fud = data.get("lastText", "")
     if task_id:
         pr_url_fud = data.get("prUrl", "")
         pr_update: dict = {}
@@ -736,7 +754,15 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
 
     task_uid = await _task_user_id(ctx.db, task_id)
 
-    if queued_payloads:
+    if stop_reason == "max_turns":
+        last_text_snippet = f' Last output: "{last_text_fud[:200]}".' if last_text_fud else ""
+        human_msg = (
+            f"[followup-done/max-turns] Worker {worker_id_msg} follow-up for task {task_id} "
+            f"hit Claude's max-turns limit before finishing. Partial work committed.{last_text_snippet} "
+            "Call send_followup with a continuation prompt to resume, or call finalize_task if "
+            "the partial work is sufficient."
+        )
+    elif queued_payloads:
         queued_summary = "\n".join(
             f"  {i + 1}. {p.get('instructions', '')}" for i, p in enumerate(queued_payloads)
         )


### PR DESCRIPTION
## Summary

- When Claude hits its `max_turns` limit, the subprocess exits cleanly (code 0) with `stop_reason="max_turns"`, so the worker correctly sends a `task-complete` message — but `handle_task_complete` was constructing the foreman trigger message as if the task finished normally, with no indication of truncation.
- The foreman would receive the generic "parked in awaiting-review" message and have no signal to issue a follow-up continuation.
- Same gap existed in `handle_task_followup_done` for follow-up runs that hit the turn limit.

## Changes

**`backend/ws_handlers.py`**
- `handle_task_complete`: reads `stopReason` from the WS payload; when it's `"max_turns"`, sends a distinct `[task-complete/max-turns]` trigger message to the foreman that explains the truncation, includes the last 200 chars of Claude's output, and explicitly prompts the foreman to call `send_followup` with a continuation prompt.
- `handle_task_followup_done`: same fix for the follow-up path (`[followup-done/max-turns]`).
- Normal completions are unchanged.

**`backend/tests/test_worker_foreman_notify.py`**
- Added `test_task_complete_max_turns_notifies_foreman`: uses the existing `_trigger_foreman` spy pattern to verify that a `task-complete` with `stopReason=max_turns` triggers a message containing `max-turns`, the task ID, `send_followup` guidance, and the `lastText` snippet.

## Test plan

- [ ] Run `python -m pytest backend/tests/test_worker_foreman_notify.py` (requires `postgres-test` container at localhost:5433)
- [ ] Manually trigger a task that hits the turn limit and verify the foreman chat shows a truncation notice and issues a follow-up

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)