### PR TITLE
Fix send directive field: expand + mobile zoom

### DIFF
--- a/frontend/src/components/chat-pane/ChatTab.vue
+++ b/frontend/src/components/chat-pane/ChatTab.vue
@@ -56,12 +56,13 @@
     </div>
   </div>
   <div class="chat-input-row">
-    <input
+    <textarea
       v-model="inputText"
       class="chat-input"
       placeholder="Send directive..."
-      @keydown.enter="onSend"
-    />
+      rows="3"
+      @keydown.enter.exact.prevent="onSend"
+    ></textarea>
     <button class="pixel-btn send-btn" @click="onSend">▶</button>
   </div>
 </template>
@@ -460,9 +461,11 @@ watch(
   border: 2px solid var(--color-brass-dark);
   color: var(--color-text);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 16px;
   padding: 6px 10px;
   outline: none;
+  resize: none;
+  line-height: 1.4;
   transition: border-color 0.15s;
 }
 


### PR DESCRIPTION
## Summary

- Changed the \"Send directive\" chat input from a single-line `<input>` to a `<textarea rows="3">` so there is comfortable typing room for longer directives
- Set `font-size: 16px` (was 12px) on the input to prevent iOS/mobile browsers from auto-zooming when the field is focused (browsers zoom inputs with font-size < 16px)
- Added `resize: none` so the textarea stays within its layout container
- Enter key sends the message; Shift+Enter inserts a newline (using Vue's `.enter.exact.prevent` modifier)
- Confirmed root containers (`html`, `body`, `#app`, `.chat-pane`) already have `overflow: hidden`, so no additional overflow-x fix needed

## Test plan

- [ ] Type a multi-line message using Shift+Enter; confirm newlines appear in the textarea
- [ ] Press Enter alone; confirm message is sent and textarea clears
- [ ] On iOS/mobile, tap the input and confirm the page does not auto-zoom
- [ ] Confirm the textarea does not overflow its container or create horizontal scroll

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)