### PR TITLE
Add typed log levels for terminal-output; surface more worker emits

### DIFF
--- a/backend/alembic/versions/20260530_000000_add_level_to_task_logs.py
+++ b/backend/alembic/versions/20260530_000000_add_level_to_task_logs.py
@@ -1,0 +1,30 @@
+"""Add level column to task_logs.
+
+Revision ID: 20260530_000000_add_level_to_task_logs
+Revises: 20260527_000000_create_push_tokens
+Create Date: 2026-05-30
+
+Adds a nullable ``level`` column that types each log line semantically
+(worker/auth/claude/thinking/…) so the frontend can style logs without
+parsing text prefixes like ``[worker]``. NULL = default agent output.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260530_000000_add_level_to_task_logs"
+down_revision: str | Sequence[str] | None = "20260527_000000_create_push_tokens"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("task_logs", sa.Column("level", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("task_logs", "level")

--- a/backend/alembic/versions/20260530_000000_add_level_to_task_logs.py
+++ b/backend/alembic/versions/20260530_000000_add_level_to_task_logs.py
@@ -1,7 +1,7 @@
 """Add level column to task_logs.
 
 Revision ID: 20260530_000000_add_level_to_task_logs
-Revises: 20260527_000000_create_push_tokens
+Revises: 20260530_000000_create_claude_usage
 Create Date: 2026-05-30
 
 Adds a nullable ``level`` column that types each log line semantically
@@ -17,7 +17,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260530_000000_add_level_to_task_logs"
-down_revision: str | Sequence[str] | None = "20260527_000000_create_push_tokens"
+down_revision: str | Sequence[str] | None = "20260530_000000_create_claude_usage"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -216,6 +216,9 @@ class TaskLog(SQLModel, table=True):
     worker_id: str | None = None
     agent_id: str | None = None
     data: str | None = None  # JSON: full tool input/output for click-to-expand
+    # Semantic line type (worker/auth/claude/thinking/…) so the frontend can
+    # style logs without parsing text prefixes. NULL = default agent output.
+    level: str | None = None
 
 
 class ClaudeCredentials(SQLModel, table=True):

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -128,6 +128,7 @@ async def get_task_logs(
             col(TaskLog.worker_id),
             col(TaskLog.agent_id),
             col(TaskLog.data),
+            col(TaskLog.level),
         )
         .where(col(TaskLog.task_id) == task_id)
         .order_by(col(TaskLog.id).asc())
@@ -167,6 +168,7 @@ async def get_guild_logs(
         col(TaskLog.agent_id),
         col(TaskLog.task_id),
         col(TaskLog.data),
+        col(TaskLog.level),
     )
     if task_id:
         stmt = stmt.where(col(TaskLog.task_id) == task_id)

--- a/backend/tests/test_terminal_output_ws_routing.py
+++ b/backend/tests/test_terminal_output_ws_routing.py
@@ -122,3 +122,42 @@ def test_worker_only_terminal_output_uses_worker_id_only(client):
     assert row.agent_id is None
     assert row.task_id is None
     assert row.line == "[worker] Pulled repo"
+
+
+def test_terminal_output_level_is_persisted_and_broadcast(client):
+    """A typed ``level`` round-trips: stored on the log row and rebroadcast."""
+    test_client, db_url = client
+    guild_id, worker_id, agent_id = "gto-2", "w-gto2", "a-gto2"
+    _insert_guild_worker(db_url, guild_id=guild_id, worker_id=worker_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws_worker:
+        _join_ws(ws_worker, agent_id, worker_id)
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws_obs:
+            _join_ws(ws_obs, "a-obs2")
+            ws_worker.receive_json()  # drain observer join broadcast
+
+            ws_worker.send_json(
+                {
+                    "type": "terminal-output",
+                    "workerId": worker_id,
+                    "line": "Online. Watching for tasks.",
+                    "level": "worker",
+                }
+            )
+
+            msg = ws_obs.receive_json()
+            assert msg["type"] == "terminal-output"
+            assert msg["level"] == "worker"
+
+            from helpers import _sync_session
+
+            with _sync_session(db_url) as session:
+                row = session.execute(
+                    select(col(TaskLog.line), col(TaskLog.level))
+                    .order_by(col(TaskLog.id).desc())
+                    .limit(1)
+                ).first()
+
+    assert row is not None
+    assert row.line == "Online. Watching for tasks."
+    assert row.level == "worker"

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -502,6 +502,7 @@ async def handle_terminal_output(ctx: WSContext, data: dict) -> None:
     line = data.get("line", "")
     task_id = data.get("taskId")
     detail = data.get("detail")
+    level = data.get("level")
     created_at = datetime.now(UTC)
     worker_id_for_log = msg_worker_id
     if worker_id_for_log is None and msg_agent_id:
@@ -518,6 +519,7 @@ async def handle_terminal_output(ctx: WSContext, data: dict) -> None:
                 worker_id=worker_id_for_log,
                 agent_id=msg_agent_id,
                 data=json.dumps(detail) if detail else None,
+                level=level,
             )
         )
         await ctx.db.commit()
