### PR TITLE
Add Pgweb as a docker-compose target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,12 +110,16 @@ services:
     restart: unless-stopped
 
   pgweb:
-    image: sosedoff/pgweb
+    image: sosedoff/pgweb:0.15.0
     profiles: [ "tools" ]
     ports:
       - "8081:8081"
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-pioneer}:${POSTGRES_PASSWORD:-pioneer_password}@postgres:5432/${POSTGRES_DB:-pioneer_square}?sslmode=disable
+      PGHOST: postgres
+      PGUSER: ${POSTGRES_USER:-pioneer}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-pioneer_password}
+      PGDATABASE: ${POSTGRES_DB:-pioneer_square}
+      PGSSLMODE: disable
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,18 @@ services:
       - backend
     restart: unless-stopped
 
+  pgweb:
+    image: sosedoff/pgweb
+    profiles: [ "tools" ]
+    ports:
+      - "8081:8081"
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-pioneer}:${POSTGRES_PASSWORD:-pioneer_password}@postgres:5432/${POSTGRES_DB:-pioneer_square}?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
   postgres-test:
     image: postgres:17
     profiles: [ "test" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,12 +113,15 @@ services:
     image: sosedoff/pgweb:0.15.0
     profiles: [ "tools" ]
     ports:
-      - "8081:8081"
+      - "${PGWEB_PORT:-8081}:8081"
     environment:
       PGHOST: postgres
       PGUSER: ${POSTGRES_USER:-pioneer}
+      # dev-only: PGPASSWORD is intentionally passed as a plain env var for local development convenience.
+      # Do not use this service configuration in shared/staging/production environments.
       PGPASSWORD: ${POSTGRES_PASSWORD:-pioneer_password}
       PGDATABASE: ${POSTGRES_DB:-pioneer_square}
+      PGPORT: "5432"
       PGSSLMODE: disable
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

- Adds `sosedoff/pgweb` as a `pgweb` service in `docker-compose.yml`
- Uses the project's existing Postgres credentials via the same env vars (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`)
- Exposes the UI on host port 8081
- Placed behind the `tools` profile (consistent with how other optional services like `foreman`, `worker`, and `postgres-test` are handled) — not auto-started with a plain `docker compose up`

**Usage:**
```bash
docker compose --profile tools up pgweb
```
Then open http://localhost:8081

Closes #516