### PR TITLE
Add Claude usage reporting from worker headless runs

### DIFF
--- a/backend/alembic/versions/20260530_000000_create_claude_usage.py
+++ b/backend/alembic/versions/20260530_000000_create_claude_usage.py
@@ -1,0 +1,55 @@
+"""Create claude_usage table.
+
+Revision ID: 20260530_000000_create_claude_usage
+Revises: 20260527_000000_create_push_tokens
+Create Date: 2026-05-30
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260530_000000_create_claude_usage"
+down_revision: str | Sequence[str] | None = "20260527_000000_create_push_tokens"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "claude_usage",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "guild_id",
+            sa.Integer(),
+            sa.ForeignKey("guilds.id"),
+            nullable=False,
+        ),
+        sa.Column("task_id", sa.Text(), sa.ForeignKey("tasks.id"), nullable=True),
+        sa.Column("worker_id", sa.Text(), sa.ForeignKey("workers.id"), nullable=True),
+        sa.Column("session_id", sa.Text(), nullable=True),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("call_index", sa.Integer(), nullable=True),
+        sa.Column("model", sa.Text(), nullable=True),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cache_read_input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cache_creation_input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cost_usd", sa.Float(), nullable=True),
+        sa.Column("num_turns", sa.Integer(), nullable=True),
+        sa.Column("stop_reason", sa.Text(), nullable=True),
+        sa.Column("repo", sa.Text(), nullable=True),
+        sa.Column("reporter", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_claude_usage_guild_id", "claude_usage", ["guild_id"])
+    op.create_index("ix_claude_usage_task_id", "claude_usage", ["task_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_claude_usage_task_id", table_name="claude_usage")
+    op.drop_index("ix_claude_usage_guild_id", table_name="claude_usage")
+    op.drop_table("claude_usage")

--- a/backend/main.py
+++ b/backend/main.py
@@ -340,6 +340,7 @@ from routes import foreman as _foreman_routes  # noqa: E402
 from routes import guilds as _guilds_routes  # noqa: E402
 from routes import push as _push_routes  # noqa: E402
 from routes import tasks as _tasks_routes  # noqa: E402
+from routes import usage as _usage_routes  # noqa: E402
 from routes import webhooks as _webhooks_routes  # noqa: E402
 from routes import websocket as _ws_routes  # noqa: E402
 from routes import wellknown as _wellknown_routes  # noqa: E402
@@ -352,6 +353,7 @@ app.include_router(_guilds_routes.router)
 app.include_router(_agents_routes.router)
 app.include_router(_workers_routes.router)
 app.include_router(_tasks_routes.router)
+app.include_router(_usage_routes.router)
 app.include_router(_foreman_routes.router)
 app.include_router(_webhooks_routes.router)
 app.include_router(_push_routes.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -318,6 +318,48 @@ class TaskEvent(SQLModel, table=True):
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
+class ClaudeUsage(SQLModel, table=True):
+    """Per-API-call usage captured from a worker's headless Claude run.
+
+    The worker parses ``claude --output-format stream-json`` and reports one
+    row per assistant message (``kind="api_call"``) carrying that message's
+    ``message.usage``, plus one ``kind="result"`` row per run holding the
+    ``result`` event's self-reported aggregate ``usage`` and
+    ``total_cost_usd``. Storing both lets the UI compare the per-call sum
+    against Claude's self-reported total (the two disagree in practice).
+    """
+
+    __tablename__ = "claude_usage"  # type: ignore[assignment]
+
+    id: int | None = Field(default=None, primary_key=True)
+    # guild_id is the integer FK to guilds.id.
+    guild_id: int = Field(foreign_key="guilds.id", index=True)
+    # Worker task this usage belongs to (NULL only for ad-hoc reports).
+    task_id: str | None = Field(default=None, foreign_key="tasks.id")
+    worker_id: str | None = Field(default=None, foreign_key="workers.id")
+    # Claude session_id (system:init) for the run this row came from.
+    session_id: str | None = None
+    # "api_call" (one assistant message) | "result" (the run's result event).
+    kind: str
+    # 0-based index of the API call within the task run; NULL for result rows.
+    call_index: int | None = None
+    # Model id (e.g. "claude-opus-4-8").
+    model: str | None = None
+    input_tokens: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
+    output_tokens: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
+    cache_read_input_tokens: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
+    cache_creation_input_tokens: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
+    # Result rows only: self-reported cost/turns/outcome (NULL on api_call rows).
+    cost_usd: float | None = None
+    num_turns: int | None = None
+    stop_reason: str | None = None
+    # workspace repo "owner/name" if known.
+    repo: str | None = None
+    # Free-text label for who reported (worker name / user). NULL if unknown.
+    reporter: str | None = None
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
 class PushToken(SQLModel, table=True):
     """APNs (or, in the future, FCM) device token registered by the iOS app.
 

