### PR TITLE
Backend: push token endpoints + APNs dispatcher

### DIFF
--- a/backend/alembic/versions/20260527_000000_create_push_tokens.py
+++ b/backend/alembic/versions/20260527_000000_create_push_tokens.py
@@ -1,0 +1,45 @@
+"""Create push_tokens table.
+
+Revision ID: 20260527_000000_create_push_tokens
+Revises: 20260526_000000_convert_datetime_columns
+Create Date: 2026-05-27
+
+Stores APNs (and, later, FCM) device tokens per user. The token is the
+primary key — Apple gives every install of the app a unique token, and
+the same token coming back from a different user means the device was
+re-provisioned, so we just overwrite the user_id.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260527_000000_create_push_tokens"
+down_revision: str | Sequence[str] | None = "20260526_000000_convert_datetime_columns"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "push_tokens",
+        sa.Column("token", sa.Text(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("platform", sa.Text(), nullable=False, server_default="ios"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_push_tokens_user_id", "push_tokens", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_push_tokens_user_id", table_name="push_tokens")
+    op.drop_table("push_tokens")

--- a/backend/main.py
+++ b/backend/main.py
@@ -329,6 +329,7 @@ from routes import agents as _agents_routes  # noqa: E402
 from routes import auth as _auth_routes  # noqa: E402
 from routes import foreman as _foreman_routes  # noqa: E402
 from routes import guilds as _guilds_routes  # noqa: E402
+from routes import push as _push_routes  # noqa: E402
 from routes import tasks as _tasks_routes  # noqa: E402
 from routes import webhooks as _webhooks_routes  # noqa: E402
 from routes import websocket as _ws_routes  # noqa: E402
@@ -344,6 +345,7 @@ app.include_router(_workers_routes.router)
 app.include_router(_tasks_routes.router)
 app.include_router(_foreman_routes.router)
 app.include_router(_webhooks_routes.router)
+app.include_router(_push_routes.router)
 app.include_router(_ws_routes.router)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -316,3 +316,22 @@ class TaskEvent(SQLModel, table=True):
     event_type: str
     payload_json: str  # JSON: instructions, preferred_worker_id
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
+class PushToken(SQLModel, table=True):
+    """APNs (or, in the future, FCM) device token registered by the iOS app.
+
+    The token is the primary key because Apple's tokens are globally unique
+    per app install — when the same token comes back from a different user
+    it means the device was re-provisioned and we overwrite ``user_id``.
+    """
+
+    __tablename__ = "push_tokens"
+
+    token: str = Field(primary_key=True)
+    user_id: str = Field(foreign_key="users.id", index=True)
+    platform: str = Field(
+        default="ios", sa_column_kwargs={"server_default": "'ios'"}
+    )  # ios | (future: android)
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    last_seen_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))

--- a/backend/push.py
+++ b/backend/push.py
@@ -1,0 +1,203 @@
+"""APNs dispatch for registered push tokens.
+
+``send_to_user(user_id, ...)`` looks up every token registered by that user
+and sends a notification to each via Apple's HTTP/2 endpoint. When APNs
+credentials aren't configured (env vars unset) the call logs and is a
+no-op, so the rest of the backend can call into this module unconditionally.
+
+Env vars (all four required to actually send):
+
+- ``APNS_KEY_P8``   — contents of the Apple .p8 private key (PEM)
+- ``APNS_KEY_ID``   — 10-character Apple key id
+- ``APNS_TEAM_ID``  — 10-character Apple team id
+- ``APNS_BUNDLE_ID``— app bundle id used as the ``apns-topic`` header
+- ``APNS_USE_SANDBOX`` — set to ``1`` to hit ``api.sandbox.push.apple.com``
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+from database import get_db
+from models import PushToken
+from sqlalchemy import delete, select
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _APNsConfig:
+    key_pem: str
+    key_id: str
+    team_id: str
+    bundle_id: str
+    sandbox: bool
+
+    @property
+    def host(self) -> str:
+        return (
+            "https://api.sandbox.push.apple.com" if self.sandbox else "https://api.push.apple.com"
+        )
+
+
+def _load_config() -> _APNsConfig | None:
+    key = os.environ.get("APNS_KEY_P8", "").strip()
+    key_id = os.environ.get("APNS_KEY_ID", "").strip()
+    team_id = os.environ.get("APNS_TEAM_ID", "").strip()
+    bundle = os.environ.get("APNS_BUNDLE_ID", "").strip()
+    if not (key and key_id and team_id and bundle):
+        return None
+    return _APNsConfig(
+        key_pem=key,
+        key_id=key_id,
+        team_id=team_id,
+        bundle_id=bundle,
+        sandbox=os.environ.get("APNS_USE_SANDBOX") == "1",
+    )
+
+
+# In-memory JWT cache. Apple requires ES256 tokens, accepts them for up to
+# 60 minutes, and rate-limits regeneration — we cap to 45 minutes for a safe
+# margin and regenerate on demand.
+_JWT_TTL_SECONDS = 45 * 60
+_jwt_cache: dict[str, tuple[str, float]] = {}
+
+
+def _b64url(data: bytes) -> str:
+    import base64
+
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _make_jwt(config: _APNsConfig) -> str:
+    cached = _jwt_cache.get(config.key_id)
+    now = time.time()
+    if cached is not None:
+        token, issued_at = cached
+        if now - issued_at < _JWT_TTL_SECONDS:
+            return token
+
+    header = {"alg": "ES256", "kid": config.key_id, "typ": "JWT"}
+    payload = {"iss": config.team_id, "iat": int(now)}
+    signing_input = (
+        _b64url(json.dumps(header, separators=(",", ":")).encode())
+        + "."
+        + _b64url(json.dumps(payload, separators=(",", ":")).encode())
+    )
+    key = serialization.load_pem_private_key(config.key_pem.encode(), password=None)
+    if not isinstance(key, ec.EllipticCurvePrivateKey):
+        raise ValueError("APNS_KEY_P8 must be an EC P-256 key")
+
+    der = key.sign(signing_input.encode(), ec.ECDSA(hashes.SHA256()))
+    # APNs requires the raw (r||s) signature, not the DER-encoded form
+    # cryptography returns by default.
+    r, s = decode_dss_signature(der)
+    raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    jwt = signing_input + "." + _b64url(raw_sig)
+    _jwt_cache[config.key_id] = (jwt, now)
+    return jwt
+
+
+async def _delete_tokens(tokens: list[str]) -> None:
+    if not tokens:
+        return
+    db = await get_db()
+    try:
+        await db.execute(delete(PushToken).where(PushToken.token.in_(tokens)))
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def send_to_user(
+    user_id: str,
+    *,
+    title: str,
+    body: str,
+    data: dict[str, Any] | None = None,
+) -> int:
+    """Send a push to every device registered by ``user_id``.
+
+    Returns the count of pushes Apple accepted (``200 OK``). When APNs creds
+    aren't configured, logs the intended push and returns ``0``. ``410 Gone``
+    tokens are removed from the database.
+    """
+    config = _load_config()
+
+    db = await get_db()
+    try:
+        result = await db.execute(select(PushToken.token).where(PushToken.user_id == user_id))
+        tokens = [row[0] for row in result.all()]
+    finally:
+        await db.close()
+
+    if not tokens:
+        return 0
+
+    if config is None:
+        logger.info(
+            "push: APNs not configured; would have sent to %d device(s) for user %s",
+            len(tokens),
+            user_id,
+        )
+        return 0
+
+    jwt = _make_jwt(config)
+    apns_payload: dict[str, Any] = {
+        "aps": {"alert": {"title": title, "body": body}, "sound": "default"}
+    }
+    if data:
+        # Custom keys live alongside ``aps`` (Apple convention).
+        apns_payload.update({k: v for k, v in data.items() if k != "aps"})
+    body_json = json.dumps(apns_payload, separators=(",", ":"))
+
+    delivered = 0
+    stale: list[str] = []
+    # http2=True requires the optional `h2` package; fall back gracefully.
+    client_kwargs: dict[str, Any] = {"timeout": 5.0}
+    try:
+        import h2  # noqa: F401
+
+        client_kwargs["http2"] = True
+    except ImportError:
+        logger.warning("push: h2 not installed; APNs will fail until 'httpx[http2]' is added")
+
+    async with httpx.AsyncClient(**client_kwargs) as client:
+        for token in tokens:
+            try:
+                resp = await client.post(
+                    f"{config.host}/3/device/{token}",
+                    headers={
+                        "authorization": f"bearer {jwt}",
+                        "apns-topic": config.bundle_id,
+                        "apns-push-type": "alert",
+                        "content-type": "application/json",
+                    },
+                    content=body_json,
+                )
+            except httpx.HTTPError as exc:
+                logger.warning("push: APNs request failed for %s: %s", token[-8:], exc)
+                continue
+            if resp.status_code == 200:
+                delivered += 1
+            elif resp.status_code == 410:
+                stale.append(token)
+            else:
+                logger.warning(
+                    "push: APNs %s for %s: %s",
+                    resp.status_code,
+                    token[-8:],
+                    resp.text[:200],
+                )
+
+    await _delete_tokens(stale)
+    return delivered

