### PR TITLE
feat: inject foreman messages on CI completion without re-triggering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,16 @@ GITHUB_TOKEN=
 
 # Debounce window (seconds) for GitHub webhook foreman dispatch.
 # Rapid webhook events for the same PR are buffered; the foreman is invoked
-# only after this many seconds of silence. Sized to cover full CI runs so all
-# check_run completions coalesce into one foreman invocation. Default: 180.
-# WEBHOOK_DEBOUNCE_SECONDS=180
+# only after this many seconds of silence. Default: 30 (CI completion is now
+# injected directly by GitHub Actions via PIONEER_CI_KEY, so the window only
+# needs to cover review comments and other rapid events).
+# WEBHOOK_DEBOUNCE_SECONDS=30
+
+# Shared secret for GitHub Actions CI completion notifications.
+# When set, the /guilds/{guild_id}/foreman/ci-notify endpoint accepts POSTs
+# from GHA workflows so the foreman is informed of CI results immediately
+# without being re-triggered automatically.
+# Add the same value as PIONEER_CI_KEY, PIONEER_GUILD_ID, and PIONEER_BACKEND_URL
+# to your GitHub repository secrets (Settings → Secrets and variables → Actions).
+# Generate: python3 -c "import secrets; print(secrets.token_hex(32))"
+# PIONEER_CI_KEY=

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -46,10 +46,14 @@ router = APIRouter()
 # Configurable via WEBHOOK_DEBOUNCE_SECONDS (default: 30 seconds).
 DEBOUNCE_WINDOW_SECONDS: float = float(os.environ.get("WEBHOOK_DEBOUNCE_SECONDS", "30"))
 
+
 # Shared secret for the /foreman/ci-notify endpoint.  GitHub Actions sets
 # Authorization: Bearer <PIONEER_CI_KEY> on each CI completion POST.
 # When empty the endpoint returns 503 (not configured).
-_CI_KEY: str = os.environ.get("PIONEER_CI_KEY", "")
+# Read at call time so monkeypatch.setenv works in tests and secrets can rotate
+# without a restart.
+def _get_ci_key() -> str:
+    return os.environ.get("PIONEER_CI_KEY", "")
 
 
 # Cap on stored payloads. GitHub webhook payloads are typically <50 KB but
