### PR TITLE
Fix foreman chat messages not showing in UI (#486)

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -469,7 +469,7 @@ async def run_foreman_ai(
                             "from": "foreman",
                             "to": "user",
                             "content": b.text.strip(),
-                            "createdAt": _now,
+                            "createdAt": _now.isoformat(),
                         },
                     )
 
@@ -490,7 +490,7 @@ async def run_foreman_ai(
                         "toolName": tu.name,
                         "toolInput": dict(tu.input) if tu.input else {},
                         "toolId": tu.id,
-                        "createdAt": _now,
+                        "createdAt": _now.isoformat(),
                     },
                 )
 
@@ -520,7 +520,7 @@ async def run_foreman_ai(
                         "toolId": result.get("tool_use_id"),
                         "toolOutput": result.get("content", ""),
                         "isError": result.get("is_error", False),
-                        "createdAt": _now,
+                        "createdAt": _now.isoformat(),
                     },
                 )
 


### PR DESCRIPTION
## Root cause

`run_foreman_ai` in `backend/foreman/runner.py` passed raw `datetime` objects as `"createdAt"` values inside the dicts handed to `broadcast()`. FastAPI's `WebSocket.send_json` uses the standard `json.dumps` with no custom encoder, so it raises `TypeError: Object of type datetime is not JSON serializable`.

The `broadcast()` helper catches **all** exceptions from `send_json` and marks the offending WebSocket as dead, removing it from the connections pool. This meant:
1. The very first foreman message failed to serialize.
2. The client's WebSocket was evicted from `connections[guild_id]`.
3. Every subsequent broadcast in the same foreman run had no recipients — silently dropped.

## Fix

Called `.isoformat()` on the three `_now` datetime objects that were passed directly into broadcast payloads (text-block, tool-use, and tool-result events). The safety-cap path on the same line range was already correct (its `_now` was assigned as an ISO string).

## Testing

Verified with `ruff check` — no issues. The change is a one-liner per call site with no logic changes.

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)