@@ -531,6 +533,7 @@ async def handle_terminal_output(ctx: WSContext, data: dict) -> None:
             "line": line,
             "timestamp": created_at.isoformat(),
             **({"detail": detail} if detail else {}),
+            **({"level": level} if level else {}),
         },
     )
 

--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -12,8 +12,8 @@
         <span class="log-time">{{ formatTime(log.timestamp) }}</span>
         <span
           class="log-text"
-          :class="[lineClass(log.line), { 'log-text--markdown': isMarkdownLine(log.line) }]"
-          v-html="renderLine(log.line)"
+          :class="[lineClass(log), { 'log-text--markdown': isMarkdownLine(log) }]"
+          v-html="renderLine(log)"
         ></span>
         <span v-if="isExpandable(log)" class="log-expand-icon">{{ expandedIdx === i ? '▲' : '▼' }}</span>
       </div>
@@ -90,33 +90,48 @@ function linkify(text: string): string {
   )
 }
 
-function isMarkdownLine(line: string): boolean {
+function isMarkdownLine(log: LogEntry): boolean {
+  const line = log.line
   if (!line) return false
-  // Tool/metadata prefixes are plain text; everything else (including Claude's output) is markdown
-  if (line.startsWith('▶') || line.startsWith('✓') || line.startsWith('✗') || line.startsWith('  →'))
+  // Tool glyphs are intrinsic plain-text formatting from Claude's own output.
+  if (
+    line.startsWith('▶') ||
+    line.startsWith('✓') ||
+    line.startsWith('✗') ||
+    line.startsWith('  →')
+  )
     return false
+  // Typed lines: worker/auth status is plain; claude/thinking framing is markdown.
+  if (log.level === 'worker' || log.level === 'auth') return false
+  if (log.level === 'claude' || log.level === 'thinking') return true
+  // Legacy fallback for pre-typed persisted logs (bracketed prefixes).
   if (line.startsWith('[') && !line.startsWith('[thinking]') && !line.startsWith('[claude]'))
     return false
   return true
 }
 
-
-function renderLine(line: string): string {
-  if (isMarkdownLine(line)) return renderMarkdown(line)
-  return linkify(line)
+function renderLine(log: LogEntry): string {
+  if (isMarkdownLine(log)) return renderMarkdown(log.line)
+  return linkify(log.line)
 }
 
 function inputRecord(input: Record<string, unknown> | string | undefined): Record<string, unknown> {
   return typeof input === 'object' && input !== null ? input : {}
 }
 
-function lineClass(line: string) {
+function lineClass(log: LogEntry) {
+  const line = log.line
   if (!line) return ''
+  // Tool glyphs carry intrinsic success/error/tool semantics from Claude's
+  // own output formatting, so they win regardless of level.
   if (line.startsWith('✓') || line.includes('Done')) return 'log-success'
   if (line.startsWith('✗') || line.includes('error') || line.includes('Error')) return 'log-error'
   if (line.startsWith('▶')) return 'log-tool'
   if (line.startsWith('  →')) return 'log-result'
-  if (line.startsWith('[worker]')) return 'log-meta'
+  // Typed lines are styled by level instead of sniffing text prefixes.
+  if (log.level === 'thinking') return 'log-thinking'
+  if (log.level === 'worker' || log.level === 'auth' || log.level === 'claude') return 'log-meta'
+  // Legacy fallback for pre-typed persisted logs (bracketed prefixes).
   if (line.startsWith('[thinking]')) return 'log-thinking'
   if (line.startsWith('[')) return 'log-meta'
   return ''

--- a/frontend/src/stores/__tests__/agents.spec.ts
+++ b/frontend/src/stores/__tests__/agents.spec.ts
@@ -129,6 +129,20 @@ describe('useAgentsStore', () => {
       expect(store.agents).toHaveLength(0)
     })
 
+    it('threads the typed level through to the stored worker log entry', () => {
+      const store = useAgentsStore()
+
+      store.handleWebSocketMessage({
+        type: 'terminal-output',
+        workerId: 'w-x',
+        line: 'Online. Watching for tasks.',
+        level: 'worker',
+        timestamp: '2026-05-20T00:00:00.000Z',
+      })
+
+      expect(store.workerLogs['w-x'][0].level).toBe('worker')
+    })
+
     it('routes task output to both the agent log and the worker log', () => {
       const store = useAgentsStore()
       store.registerAgent({ agentId: 'a-1', workerId: 'w-x', state: 'working', taskId: 't-1' })

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -4,7 +4,16 @@ import { useGuildStore } from './guild'
 import { api } from '../utils/api'
 import { formatWorkerId } from '../utils/format'
 import { taskTabId } from './tasks'
-import type { Agent, AgentActivity, AgentState, LogDetail, LogEntry, Worker, WSInbound } from '../types'
+import type {
+  Agent,
+  AgentActivity,
+  AgentState,
+  LogDetail,
+  LogEntry,
+  LogLevel,
+  Worker,
+  WSInbound,
+} from '../types'
 
 const STATE_RANK: Record<string, number> = {
   working: 0,
@@ -121,20 +130,37 @@ export const useAgentsStore = defineStore('agents', () => {
     if (match) updateAgentState(match.id, 'idle', null, null)
   }
 
-  function addLog(agentId: string, line: string, timestamp?: string, detail?: LogDetail | null) {
+  function addLog(
+    agentId: string,
+    line: string,
+    timestamp?: string,
+    detail?: LogDetail | null,
+    level?: LogLevel | null,
+  ) {
     const agent = agents.value.find((a) => a.id === agentId)
     if (agent && line) {
       const ts = timestamp || new Date().toISOString()
-      agent.logs.push({ line, timestamp: ts, detail: detail || null })
+      agent.logs.push({ line, timestamp: ts, detail: detail || null, level: level || null })
       if (agent.logs.length > 500) agent.logs.shift()
     }
   }
 
-  function addWorkerLog(workerId: string, line: string, timestamp?: string, detail?: LogDetail | null) {
+  function addWorkerLog(
+    workerId: string,
+    line: string,
+    timestamp?: string,
+    detail?: LogDetail | null,
+    level?: LogLevel | null,
+  ) {
     if (!line) return
     if (!workerLogs.value[workerId]) workerLogs.value[workerId] = []
     const ts = timestamp || new Date().toISOString()
-    workerLogs.value[workerId].push({ line, timestamp: ts, detail: detail || null })
+    workerLogs.value[workerId].push({
+      line,
+      timestamp: ts,
+      detail: detail || null,
+      level: level || null,
+    })
     if (workerLogs.value[workerId].length > 500) workerLogs.value[workerId].shift()
   }
 
@@ -299,13 +325,13 @@ export const useAgentsStore = defineStore('agents', () => {
       resetAgentForTask(data)
     } else if (data.type === 'terminal-output') {
       // Route to per-agent log buffer (includes task logs for agent-tab view)
-      if (data.agentId) addLog(data.agentId, data.line, data.timestamp, data.detail)
+      if (data.agentId) addLog(data.agentId, data.line, data.timestamp, data.detail, data.level)
       // Route to per-worker log buffer; worker-wide lines may arrive with only
       // workerId, while agent/task lines include both workerId and agentId.
       const wid =
         data.workerId ||
         (data.agentId ? agents.value.find((a) => a.id === data.agentId)?.workerId : null)
-      if (wid) addWorkerLog(wid, data.line, data.timestamp, data.detail)
+      if (wid) addWorkerLog(wid, data.line, data.timestamp, data.detail, data.level)
     }
   }
 

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -87,13 +87,14 @@ export const useTasksStore = defineStore('tasks', () => {
 
   async function fetchTaskLogs(guildId: string, taskId: string) {
     try {
-      const raw = await api<Array<{ line: string; timestamp: string; detail?: unknown }>>(
-        `/guilds/${guildId}/tasks/${taskId}/logs`,
-      )
+      const raw = await api<
+        Array<{ line: string; timestamp: string; detail?: unknown; level?: unknown }>
+      >(`/guilds/${guildId}/tasks/${taskId}/logs`)
       const logs: LogEntry[] = raw.map((r) => ({
         line: r.line,
         timestamp: r.timestamp,
         detail: (r.detail as LogEntry['detail']) || null,
+        level: (r.level as LogEntry['level']) || null,
       }))
       taskLogs.value[taskId] = logs
       return logs
@@ -195,10 +196,15 @@ export const useTasksStore = defineStore('tasks', () => {
       const task = tasks.value.find((t) => t.id === data.taskId)
       if (task && !TERMINAL_STATES.has(task.state)) task.state = 'awaiting-review'
     } else if (data.type === 'terminal-output' && data.taskId) {
-      const { taskId, line, timestamp, detail } = data
+      const { taskId, line, timestamp, detail, level } = data
       if (line) {
         if (!taskLogs.value[taskId]) taskLogs.value[taskId] = []
-        taskLogs.value[taskId].push({ line, timestamp, detail: detail || null })
+        taskLogs.value[taskId].push({
+          line,
+          timestamp,
+          detail: detail || null,
+          level: level || null,
+        })
         if (taskLogs.value[taskId].length > 2000) taskLogs.value[taskId].shift()
       }
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -21,10 +21,21 @@ export interface LogDetail {
   [key: string]: unknown
 }
 
+// Semantic type of a terminal-output line, set by the producer (worker) so the
+// frontend can style logs without parsing text prefixes. Keep in sync with the
+// LEVEL_* constants in worker/pioneer_worker/worker.py.
+//   info     — default agent/Claude output (rendered as markdown)
+//   worker   — worker-level status / lifecycle line
+//   auth     — Claude login / credential flow
+//   claude   — Claude runner framing (start / exit / stderr)
+//   thinking — extended-thinking text
+export type LogLevel = 'info' | 'worker' | 'auth' | 'claude' | 'thinking'
+
 export interface LogEntry {
   line: string
   timestamp: string
   detail?: LogDetail | null
+  level?: LogLevel | null
 }
 
 export interface Agent {
@@ -195,6 +206,7 @@ export interface TerminalOutputWS {
   line: string
   timestamp?: string
   detail?: LogDetail | null
+  level?: LogLevel | null
 }
 
 export interface TaskCreatedWS {

--- a/worker/pioneer_worker/git_ops.py
+++ b/worker/pioneer_worker/git_ops.py
@@ -10,7 +10,10 @@ from collections.abc import Awaitable, Callable
 
 logger = logging.getLogger(__name__)
 
-EmitFn = Callable[[str], Awaitable[None]]
+# emit(line, detail=None, level=...) — accepts an optional ``level`` kwarg that
+# types the line for the frontend. Lines emitted here are worker-owned status.
+EmitFn = Callable[..., Awaitable[None]]
+_LEVEL = "worker"
 
 
 async def run_git(args: list[str], cwd: str | None = None) -> tuple[int, str, str]:
@@ -145,7 +148,7 @@ async def pull_repos(
         await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
         if rc == 0:
             logger.info("pull_repos: pulled %s", repo_full)
-            await emit(f"[worker] Pulled {repo_full}")
+            await emit(f"Pulled {repo_full}", level=_LEVEL)
         else:
             logger.warning("pull_repos: fetch warn for %s: %s", repo_full, err.strip()[:120])
-            await emit(f"[worker] Pull warn {repo_full}: {err.strip()[:60]}")
+            await emit(f"Pull warn {repo_full}: {err.strip()[:60]}", level=_LEVEL)

--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -12,9 +12,14 @@ from collections.abc import Awaitable, Callable
 
 from . import git_ops
 
-EmitFn = Callable[[str], Awaitable[None]]
+# emit(line, detail=None, level=...) — the worker's task/worker emit closures
+# accept an optional ``level`` kwarg that types the line for the frontend.
+EmitFn = Callable[..., Awaitable[None]]
 
 logger = logging.getLogger(__name__)
+
+# Lines emitted here are worker-owned status, not Claude output.
+_LEVEL = "worker"
 
 
 # GitHub webhook events the foreman cares about — kept narrow so a single
@@ -75,22 +80,22 @@ async def push_branch(
     # (can happen on max-turns, plan-phase completion, or normal task end).
     rc_status, status_out, _ = await git_ops.run_git(["status", "--porcelain"], cwd=worktree_path)
     if rc_status == 0 and status_out.strip():
-        await emit("[worker] Uncommitted changes detected — auto-committing before push")
+        await emit("Uncommitted changes detected — auto-committing before push", level=_LEVEL)
         await git_ops.run_git(["add", "-A"], cwd=worktree_path)
         rc_commit, _, commit_err = await git_ops.run_git(
             ["commit", "-m", "chore: save uncommitted work before push [auto-commit]"],
             cwd=worktree_path,
         )
         if rc_commit != 0:
-            await emit(f"[worker] ✗ Auto-commit failed: {commit_err.strip()[:120]}")
+            await emit(f"✗ Auto-commit failed: {commit_err.strip()[:120]}", level=_LEVEL)
             return False
 
-    await emit(f"[worker] Pushing {branch}...")
+    await emit(f"Pushing {branch}...", level=_LEVEL)
     rc, _, err = await git_ops.run_git(["push", "-u", "origin", branch], cwd=worktree_path)
     if rc != 0:
-        await emit(f"[worker] ✗ Push failed: {err.strip()[:120]}")
+        await emit(f"✗ Push failed: {err.strip()[:120]}", level=_LEVEL)
         return False
-    await emit(f"[worker] ✓ Pushed {branch}")
+    await emit(f"✓ Pushed {branch}", level=_LEVEL)
     return True
 
 
@@ -145,7 +150,7 @@ async def open_pr(
 ) -> str | None:
     """Create a GitHub PR for *branch*. Returns PR URL or None on failure."""
     if not token:
-        await emit("[worker] No GitHub token — skipping PR")
+        await emit("No GitHub token — skipping PR", level=_LEVEL)
         return None
 
     repo_full = task.get("issue_repo")
@@ -156,7 +161,7 @@ async def open_pr(
             if m:
                 repo_full = m.group(1)
     if not repo_full:
-        await emit("[worker] Could not determine repo — skipping PR")
+        await emit("Could not determine repo — skipping PR", level=_LEVEL)
         return None
 
     task_name = task.get("name") or task.get("description") or ""
@@ -193,25 +198,27 @@ async def open_pr(
     try:
         result = await asyncio.to_thread(_create_pr)
         pr_url = result.get("html_url", "")
-        await emit(f"[worker] ✓ PR: {pr_url}")
+        await emit(f"✓ PR: {pr_url}", level=_LEVEL)
         return pr_url
     except urllib.error.HTTPError as exc:
         if exc.fp is not None:
             exc.fp.close()
         if exc.code == 422:
-            await emit(f"[worker] PR creation returned 422 — checking for existing PR on {branch}")
+            await emit(
+                f"PR creation returned 422 — checking for existing PR on {branch}", level=_LEVEL
+            )
             existing = await find_existing_pr(
                 branch=branch, worktree_path=worktree_path, token=token
             )
             if existing:
-                await emit(f"[worker] ✓ Found existing PR: {existing}")
+                await emit(f"✓ Found existing PR: {existing}", level=_LEVEL)
                 return existing
-            await emit(f"[worker] PR failed: {exc}")
+            await emit(f"PR failed: {exc}", level=_LEVEL)
             return None
         logger.error("PR creation failed: %s", exc)
         raise
     except (urllib.error.URLError, OSError) as exc:
-        await emit(f"[worker] PR failed: {exc}")
+        await emit(f"PR failed: {exc}", level=_LEVEL)
         return None
 
 
@@ -271,17 +278,17 @@ async def ensure_webhook(
     or events list drift). Otherwise a new hook is created.
     """
     if not auth_token:
-        await emit("[worker] webhook setup skipped — no worker auth_token")
+        await emit("webhook setup skipped — no worker auth_token", level=_LEVEL)
         return False
     if not github_token:
-        await emit("[worker] webhook setup skipped — no GitHub token")
+        await emit("webhook setup skipped — no GitHub token", level=_LEVEL)
         return False
 
     secret = await _fetch_webhook_secret(
         http_url=http_url, guild_id=guild_id, auth_token=auth_token
     )
     if not secret:
-        await emit("[worker] webhook setup skipped — backend did not return a secret")
+        await emit("webhook setup skipped — backend did not return a secret", level=_LEVEL)
         return False
 
     def _list_hooks() -> list:
@@ -353,10 +360,10 @@ async def ensure_webhook(
     except urllib.error.HTTPError as exc:
         # 403 => token lacks admin:repo_hook (or admin access on the repo).
         # Treat as a non-fatal warning; the operator can configure manually.
-        await emit(f"[worker] webhook list failed ({exc.code}): {exc.reason}")
+        await emit(f"webhook list failed ({exc.code}): {exc.reason}", level=_LEVEL)
         return False
     except (urllib.error.URLError, OSError) as exc:
-        await emit(f"[worker] webhook list failed: {exc}")
+        await emit(f"webhook list failed: {exc}", level=_LEVEL)
         return False
 
     existing = next(
@@ -373,14 +380,14 @@ async def ensure_webhook(
             # Always re-PATCH: the secret may have been rotated, the events
             # list may have grown, or the hook may have been deactivated.
             await asyncio.to_thread(_patch_hook, int(existing["id"]))
-            await emit(f"[worker] ✓ Webhook refreshed on {repo}")
+            await emit(f"✓ Webhook refreshed on {repo}", level=_LEVEL)
         else:
             await asyncio.to_thread(_create_hook)
-            await emit(f"[worker] ✓ Webhook installed on {repo} → {target_url}")
+            await emit(f"✓ Webhook installed on {repo} → {target_url}", level=_LEVEL)
         return True
     except urllib.error.HTTPError as exc:
-        await emit(f"[worker] webhook setup failed ({exc.code}): {exc.reason}")
+        await emit(f"webhook setup failed ({exc.code}): {exc.reason}", level=_LEVEL)
         return False
     except (urllib.error.URLError, OSError) as exc:
-        await emit(f"[worker] webhook setup failed: {exc}")
+        await emit(f"webhook setup failed: {exc}", level=_LEVEL)
         return False

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -37,6 +37,16 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+# Semantic line "levels" carried on terminal-output frames so the frontend can
+# style log lines by type instead of sniffing text prefixes like "[worker]".
+# Keep these in sync with the LogLevel union in frontend/src/types.ts.
+LEVEL_INFO = "info"  # default — agent/Claude output, rendered as markdown
+LEVEL_WORKER = "worker"  # worker-level status / lifecycle line
+LEVEL_AUTH = "auth"  # Claude login / credential flow
+LEVEL_CLAUDE = "claude"  # Claude runner framing (start / exit / stderr)
+LEVEL_THINKING = "thinking"  # extended-thinking text
+
+
 def _slug(text: str, max_len: int = 60) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text[:max_len].lower()).strip("-")
 
@@ -417,7 +427,7 @@ class Worker:
         except Exception as exc:
             logger.warning("Could not fetch Claude credentials from backend: %s", exc)
 
-        await self._emit("[auth] No Claude credentials found — starting login...")
+        await self._emit("No Claude credentials found — starting login...", level=LEVEL_AUTH)
         await self._run_claude_login()
 
     async def _run_claude_login(self) -> None:
@@ -514,7 +524,7 @@ class Worker:
                     line = line.rstrip()
                     if line:
                         logger.info("[claude setup-token] %s", line)
-                        await self._emit(f"[auth] {line}")
+                        await self._emit(line, level=LEVEL_AUTH)
 
                 # Detect the OAuth URL once it's been emitted. Ink word-wraps
                 # the URL across multiple lines (often after each ~80 chars),
@@ -537,7 +547,8 @@ class Worker:
                             }
                         )
                         await self._emit(
-                            "[auth] Waiting for auth code — paste it into the auth panel in the UI..."
+                            "Waiting for auth code — paste it into the auth panel in the UI...",
+                            level=LEVEL_AUTH,
                         )
                         logger.info("Auth login: awaiting code from queue (timeout=300s)")
                         try:
@@ -547,7 +558,8 @@ class Worker:
                         except TimeoutError:
                             logger.warning("Auth login: timed out waiting for code from queue")
                             await self._emit(
-                                "[auth] Timed out waiting for auth code — restart the worker to retry"
+                                "Timed out waiting for auth code — restart the worker to retry",
+                                level=LEVEL_AUTH,
                             )
                             proc.kill()
                             await proc.wait()
@@ -557,7 +569,9 @@ class Worker:
                             len(code),
                             proc.returncode is None,
                         )
-                        await self._emit("[auth] Code received — submitting to Claude CLI...")
+                        await self._emit(
+                            "Code received — submitting to Claude CLI...", level=LEVEL_AUTH
+                        )
                         try:
                             os.write(master_fd, code.strip().encode())
                             # Ink batches consecutive bytes into one paste
@@ -569,7 +583,9 @@ class Worker:
                             os.write(master_fd, b"\r")
                         except OSError as exc:
                             logger.warning("Auth login: PTY write failed: %s", exc)
-                            await self._emit(f"[auth] Failed to send code to Claude: {exc}")
+                            await self._emit(
+                                f"Failed to send code to Claude: {exc}", level=LEVEL_AUTH
+                            )
                             proc.kill()
                             await proc.wait()
                             return
@@ -599,14 +615,18 @@ class Worker:
         token = self._extract_oauth_token(cleaned_full)
         if not token:
             await self._emit(
-                "[auth] Login finished but could not extract OAuth token from output — please retry"
+                "Login finished but could not extract OAuth token from output — please retry",
+                level=LEVEL_AUTH,
             )
             logger.warning("Could not locate OAuth token in setup-token output")
             return
 
         os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = token
         logger.info("Captured CLAUDE_CODE_OAUTH_TOKEN (len=%d) and set in env", len(token))
-        await self._emit("[auth] Token captured — saving to backend so future workers can reuse it")
+        await self._emit(
+            "Token captured — saving to backend so future workers can reuse it",
+            level=LEVEL_AUTH,
+        )
 
         try:
             blob = base64.b64encode(json.dumps({"oauth_token": token}).encode()).decode()
@@ -615,11 +635,11 @@ class Worker:
                     "/auth/claude/credentials",
                     json={"guild_id": self.cfg.guild_id, "credentials_blob": blob},
                 )
-            await self._emit("[auth] Credentials saved")
+            await self._emit("Credentials saved", level=LEVEL_AUTH)
             logger.info("Posted OAuth token to backend credentials store")
         except Exception as exc:
             logger.warning("Could not store Claude credentials: %s", exc)
-            await self._emit(f"[auth] Warning: could not store credentials: {exc}")
+            await self._emit(f"Warning: could not store credentials: {exc}", level=LEVEL_AUTH)
 
     @staticmethod
     def _extract_oauth_token(cleaned_output: str) -> str | None:
@@ -694,14 +714,21 @@ class Worker:
     async def _send(self, payload: dict) -> None:
         await self.ws.send(payload)
 
-    async def _emit(self, line: str, detail: dict | None = None) -> None:
-        """Emit a worker-level log line."""
+    async def _emit(self, line: str, detail: dict | None = None, level: str = LEVEL_WORKER) -> None:
+        """Emit a worker-level log line.
+
+        ``level`` classifies the line semantically (see the ``LEVEL_*``
+        constants) so the frontend can style it without parsing text prefixes.
+        Worker-level lines default to ``LEVEL_WORKER``.
+        """
         msg: dict = {
             "type": "terminal-output",
             "workerId": self.cfg.worker_id,
             "line": line,
             "timestamp": _now_iso(),
         }
+        if level and level != LEVEL_INFO:
+            msg["level"] = level
         if detail:
             msg["detail"] = detail
         await self._send(msg)
@@ -709,7 +736,9 @@ class Worker:
     def _task_emit(self, task_id: str, slot: Agent):
         """Return an emit function scoped to a task and agent slot."""
 
-        async def _emit_task(line: str, detail: dict | None = None) -> None:
+        async def _emit_task(
+            line: str, detail: dict | None = None, level: str = LEVEL_INFO
+        ) -> None:
             msg: dict = {
                 "type": "terminal-output",
                 "workerId": self.cfg.worker_id,
@@ -718,6 +747,8 @@ class Worker:
                 "line": line,
                 "timestamp": _now_iso(),
             }
+            if level and level != LEVEL_INFO:
+                msg["level"] = level
             if detail:
                 msg["detail"] = detail
             await self._send(msg)
@@ -860,7 +891,7 @@ class Worker:
         logger.info("Graceful shutdown initiated: %s", reason)
         try:
             await self._emit(
-                f"[worker] Shutdown requested ({reason}). Idle agents stopping; "
+                f"Shutdown requested ({reason}). Idle agents stopping; "
                 "busy agents will finish their current task."
             )
         except Exception as exc:
@@ -1005,7 +1036,7 @@ class Worker:
                 )
             )
 
-        await self._emit("[worker] Online. Watching for tasks.")
+        await self._emit("Online. Watching for tasks.")
         for slot in self.agents:
             await self._set_state("idle", slot)
 
@@ -1131,13 +1162,13 @@ class Worker:
                             "Auth code received via worker-message (login flow) len=%d",
                             len(text),
                         )
-                        await self._emit("[worker] Auth code received and forwarded to login flow")
+                        await self._emit("Auth code received and forwarded to login flow")
                     else:
                         active = next((s for s in self.agents if s.current_claude), None)
                         if active:
                             delivered = await active.current_claude.send_message(text)
                             if delivered:
-                                await self._emit(f"[worker] Injected: {text[:80]}")
+                                await self._emit(f"Injected: {text[:80]}")
                             else:
                                 logger.warning("Failed to inject message (stdin closed?)")
                         else:
@@ -1554,7 +1585,7 @@ class Worker:
                 await self._execute_task(task, slot)
             except Exception as exc:
                 logger.exception("Task %s crashed: %s", task_id, exc)
-                await self._emit(f"[worker] ✗ Internal error on task {task_id}: {exc}")
+                await self._emit(f"✗ Internal error on task {task_id}: {exc}")
                 await self._task_update(
                     task["id"], agent=slot, state="failed", finishedAt=_now_iso()
                 )
@@ -1612,22 +1643,32 @@ class Worker:
 
         emit = self._task_emit(task_id, agent)
         if is_followup:
-            await emit(f"[worker] Follow-up: {followup_instructions[:120]}")
-            await emit(f"[worker] Branch: {branch}")
+            await emit(f"Follow-up: {followup_instructions[:120]}", level=LEVEL_WORKER)
+            await emit(f"Branch: {branch}", level=LEVEL_WORKER)
         else:
-            await emit(f"[worker] Task: {desc}")
-            await emit(f"[worker] Branch: {branch}")
+            await emit(f"Task: {desc}", level=LEVEL_WORKER)
+            await emit(f"Branch: {branch}", level=LEVEL_WORKER)
 
         worktree_entries: list[tuple[str, str, str]] = []
         primary_wt: str | None = None
 
         for repo_full in repos:
             logger.info("Task %s: preparing repo %s", task_id, repo_full)
-            await emit(f"[worker] Preparing {repo_full}...")
+            await emit(f"Preparing {repo_full}...", level=LEVEL_WORKER)
+            # Surface the first-time clone (a slow op) so the UI isn't silent
+            # while git fetches the repo; subsequent runs just fast-forward.
+            repo_parts = repo_full.split("/", 1)
+            already_cloned = len(repo_parts) == 2 and os.path.isdir(
+                os.path.join(self.cfg.repos_dir, repo_parts[0], repo_parts[1], ".git")
+            )
+            if not already_cloned:
+                await emit(
+                    f"Cloning {repo_full} (first run, may take a moment)…", level=LEVEL_WORKER
+                )
             repo_path = await git_ops.ensure_repo(self.cfg.repos_dir, repo_full, token)
             if not repo_path:
                 logger.error("Task %s: clone/fetch failed for %s", task_id, repo_full)
-                await emit(f"[worker] ✗ Clone failed: {repo_full}")
+                await emit(f"✗ Clone failed: {repo_full}", level=LEVEL_WORKER)
                 continue
             repo_name = repo_full.split("/")[-1]
             wt_path = os.path.join(work_dir, repo_name)
@@ -1640,7 +1681,7 @@ class Worker:
                 # the latest origin state for the branch so a different worker
                 # that pushed changes is reflected here.
                 logger.info("Task %s: reusing worktree at %s", task_id, wt_path)
-                await emit(f"[worker] Reusing worktree {repo_name}")
+                await emit(f"Reusing worktree {repo_name}", level=LEVEL_WORKER)
                 if is_followup:
                     await git_ops.run_git(["fetch", "origin", branch], cwd=wt_path)
                 worktree_entries.append((repo_full, repo_path, wt_path))
@@ -1661,7 +1702,8 @@ class Worker:
                         branch,
                     )
                     await emit(
-                        f"[worker] Branch not found on origin; creating fresh branch {branch[:50]}"
+                        f"Branch not found on origin; creating fresh branch {branch[:50]}",
+                        level=LEVEL_WORKER,
                     )
                     ok = await git_ops.create_worktree(repo_path, wt_path, branch)
             else:
@@ -1669,16 +1711,17 @@ class Worker:
                 ok = await git_ops.create_worktree(repo_path, wt_path, branch)
             if ok:
                 logger.info("Task %s: worktree ready at %s", task_id, wt_path)
+                await emit(f"Worktree ready: {repo_name}", level=LEVEL_WORKER)
                 worktree_entries.append((repo_full, repo_path, wt_path))
                 if primary_wt is None:
                     primary_wt = wt_path
             else:
                 logger.error("Task %s: worktree failed for %s", task_id, repo_full)
-                await emit(f"[worker] ✗ Worktree failed: {repo_full}")
+                await emit(f"✗ Worktree failed: {repo_full}", level=LEVEL_WORKER)
 
         if not primary_wt:
             logger.error("Task %s: no worktrees created — aborting", task_id)
-            await emit("[worker] ✗ No worktrees — aborting.")
+            await emit("✗ No worktrees — aborting.", level=LEVEL_WORKER)
             await self._task_update(task_id, agent=agent, state="failed", finishedAt=_now_iso())
             await self._set_state("error", agent)
             return
@@ -1818,7 +1861,7 @@ class Worker:
                 )
 
                 if task_id in self._cancelled_tasks:
-                    await emit("[worker] Task cancelled.")
+                    await emit("Task cancelled.", level=LEVEL_WORKER)
                     await self._task_update(
                         task_id, agent=agent, state="cancelled", finishedAt=_now_iso()
                     )
@@ -1832,7 +1875,7 @@ class Worker:
                     redirect_instr = None
 
                 if redirect_instr is _CANCEL_SENTINEL:
-                    await emit("[worker] Task cancelled.")
+                    await emit("Task cancelled.", level=LEVEL_WORKER)
                     await self._task_update(
                         task_id, agent=agent, state="cancelled", finishedAt=_now_iso()
                     )
@@ -1841,7 +1884,7 @@ class Worker:
                     return
 
                 if redirect_instr is not None and not self._shutdown_event.is_set():
-                    await emit(f"[worker] ↩ Redirected: {redirect_instr[:120]}")
+                    await emit(f"↩ Redirected: {redirect_instr[:120]}", level=LEVEL_WORKER)
                     current_desc = redirect_instr
                     await self._task_update(task_id, agent=agent, state="working")
                     continue
@@ -1863,7 +1906,7 @@ class Worker:
                 emit=emit,
             )
             if push_ok:
-                await emit(f"[worker] Branch pushed: {branch}")
+                await emit(f"Branch pushed: {branch}", level=LEVEL_WORKER)
 
             pr_url = await github_pr.find_existing_pr(
                 branch=branch,
@@ -1871,7 +1914,7 @@ class Worker:
                 token=token,
             )
             if pr_url:
-                await emit(f"[worker] ✓ Claude-authored PR: {pr_url}")
+                await emit(f"✓ Claude-authored PR: {pr_url}", level=LEVEL_WORKER)
                 await self._ensure_pr_webhook(pr_url, emit)
 
             logger.info("Task %s: pr_url=%s", task_id, pr_url)

--- a/worker/tests/test_org_clone.py
+++ b/worker/tests/test_org_clone.py
@@ -306,7 +306,7 @@ async def test_pull_repos_skips_uncloned_repo(tmp_path):
     repos_dir = tmp_path / "repos"
     emitted: list[str] = []
 
-    async def fake_emit(msg: str) -> None:
+    async def fake_emit(msg: str, detail=None, level=None) -> None:
         emitted.append(msg)
 
     cloned: list[str] = []
@@ -331,7 +331,7 @@ async def test_pull_repos_updates_already_cloned_repo(tmp_path):
 
     emitted: list[str] = []
 
-    async def fake_emit(msg: str) -> None:
+    async def fake_emit(msg: str, detail=None, level=None) -> None:
         emitted.append(msg)
 
     git_calls: list[list[str]] = []
@@ -356,7 +356,7 @@ async def test_pull_repos_skips_uncloned_but_pulls_cloned(tmp_path):
 
     emitted: list[str] = []
 
-    async def fake_emit(msg: str) -> None:
+    async def fake_emit(msg: str, detail=None, level=None) -> None:
         emitted.append(msg)
 
     ensure_calls: list[str] = []


### PR DESCRIPTION
Replace text-prefix sniffing (e.g. "[worker]") with a first-class `level`
field on the terminal-output protocol so the frontend styles log lines by
type instead of parsing their text.

Protocol/backend:
- New nullable `level` column on task_logs (Alembic migration) + model field
- handle_terminal_output persists and rebroadcasts `level`
- Task/guild log REST endpoints return `level`

Worker:
- _emit/_task_emit accept a `level` kwarg (worker/auth/claude/thinking/info)
- Drop the literal "[worker]"/"[auth]" text prefixes; set level instead
- github_pr.py / git_ops.py emit worker-owned lines with level="worker"
- Surface first-run clone and worktree-ready milestones (were log-only)

Frontend:
- LogLevel type; thread `level` through stores and LogEntry
- LogList styles by level, falling back to the legacy prefix heuristics for
  pre-typed persisted logs and Claude's intrinsic ✓/✗/▶ glyph formatting

Tests: backend level round-trip, frontend level threading; updated emit
mocks to accept the new kwarg.