@@ -695,13 +699,14 @@ async def ci_notify(guild_id: str, body: CINotifyPayload, request: Request) -> R
     Auth: ``Authorization: Bearer <PIONEER_CI_KEY>`` where the key matches
     the ``PIONEER_CI_KEY`` environment variable on the backend.
     """
-    if not _CI_KEY:
+    ci_key = _get_ci_key()
+    if not ci_key:
         raise HTTPException(
             status_code=503, detail="CI notifications not configured (PIONEER_CI_KEY not set)"
         )
     auth = request.headers.get("authorization", "")
     provided = auth[len("Bearer ") :] if auth.startswith("Bearer ") else ""
-    if not hmac.compare_digest(provided.encode(), _CI_KEY.encode()):
+    if not hmac.compare_digest(provided.encode(), ci_key.encode()):
         raise HTTPException(status_code=401, detail="Invalid CI key")
 
     repo = body.repo or ""
@@ -742,25 +747,25 @@ async def ci_notify(guild_id: str, body: CINotifyPayload, request: Request) -> R
             )
         )
         await db.commit()
+        await broadcast(
+            guild_id,
+            {
+                "type": "chat",
+                "from": "github",
+                "to": "foreman",
+                "content": content,
+                "createdAt": created_at.isoformat(),
+            },
+        )
+        logger.info(
+            "ci-notify guild=%s repo=%s pr=%s task=%s conclusion=%s",
+            guild_id,
+            repo,
+            body.pr_number,
+            task_id,
+            conclusion,
+        )
     finally:
         await db.close()
 
-    await broadcast(
-        guild_id,
-        {
-            "type": "chat",
-            "from": "github",
-            "to": "foreman",
-            "content": content,
-            "createdAt": created_at.isoformat(),
-        },
-    )
-    logger.info(
-        "ci-notify guild=%s repo=%s pr=%s task=%s conclusion=%s",
-        guild_id,
-        repo,
-        body.pr_number,
-        task_id,
-        conclusion,
-    )
     return Response(status_code=202)

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -26,6 +26,7 @@ from database import get_db
 from events import broadcast
 from fastapi import APIRouter, HTTPException, Request, Response
 from models import GithubEvent, Guild, Message, Task
+from pydantic import BaseModel
 from sqlalchemy import update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
@@ -38,12 +39,17 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # How long (seconds) to wait for further events on the same PR before
-# delivering the buffered batch to the foreman.  GitHub CI pipelines commonly
-# take 1–3 minutes; using a window long enough to cover the full CI run means
-# the foreman sees one coalesced batch (all check_run completions + any review
-# comments) rather than firing once per check.
-# Configurable via WEBHOOK_DEBOUNCE_SECONDS (default: 180 seconds).
-DEBOUNCE_WINDOW_SECONDS: float = float(os.environ.get("WEBHOOK_DEBOUNCE_SECONDS", "180"))
+# delivering the buffered batch to the foreman.  Previously defaulted to 180s
+# to cover the full CI run, but CI completion is now injected directly by
+# GitHub Actions (POST /foreman/ci-notify), so a short window is sufficient
+# to coalesce review comments and other rapid events.
+# Configurable via WEBHOOK_DEBOUNCE_SECONDS (default: 30 seconds).
+DEBOUNCE_WINDOW_SECONDS: float = float(os.environ.get("WEBHOOK_DEBOUNCE_SECONDS", "30"))
+
+# Shared secret for the /foreman/ci-notify endpoint.  GitHub Actions sets
+# Authorization: Bearer <PIONEER_CI_KEY> on each CI completion POST.
+# When empty the endpoint returns 503 (not configured).
+_CI_KEY: str = os.environ.get("PIONEER_CI_KEY", "")
 
 
 # Cap on stored payloads. GitHub webhook payloads are typically <50 KB but
@@ -655,4 +661,106 @@ async def github_webhook(guild_id: str, request: Request) -> Response:
             skip_reason,
         )
 
+    return Response(status_code=202)
+
+
+# ---------------------------------------------------------------------------
+# CI completion notification (GitHub Actions → foreman context)
+# ---------------------------------------------------------------------------
+
+
+class CINotifyPayload(BaseModel):
+    """Body for POST /guilds/{guild_id}/foreman/ci-notify."""
+
+    repo: str
+    pr_number: int | None = None
+    workflow_name: str
+    conclusion: str  # success | failure | cancelled | timed_out
+    task_id: str | None = None
+    run_id: str | None = None
+    run_url: str | None = None
+    branch: str | None = None
+
+
+@router.post("/guilds/{guild_id}/foreman/ci-notify")
+async def ci_notify(guild_id: str, body: CINotifyPayload, request: Request) -> Response:
+    """CI completion notification injected directly by GitHub Actions.
+
+    Persists a structured ``[ci-notify]`` chat message so the foreman has
+    CI context the next time it runs, **without** triggering a new foreman
+    AI invocation.  This is the event-driven counterpart to the webhook
+    debounce: GHA posts here the moment the workflow finishes, giving the
+    foreman immediate context while avoiding an automatic re-trigger.
+
+    Auth: ``Authorization: Bearer <PIONEER_CI_KEY>`` where the key matches
+    the ``PIONEER_CI_KEY`` environment variable on the backend.
+    """
+    if not _CI_KEY:
+        raise HTTPException(
+            status_code=503, detail="CI notifications not configured (PIONEER_CI_KEY not set)"
+        )
+    auth = request.headers.get("authorization", "")
+    provided = auth[len("Bearer ") :] if auth.startswith("Bearer ") else ""
+    if not hmac.compare_digest(provided.encode(), _CI_KEY.encode()):
+        raise HTTPException(status_code=401, detail="Invalid CI key")
+
+    repo = body.repo or ""
+    pr_part = f"#{body.pr_number}" if body.pr_number is not None else ""
+    workflow = body.workflow_name or "CI"
+    conclusion = body.conclusion or "unknown"
+
+    db = await get_db()
+    try:
+        guild_res = await db.exec(select(col(Guild.id)).where(col(Guild.guild_id) == guild_id))
+        guild_row = guild_res.one_or_none()
+        if guild_row is None:
+            raise HTTPException(status_code=404, detail="Guild not found")
+        guild_pk = guild_row.id
+
+        task_id = body.task_id
+        if not task_id and body.pr_number is not None:
+            task_row = await _find_task(db, guild_pk, repo, body.pr_number)
+            task_id = task_row.id if task_row else None
+
+        task_part = f" (task {task_id})" if task_id else ""
+        run_part = (
+            f" — {body.run_url}"
+            if body.run_url
+            else (f" — run {body.run_id}" if body.run_id else "")
+        )
+        content = f"[ci-notify] {workflow}/{conclusion} on {repo}{pr_part}{task_part}{run_part}"
+
+        created_at = datetime.now(UTC)
+        db.add(
+            Message(
+                guild_id=guild_pk,
+                from_agent="github",
+                to_agent="foreman",
+                content=content,
+                message_type="chat",
+                created_at=created_at,
+            )
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+    await broadcast(
+        guild_id,
+        {
+            "type": "chat",
+            "from": "github",
+            "to": "foreman",
+            "content": content,
+            "createdAt": created_at.isoformat(),
+        },
+    )
+    logger.info(
+        "ci-notify guild=%s repo=%s pr=%s task=%s conclusion=%s",
+        guild_id,
+        repo,
+        body.pr_number,
+        task_id,
+        conclusion,
+    )
     return Response(status_code=202)

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -717,10 +717,9 @@ async def ci_notify(guild_id: str, body: CINotifyPayload, request: Request) -> R
     db = await get_db()
     try:
         guild_res = await db.exec(select(col(Guild.id)).where(col(Guild.guild_id) == guild_id))
-        guild_row = guild_res.one_or_none()
-        if guild_row is None:
+        guild_pk = guild_res.one_or_none()
+        if guild_pk is None:
             raise HTTPException(status_code=404, detail="Guild not found")
-        guild_pk = guild_row.id
 
         task_id = body.task_id
         if not task_id and body.pr_number is not None:

--- a/backend/tests/test_github_webhooks.py
+++ b/backend/tests/test_github_webhooks.py
@@ -515,6 +515,143 @@ def test_webhook_backfills_task_pr_url(client):
     assert pr_url == "https://github.com/org/my-repo/pull/55"
 
 
+# ---------------------------------------------------------------------------
+# /guilds/{guild_id}/foreman/ci-notify
+# ---------------------------------------------------------------------------
+
+
+def test_ci_notify_returns_503_when_key_not_configured(client):
+    """503 when PIONEER_CI_KEY is empty (not configured)."""
+    import routes.webhooks as webhooks_mod
+
+    test_client, db_url = client
+    insert_guild(db_url, "gcn0")
+    # _CI_KEY is "" by default in test env
+    assert webhooks_mod._CI_KEY == ""
+    resp = test_client.post(
+        "/guilds/gcn0/foreman/ci-notify",
+        json={"repo": "o/r", "workflow_name": "CI", "conclusion": "success"},
+    )
+    assert resp.status_code == 503
+
+
+def test_ci_notify_returns_401_without_auth(client, monkeypatch):
+    """401 when Authorization header is missing."""
+    import routes.webhooks as webhooks_mod
+
+    test_client, db_url = client
+    insert_guild(db_url, "gcn1")
+    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "secret")
+    resp = test_client.post(
+        "/guilds/gcn1/foreman/ci-notify",
+        json={"repo": "o/r", "workflow_name": "CI", "conclusion": "success"},
+    )
+    assert resp.status_code == 401
+
+
+def test_ci_notify_returns_401_with_wrong_key(client, monkeypatch):
+    """401 when Bearer token doesn't match PIONEER_CI_KEY."""
+    import routes.webhooks as webhooks_mod
+
+    test_client, db_url = client
+    insert_guild(db_url, "gcn2")
+    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "correct-key")
+    resp = test_client.post(
+        "/guilds/gcn2/foreman/ci-notify",
+        json={"repo": "o/r", "workflow_name": "CI", "conclusion": "success"},
+        headers={"Authorization": "Bearer wrong-key"},
+    )
+    assert resp.status_code == 401
+
+
+def test_ci_notify_returns_404_for_unknown_guild(client, monkeypatch):
+    import routes.webhooks as webhooks_mod
+
+    test_client, _ = client
+    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "key")
+    resp = test_client.post(
+        "/guilds/nosuchguild/foreman/ci-notify",
+        json={"repo": "o/r", "workflow_name": "CI", "conclusion": "success"},
+        headers={"Authorization": "Bearer key"},
+    )
+    assert resp.status_code == 404
+
+
+def test_ci_notify_persists_message_and_returns_202(client, monkeypatch):
+    """Happy path: message stored and 202 returned without triggering foreman."""
+    import routes.webhooks as webhooks_mod
+
+    test_client, db_url = client
+    insert_guild(db_url, "gcn5")
+    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "mykey")
+    resp = test_client.post(
+        "/guilds/gcn5/foreman/ci-notify",
+        json={
+            "repo": "owner/repo",
+            "pr_number": 42,
+            "workflow_name": "CI",
+            "conclusion": "success",
+            "run_id": "12345",
+            "run_url": "https://github.com/owner/repo/actions/runs/12345",
+            "branch": "claude/some-task-t-abc123",
+        },
+        headers={"Authorization": "Bearer mykey"},
+    )
+    assert resp.status_code == 202
+
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(
+            select(col(Guild.id)).where(
+                col(Guild.guild_id) == "gcn5", col(Guild.deleted_at).is_(None)
+            )
+        )
+        row = session.execute(
+            select(Message).where(col(Message.guild_id) == guild_pk)
+        ).scalar_one_or_none()
+    assert row is not None
+    assert row.from_agent == "github"
+    assert row.to_agent == "foreman"
+    assert row.message_type == "chat"
+    assert "[ci-notify] CI/success on owner/repo#42" in row.content
+    assert "https://github.com/owner/repo/actions/runs/12345" in row.content
+
+
+def test_ci_notify_resolves_task_from_pr_number(client, monkeypatch):
+    """task_id is looked up from (repo, pr_number) when not provided in the payload."""
+    import routes.webhooks as webhooks_mod
+
+    test_client, db_url = client
+    insert_guild(db_url, "gcn6")
+    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "key6")
+    _insert_task_with_worker(
+        db_url,
+        task_id="t-cn6",
+        guild_id="gcn6",
+        pr_number=7,
+        pr_repo="org/proj",
+        pr_url="https://github.com/org/proj/pull/7",
+    )
+    resp = test_client.post(
+        "/guilds/gcn6/foreman/ci-notify",
+        json={"repo": "org/proj", "pr_number": 7, "workflow_name": "CI", "conclusion": "failure"},
+        headers={"Authorization": "Bearer key6"},
+    )
+    assert resp.status_code == 202
+
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(
+            select(col(Guild.id)).where(
+                col(Guild.guild_id) == "gcn6", col(Guild.deleted_at).is_(None)
+            )
+        )
+        row = session.execute(
+            select(Message).where(col(Message.guild_id) == guild_pk)
+        ).scalar_one_or_none()
+    assert row is not None
+    assert "task t-cn6" in row.content
+    assert "CI/failure" in row.content
+
+
 def test_webhook_does_not_overwrite_existing_pr_url(client):
     """Webhook must not clobber a pr_url that was already set by the worker."""
     test_client, db_url = client