--- a/backend/routes/push.py
+++ b/backend/routes/push.py
@@ -1,0 +1,143 @@
+"""Push notification token registration.
+
+The iOS app (see ``ios/PioneerSquare/PushManager.swift``) receives an APNs
+device token after the user grants notification permission and POSTs it
+here. The token is keyed to the authenticated GitHub user so server-side
+code can fan a notification out to every device that user has signed in
+on. Re-registering the same token bumps ``last_seen_at`` so we can prune
+stale rows.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from auth_deps import require_user
+from database import get_db
+from fastapi import APIRouter, Depends, HTTPException
+from models import PushToken
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+router = APIRouter()
+
+
+_SUPPORTED_PLATFORMS = {"ios"}
+
+
+class RegisterRequest(BaseModel):
+    token: str = Field(min_length=1, max_length=400)
+    platform: str = "ios"
+
+
+@router.post("/api/push/register")
+async def register_push_token(
+    body: RegisterRequest,
+    github_user_id: str = Depends(require_user),
+) -> dict[str, str]:
+    """Register or refresh a device token for the authenticated user.
+
+    Returns ``{"status": "ok"}`` on success. Re-registering the same token
+    is idempotent and bumps ``last_seen_at``; the row may also move between
+    users if a device is signed into a new account.
+    """
+    if body.platform not in _SUPPORTED_PLATFORMS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported platform: {body.platform!r}",
+        )
+
+    now = datetime.now(UTC)
+    db = await get_db()
+    try:
+        stmt = (
+            pg_insert(PushToken)
+            .values(
+                token=body.token,
+                user_id=github_user_id,
+                platform=body.platform,
+                created_at=now,
+                last_seen_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=["token"],
+                set_={
+                    "user_id": github_user_id,
+                    "platform": body.platform,
+                    "last_seen_at": now,
+                },
+            )
+        )
+        await db.execute(stmt)
+        await db.commit()
+    finally:
+        await db.close()
+    return {"status": "ok"}
+
+
+class UnregisterRequest(BaseModel):
+    token: str = Field(min_length=1, max_length=400)
+
+
+@router.delete("/api/push/register")
+async def unregister_push_token(
+    body: UnregisterRequest,
+    github_user_id: str = Depends(require_user),
+) -> dict[str, str]:
+    """Delete the caller's row for ``token``.
+
+    Only deletes when the token is owned by the authenticated user, so one
+    user can't silence another's device by guessing its token.
+    """
+    db = await get_db()
+    try:
+        await db.execute(
+            delete(PushToken).where(
+                PushToken.token == body.token,
+                PushToken.user_id == github_user_id,
+            )
+        )
+        await db.commit()
+    finally:
+        await db.close()
+    return {"status": "ok"}
+
+
+@router.get("/api/push/tokens")
+async def list_my_tokens(
+    github_user_id: str = Depends(require_user),
+) -> dict[str, list[dict]]:
+    """List the caller's registered devices.
+
+    Useful for a future "logged-in devices" settings screen and for
+    debugging — exposes only the caller's own rows.
+    """
+    db = await get_db()
+    try:
+        result = await db.execute(
+            select(
+                PushToken.token,
+                PushToken.platform,
+                PushToken.created_at,
+                PushToken.last_seen_at,
+            )
+            .where(PushToken.user_id == github_user_id)
+            .order_by(PushToken.last_seen_at.desc())
+        )
+        rows = result.all()
+    finally:
+        await db.close()
+    return {
+        "tokens": [
+            {
+                # Don't echo the full token back — only the suffix is enough
+                # for the user to recognise which device this is.
+                "token_suffix": row.token[-8:],
+                "platform": row.platform,
+                "created_at": row.created_at.isoformat(),
+                "last_seen_at": row.last_seen_at.isoformat(),
+            }
+            for row in rows
+        ]
+    }

--- a/backend/tests/test_push_tokens.py
+++ b/backend/tests/test_push_tokens.py
@@ -1,0 +1,274 @@
+"""Tests for the /api/push/register endpoints and the push dispatcher.
+
+Covers the auth gate, idempotent re-registration, ownership-scoped deletion,
+the listing endpoint's token-suffix redaction, and the dispatcher behaviour
+when APNs is not configured (the only path exercised in CI — actual APNs
+HTTP/2 calls require a real Apple key and aren't part of the suite).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import UTC, datetime
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from helpers import _sync_session, make_auth_token
+from models import PushToken, User
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+
+def _ensure_user(db_url: str, user_id: str) -> None:
+    """Create a users row so PushToken's FK to users.id resolves.
+
+    The default ``make_auth_token`` helper only seeds ``github_tokens`` and
+    ``user_sessions``; production OAuth populates ``users`` as well, but the
+    test helper doesn't and won't be changed in this PR.
+    """
+    now = datetime.now(UTC)
+    with _sync_session(db_url) as session:
+        session.execute(
+            pg_insert(User)
+            .values(
+                id=user_id,
+                github_id=user_id,
+                github_login=user_id,
+                created_at=now,
+                updated_at=now,
+            )
+            .on_conflict_do_nothing(index_elements=["id"])
+        )
+        session.commit()
+
+
+def _login(db_url: str, user_id: str = "gh-user-test", username: str = "testuser") -> str:
+    """Seed a logged-in user (auth token + users row) and return the bearer."""
+    token = make_auth_token(db_url, user_id=user_id, username=username)
+    _ensure_user(db_url, user_id)
+    return token
+
+
+def _seed_token(db_url: str, token: str, user_id: str = "gh-user-test") -> None:
+    _ensure_user(db_url, user_id)
+    now = datetime.now(UTC)
+    with _sync_session(db_url) as session:
+        session.add(
+            PushToken(
+                token=token,
+                user_id=user_id,
+                platform="ios",
+                created_at=now,
+                last_seen_at=now,
+            )
+        )
+        session.commit()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/push/register
+# ---------------------------------------------------------------------------
+
+
+def test_register_requires_auth(client):
+    test_client, _ = client
+    resp = test_client.post("/api/push/register", json={"token": "abc"})
+    assert resp.status_code == 401
+
+
+def test_register_rejects_unknown_platform(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    resp = test_client.post(
+        "/api/push/register",
+        json={"token": "device-tok-1", "platform": "android"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_register_persists_row(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    resp = test_client.post(
+        "/api/push/register",
+        json={"token": "device-tok-2"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    with _sync_session(db_url) as session:
+        row = session.scalar(select(PushToken).where(PushToken.token == "device-tok-2"))
+        assert row is not None
+        assert row.user_id == "gh-user-test"
+        assert row.platform == "ios"
+
+
+def test_register_is_idempotent_and_bumps_last_seen(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = test_client.post("/api/push/register", json={"token": "device-tok-3"}, headers=headers)
+    assert resp.status_code == 200
+    with _sync_session(db_url) as session:
+        first_seen = session.scalar(
+            select(PushToken.last_seen_at).where(PushToken.token == "device-tok-3")
+        )
+
+    # Force enough wall-clock drift that the second timestamp differs.
+    import time
+
+    time.sleep(0.01)
+    resp = test_client.post("/api/push/register", json={"token": "device-tok-3"}, headers=headers)
+    assert resp.status_code == 200
+    with _sync_session(db_url) as session:
+        second_seen = session.scalar(
+            select(PushToken.last_seen_at).where(PushToken.token == "device-tok-3")
+        )
+        rows = session.scalars(select(PushToken).where(PushToken.token == "device-tok-3")).all()
+    assert len(rows) == 1, "re-register should not insert a duplicate row"
+    assert second_seen >= first_seen
+
+
+def test_register_moves_token_between_users(client):
+    """Apple recycles tokens when a device is signed into a new account.
+    The latest user wins so the previous owner stops receiving the device's
+    notifications."""
+    test_client, db_url = client
+    alice = _login(db_url, user_id="alice", username="alice")
+    bob = _login(db_url, user_id="bob", username="bob")
+
+    test_client.post(
+        "/api/push/register",
+        json={"token": "device-tok-4"},
+        headers={"Authorization": f"Bearer {alice}"},
+    )
+    test_client.post(
+        "/api/push/register",
+        json={"token": "device-tok-4"},
+        headers={"Authorization": f"Bearer {bob}"},
+    )
+
+    with _sync_session(db_url) as session:
+        row = session.scalar(select(PushToken).where(PushToken.token == "device-tok-4"))
+        assert row is not None
+        assert row.user_id == "bob"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/push/register
+# ---------------------------------------------------------------------------
+
+
+def test_unregister_removes_own_token(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    _seed_token(db_url, "device-tok-5", user_id="gh-user-test")
+
+    resp = test_client.request(
+        "DELETE",
+        "/api/push/register",
+        json={"token": "device-tok-5"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    with _sync_session(db_url) as session:
+        row = session.scalar(select(PushToken).where(PushToken.token == "device-tok-5"))
+        assert row is None
+
+
+def test_unregister_does_not_touch_other_users_tokens(client):
+    test_client, db_url = client
+    _login(db_url, user_id="alice2", username="alice2")
+    bob_session = _login(db_url, user_id="bob2", username="bob2")
+    _seed_token(db_url, "device-tok-6", user_id="alice2")
+
+    resp = test_client.request(
+        "DELETE",
+        "/api/push/register",
+        json={"token": "device-tok-6"},
+        headers={"Authorization": f"Bearer {bob_session}"},
+    )
+    # 200 even when nothing matched — deletion is idempotent and we don't
+    # want to leak whether a token exists.
+    assert resp.status_code == 200
+    with _sync_session(db_url) as session:
+        row = session.scalar(select(PushToken).where(PushToken.token == "device-tok-6"))
+        assert row is not None, "Bob should not be able to delete Alice's token"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/push/tokens
+# ---------------------------------------------------------------------------
+
+
+def test_list_tokens_returns_only_own_devices_with_redacted_suffix(client):
+    test_client, db_url = client
+    session_token = _login(db_url, user_id="carol", username="carol")
+    _login(db_url, user_id="dave", username="dave")
+    _seed_token(db_url, "carol-device-aaaaaaaa", user_id="carol")
+    _seed_token(db_url, "dave-device-bbbbbbbb", user_id="dave")
+
+    resp = test_client.get(
+        "/api/push/tokens",
+        headers={"Authorization": f"Bearer {session_token}"},
+    )
+    assert resp.status_code == 200
+    tokens = resp.json()["tokens"]
+    assert len(tokens) == 1
+    assert tokens[0]["token_suffix"] == "aaaaaaaa"
+    # Full token must not leak.
+    assert "carol-device" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher (no-APNs path)
+# ---------------------------------------------------------------------------
+
+
+def test_send_to_user_logs_and_returns_zero_when_apns_unconfigured(client, monkeypatch, caplog):
+    test_client, db_url = client
+    _login(db_url, user_id="eve", username="eve")
+    _seed_token(db_url, "eve-device-cccccccc", user_id="eve")
+
+    for var in ("APNS_KEY_P8", "APNS_KEY_ID", "APNS_TEAM_ID", "APNS_BUNDLE_ID"):
+        monkeypatch.delenv(var, raising=False)
+
+    from push import send_to_user
+
+    with caplog.at_level("INFO", logger="push"):
+        delivered = asyncio.run(send_to_user("eve", title="hi", body="there"))
+
+    assert delivered == 0
+    assert any("APNs not configured" in rec.message for rec in caplog.records)
+
+
+def test_send_to_user_returns_zero_when_no_devices(client, monkeypatch):
+    test_client, db_url = client
+    _login(db_url, user_id="frank", username="frank")
+    for var in ("APNS_KEY_P8", "APNS_KEY_ID", "APNS_TEAM_ID", "APNS_BUNDLE_ID"):
+        monkeypatch.delenv(var, raising=False)
+
+    from push import send_to_user
+
+    delivered = asyncio.run(send_to_user("frank", title="hi", body="there"))
+    assert delivered == 0
+
+
+@pytest.mark.skipif(
+    not os.environ.get("APNS_LIVE_TEST"),
+    reason="Needs real APNs credentials; set APNS_LIVE_TEST=1 and APNS_* vars to run.",
+)
+def test_send_to_user_signs_jwt_with_real_credentials():  # pragma: no cover
+    """Smoke test for the JWT signing path — only runs when explicitly
+    enabled via APNS_LIVE_TEST=1. Not part of CI."""
+    from push import _load_config, _make_jwt
+
+    config = _load_config()
+    assert config is not None
+    jwt = _make_jwt(config)
+    assert jwt.count(".") == 2


### PR DESCRIPTION
## Summary

Backend half of the iOS shell work (companion to #483). The iOS app POSTs its APNs device token to `/api/push/register` after the user grants permission; the server stores it keyed by GitHub user so server-side code can later fan a notification out to every device that user has signed in on.

- **Migration + `PushToken` model.** `token` is the primary key (Apple's tokens are globally unique per app install). `user_id` FKs to `users.id` with `ON DELETE CASCADE`, `last_seen_at` is refreshed on every register call so we can prune stale rows.
- **`routes/push.py`**
  - `POST /api/push/register` — idempotent upsert. Re-registering the same token bumps `last_seen_at` and moves ownership if the device signed into a new account.
  - `DELETE /api/push/register` — ownership-scoped: a user can only delete their own rows.
  - `GET /api/push/tokens` — lists the caller's registered devices with a redacted token suffix (last 8 chars only), so a future "logged-in devices" UI doesn't have to handle full tokens.
- **`push.py` dispatcher** — `send_to_user(user_id, *, title, body, data=None)`. Reads `APNS_KEY_P8` / `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_BUNDLE_ID` from env, signs an ES256 JWT (cached 45 min), and POSTs to APNs over HTTP/2. No-ops with a log line when credentials aren't configured, so the rest of the backend can call it unconditionally. `410 Gone` responses prune the token from the DB.

Frontend already has the typed wrapper in `frontend/src/utils/nativeBridge.ts` (from #483) — `onPushToken((token) => api.post('/api/push/register', { token }))` is the intended call site.

## Test plan

- [ ] CI: backend tests pass (covers auth gate, idempotency, cross-user delete safety, suffix redaction, no-APNs dispatcher path)
- [ ] Locally with `docker compose up -d postgres-test` then `pytest backend/tests/test_push_tokens.py`
- [ ] With real APNs creds: `APNS_LIVE_TEST=1 APNS_KEY_P8=... APNS_KEY_ID=... APNS_TEAM_ID=... APNS_BUNDLE_ID=... pytest -k signs_jwt` exercises the signing path
- [ ] End-to-end: deploy, set the APNS env vars, register a real device from the iOS app, then `curl -X POST -H "Authorization: Bearer ..." /api/push/test` (a debug endpoint left for a future PR) — confirm the device gets a banner

## Out of scope

- Wiring `send_to_user` into `task-complete` / `needs-input` / `@foreman` mention events. The dispatcher exists and is independently testable; hooking it into the existing WS broadcast paths is a focused follow-up that needs UX decisions (which events warrant a push, what the titles/bodies say, whether to include task IDs in the payload for deep-linking).
- The `httpx[http2]` dep upgrade. The dispatcher tries `import h2` and logs a warning if missing — it still installs and imports cleanly without HTTP/2, but APNs requests will fail until `h2` is added to `requirements.txt`. Easy follow-up once we're ready to actually send pushes.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Z9YPT87cxeLvPYPv8S5Dz)_