--- a/backend/routes/usage.py
+++ b/backend/routes/usage.py
@@ -1,0 +1,145 @@
+"""Claude usage reporting from workers' headless runs.
+
+Workers parse ``claude --output-format stream-json`` and POST per-API-call
+usage (one record per assistant message) plus a single ``result`` record per
+run. Rows are stored in ``claude_usage`` and a summary is broadcast so the
+frontend can surface live token/cost figures per task.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
+from database import get_db_dep
+from events import broadcast
+from fastapi import APIRouter, Depends, HTTPException
+from models import ClaudeUsage
+from pydantic import BaseModel
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from utils import row_to_dict
+
+router = APIRouter()
+
+
+class UsageRecord(BaseModel):
+    kind: str  # "api_call" | "result"
+    call_index: int | None = None
+    model: str | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cost_usd: float | None = None
+    num_turns: int | None = None
+    stop_reason: str | None = None
+
+
+class UsageReport(BaseModel):
+    task_id: str | None = None
+    worker_id: str | None = None
+    session_id: str | None = None
+    repo: str | None = None
+    reporter: str | None = None
+    records: list[UsageRecord]
+
+
+def _summarize(records: list[UsageRecord]) -> dict:
+    """Aggregate a batch into a compact summary for the WS broadcast."""
+    calls = [r for r in records if r.kind == "api_call"]
+    result = next((r for r in records if r.kind == "result"), None)
+    summed_input = sum(r.input_tokens for r in calls)
+    summed_output = sum(r.output_tokens for r in calls)
+    summed_cache_read = sum(r.cache_read_input_tokens for r in calls)
+    summed_cache_creation = sum(r.cache_creation_input_tokens for r in calls)
+    return {
+        "apiCalls": len(calls),
+        "summedInputTokens": summed_input,
+        "summedOutputTokens": summed_output,
+        "summedCacheReadTokens": summed_cache_read,
+        "summedCacheCreationTokens": summed_cache_creation,
+        # Claude's self-reported result figures (may disagree with the sums above).
+        "reportedInputTokens": result.input_tokens if result else None,
+        "reportedOutputTokens": result.output_tokens if result else None,
+        "reportedCacheReadTokens": result.cache_read_input_tokens if result else None,
+        "reportedCacheCreationTokens": result.cache_creation_input_tokens if result else None,
+        "costUsd": result.cost_usd if result else None,
+        "numTurns": result.num_turns if result else None,
+        "stopReason": result.stop_reason if result else None,
+    }
+
+
+@router.post("/guilds/{guild_id}/usage")
+async def report_usage(
+    guild_id: str,
+    data: UsageReport,
+    principal: str = Depends(require_worker_or_member_path),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Persist a batch of usage records for a task run and broadcast a summary."""
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    if not data.records:
+        return {"stored": 0}
+
+    created_at = datetime.now(UTC)
+    for rec in data.records:
+        db.add(
+            ClaudeUsage(
+                guild_id=guild_pk,
+                task_id=data.task_id,
+                worker_id=data.worker_id,
+                session_id=data.session_id,
+                kind=rec.kind,
+                call_index=rec.call_index,
+                model=rec.model,
+                input_tokens=rec.input_tokens,
+                output_tokens=rec.output_tokens,
+                cache_read_input_tokens=rec.cache_read_input_tokens,
+                cache_creation_input_tokens=rec.cache_creation_input_tokens,
+                cost_usd=rec.cost_usd,
+                num_turns=rec.num_turns,
+                stop_reason=rec.stop_reason,
+                repo=data.repo,
+                reporter=data.reporter,
+                created_at=created_at,
+            )
+        )
+    await db.commit()
+
+    await broadcast(
+        guild_id,
+        {
+            "type": "claude-usage",
+            "taskId": data.task_id,
+            "workerId": data.worker_id,
+            "sessionId": data.session_id,
+            "model": next((r.model for r in data.records if r.model), None),
+            "repo": data.repo,
+            "reporter": data.reporter,
+            **_summarize(data.records),
+        },
+    )
+    return {"stored": len(data.records)}
+
+
+@router.get("/guilds/{guild_id}/usage")
+async def list_usage(
+    guild_id: str,
+    task_id: str | None = None,
+    limit: int = 500,
+    github_user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """List usage rows for a guild, most recent first (optionally one task)."""
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    query = select(ClaudeUsage).where(col(ClaudeUsage.guild_id) == guild_pk)
+    if task_id is not None:
+        query = query.where(col(ClaudeUsage.task_id) == task_id)
+    query = query.order_by(col(ClaudeUsage.id).desc()).limit(min(limit, 2000))
+    result = await db.exec(query)
+    return [row_to_dict(r) for r in result.all()]

--- a/backend/tests/test_usage_api.py
+++ b/backend/tests/test_usage_api.py
@@ -1,0 +1,148 @@
+"""Tests for the Claude usage reporting routes (routes/usage.py).
+
+Requires the postgres-test container (localhost:5433); see CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import events as events_module
+from helpers import insert_guild, insert_task, insert_worker, make_auth_token
+
+
+def _auth(db_url: str) -> dict:
+    return {"Authorization": f"Bearer {make_auth_token(db_url)}"}
+
+
+def _sample_records() -> list[dict]:
+    return [
+        {
+            "kind": "api_call",
+            "call_index": 0,
+            "model": "claude-opus-4-8",
+            "input_tokens": 5,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 1,
+            "cache_creation_input_tokens": 2,
+        },
+        {
+            "kind": "api_call",
+            "call_index": 1,
+            "model": "claude-opus-4-8",
+            "input_tokens": 3,
+            "output_tokens": 4,
+        },
+        {
+            "kind": "result",
+            "model": "claude-opus-4-8",
+            "input_tokens": 100,
+            "output_tokens": 11,
+            "cost_usd": 0.5,
+            "num_turns": 2,
+            "stop_reason": "success",
+        },
+    ]
+
+
+def test_report_usage_stores_rows_and_broadcasts(client, monkeypatch):
+    test_client, db_url = client
+    insert_guild(db_url, "guseu1")
+    insert_worker(db_url, "guseu1", "w-use01")
+    insert_task(db_url, "guseu1", "t-use01", worker_id="w-use01")
+
+    captured: list[tuple[str, dict]] = []
+
+    async def _fake_broadcast(guild_id, message, exclude=None):
+        captured.append((guild_id, message))
+
+    monkeypatch.setattr(events_module, "broadcast", _fake_broadcast)
+    # routes.usage imported broadcast by name, so patch it there too.
+    import routes.usage as usage_module
+
+    monkeypatch.setattr(usage_module, "broadcast", _fake_broadcast)
+
+    resp = test_client.post(
+        "/guilds/guseu1/usage",
+        json={
+            "task_id": "t-use01",
+            "worker_id": "w-use01",
+            "session_id": "sess-1",
+            "repo": "owner/repo",
+            "reporter": "tok/w-use01",
+            "records": _sample_records(),
+        },
+        headers=_auth(db_url),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"stored": 3}
+
+    # Broadcast carried the summed-vs-reported discrepancy.
+    assert len(captured) == 1
+    _, msg = captured[0]
+    assert msg["type"] == "claude-usage"
+    assert msg["taskId"] == "t-use01"
+    assert msg["apiCalls"] == 2
+    assert msg["summedInputTokens"] == 8
+    assert msg["reportedInputTokens"] == 100
+    assert msg["costUsd"] == 0.5
+    assert msg["stopReason"] == "success"
+
+
+def test_list_usage_returns_rows(client):
+    test_client, db_url = client
+    insert_guild(db_url, "guseu2")
+    insert_worker(db_url, "guseu2", "w-use02")
+    insert_task(db_url, "guseu2", "t-use02", worker_id="w-use02")
+
+    post = test_client.post(
+        "/guilds/guseu2/usage",
+        json={"task_id": "t-use02", "worker_id": "w-use02", "records": _sample_records()},
+        headers=_auth(db_url),
+    )
+    assert post.status_code == 200, post.text
+
+    resp = test_client.get("/guilds/guseu2/usage", headers=_auth(db_url))
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    assert len(rows) == 3
+    kinds = sorted(r["kind"] for r in rows)
+    assert kinds == ["api_call", "api_call", "result"]
+    result_row = next(r for r in rows if r["kind"] == "result")
+    assert result_row["cost_usd"] == 0.5
+    assert result_row["num_turns"] == 2
+
+    # Filtering by an unrelated task returns nothing.
+    empty = test_client.get("/guilds/guseu2/usage?task_id=t-nope", headers=_auth(db_url))
+    assert empty.status_code == 200
+    assert empty.json() == []
+
+
+def test_report_usage_unknown_guild_404(client):
+    test_client, db_url = client
+    resp = test_client.post(
+        "/guilds/nope01/usage",
+        json={"task_id": "t-x", "records": _sample_records()},
+        headers=_auth(db_url),
+    )
+    assert resp.status_code == 404
+
+
+def test_report_usage_requires_auth(client):
+    test_client, db_url = client
+    insert_guild(db_url, "guseu3")
+    resp = test_client.post(
+        "/guilds/guseu3/usage",
+        json={"task_id": "t-x", "records": _sample_records()},
+    )
+    assert resp.status_code == 401
+
+
+def test_report_usage_empty_records_noop(client):
+    test_client, db_url = client
+    insert_guild(db_url, "guseu4")
+    resp = test_client.post(
+        "/guilds/guseu4/usage",
+        json={"task_id": "t-x", "records": []},
+        headers=_auth(db_url),
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"stored": 0}

--- a/frontend/src/components/LogPane.vue
+++ b/frontend/src/components/LogPane.vue
@@ -22,6 +22,7 @@
           :task-created-at="task.created_at"
           :task-description="task.description"
         />
+        <UsagePanel :task-id="id" />
       </div>
     </template>
 
@@ -56,6 +57,7 @@ import AgentActions from './log-pane/AgentActions.vue'
 import WorkerActions from './log-pane/WorkerActions.vue'
 import TaskHeader from './log-pane/TaskHeader.vue'
 import TaskActions from './log-pane/TaskActions.vue'
+import UsagePanel from './log-pane/UsagePanel.vue'
 
 const TASK_INFO_STORAGE_KEY = 'taskInfoPaneCollapsed'
 const infoCollapsed = ref(localStorage.getItem(TASK_INFO_STORAGE_KEY) === 'true')

--- a/frontend/src/components/log-pane/UsagePanel.vue
+++ b/frontend/src/components/log-pane/UsagePanel.vue
@@ -1,0 +1,162 @@
+<template>
+  <div v-if="usage" class="usage-panel">
+    <div class="usage-row usage-head">
+      <span class="usage-label">CLAUDE USAGE</span>
+      <span class="usage-meta">
+        {{ usage.apiCalls }} call{{ usage.apiCalls === 1 ? '' : 's' }}
+        <template v-if="usage.numTurns != null"> · {{ usage.numTurns }} turns</template>
+        <template v-if="usage.model"> · {{ shortModel }}</template>
+      </span>
+    </div>
+
+    <table class="usage-table">
+      <thead>
+        <tr>
+          <th></th>
+          <th>in</th>
+          <th>out</th>
+          <th>cache r</th>
+          <th>cache w</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="usage-rowlabel" title="Sum of each assistant message's usage">Σ per-call</td>
+          <td>{{ fmt(usage.summedInputTokens) }}</td>
+          <td>{{ fmt(usage.summedOutputTokens) }}</td>
+          <td>{{ fmt(usage.summedCacheReadTokens) }}</td>
+          <td>{{ fmt(usage.summedCacheCreationTokens) }}</td>
+        </tr>
+        <tr v-if="hasReported">
+          <td class="usage-rowlabel" title="The result event's self-reported totals">reported</td>
+          <td :class="cellClass(usage.reportedInputTokens, usage.summedInputTokens)">
+            {{ fmt(usage.reportedInputTokens) }}
+          </td>
+          <td :class="cellClass(usage.reportedOutputTokens, usage.summedOutputTokens)">
+            {{ fmt(usage.reportedOutputTokens) }}
+          </td>
+          <td :class="cellClass(usage.reportedCacheReadTokens, usage.summedCacheReadTokens)">
+            {{ fmt(usage.reportedCacheReadTokens) }}
+          </td>
+          <td :class="cellClass(usage.reportedCacheCreationTokens, usage.summedCacheCreationTokens)">
+            {{ fmt(usage.reportedCacheCreationTokens) }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="usage-row usage-foot">
+      <span v-if="usage.costUsd != null" class="usage-cost">${{ usage.costUsd.toFixed(4) }}</span>
+      <span v-if="mismatch" class="usage-warn" title="Per-call sum disagrees with reported totals">
+        ⚠ sum ≠ reported
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useUsageStore } from '../../stores/usage'
+
+const props = defineProps<{ taskId: string }>()
+const usageStore = useUsageStore()
+
+const usage = computed(() => usageStore.usageForTask(props.taskId))
+
+const shortModel = computed(() => (usage.value?.model || '').replace(/^claude-/, ''))
+
+const hasReported = computed(() => usage.value?.reportedInputTokens != null)
+
+function fmt(n: number | null | undefined): string {
+  return (n ?? 0).toLocaleString()
+}
+
+// Highlight a reported cell when it differs from the per-call sum.
+function cellClass(reported: number | null | undefined, summed: number): string {
+  return reported != null && reported !== summed ? 'usage-diff' : ''
+}
+
+const mismatch = computed(() => {
+  const u = usage.value
+  if (!u || !hasReported.value) return false
+  return (
+    u.reportedInputTokens !== u.summedInputTokens ||
+    u.reportedOutputTokens !== u.summedOutputTokens ||
+    u.reportedCacheReadTokens !== u.summedCacheReadTokens ||
+    u.reportedCacheCreationTokens !== u.summedCacheCreationTokens
+  )
+})
+</script>
+
+<style scoped>
+.usage-panel {
+  padding: 6px 10px 8px;
+  border-top: 1px solid var(--color-brass-dark);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+
+.usage-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.usage-label {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 1px;
+  color: var(--color-brass-light);
+}
+
+.usage-meta {
+  font-size: 9px;
+  color: var(--color-text-dim);
+}
+
+.usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 4px 0;
+}
+
+.usage-table th {
+  font-weight: normal;
+  text-align: right;
+  color: var(--color-text-dim);
+  opacity: 0.7;
+  font-size: 9px;
+  padding: 1px 4px;
+}
+
+.usage-table td {
+  text-align: right;
+  padding: 1px 4px;
+  color: var(--color-text);
+}
+
+.usage-rowlabel {
+  text-align: left !important;
+  color: var(--color-text-dim) !important;
+}
+
+.usage-diff {
+  color: var(--color-brass-light);
+  font-weight: bold;
+}
+
+.usage-foot {
+  margin-top: 2px;
+}
+
+.usage-cost {
+  color: var(--color-teal);
+}
+
+.usage-warn {
+  color: var(--color-brass-light);
+  font-size: 9px;
+}
+</style>

--- a/frontend/src/stores/__tests__/usage.spec.ts
+++ b/frontend/src/stores/__tests__/usage.spec.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useUsageStore } from '../usage'
+import type { ClaudeUsageWS } from '../../types'
+
+function wsEvent(over: Partial<ClaudeUsageWS> = {}): ClaudeUsageWS {
+  return {
+    type: 'claude-usage',
+    taskId: 't-1',
+    apiCalls: 2,
+    summedInputTokens: 8,
+    summedOutputTokens: 11,
+    summedCacheReadTokens: 1,
+    summedCacheCreationTokens: 2,
+    reportedInputTokens: 100,
+    reportedOutputTokens: 11,
+    reportedCacheReadTokens: 0,
+    reportedCacheCreationTokens: 0,
+    costUsd: 0.5,
+    numTurns: 2,
+    stopReason: 'success',
+    model: 'claude-opus-4-8',
+    ...over,
+  }
+}
+
+describe('useUsageStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('handleWebSocketMessage', () => {
+    it('records a claude-usage summary keyed by task', () => {
+      const store = useUsageStore()
+      store.handleWebSocketMessage(wsEvent())
+      const u = store.usageForTask('t-1')
+      expect(u).not.toBeNull()
+      expect(u?.apiCalls).toBe(2)
+      expect(u?.summedInputTokens).toBe(8)
+      expect(u?.reportedInputTokens).toBe(100)
+      expect(u?.costUsd).toBe(0.5)
+    })
+
+    it('latest event replaces the prior summary for a task', () => {
+      const store = useUsageStore()
+      store.handleWebSocketMessage(wsEvent({ apiCalls: 1 }))
+      store.handleWebSocketMessage(wsEvent({ apiCalls: 5 }))
+      expect(store.usageForTask('t-1')?.apiCalls).toBe(5)
+    })
+
+    it('ignores non-usage messages and usage without a task id', () => {
+      const store = useUsageStore()
+      store.handleWebSocketMessage({ type: 'task-followup-done', taskId: 't-1' })
+      store.handleWebSocketMessage(wsEvent({ taskId: null }))
+      expect(store.summaries).toHaveLength(0)
+    })
+  })
+
+  describe('totals', () => {
+    it('sums api calls, tokens and cost across tasks', () => {
+      const store = useUsageStore()
+      store.handleWebSocketMessage(wsEvent({ taskId: 't-1', apiCalls: 2, costUsd: 0.5 }))
+      store.handleWebSocketMessage(
+        wsEvent({ taskId: 't-2', apiCalls: 3, summedInputTokens: 10, costUsd: 1.25 }),
+      )
+      expect(store.totals.apiCalls).toBe(5)
+      expect(store.totals.inputTokens).toBe(18)
+      expect(store.totals.costUsd).toBeCloseTo(1.75)
+    })
+  })
+
+  describe('fetchUsage', () => {
+    it('aggregates per-call and result rows into a task summary', async () => {
+      const rows = [
+        { task_id: 't-9', kind: 'api_call', input_tokens: 5, output_tokens: 7,
+          cache_read_input_tokens: 1, cache_creation_input_tokens: 2, model: 'claude-opus-4-8',
+          cost_usd: null, num_turns: null, stop_reason: null, worker_id: 'w-1', session_id: 's',
+          call_index: 0, repo: 'o/r', reporter: 'x' },
+        { task_id: 't-9', kind: 'api_call', input_tokens: 3, output_tokens: 4,
+          cache_read_input_tokens: 0, cache_creation_input_tokens: 0, model: 'claude-opus-4-8',
+          cost_usd: null, num_turns: null, stop_reason: null, worker_id: 'w-1', session_id: 's',
+          call_index: 1, repo: 'o/r', reporter: 'x' },
+        { task_id: 't-9', kind: 'result', input_tokens: 100, output_tokens: 11,
+          cache_read_input_tokens: 0, cache_creation_input_tokens: 0, model: 'claude-opus-4-8',
+          cost_usd: 0.5, num_turns: 2, stop_reason: 'success', worker_id: 'w-1', session_id: 's',
+          call_index: null, repo: 'o/r', reporter: 'x' },
+      ]
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(rows) }),
+      )
+      const store = useUsageStore()
+      await store.fetchUsage('g-1')
+      const u = store.usageForTask('t-9')
+      expect(u?.apiCalls).toBe(2)
+      expect(u?.summedInputTokens).toBe(8)
+      expect(u?.summedOutputTokens).toBe(11)
+      expect(u?.reportedInputTokens).toBe(100)
+      expect(u?.costUsd).toBe(0.5)
+      expect(u?.numTurns).toBe(2)
+    })
+
+    it('no-ops on empty guild id', async () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+      const store = useUsageStore()
+      await store.fetchUsage('')
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clearUsage', () => {
+    it('drops all summaries', () => {
+      const store = useUsageStore()
+      store.handleWebSocketMessage(wsEvent())
+      store.clearUsage()
+      expect(store.summaries).toHaveLength(0)
+    })
+  })
+})

--- a/frontend/src/stores/usage.ts
+++ b/frontend/src/stores/usage.ts
@@ -1,0 +1,127 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { api } from '../utils/api'
+import type { ClaudeUsageWS, WSInbound } from '../types'
+
+// Per-task usage summary — the shape broadcast over WS, also what we aggregate
+// REST rows into so the UI has a single type to render.
+export type UsageSummary = Omit<ClaudeUsageWS, 'type'>
+
+// One raw row as stored in claude_usage (per API call or the run's result).
+interface UsageRow {
+  task_id: string | null
+  worker_id: string | null
+  session_id: string | null
+  kind: string
+  call_index: number | null
+  model: string | null
+  input_tokens: number
+  output_tokens: number
+  cache_read_input_tokens: number
+  cache_creation_input_tokens: number
+  cost_usd: number | null
+  num_turns: number | null
+  stop_reason: string | null
+  repo: string | null
+  reporter: string | null
+}
+
+function _emptySummary(taskId: string | null): UsageSummary {
+  return {
+    taskId,
+    apiCalls: 0,
+    summedInputTokens: 0,
+    summedOutputTokens: 0,
+    summedCacheReadTokens: 0,
+    summedCacheCreationTokens: 0,
+    reportedInputTokens: null,
+    reportedOutputTokens: null,
+    reportedCacheReadTokens: null,
+    reportedCacheCreationTokens: null,
+    costUsd: null,
+    numTurns: null,
+    stopReason: null,
+  }
+}
+
+function _aggregate(rows: UsageRow[]): Record<string, UsageSummary> {
+  const out: Record<string, UsageSummary> = {}
+  for (const r of rows) {
+    if (!r.task_id) continue
+    const s = (out[r.task_id] ??= _emptySummary(r.task_id))
+    s.model ??= r.model
+    s.repo ??= r.repo
+    s.reporter ??= r.reporter
+    s.workerId ??= r.worker_id
+    s.sessionId ??= r.session_id
+    if (r.kind === 'api_call') {
+      s.apiCalls += 1
+      s.summedInputTokens += r.input_tokens
+      s.summedOutputTokens += r.output_tokens
+      s.summedCacheReadTokens += r.cache_read_input_tokens
+      s.summedCacheCreationTokens += r.cache_creation_input_tokens
+    } else if (r.kind === 'result') {
+      s.reportedInputTokens = r.input_tokens
+      s.reportedOutputTokens = r.output_tokens
+      s.reportedCacheReadTokens = r.cache_read_input_tokens
+      s.reportedCacheCreationTokens = r.cache_creation_input_tokens
+      s.costUsd = r.cost_usd
+      s.numTurns = r.num_turns
+      s.stopReason = r.stop_reason
+    }
+  }
+  return out
+}
+
+export const useUsageStore = defineStore('usage', () => {
+  // Latest usage summary keyed by task id.
+  const byTask = ref<Record<string, UsageSummary>>({})
+
+  const summaries = computed(() => Object.values(byTask.value))
+
+  // Guild-wide totals across every reported task.
+  const totals = computed(() => {
+    const acc = { apiCalls: 0, inputTokens: 0, outputTokens: 0, costUsd: 0 }
+    for (const s of Object.values(byTask.value)) {
+      acc.apiCalls += s.apiCalls
+      acc.inputTokens += s.summedInputTokens
+      acc.outputTokens += s.summedOutputTokens
+      acc.costUsd += s.costUsd ?? 0
+    }
+    return acc
+  })
+
+  async function fetchUsage(guildId: string) {
+    if (!guildId) return
+    try {
+      const rows = await api<UsageRow[]>(`/guilds/${guildId}/usage`)
+      byTask.value = _aggregate(rows)
+    } catch (e) {
+      console.error('Failed to fetch usage', e)
+    }
+  }
+
+  function handleWebSocketMessage(data: WSInbound) {
+    if (data.type !== 'claude-usage' || !data.taskId) return
+    const { type: _t, ...summary } = data
+    byTask.value = { ...byTask.value, [data.taskId]: summary }
+  }
+
+  function usageForTask(taskId: string): UsageSummary | null {
+    return byTask.value[taskId] ?? null
+  }
+
+  function clearUsage() {
+    byTask.value = {}
+  }
+
+  return {
+    byTask,
+    summaries,
+    totals,
+    fetchUsage,
+    handleWebSocketMessage,
+    usageForTask,
+    clearUsage,
+  }
+})

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -271,6 +271,28 @@ export interface ForemanPollStatusWS {
   nextCheckIn?: number
 }
 
+export interface ClaudeUsageWS {
+  type: 'claude-usage'
+  taskId: string | null
+  workerId?: string | null
+  sessionId?: string | null
+  model?: string | null
+  repo?: string | null
+  reporter?: string | null
+  apiCalls: number
+  summedInputTokens: number
+  summedOutputTokens: number
+  summedCacheReadTokens: number
+  summedCacheCreationTokens: number
+  reportedInputTokens?: number | null
+  reportedOutputTokens?: number | null
+  reportedCacheReadTokens?: number | null
+  reportedCacheCreationTokens?: number | null
+  costUsd?: number | null
+  numTurns?: number | null
+  stopReason?: string | null
+}
+
 export type WSInbound =
   | ChatWS
   | GuildUpdatedWS
@@ -287,6 +309,7 @@ export type WSInbound =
   | ClaudeAuthSuccessWS
   | ClaudeAuthClearedWS
   | ForemanPollStatusWS
+  | ClaudeUsageWS
 
 // Outbound: producer-side; we accept any object with a `type`.
 export interface WSOutbound {

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -39,6 +39,7 @@ import { useAgentsStore } from '../stores/agents'
 import { useAuthStore } from '../stores/auth'
 import { useGitHubStore } from '../stores/github'
 import { useTasksStore } from '../stores/tasks'
+import { useUsageStore } from '../stores/usage'
 import GuildSidebar from '../components/GuildSidebar.vue'
 import MainView from '../components/MainView.vue'
 import ChatPane from '../components/ChatPane.vue'
@@ -64,6 +65,7 @@ const agentsStore = useAgentsStore()
 const authStore = useAuthStore()
 const ghStore = useGitHubStore()
 const tasksStore = useTasksStore()
+const usageStore = useUsageStore()
 
 async function initGuild(guildId: string) {
   if (!authStore.isLoggedIn) {
@@ -84,6 +86,7 @@ async function initGuild(guildId: string) {
 
   agentsStore.clearAgents()
   tasksStore.clearTasks()
+  usageStore.clearUsage()
   const guild = await guildStore.joinGuild(guildId)
   if (!guild) {
     router.replace('/')
@@ -91,6 +94,7 @@ async function initGuild(guildId: string) {
   }
   // Load existing tasks for this guild
   await tasksStore.fetchTasks(guildId)
+  usageStore.fetchUsage(guildId)
 
   if (guild.agents) {
     guild.agents
@@ -112,6 +116,7 @@ async function initGuild(guildId: string) {
   guildStore.connectWebSocket(guildId, (data) => {
     agentsStore.handleWebSocketMessage(data)
     tasksStore.handleWebSocketMessage(data)
+    usageStore.handleWebSocketMessage(data)
   })
 
   if (ghStore.isConfigured) {
@@ -140,6 +145,7 @@ onMounted(async () => {
 onUnmounted(() => {
   guildStore.disconnectWebSocket()
   tasksStore.clearTasks()
+  usageStore.clearUsage()
   document.title = 'Pioneer Square'
 })
 

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -11,6 +11,17 @@ from collections.abc import Awaitable, Callable
 logger = logging.getLogger(__name__)
 
 EmitFn = Callable[..., Awaitable[None]]  # emit(line: str, detail: dict | None = None)
+UsageFn = Callable[[dict], Awaitable[None]]  # on_usage(record: dict)
+
+
+def _usage_tokens(usage: dict) -> dict:
+    """Extract the four token counts from a message/result ``usage`` block."""
+    return {
+        "input_tokens": int(usage.get("input_tokens") or 0),
+        "output_tokens": int(usage.get("output_tokens") or 0),
+        "cache_read_input_tokens": int(usage.get("cache_read_input_tokens") or 0),
+        "cache_creation_input_tokens": int(usage.get("cache_creation_input_tokens") or 0),
+    }
 
 
 def _summarize_lines(lines: list[str], prefix: str = "  → ") -> str:
@@ -274,6 +285,7 @@ async def run_claude_auto(
     max_turns: int,
     emit: EmitFn,
     on_proc: Callable[[ClaudeProcess], None] | None = None,
+    on_usage: UsageFn | None = None,
     claude_path: str = "claude",
     resume_session_id: str | None = None,
 ) -> tuple[bool, str, str, str | None]:
@@ -355,6 +367,30 @@ async def run_claude_auto(
                     logger.info("claude[%d] session_id=%s", proc.pid, session_id)
             if event.get("type") == "result":
                 stop_reason = event.get("subtype", "success")
+            if on_usage is not None:
+                etype = event.get("type")
+                if etype == "assistant":
+                    msg = event.get("message", {})
+                    usage = msg.get("usage")
+                    if isinstance(usage, dict):
+                        await on_usage(
+                            {
+                                "kind": "api_call",
+                                "model": msg.get("model"),
+                                **_usage_tokens(usage),
+                            }
+                        )
+                elif etype == "result":
+                    usage = event.get("usage")
+                    rec = {
+                        "kind": "result",
+                        "model": event.get("model"),
+                        "cost_usd": event.get("total_cost_usd", event.get("cost_usd")),
+                        "num_turns": event.get("num_turns"),
+                        "stop_reason": event.get("subtype", "success"),
+                        **(_usage_tokens(usage) if isinstance(usage, dict) else {}),
+                    }
+                    await on_usage(rec)
             for text, detail in parse_claude_event(event):
                 await emit(text, detail)
                 if not text.startswith(("▶", "✓", "✗", "[", "  →")):

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -189,6 +189,41 @@ class Worker:
             self.cfg.user or "<unattributed>",
         )
 
+    async def _report_usage(
+        self,
+        *,
+        task_id: str,
+        session_id: str | None,
+        repo: str | None,
+        records: list[dict],
+    ) -> None:
+        """Best-effort POST of per-API-call usage for a finished run.
+
+        Never raises — usage reporting must not affect task outcome.
+        """
+        if not records:
+            return
+        body = {
+            "task_id": task_id,
+            "worker_id": self.cfg.worker_id,
+            "session_id": session_id,
+            "repo": repo,
+            "reporter": self._worker_name or self.cfg.worker_id,
+            "records": records,
+        }
+        try:
+            async with await self._http(authed=True) as client:
+                resp = await client.post(f"/guilds/{self.cfg.guild_id}/usage", json=body)
+                if resp.status_code >= 400:
+                    logger.warning(
+                        "Usage report for task %s rejected (status %d): %s",
+                        task_id,
+                        resp.status_code,
+                        resp.text[:200],
+                    )
+        except Exception as exc:
+            logger.warning("Usage report for task %s failed: %s", task_id, exc)
+
     async def _fetch_github_token_if_needed(self) -> None:
         if not self.cfg.github_token:
             try:
@@ -1708,6 +1743,20 @@ class Worker:
         def _on_proc(proc: claude_runner.ClaudeProcess) -> None:
             agent.current_claude = proc
 
+        # Per-API-call usage captured from the claude stream across all runs of
+        # this task (the redirect loop may invoke claude more than once). Each
+        # api_call gets a task-global call_index; reported to the backend once
+        # the run finishes.
+        usage_records: list[dict] = []
+        _api_call_n = 0
+
+        async def _collect_usage(rec: dict) -> None:
+            nonlocal _api_call_n
+            if rec.get("kind") == "api_call":
+                rec = {**rec, "call_index": _api_call_n}
+                _api_call_n += 1
+            usage_records.append(rec)
+
         try:
             # ── Main execution with redirect loop ──────────────────────────
             if is_followup:
@@ -1804,6 +1853,7 @@ class Worker:
                         max_turns=self.cfg.claude_max_turns,
                         emit=emit,
                         on_proc=_on_proc,
+                        on_usage=_collect_usage,
                         claude_path=self.cfg.claude_path,
                         resume_session_id=resume_session_id,
                     )
@@ -1854,6 +1904,15 @@ class Worker:
                 success,
                 stop_reason,
             )
+
+            # Report captured per-API-call usage (claude tasks only). Best-effort.
+            if usage_records:
+                await self._report_usage(
+                    task_id=task_id,
+                    session_id=resume_session_id,
+                    repo=repos[0] if repos else None,
+                    records=usage_records,
+                )
 
             # Push the branch regardless of outcome so partial work is visible
             # and a follow-up run can build on it.

--- a/worker/tests/test_claude_runner.py
+++ b/worker/tests/test_claude_runner.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
+import json
+from unittest.mock import patch
+
 import pytest
-from pioneer_worker.claude_runner import _summarize_lines, _truncate_at_word, parse_claude_event
+from pioneer_worker.claude_runner import (
+    _summarize_lines,
+    _truncate_at_word,
+    _usage_tokens,
+    parse_claude_event,
+    run_claude_auto,
+)
 
 # ---------------------------------------------------------------------------
 # _summarize_lines
@@ -314,3 +323,162 @@ def test_parse_unknown_type_returns_empty():
 
 def test_parse_empty_event_returns_empty():
     assert parse_claude_event({}) == []
+
+
+# ---------------------------------------------------------------------------
+# _usage_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_usage_tokens_full():
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "cache_read_input_tokens": 30,
+        "cache_creation_input_tokens": 40,
+    }
+    assert _usage_tokens(usage) == {
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "cache_read_input_tokens": 30,
+        "cache_creation_input_tokens": 40,
+    }
+
+
+def test_usage_tokens_missing_and_none_default_zero():
+    assert _usage_tokens({"input_tokens": None}) == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# run_claude_auto — on_usage callback
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    """Async-iterable byte stream of pre-baked lines."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = lines
+
+    def __aiter__(self):
+        async def _gen():
+            for ln in self._lines:
+                yield ln
+
+        return _gen()
+
+
+class _FakeProc:
+    def __init__(self, stdout_lines: list[bytes]) -> None:
+        self.pid = 4242
+        self.stdout = _FakeStream(stdout_lines)
+        self.stderr = _FakeStream([])
+        self.stdin = None
+
+    async def wait(self) -> int:
+        return 0
+
+
+async def test_run_claude_auto_emits_per_call_and_result_usage():
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "sess-1", "tools": []},
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-8",
+                "content": [{"type": "text", "text": "hi"}],
+                "usage": {
+                    "input_tokens": 5,
+                    "output_tokens": 7,
+                    "cache_read_input_tokens": 1,
+                    "cache_creation_input_tokens": 2,
+                },
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-8",
+                "content": [{"type": "text", "text": "bye"}],
+                "usage": {"input_tokens": 3, "output_tokens": 4},
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "num_turns": 2,
+            "total_cost_usd": 0.5,
+            "usage": {"input_tokens": 100, "output_tokens": 11},
+        },
+    ]
+    lines = [(json.dumps(e) + "\n").encode() for e in events]
+
+    captured: list[dict] = []
+
+    async def _emit(text, detail=None):
+        return None
+
+    async def _on_usage(rec):
+        captured.append(rec)
+
+    async def _fake_exec(*args, **kwargs):
+        return _FakeProc(lines)
+
+    with patch("asyncio.create_subprocess_exec", _fake_exec):
+        success, stop_reason, last_text, session_id = await run_claude_auto(
+            "do it",
+            "/tmp",
+            max_turns=10,
+            emit=_emit,
+            on_usage=_on_usage,
+        )
+
+    assert success is True
+    assert stop_reason == "success"
+    assert session_id == "sess-1"
+
+    api_calls = [r for r in captured if r["kind"] == "api_call"]
+    results = [r for r in captured if r["kind"] == "result"]
+    assert len(api_calls) == 2
+    assert len(results) == 1
+
+    assert api_calls[0]["input_tokens"] == 5
+    assert api_calls[0]["output_tokens"] == 7
+    assert api_calls[0]["cache_read_input_tokens"] == 1
+    assert api_calls[0]["model"] == "claude-opus-4-8"
+    # second call's missing cache fields default to 0
+    assert api_calls[1]["cache_read_input_tokens"] == 0
+
+    # The result event's self-reported total (100) differs from the per-call
+    # input sum (5 + 3 = 8) — the discrepancy this feature surfaces.
+    assert results[0]["input_tokens"] == 100
+    assert sum(c["input_tokens"] for c in api_calls) == 8
+    assert results[0]["cost_usd"] == 0.5
+    assert results[0]["num_turns"] == 2
+    assert results[0]["stop_reason"] == "success"
+
+
+async def test_run_claude_auto_no_usage_callback_is_optional():
+    events = [
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}},
+        {"type": "result", "subtype": "success", "num_turns": 1},
+    ]
+    lines = [(json.dumps(e) + "\n").encode() for e in events]
+
+    async def _emit(text, detail=None):
+        return None
+
+    async def _fake_exec(*args, **kwargs):
+        return _FakeProc(lines)
+
+    with patch("asyncio.create_subprocess_exec", _fake_exec):
+        success, stop_reason, _last, _sid = await run_claude_auto(
+            "do it", "/tmp", max_turns=10, emit=_emit
+        )
+    assert success is True
+    assert stop_reason == "success"


### PR DESCRIPTION
Capture per-API-call token usage from the worker's
`claude --output-format stream-json` runs and report it to the backend
per task. Each assistant message becomes an `api_call` row carrying its
`message.usage`; the run's `result` event becomes a `result` row holding
Claude's self-reported aggregate usage and cost. Storing both surfaces
the discrepancy between the per-call sum and the self-reported total.

- backend: ClaudeUsage table + migration; POST/GET /guilds/{id}/usage
  (worker auth_token), broadcasts a claude-usage summary over WS.
- worker: on_usage callback in claude_runner; collect + best-effort POST
  after each claude task (never affects task outcome).
- frontend: usage store (WS + REST aggregation) and a UsagePanel in the
  task info pane showing Σ per-call vs reported with a mismatch flag.

https://claude.ai/code/session_019xdx9DGCbjWspQB84V55eJ