### PR TITLE
Tighten broadcast() + datetime-aware WS JSON (#490)

### DIFF
--- a/backend/events.py
+++ b/backend/events.py
@@ -12,7 +12,7 @@ from typing import Any
 from uuid import UUID
 
 from database import get_db
-from fastapi import WebSocket
+from fastapi import WebSocket, WebSocketDisconnect
 from models import Agent, TaskLog
 from sqlalchemy import select
 
@@ -97,8 +97,11 @@ async def broadcast(guild_id: str, message: dict, exclude: WebSocket | None = No
             continue
         try:
             await ws.send_text(data)
-        except Exception as exc:
+        except (WebSocketDisconnect, RuntimeError, OSError) as exc:
             logger.warning("broadcast: send failed for %s guild=%s: %s", ws, guild_id, exc)
+            dead.append(ws)
+        except Exception as exc:
+            logger.warning("Unexpected error evicting WebSocket: %s", exc, exc_info=True)
             dead.append(ws)
     for ws in dead:
         connections[guild_id].remove(ws)

--- a/backend/events.py
+++ b/backend/events.py
@@ -5,8 +5,11 @@ broadcast/emit_terminal_line without circular dependencies.
 """
 
 import asyncio
+import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from typing import Any
+from uuid import UUID
 
 from database import get_db
 from fastapi import WebSocket
@@ -14,6 +17,20 @@ from models import Agent, TaskLog
 from sqlalchemy import select
 
 logger = logging.getLogger(__name__)
+
+
+def _json_default(obj: Any) -> Any:
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, UUID):
+        return str(obj)
+    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+
+def ws_dumps(payload: Any) -> str:
+    """Serialize payload to a JSON string with datetime/UUID support."""
+    return json.dumps(payload, default=_json_default)
+
 
 # In-memory WebSocket connections: guild_id -> list of WebSocket
 connections: dict[str, list[WebSocket]] = {}
@@ -71,12 +88,15 @@ async def broadcast(guild_id: str, message: dict, exclude: WebSocket | None = No
         return
     if guild_id not in connections:
         return
+    # Serialize once before iterating — let TypeError propagate immediately so
+    # serialization bugs are visible rather than silently evicting connections.
+    data = ws_dumps(message)
     dead = []
     for ws in connections[guild_id]:
         if ws is exclude:
             continue
         try:
-            await ws.send_json(message)
+            await ws.send_text(data)
         except Exception:
             dead.append(ws)
     for ws in dead:

--- a/backend/events.py
+++ b/backend/events.py
@@ -97,7 +97,8 @@ async def broadcast(guild_id: str, message: dict, exclude: WebSocket | None = No
             continue
         try:
             await ws.send_text(data)
-        except Exception:
+        except Exception as exc:
+            logger.warning("broadcast: send failed for %s guild=%s: %s", ws, guild_id, exc)
             dead.append(ws)
     for ws in dead:
         connections[guild_id].remove(ws)

--- a/backend/tests/test_ws_dumps.py
+++ b/backend/tests/test_ws_dumps.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime, timezone
 from uuid import UUID
 
 import pytest
@@ -16,7 +16,7 @@ from events import ws_dumps  # noqa: E402
 
 
 def test_datetime_serializes_to_iso8601():
-    dt = datetime(2024, 3, 15, 10, 30, 0, tzinfo=timezone.utc)
+    dt = datetime(2024, 3, 15, 10, 30, 0, tzinfo=UTC)
     result = json.loads(ws_dumps({"ts": dt}))
     assert result["ts"] == "2024-03-15T10:30:00+00:00"
 

--- a/backend/tests/test_ws_dumps.py
+++ b/backend/tests/test_ws_dumps.py
@@ -1,0 +1,47 @@
+"""Unit tests for ws_dumps in events.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import date, datetime, timezone
+from uuid import UUID
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from events import ws_dumps  # noqa: E402
+
+
+def test_datetime_serializes_to_iso8601():
+    dt = datetime(2024, 3, 15, 10, 30, 0, tzinfo=timezone.utc)
+    result = json.loads(ws_dumps({"ts": dt}))
+    assert result["ts"] == "2024-03-15T10:30:00+00:00"
+
+
+def test_date_serializes_to_iso8601():
+    d = date(2024, 3, 15)
+    result = json.loads(ws_dumps({"d": d}))
+    assert result["d"] == "2024-03-15"
+
+
+def test_uuid_serializes_to_string():
+    uid = UUID("12345678-1234-5678-1234-567812345678")
+    result = json.loads(ws_dumps({"id": uid}))
+    assert result["id"] == "12345678-1234-5678-1234-567812345678"
+
+
+def test_plain_dict_passes_through():
+    payload = {"type": "ping", "value": 42, "flag": True, "none": None}
+    result = json.loads(ws_dumps(payload))
+    assert result == payload
+
+
+def test_unhandled_type_raises_type_error():
+    class _Custom:
+        pass
+
+    with pytest.raises(TypeError):
+        ws_dumps({"obj": _Custom()})


### PR DESCRIPTION
## Summary

- Adds `ws_dumps()` helper in `backend/events.py` with a custom `json.dumps` encoder that serialises `datetime`/`date` values to ISO-8601 and `UUID` to `str` — preventing silent failures when broadcast payloads contain these types.
- Splits `broadcast()` into two distinct steps:
  - **Serialisation** (`ws_dumps()`): `TypeError` propagates immediately — the connection is healthy, so the bug should be loud and visible, not swallowed.
  - **Send** (`ws.send_text(data)`): network/connection errors still evict the dead WebSocket as before.
- Switches from `ws.send_json()` to `ws.send_text(ws_dumps())` so the single encoder is used consistently for every outbound message.
- Adds `logger.warning()` on send failures so evictions are visible in logs.
- Adds unit tests for `ws_dumps` covering datetime, date, UUID, plain dict, and unhandled type.

## Test plan

- [x] Broadcast a payload containing a `datetime` field — verify it serialises to an ISO-8601 string on the client side with no error
- [x] Broadcast a payload containing an unserializable type — verify `TypeError` is raised immediately (not silently swallowed)
- [x] Disconnect a client while the backend is running — verify the dead WebSocket is still evicted on the next send attempt

Closes #490
Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)