--- a/backend/tests/test_github_webhooks.py
+++ b/backend/tests/test_github_webhooks.py
@@ -520,16 +520,13 @@ def test_webhook_backfills_task_pr_url(client):
 # ---------------------------------------------------------------------------
 
 
-def test_ci_notify_returns_503_when_key_not_configured(client):
+def test_ci_notify_returns_503_when_key_not_configured(client, monkeypatch):
     """503 when PIONEER_CI_KEY is empty (not configured)."""
-    import routes.webhooks as webhooks_mod
-
     test_client, db_url = client
-    insert_guild(db_url, "gcn0")
-    # _CI_KEY is "" by default in test env
-    assert webhooks_mod._CI_KEY == ""
+    insert_guild(db_url, "gcn1")
+    monkeypatch.delenv("PIONEER_CI_KEY", raising=False)
     resp = test_client.post(
-        "/guilds/gcn0/foreman/ci-notify",
+        "/guilds/gcn1/foreman/ci-notify",
         json={"repo": "o/r", "workflow_name": "CI", "conclusion": "success"},
     )
     assert resp.status_code == 503
@@ -537,13 +534,11 @@ def test_ci_notify_returns_503_when_key_not_configured(client):
 
 def test_ci_notify_returns_401_without_auth(client, monkeypatch):
     """401 when Authorization header is missing."""
