### PR TITLE
Scope directives font-size 16px to mobile only

### DIFF
--- a/frontend/src/components/chat-pane/ChatTab.vue
+++ b/frontend/src/components/chat-pane/ChatTab.vue
@@ -461,12 +461,17 @@ watch(
   border: 2px solid var(--color-brass-dark);
   color: var(--color-text);
   font-family: var(--font-mono);
-  font-size: 16px;
   padding: 6px 10px;
   outline: none;
   resize: none;
   line-height: 1.4;
   transition: border-color 0.15s;
+}
+
+@media (max-width: 768px) {
+  .chat-input {
+    font-size: 16px;
+  }
 }
 
 .chat-input:focus {


### PR DESCRIPTION
## Summary

- Removes `font-size: 16px` from the base `.chat-input` rule in `ChatTab.vue`
- Moves it into a `@media (max-width: 768px)` block so it only applies on mobile
- All other styles from the previous commit (resize: none, line-height, padding, etc.) are untouched

## Why

iOS Safari auto-zooms any input/textarea with a font-size below 16px on focus. The 16px fix was added unconditionally but isn't needed on desktop, where the inherited font size from the design system should apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)