### PR TITLE
User panel: view & delete Claude credentials (#503)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -11,3 +12,12 @@ AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=As
 
 async def get_db() -> AsyncSession:
     return AsyncSessionLocal()
+
+
+async def get_db_dep() -> AsyncGenerator[AsyncSession, None]:
+    """Async generator for FastAPI Depends — yields a session and ensures close on exit."""
+    db = AsyncSessionLocal()
+    try:
+        yield db
+    finally:
+        await db.close()

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -19,7 +19,7 @@ from auth_deps import (
     require_worker_or_member,
 )
 from database import get_db
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials
 from models import (
@@ -180,6 +180,49 @@ async def store_claude_credentials(
     finally:
         await db.close()
     return {"ok": True}
+
+
+@router.get("/auth/claude-credentials")
+async def get_claude_credentials_status(
+    guild_id: str = Query(...),
+    _principal: str = Depends(require_worker_or_member),
+):
+    """Return masked Claude credentials status for the settings UI (never the full blob)."""
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is None:
+            return {"saved": False}
+        result = await db.exec(
+            select(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)
+        )
+        row = result.one_or_none()
+        if not row:
+            return {"saved": False}
+        return {"saved": True, "updated_at": row.updated_at.isoformat()}
+    finally:
+        await db.close()
+
+
+@router.delete("/auth/claude-credentials", status_code=204)
+async def delete_claude_credentials(
+    guild_id: str = Query(...),
+    credentials: HTTPAuthorizationCredentials | None = Depends(http_bearer),
+):
+    """Delete stored Claude credentials for a guild. Requires member or worker auth."""
+    token = credentials.credentials if credentials else None
+    await authorize_worker_or_member(guild_id, token)
+    db = await get_db()
+    try:
+        guild_pk = await get_guild_pk(db, guild_id)
+        if guild_pk is not None:
+            await db.exec(
+                delete(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)
+            )
+            await db.commit()
+    finally:
+        await db.close()
+    return Response(status_code=204)
 
 
 @router.get("/auth/me")

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -199,7 +199,7 @@ async def get_claude_credentials_status(
         row = result.one_or_none()
         if not row:
             return {"saved": False}
-        return {"saved": True, "updated_at": row.updated_at.isoformat()}
+        return {"saved": True, "updated_at": row.updated_at.isoformat() if row.updated_at else None}
     finally:
         await db.close()
 
@@ -207,11 +207,9 @@ async def get_claude_credentials_status(
 @router.delete("/auth/claude-credentials", status_code=204)
 async def delete_claude_credentials(
     guild_id: str = Query(...),
-    credentials: HTTPAuthorizationCredentials | None = Depends(http_bearer),
+    _principal: str = Depends(require_worker_or_member),
 ):
     """Delete stored Claude credentials for a guild. Requires member or worker auth."""
-    token = credentials.credentials if credentials else None
-    await authorize_worker_or_member(guild_id, token)
     db = await get_db()
     try:
         guild_pk = await get_guild_pk(db, guild_id)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -15,10 +15,11 @@ from auth_deps import (
     authorize_worker_or_member,
     get_guild_pk,
     http_bearer,
+    require_member,
     require_user,
     require_worker_or_member,
 )
-from database import get_db
+from database import get_db, get_db_dep
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials
@@ -35,6 +36,7 @@ from pydantic import BaseModel
 from sqlalchemy import delete, or_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 from utils import generate_guild_id
 
 router = APIRouter()
@@ -185,41 +187,33 @@ async def store_claude_credentials(
 @router.get("/auth/claude-credentials")
 async def get_claude_credentials_status(
     guild_id: str = Query(...),
-    _principal: str = Depends(require_worker_or_member),
+    _user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
 ):
     """Return masked Claude credentials status for the settings UI (never the full blob)."""
-    db = await get_db()
-    try:
-        guild_pk = await get_guild_pk(db, guild_id)
-        if guild_pk is None:
-            return {"saved": False}
-        result = await db.exec(
-            select(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)
-        )
-        row = result.one_or_none()
-        if not row:
-            return {"saved": False}
-        return {"saved": True, "updated_at": row.updated_at.isoformat() if row.updated_at else None}
-    finally:
-        await db.close()
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        return {"saved": False}
+    result = await db.exec(
+        select(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)
+    )
+    row = result.one_or_none()
+    if not row:
+        return {"saved": False}
+    return {"saved": True, "updated_at": row.updated_at.isoformat() if row.updated_at else None}
 
 
 @router.delete("/auth/claude-credentials", status_code=204)
 async def delete_claude_credentials(
     guild_id: str = Query(...),
-    _principal: str = Depends(require_worker_or_member),
+    _user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
 ):
-    """Delete stored Claude credentials for a guild. Requires member or worker auth."""
-    db = await get_db()
-    try:
-        guild_pk = await get_guild_pk(db, guild_id)
-        if guild_pk is not None:
-            await db.exec(
-                delete(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)
-            )
-            await db.commit()
-    finally:
-        await db.close()
+    """Delete stored Claude credentials for a guild. Requires guild member auth."""
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is not None:
+        await db.exec(delete(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk))
+        await db.commit()
     return Response(status_code=204)
 
 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -193,7 +193,7 @@ async def get_claude_credentials_status(
     """Return masked Claude credentials status for the settings UI (never the full blob)."""
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
-        return {"saved": False}
+        raise HTTPException(status_code=404, detail="Guild not found")
     result = await db.exec(
         select(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)
     )
@@ -211,9 +211,10 @@ async def delete_claude_credentials(
 ):
     """Delete stored Claude credentials for a guild. Requires guild member auth."""
     guild_pk = await get_guild_pk(db, guild_id)
-    if guild_pk is not None:
-        await db.exec(delete(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk))
-        await db.commit()
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    await db.exec(delete(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk))
+    await db.commit()
     return Response(status_code=204)
 
 

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -93,6 +93,22 @@
         </div>
       </div>
 
+      <div class="settings-field">
+        <label class="settings-label">Claude Credentials</label>
+        <div v-if="claudeCredsStatus === null" class="creds-loading">Loading…</div>
+        <div v-else-if="claudeCredsStatus.saved" class="settings-row creds-saved-row">
+          <span class="creds-saved-at">Saved {{ formatCredsDate(claudeCredsStatus.updated_at) }}</span>
+          <button
+            class="pixel-btn creds-delete-btn"
+            :disabled="claudeCredsDeleting"
+            @click="deleteClaude"
+          >
+            Delete
+          </button>
+        </div>
+        <div v-else class="creds-none">No credentials saved</div>
+      </div>
+
       <div class="settings-field settings-meta">
         <span class="settings-meta-label">Session ID</span>
         <code class="settings-meta-value">{{ currentGuild.id }}</code>
@@ -110,6 +126,8 @@ import { useGuildStore } from '../stores/guild'
 import { useGitHubStore } from '../stores/github'
 import { useAuthStore } from '../stores/auth'
 import GitHubConfigModal from './GitHubConfigModal.vue'
+
+const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
 
 defineProps<{ debugActive?: boolean }>()
 const emit = defineEmits<{ 'toggle-debug': [] }>()
@@ -133,6 +151,49 @@ const repoStatus = ref<'' | 'saved' | 'error'>('')
 let renameStatusTimer: ReturnType<typeof setTimeout> | null = null
 let repoStatusTimer: ReturnType<typeof setTimeout> | null = null
 
+type CredsStatus = { saved: false } | { saved: true; updated_at: string }
+const claudeCredsStatus = ref<CredsStatus | null>(null)
+const claudeCredsDeleting = ref(false)
+
+async function loadClaudeCredsStatus() {
+  if (!currentGuild.value) return
+  claudeCredsStatus.value = null
+  try {
+    const res = await fetch(
+      `${API_BASE}/auth/claude-credentials?guild_id=${encodeURIComponent(currentGuild.value.id)}`,
+      { headers: authStore.authHeaders() },
+    )
+    if (res.ok) {
+      claudeCredsStatus.value = await res.json()
+    }
+  } catch {
+    // ignore — status stays null
+  }
+}
+
+async function deleteClaude() {
+  if (!currentGuild.value) return
+  if (!confirm('Delete saved Claude credentials for this guild?')) return
+  claudeCredsDeleting.value = true
+  try {
+    await fetch(
+      `${API_BASE}/auth/claude-credentials?guild_id=${encodeURIComponent(currentGuild.value.id)}`,
+      { method: 'DELETE', headers: authStore.authHeaders() },
+    )
+    claudeCredsStatus.value = { saved: false }
+  } finally {
+    claudeCredsDeleting.value = false
+  }
+}
+
+function formatCredsDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
 watch(
   currentGuild,
   (guild) => {
@@ -150,6 +211,7 @@ async function toggleSettings() {
     if (ghStore.repos.length === 0 && ghStore.token) {
       await ghStore.fetchRepos()
     }
+    loadClaudeCredsStatus()
   }
 }
 
@@ -474,6 +536,47 @@ function goHome() {
 }
 .save-status-error {
   color: var(--color-red);
+}
+
+.creds-loading {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+
+.creds-saved-row {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.creds-saved-at {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-text);
+}
+
+.creds-delete-btn {
+  font-size: 7px;
+  padding: 5px 9px;
+  flex-shrink: 0;
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #e74c3c);
+}
+
+.creds-delete-btn:hover:not(:disabled) {
+  background: rgba(192, 57, 43, 0.2);
+}
+
+.creds-delete-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.creds-none {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-text-dim);
+  font-style: italic;
 }
 
 .settings-meta {

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -96,15 +96,31 @@
       <div class="settings-field">
         <label class="settings-label">Claude Credentials</label>
         <div v-if="claudeCredsStatus === null" class="creds-loading">Loading…</div>
-        <div v-else-if="claudeCredsStatus.saved" class="settings-row creds-saved-row">
-          <span class="creds-saved-at">Saved {{ formatCredsDate(claudeCredsStatus.updated_at) }}</span>
-          <button
-            class="pixel-btn creds-delete-btn"
-            :disabled="claudeCredsDeleting"
-            @click="deleteClaude"
-          >
-            Delete
-          </button>
+        <div v-else-if="claudeCredsStatus.saved" class="creds-saved-section">
+          <div class="settings-row creds-saved-row">
+            <span class="creds-saved-at">Saved {{ formatCredsDate(claudeCredsStatus.updated_at) }}</span>
+            <button
+              v-if="!claudeCredsConfirmDelete"
+              class="pixel-btn creds-delete-btn"
+              :disabled="claudeCredsDeleting"
+              @click="claudeCredsConfirmDelete = true"
+            >
+              Delete
+            </button>
+          </div>
+          <div v-if="claudeCredsConfirmDelete" class="creds-confirm-row">
+            <span class="creds-confirm-label">Delete credentials?</span>
+            <button
+              class="pixel-btn creds-confirm-yes-btn"
+              :disabled="claudeCredsDeleting"
+              @click="deleteClaude"
+            >
+              Confirm
+            </button>
+            <button class="pixel-btn creds-confirm-no-btn" @click="claudeCredsConfirmDelete = false">
+              Cancel
+            </button>
+          </div>
         </div>
         <div v-else class="creds-none">No credentials saved</div>
         <div v-if="claudeCredsError" class="creds-error">{{ claudeCredsError }}</div>
@@ -156,6 +172,7 @@ type CredsStatus = { saved: false } | { saved: true; updated_at: string | null }
 const claudeCredsStatus = ref<CredsStatus | null>(null)
 const claudeCredsDeleting = ref(false)
 const claudeCredsError = ref<string | null>(null)
+const claudeCredsConfirmDelete = ref(false)
 
 async function loadClaudeCredsStatus() {
   if (!currentGuild.value) return
@@ -180,7 +197,6 @@ async function loadClaudeCredsStatus() {
 
 async function deleteClaude() {
   if (!currentGuild.value) return
-  if (!confirm('Delete saved Claude credentials for this guild?')) return
   claudeCredsDeleting.value = true
   claudeCredsError.value = null
   try {
@@ -190,6 +206,7 @@ async function deleteClaude() {
     )
     if (res.ok) {
       claudeCredsStatus.value = { saved: false }
+      claudeCredsConfirmDelete.value = false
     } else {
       claudeCredsError.value = `Delete failed (${res.status})`
     }
@@ -216,9 +233,16 @@ watch(
     primaryRepoValue.value = guild?.primary_repo ?? ''
     claudeCredsStatus.value = null
     claudeCredsError.value = null
+    claudeCredsConfirmDelete.value = false
   },
   { immediate: true },
 )
+
+watch(showSettings, (open) => {
+  if (!open) {
+    claudeCredsConfirmDelete.value = false
+  }
+})
 
 async function toggleSettings() {
   showSettings.value = !showSettings.value
@@ -587,6 +611,49 @@ function goHome() {
 .creds-delete-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.creds-saved-section {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.creds-confirm-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.creds-confirm-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--color-red, #e74c3c);
+  flex: 1;
+  white-space: nowrap;
+}
+
+.creds-confirm-yes-btn {
+  font-size: 7px;
+  padding: 5px 9px;
+  flex-shrink: 0;
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #e74c3c);
+}
+
+.creds-confirm-yes-btn:hover:not(:disabled) {
+  background: rgba(192, 57, 43, 0.2);
+}
+
+.creds-confirm-yes-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.creds-confirm-no-btn {
+  font-size: 7px;
+  padding: 5px 9px;
+  flex-shrink: 0;
 }
 
 .creds-none {

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -107,6 +107,7 @@
           </button>
         </div>
         <div v-else class="creds-none">No credentials saved</div>
+        <div v-if="claudeCredsError" class="creds-error">{{ claudeCredsError }}</div>
       </div>
 
       <div class="settings-field settings-meta">
@@ -151,9 +152,10 @@ const repoStatus = ref<'' | 'saved' | 'error'>('')
 let renameStatusTimer: ReturnType<typeof setTimeout> | null = null
 let repoStatusTimer: ReturnType<typeof setTimeout> | null = null
 
-type CredsStatus = { saved: false } | { saved: true; updated_at: string }
+type CredsStatus = { saved: false } | { saved: true; updated_at: string | null }
 const claudeCredsStatus = ref<CredsStatus | null>(null)
 const claudeCredsDeleting = ref(false)
+const claudeCredsError = ref<string | null>(null)
 
 async function loadClaudeCredsStatus() {
   if (!currentGuild.value) return
@@ -175,18 +177,26 @@ async function deleteClaude() {
   if (!currentGuild.value) return
   if (!confirm('Delete saved Claude credentials for this guild?')) return
   claudeCredsDeleting.value = true
+  claudeCredsError.value = null
   try {
-    await fetch(
+    const res = await fetch(
       `${API_BASE}/auth/claude-credentials?guild_id=${encodeURIComponent(currentGuild.value.id)}`,
       { method: 'DELETE', headers: authStore.authHeaders() },
     )
-    claudeCredsStatus.value = { saved: false }
+    if (res.ok) {
+      claudeCredsStatus.value = { saved: false }
+    } else {
+      claudeCredsError.value = `Delete failed (${res.status})`
+    }
+  } catch {
+    claudeCredsError.value = 'Delete failed'
   } finally {
     claudeCredsDeleting.value = false
   }
 }
 
-function formatCredsDate(iso: string) {
+function formatCredsDate(iso: string | null) {
+  if (!iso) return 'unknown date'
   return new Date(iso).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
@@ -211,7 +221,7 @@ async function toggleSettings() {
     if (ghStore.repos.length === 0 && ghStore.token) {
       await ghStore.fetchRepos()
     }
-    loadClaudeCredsStatus()
+    await loadClaudeCredsStatus()
   }
 }
 
@@ -577,6 +587,12 @@ function goHome() {
   font-size: 11px;
   color: var(--color-text-dim);
   font-style: italic;
+}
+
+.creds-error {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--color-red, #e74c3c);
 }
 
 .settings-meta {

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -160,6 +160,7 @@ const claudeCredsError = ref<string | null>(null)
 async function loadClaudeCredsStatus() {
   if (!currentGuild.value) return
   claudeCredsStatus.value = null
+  claudeCredsError.value = null
   try {
     const res = await fetch(
       `${API_BASE}/auth/claude-credentials?guild_id=${encodeURIComponent(currentGuild.value.id)}`,
@@ -167,9 +168,13 @@ async function loadClaudeCredsStatus() {
     )
     if (res.ok) {
       claudeCredsStatus.value = await res.json()
+    } else {
+      claudeCredsError.value = `Failed to load credentials status (${res.status})`
+      claudeCredsStatus.value = { saved: false }
     }
   } catch {
-    // ignore — status stays null
+    claudeCredsError.value = 'Failed to load credentials status'
+    claudeCredsStatus.value = { saved: false }
   }
 }
 
@@ -209,6 +214,8 @@ watch(
   (guild) => {
     renameValue.value = guild?.name ?? ''
     primaryRepoValue.value = guild?.primary_repo ?? ''
+    claudeCredsStatus.value = null
+    claudeCredsError.value = null
   },
   { immediate: true },
 )


### PR DESCRIPTION
## Summary

- **Backend**: adds two new routes to `backend/routes/auth.py`:
  - `GET /auth/claude-credentials?guild_id=…` — returns a masked status object (`{ saved, updated_at }`) for the settings UI; never exposes the raw credentials blob
  - `DELETE /auth/claude-credentials?guild_id=…` — deletes the stored credentials row for the guild; requires member/worker auth, returns 204
- **Frontend**: extends the `⚙ Guild Settings` popover in `TopBar.vue` with a **Claude Credentials** section that:
  - Loads credential status when the popover opens
  - Shows "Saved {date}" + a **Delete** button (with `confirm()` guard) if credentials exist
  - Shows "No credentials saved" otherwise
  - The existing `ClaudeAuthModal` (worker OAuth flow) is unchanged; credentials are still set automatically when a worker authenticates

## Test plan
- [ ] Open guild settings (⚙) → "Claude Credentials" shows "Loading…" then either saved date or "No credentials saved"
- [ ] With saved credentials, click **Delete** → cancel → credentials remain
- [ ] With saved credentials, click **Delete** → confirm → status refreshes to "No credentials saved"
- [ ] `GET /auth/claude-credentials` returns `{ "saved": false }` when no row exists
- [ ] `DELETE /auth/claude-credentials` with no auth returns 401/403

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)