-    import routes.webhooks as webhooks_mod
-
     test_client, db_url = client
-    insert_guild(db_url, "gcn1")
-    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "secret")
+    insert_guild(db_url, "gcn2")
+    monkeypatch.setenv("PIONEER_CI_KEY", "secret")
     resp = test_client.post(
-        "/guilds/gcn1/foreman/ci-notify",
+        "/guilds/gcn2/foreman/ci-notify",
         json={"repo": "o/r", "workflow_name": "CI", "conclusion": "success"},
     )
     assert resp.status_code == 401
@@ -551,13 +546,11 @@ def test_ci_notify_returns_401_without_auth(client, monkeypatch):
 
 def test_ci_notify_returns_401_with_wrong_key(client, monkeypatch):
     """401 when Bearer token doesn't match PIONEER_CI_KEY."""
-    import routes.webhooks as webhooks_mod
-
     test_client, db_url = client
-    insert_guild(db_url, "gcn2")
-    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "correct-key")
+    insert_guild(db_url, "gcn3")
+    monkeypatch.setenv("PIONEER_CI_KEY", "correct-key")
     resp = test_client.post(
-        "/guilds/gcn2/foreman/ci-notify",
+        "/guilds/gcn3/foreman/ci-notify",
         json={"repo": "o/r", "workflow_name": "CI", "conclusion": "success"},
         headers={"Authorization": "Bearer wrong-key"},
     )
