### PR TITLE
Split FOREMAN_MODEL for Bedrock vs direct API (#498)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,12 @@ GITHUB_CLIENT_SECRET=
 # workers — workers run the claude CLI under the user's OAuth subscription.
 ANTHROPIC_API_KEY=
 
-# Claude model used by the foreman AI. Defaults to claude-haiku-4-5-20251001.
-# Override to switch models without code changes.
-# FOREMAN_MODEL=claude-haiku-4-5-20251001
+# Claude model used by the foreman AI (direct Anthropic API). Default: claude-sonnet-4-6.
+# FOREMAN_MODEL=claude-sonnet-4-6
+
+# Bedrock inference profile for the foreman AI when FOREMAN_PROVIDER=bedrock.
+# Must be a cross-region inference profile ID, not a plain model ID.
+# FOREMAN_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6-20250514-v1:0
 
 # Claude OAuth token for the `claude` CLI inside workers. Generate with
 # `claude setup-token` on a machine where you've logged in. When set, workers

--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ ANTHROPIC_API_KEY=
 
 # Bedrock inference profile for the foreman AI when FOREMAN_PROVIDER=bedrock.
 # Must be a cross-region inference profile ID, not a plain model ID.
-# FOREMAN_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6-20250514-v1:0
+# FOREMAN_BEDROCK_MODEL=arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6
 
 # Claude OAuth token for the `claude` CLI inside workers. Generate with
 # `claude setup-token` on a machine where you've logged in. When set, workers

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -16,7 +16,7 @@ from foreman_core.constants import (
     _TERMINAL_STATES,
     MAX_FOREMAN_ROUNDS,
 )
-from foreman_core.llm import FOREMAN_MODEL, HAS_ANTHROPIC, make_anthropic_client
+from foreman_core.llm import HAS_ANTHROPIC, get_foreman_model, make_anthropic_client
 from foreman_core.message_utils import (
     _inject_state_preamble,
     _serialize_content,
@@ -430,7 +430,7 @@ async def run_foreman_ai(
                 len(messages),
             )
             resp = await client.messages.create(
-                model=FOREMAN_MODEL,
+                model=get_foreman_model(),
                 max_tokens=1024,
                 system=system_blocks,  # type: ignore[arg-type]
                 messages=messages,  # type: ignore[arg-type]
@@ -611,7 +611,7 @@ async def run_foreman_ai(
             messages = strip_orphaned_tool_results(messages)
             _stamp_message_cache_breakpoint(messages)
             wrap_resp = await client.messages.create(
-                model=FOREMAN_MODEL,
+                model=get_foreman_model(),
                 max_tokens=1024,
                 system=system_blocks,  # type: ignore[arg-type]
                 messages=messages,  # type: ignore[arg-type]

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from database import get_db
 from events import broadcast, emit_terminal_line
+from foreman_core.llm import get_foreman_model
 from foreman_core.tools_schema import (
     FOREMAN_TOOLS,  # noqa: F401 — re-exported for test compatibility
 )
@@ -39,8 +40,6 @@ from sqlalchemy import delete, update
 from sqlmodel import col, select
 
 logger = logging.getLogger(__name__)
-
-FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 
 # Default soft-delete window (seconds) when finalize_task is called without
 # an explicit expiry. Mirrors backend.main.DEFAULT_FINALIZE_TTL.
@@ -1440,7 +1439,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     "- Keep each comment concise (1-3 sentences)"
                                 )
                                 ai_msg = await _ai.messages.create(
-                                    model=FOREMAN_MODEL,
+                                    model=get_foreman_model(),
                                     max_tokens=2048,
                                     messages=[{"role": "user", "content": review_prompt}],
                                 )

--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -20,15 +20,27 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
+# Bedrock uses cross-region inference profiles, not plain model IDs.
+# Set this to the profile ARN/ID appropriate for your region, e.g.:
+#   us.anthropic.claude-sonnet-4-6-20250514-v1:0
+FOREMAN_BEDROCK_MODEL = os.environ.get(
+    "FOREMAN_BEDROCK_MODEL", "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
+)
 
 # Set FOREMAN_PROVIDER=bedrock to use Amazon Bedrock instead of the Anthropic API.
 # Requires: pip install "anthropic[bedrock]"  +  AWS credentials in env / IAM role.
-# On Bedrock, model IDs use the "anthropic." prefix, e.g.:
-#   anthropic.claude-sonnet-4-5   (Sonnet 4.x on Bedrock)
-#   anthropic.claude-opus-4-5     (Opus 4.x on Bedrock)
-# Check your Bedrock console for exact IDs available in your region.
 FOREMAN_PROVIDER = os.environ.get("FOREMAN_PROVIDER", "anthropic").lower()
 _BEDROCK_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+
+def get_foreman_model(provider: str | None = None) -> str:
+    """Return the model ID to use for the given provider.
+
+    When provider is 'bedrock' (or FOREMAN_PROVIDER=bedrock), returns
+    FOREMAN_BEDROCK_MODEL; otherwise returns FOREMAN_MODEL.
+    """
+    resolved = (provider or FOREMAN_PROVIDER).lower()
+    return FOREMAN_BEDROCK_MODEL if resolved == "bedrock" else FOREMAN_MODEL
 
 
 def make_anthropic_client(
@@ -53,7 +65,7 @@ def make_anthropic_client(
         logger.info(
             "Foreman using Amazon Bedrock (region=%s, model=%s)",
             resolved_region,
-            FOREMAN_MODEL,
+            get_foreman_model("bedrock"),
         )
         return client
 

--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -19,13 +19,13 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
+
 FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 # Bedrock uses cross-region inference profiles, not plain model IDs.
 # Set this to the profile ARN/ID appropriate for your region, e.g.:
 #   us.anthropic.claude-sonnet-4-6-20250514-v1:0
-FOREMAN_BEDROCK_MODEL = os.environ.get(
-    "FOREMAN_BEDROCK_MODEL", "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
-)
+FOREMAN_BEDROCK_MODEL = os.environ.get("FOREMAN_BEDROCK_MODEL", _DEFAULT_BEDROCK_MODEL)
 
 # Set FOREMAN_PROVIDER=bedrock to use Amazon Bedrock instead of the Anthropic API.
 # Requires: pip install "anthropic[bedrock]"  +  AWS credentials in env / IAM role.
@@ -38,9 +38,13 @@ def get_foreman_model(provider: str | None = None) -> str:
 
     When provider is 'bedrock' (or FOREMAN_PROVIDER=bedrock), returns
     FOREMAN_BEDROCK_MODEL; otherwise returns FOREMAN_MODEL.
+
+    Reads os.environ on every call so that tests can patch env vars directly.
     """
-    resolved = (provider or FOREMAN_PROVIDER).lower()
-    return FOREMAN_BEDROCK_MODEL if resolved == "bedrock" else FOREMAN_MODEL
+    resolved = (provider or os.environ.get("FOREMAN_PROVIDER", "anthropic")).lower()
+    if resolved == "bedrock":
+        return os.environ.get("FOREMAN_BEDROCK_MODEL", _DEFAULT_BEDROCK_MODEL)
+    return os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 
 
 def make_anthropic_client(

--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -19,12 +19,14 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
+_DEFAULT_BEDROCK_MODEL = (
+    "arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6"
+)
 
 FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 # Bedrock uses cross-region inference profiles, not plain model IDs.
 # Set this to the profile ARN/ID appropriate for your region, e.g.:
-#   us.anthropic.claude-sonnet-4-6-20250514-v1:0
+#   arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6
 FOREMAN_BEDROCK_MODEL = os.environ.get("FOREMAN_BEDROCK_MODEL", _DEFAULT_BEDROCK_MODEL)
 
 # Set FOREMAN_PROVIDER=bedrock to use Amazon Bedrock instead of the Anthropic API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,10 +65,10 @@ services:
       # Model and provider — set FOREMAN_PROVIDER=bedrock to use Amazon Bedrock.
       # Direct Anthropic API: FOREMAN_MODEL is a plain model ID (e.g. claude-sonnet-4-6).
       # Amazon Bedrock: FOREMAN_BEDROCK_MODEL must be a cross-region inference profile, e.g.:
-      #   us.anthropic.claude-sonnet-4-6-20250514-v1:0
+      #   arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6
       # When FOREMAN_PROVIDER=bedrock, FOREMAN_BEDROCK_MODEL is used; otherwise FOREMAN_MODEL.
       FOREMAN_MODEL: ${FOREMAN_MODEL:-claude-sonnet-4-6}
-      FOREMAN_BEDROCK_MODEL: ${FOREMAN_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-6-20250514-v1:0}
+      FOREMAN_BEDROCK_MODEL: ${FOREMAN_BEDROCK_MODEL:-arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6}
       FOREMAN_PROVIDER: ${FOREMAN_PROVIDER:-anthropic}
       # Shared HMAC secret for JWT auth between the foreman and backend.
       PIONEER_FOREMAN_KEY: ${PIONEER_FOREMAN_KEY:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,9 +63,12 @@ services:
       GUILD_ID: ${GUILD_ID:-}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       # Model and provider — set FOREMAN_PROVIDER=bedrock to use Amazon Bedrock.
-      # Bedrock model IDs use the cross-region inference prefix, e.g.:
-      #   us.anthropic.claude-sonnet-4-5-20251001-v2:0
+      # Direct Anthropic API: FOREMAN_MODEL is a plain model ID (e.g. claude-sonnet-4-6).
+      # Amazon Bedrock: FOREMAN_BEDROCK_MODEL must be a cross-region inference profile, e.g.:
+      #   us.anthropic.claude-sonnet-4-6-20250514-v1:0
+      # When FOREMAN_PROVIDER=bedrock, FOREMAN_BEDROCK_MODEL is used; otherwise FOREMAN_MODEL.
       FOREMAN_MODEL: ${FOREMAN_MODEL:-claude-sonnet-4-6}
+      FOREMAN_BEDROCK_MODEL: ${FOREMAN_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-6-20250514-v1:0}
       FOREMAN_PROVIDER: ${FOREMAN_PROVIDER:-anthropic}
       # Shared HMAC secret for JWT auth between the foreman and backend.
       PIONEER_FOREMAN_KEY: ${PIONEER_FOREMAN_KEY:-}

--- a/foreman/main.py
+++ b/foreman/main.py
@@ -16,9 +16,10 @@ Environment variables:
     GUILD_ID         Guild this foreman instance manages (required)
     DB_PATH          Path to the SQLite database file   (default: pioneer_square.db)
     DATABASE_URL     Full SQLAlchemy URL; overrides DB_PATH
-    ANTHROPIC_API_KEY  Anthropic key for the AI loop
-    FOREMAN_MODEL    Claude model for the foreman AI    (default: claude-sonnet-4-6)
-    LOG_LEVEL        Logging level                       (default: INFO)
+    ANTHROPIC_API_KEY      Anthropic key for the AI loop
+    FOREMAN_MODEL          Claude model for direct Anthropic API  (default: claude-sonnet-4-6)
+    FOREMAN_BEDROCK_MODEL  Bedrock inference profile ID           (default: us.anthropic.claude-sonnet-4-6-20250514-v1:0)
+    LOG_LEVEL              Logging level                          (default: INFO)
 """
 
 from __future__ import annotations

--- a/foreman/main.py
+++ b/foreman/main.py
@@ -18,7 +18,7 @@ Environment variables:
     DATABASE_URL     Full SQLAlchemy URL; overrides DB_PATH
     ANTHROPIC_API_KEY      Anthropic key for the AI loop
     FOREMAN_MODEL          Claude model for direct Anthropic API  (default: claude-sonnet-4-6)
-    FOREMAN_BEDROCK_MODEL  Bedrock inference profile ID           (default: us.anthropic.claude-sonnet-4-6-20250514-v1:0)
+    FOREMAN_BEDROCK_MODEL  Bedrock inference profile ID           (default: arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6)
     LOG_LEVEL              Logging level                          (default: INFO)
 """
 

--- a/foreman/pioneer-foreman.toml.example
+++ b/foreman/pioneer-foreman.toml.example
@@ -12,18 +12,19 @@ backend_key = ""
 # auth_token = ""
 
 [claude]
-model         = "claude-sonnet-4-6"
+model         = "claude-sonnet-4-6"    # used when provider = "anthropic"
 api_key       = ""                     # falls back to ANTHROPIC_API_KEY env var
 max_rounds    = 10
 history_limit = 40
 
 # AI provider: "anthropic" (default) or "bedrock" (Amazon Bedrock).
 # When using Bedrock: set provider = "bedrock", ensure AWS credentials are
-# available (env vars, ~/.aws/credentials, or IAM role), and update model to
-# the Bedrock model ID (e.g. "anthropic.claude-sonnet-4-5").
+# available (env vars, ~/.aws/credentials, or IAM role), and set bedrock_model
+# to a cross-region inference profile ID (not a plain model ID).
 # Requires: pip install "anthropic[bedrock]"
-# provider   = "anthropic"
-# aws_region = "us-east-1"             # falls back to AWS_DEFAULT_REGION env var
+# provider      = "anthropic"
+# bedrock_model = "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
+# aws_region    = "us-east-1"          # falls back to AWS_DEFAULT_REGION env var
 
 [poll]
 min_interval = 60     # seconds (doubles each cycle up to max_interval)

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
+from backend.foreman_core.llm import _DEFAULT_BEDROCK_MODEL
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_NAME = "pioneer-foreman.toml"
@@ -31,7 +33,7 @@ class Config:
     model: str = "claude-sonnet-4-6"
     # Bedrock uses cross-region inference profiles, not plain model IDs.
     # Ignored when provider != "bedrock".
-    bedrock_model: str = "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
+    bedrock_model: str = _DEFAULT_BEDROCK_MODEL
     api_key: str | None = None
     # "anthropic" (default) or "bedrock" (Amazon Bedrock via AsyncAnthropicBedrock)
     provider: str = "anthropic"
@@ -49,7 +51,13 @@ class Config:
 
     @property
     def effective_model(self) -> str:
-        """Return the model ID appropriate for the configured provider."""
+        """Return the model ID appropriate for the configured provider.
+
+        Intentional duplication of the provider-branching logic in
+        backend.foreman_core.llm.get_foreman_model(): Config is used by the
+        standalone foreman without the full backend env-var stack, so it needs
+        its own copy operating on dataclass fields rather than os.environ.
+        """
         return self.bedrock_model if self.provider == "bedrock" else self.model
 
     @property
@@ -151,7 +159,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         overrides.get("bedrock_model")
         or claude_block.get("bedrock_model")
         or os.environ.get("FOREMAN_BEDROCK_MODEL")
-        or "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
+        or _DEFAULT_BEDROCK_MODEL
     )
 
     provider = (

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -29,6 +29,9 @@ class Config:
     auth_token: str | None = None
     # Claude / AI provider settings
     model: str = "claude-sonnet-4-6"
+    # Bedrock uses cross-region inference profiles, not plain model IDs.
+    # Ignored when provider != "bedrock".
+    bedrock_model: str = "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
     api_key: str | None = None
     # "anthropic" (default) or "bedrock" (Amazon Bedrock via AsyncAnthropicBedrock)
     provider: str = "anthropic"
@@ -43,6 +46,11 @@ class Config:
     log_level: str = "INFO"
 
     config_path: Path = field(default_factory=Path)
+
+    @property
+    def effective_model(self) -> str:
+        """Return the model ID appropriate for the configured provider."""
+        return self.bedrock_model if self.provider == "bedrock" else self.model
 
     @property
     def http_url(self) -> str:
@@ -139,6 +147,13 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         or "claude-sonnet-4-6"
     )
 
+    bedrock_model = (
+        overrides.get("bedrock_model")
+        or claude_block.get("bedrock_model")
+        or os.environ.get("FOREMAN_BEDROCK_MODEL")
+        or "us.anthropic.claude-sonnet-4-6-20250514-v1:0"
+    )
+
     provider = (
         overrides.get("provider")
         or claude_block.get("provider")
@@ -167,6 +182,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         backend_key=backend_key,
         auth_token=auth_token,
         model=model,
+        bedrock_model=bedrock_model,
         api_key=api_key,
         provider=provider,
         aws_region=aws_region,

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -199,7 +199,7 @@ async def run_foreman_ai(
                 len(messages),
             )
             resp = await client.messages.create(
-                model=config.model,
+                model=config.effective_model,
                 max_tokens=1024,
                 system=system_blocks,
                 messages=messages,
@@ -310,7 +310,7 @@ async def run_foreman_ai(
             messages = strip_orphaned_tool_results(messages)
             _stamp_message_cache_breakpoint(messages)
             wrap_resp = await client.messages.create(
-                model=config.model,
+                model=config.effective_model,
                 max_tokens=1024,
                 system=system_blocks,
                 messages=messages,


### PR DESCRIPTION
## Summary

- Add `FOREMAN_BEDROCK_MODEL` env var for Amazon Bedrock cross-region inference profile IDs (e.g. `us.anthropic.claude-sonnet-4-6-20250514-v1:0`), which are not interchangeable with the plain model IDs used by the direct Anthropic API
- Add `get_foreman_model(provider=None)` helper in `backend/foreman_core/llm.py` that returns the right model ID based on `FOREMAN_PROVIDER` (or a caller-supplied value)
- Remove the duplicate `FOREMAN_MODEL` definition from `backend/foreman/tools.py`; both the embedded runner and tools now call `get_foreman_model()`
- For the standalone foreman, add a `bedrock_model` field to `Config` (resolved from `FOREMAN_BEDROCK_MODEL`) and an `effective_model` property; the runner uses `config.effective_model` instead of `config.model`
- Update `docker-compose.yml`, `.env.example`, `pioneer-foreman.toml.example`, and `foreman/main.py` to document both vars

**Example values:**
```
FOREMAN_MODEL=claude-sonnet-4-6                                    # direct Anthropic API
FOREMAN_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6-20250514-v1:0 # Amazon Bedrock
```

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)