@@ -565,10 +558,8 @@ def test_ci_notify_returns_401_with_wrong_key(client, monkeypatch):
 
 
 def test_ci_notify_returns_404_for_unknown_guild(client, monkeypatch):
-    import routes.webhooks as webhooks_mod
-
     test_client, _ = client
-    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "key")
+    monkeypatch.setenv("PIONEER_CI_KEY", "key")
     resp = test_client.post(
         "/guilds/nosuchguild/foreman/ci-notify",
         json={"repo": "o/r", "workflow_name": "CI", "conclusion": "success"},
@@ -579,13 +570,11 @@ def test_ci_notify_returns_404_for_unknown_guild(client, monkeypatch):
 
 def test_ci_notify_persists_message_and_returns_202(client, monkeypatch):
     """Happy path: message stored and 202 returned without triggering foreman."""
-    import routes.webhooks as webhooks_mod
-
     test_client, db_url = client
-    insert_guild(db_url, "gcn5")
-    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "mykey")
+    insert_guild(db_url, "gcn4")
+    monkeypatch.setenv("PIONEER_CI_KEY", "mykey")
     resp = test_client.post(
-        "/guilds/gcn5/foreman/ci-notify",
+        "/guilds/gcn4/foreman/ci-notify",
         json={
             "repo": "owner/repo",
             "pr_number": 42,
@@ -602,7 +591,7 @@ def test_ci_notify_persists_message_and_returns_202(client, monkeypatch):
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(
             select(col(Guild.id)).where(
-                col(Guild.guild_id) == "gcn5", col(Guild.deleted_at).is_(None)
+                col(Guild.guild_id) == "gcn4", col(Guild.deleted_at).is_(None)
             )
         )
         row = session.execute(
@@ -618,22 +607,61 @@ def test_ci_notify_persists_message_and_returns_202(client, monkeypatch):
 
 def test_ci_notify_resolves_task_from_pr_number(client, monkeypatch):
     """task_id is looked up from (repo, pr_number) when not provided in the payload."""
-    import routes.webhooks as webhooks_mod
-
     test_client, db_url = client
-    insert_guild(db_url, "gcn6")
-    monkeypatch.setattr(webhooks_mod, "_CI_KEY", "key6")
+    insert_guild(db_url, "gcn5")
+    monkeypatch.setenv("PIONEER_CI_KEY", "key5")
     _insert_task_with_worker(
         db_url,
-        task_id="t-cn6",
-        guild_id="gcn6",
+        task_id="t-cn5",
+        guild_id="gcn5",
         pr_number=7,
         pr_repo="org/proj",
         pr_url="https://github.com/org/proj/pull/7",
     )
     resp = test_client.post(
-        "/guilds/gcn6/foreman/ci-notify",
+        "/guilds/gcn5/foreman/ci-notify",
         json={"repo": "org/proj", "pr_number": 7, "workflow_name": "CI", "conclusion": "failure"},
+        headers={"Authorization": "Bearer key5"},
+    )
+    assert resp.status_code == 202
+
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(
+            select(col(Guild.id)).where(
+                col(Guild.guild_id) == "gcn5", col(Guild.deleted_at).is_(None)
+            )
+        )
+        row = session.execute(
+            select(Message).where(col(Message.guild_id) == guild_pk)
+        ).scalar_one_or_none()
+    assert row is not None
+    assert "task t-cn5" in row.content
+    assert "CI/failure" in row.content
+
+
+def test_ci_notify_uses_explicit_task_id(client, monkeypatch):
+    """When task_id is in the payload, the DB lookup is skipped and the given id is used."""
+    test_client, db_url = client
+    insert_guild(db_url, "gcn6")
+    monkeypatch.setenv("PIONEER_CI_KEY", "key6")
+    # Insert a task that would be found by (repo, pr_number) lookup — but it should be bypassed.
+    _insert_task_with_worker(
+        db_url,
+        task_id="t-db-cn6",
+        guild_id="gcn6",
+        pr_number=11,
+        pr_repo="org/repo",
+        pr_url="https://github.com/org/repo/pull/11",
+    )
+    resp = test_client.post(
+        "/guilds/gcn6/foreman/ci-notify",
+        json={
+            "repo": "org/repo",
+            "pr_number": 11,
+            "workflow_name": "CI",
+            "conclusion": "success",
+            "task_id": "t-explicit",
+        },
         headers={"Authorization": "Bearer key6"},
     )
     assert resp.status_code == 202
@@ -648,8 +676,8 @@ def test_ci_notify_resolves_task_from_pr_number(client, monkeypatch):
             select(Message).where(col(Message.guild_id) == guild_pk)
         ).scalar_one_or_none()
     assert row is not None
-    assert "task t-cn6" in row.content
-    assert "CI/failure" in row.content
+    assert "task t-explicit" in row.content
+    assert "t-db-cn6" not in row.content  # DB lookup was bypassed
 
 
 def test_webhook_does_not_overwrite_existing_pr_url(client):


### PR DESCRIPTION
## Summary

- **New endpoint** `POST /guilds/{guild_id}/foreman/ci-notify`: accepts CI completion payloads from GitHub Actions and persists a structured `[ci-notify]` chat message so the foreman has CI context next time it runs, **without** triggering a new AI invocation.
- **Reduced debounce window** from 180 s → 30 s: CI completion is now event-driven (GHA posts directly), so the debounce only needs to cover rapid review comments, not full CI runs.
- **New env var** `PIONEER_CI_KEY`: shared Bearer secret between GHA and the backend; documented in `.env.example`.
- **GHA `notify` job** added to `.github/workflows/ci.yml`: runs after all other jobs, POSTs a JSON payload (repo, PR number, workflow name, conclusion, task ID, run URL) to the backend. Only fires when all three secrets are set — skips silently otherwise. ⚠️ *The workflow file could not be pushed automatically (token lacks `workflow` scope); see note below.*
- **7 new tests** in `backend/tests/test_github_webhooks.py` covering auth failure, 404, task-ID resolution, and happy-path message persistence.

## Why this doesn't re-trigger the fire

The endpoint persists a `Message` row and broadcasts a `chat` event — it does **not** call `trigger_foreman()` or enqueue any asyncio task. The foreman reads the message the next time it's invoked for some other reason (e.g. a human chat or a subsequent webhook).

## Workflow scope note

The `.github/workflows/ci.yml` change (adding the `notify` job) is committed locally on this branch but **could not be pushed** — the `GITHUB_TOKEN` used by this worker lacks the `workflow` OAuth scope required by GitHub. To include it:

```bash
# In a terminal with a PAT that has `workflow` scope:
git fetch origin
git checkout claude/gha-inject-foreman-messages-on-ci-completion-501-t-6iae
git cherry-pick 907cb8e   # the local commit with all 4 changes
git push origin claude/gha-inject-foreman-messages-on-ci-completion-501-t-6iae
```

Or add `workflow` scope to the `GITHUB_TOKEN` secret used by the worker.

## Test plan
- [ ] `cd backend && python -m pytest backend/tests/test_github_webhooks.py -k ci_notify` — all 7 new tests pass
- [ ] Set `PIONEER_CI_KEY`, `PIONEER_GUILD_ID`, and `PIONEER_BACKEND_URL` as GitHub secrets; trigger a CI run; verify a `[ci-notify]` message appears in the guild chat
- [ ] Verify no foreman invocation fires automatically on CI notify

Closes #501

🤖 Generated with [Claude Code](https://claude.ai/claude-code)