### PR TITLE
Strongly type _listen WS messages with WSMessage union

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "marked": "^18.0.4",
         "pinia": "^3.0.4",
         "vue": "^3.5.35",
-        "vue-router": "^5.1.0"
+        "vue-router": "^5.1.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4870,6 +4871,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "marked": "^18.0.4",
     "pinia": "^3.0.4",
     "vue": "^3.5.35",
-    "vue-router": "^5.1.0"
+    "vue-router": "^5.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/components/ChatPane.vue
+++ b/frontend/src/components/ChatPane.vue
@@ -85,46 +85,54 @@ function onSubmitAuth({ workerId, code }: { workerId: string; code: string }) {
 }
 
 function handleTaskEvent(data: WSInbound) {
-  if (data.type === 'task-complete') {
-    guildStore.messages.push({
-      type: 'chat',
-      from: 'system',
-      to: 'user',
-      content: data.prUrl
-        ? `✓ ${agentsStore.workerDisplayName(data.workerId)} done — PR: ${data.prUrl}`
-        : `✓ ${agentsStore.workerDisplayName(data.workerId)} finished (no PR)`,
-      prUrl: data.prUrl || null,
-      createdAt: new Date().toISOString(),
-    })
-  } else if (data.type === 'needs-input') {
-    guildStore.messages.push({
-      type: 'chat',
-      from: 'system',
-      to: 'user',
-      content: `⚠ ${agentsStore.workerDisplayName(data.workerId)} needs attention on: "${data.description}"`,
-      createdAt: new Date().toISOString(),
-    })
-  } else if (data.type === 'claude-auth-required') {
-    claudeAuthPending.value = { workerId: data.workerId, url: data.url }
-    guildStore.messages.push({
-      type: 'chat',
-      from: 'system',
-      to: 'user',
-      content: `⚿ ${agentsStore.workerDisplayName(data.workerId)} needs Claude auth — visit the URL and paste the code below`,
-      createdAt: new Date().toISOString(),
-    })
-  } else if (data.type === 'task-assigned') {
-    const taskName = (data.name || data.description || '').slice(0, 60)
-    guildStore.messages.push({
-      type: 'chat',
-      from: 'system',
-      to: 'user',
-      content: `→ ${agentsStore.workerDisplayName(data.workerId)} assigned: ${taskName}`,
-      createdAt: new Date().toISOString(),
-    })
-  } else if (data.type === 'foreman-poll-status') {
-    const secs = typeof data.nextCheckIn === 'number' ? data.nextCheckIn : null
-    nextPollAt.value = secs !== null ? Date.now() + secs * 1000 : null
+  switch (data.type) {
+    case 'task-complete':
+      guildStore.messages.push({
+        type: 'chat',
+        from: 'system',
+        to: 'user',
+        content: data.prUrl
+          ? `✓ ${agentsStore.workerDisplayName(data.workerId ?? '')} done — PR: ${data.prUrl}`
+          : `✓ ${agentsStore.workerDisplayName(data.workerId ?? '')} finished (no PR)`,
+        prUrl: data.prUrl || null,
+        createdAt: new Date().toISOString(),
+      })
+      break
+    case 'needs-input':
+      guildStore.messages.push({
+        type: 'chat',
+        from: 'system',
+        to: 'user',
+        content: `⚠ ${agentsStore.workerDisplayName(data.workerId)} needs attention on: "${data.description}"`,
+        createdAt: new Date().toISOString(),
+      })
+      break
+    case 'claude-auth-required':
+      claudeAuthPending.value = { workerId: data.workerId, url: data.url }
+      guildStore.messages.push({
+        type: 'chat',
+        from: 'system',
+        to: 'user',
+        content: `⚿ ${agentsStore.workerDisplayName(data.workerId)} needs Claude auth — visit the URL and paste the code below`,
+        createdAt: new Date().toISOString(),
+      })
+      break
+    case 'task-assigned':
+      guildStore.messages.push({
+        type: 'chat',
+        from: 'system',
+        to: 'user',
+        content: `→ ${agentsStore.workerDisplayName(data.workerId)} assigned: ${(data.name || data.description || '').slice(0, 60)}`,
+        createdAt: new Date().toISOString(),
+      })
+      break
+    case 'foreman-poll-status': {
+      const secs = typeof data.nextCheckIn === 'number' ? data.nextCheckIn : null
+      nextPollAt.value = secs !== null ? Date.now() + secs * 1000 : null
+      break
+    }
+    default:
+      break
   }
 }
 

--- a/frontend/src/components/log-pane/WorkerActions.vue
+++ b/frontend/src/components/log-pane/WorkerActions.vue
@@ -100,13 +100,16 @@ async function fetchPendingAuth() {
 }
 
 function handleAuthEvent(data: WSInbound) {
-  if (data.type === 'claude-auth-required' && data.workerId === props.workerId) {
-    pendingAuthUrl.value = data.url
-  } else if (
-    (data.type === 'claude-auth-success' || data.type === 'claude-auth-cleared') &&
-    data.workerId === props.workerId
-  ) {
-    pendingAuthUrl.value = null
+  switch (data.type) {
+    case 'claude-auth-required':
+      if (data.workerId === props.workerId) pendingAuthUrl.value = data.url
+      break
+    case 'claude-auth-success':
+    case 'claude-auth-cleared':
+      if (data.workerId === props.workerId) pendingAuthUrl.value = null
+      break
+    default:
+      break
   }
 }
 

--- a/frontend/src/stores/__tests__/guild.spec.ts
+++ b/frontend/src/stores/__tests__/guild.spec.ts
@@ -146,8 +146,10 @@ describe('useGuildStore', () => {
       const store = useGuildStore()
       store.connectWebSocket('g-1', onMessage)
       const ws = FakeWebSocket.instances[0]
-      ws.simulateMessage({ type: 'agent-state', state: 'idle' })
-      expect(onMessage).toHaveBeenCalledWith({ type: 'agent-state', state: 'idle' })
+      ws.simulateMessage({ type: 'agent-state', agentId: 'a-1', state: 'idle' })
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'agent-state', agentId: 'a-1', state: 'idle' }),
+      )
     })
 
     it('fans out messages to all registered handlers', () => {
@@ -174,7 +176,7 @@ describe('useGuildStore', () => {
       store.addMessageHandler(good)
 
       store.connectWebSocket('g-1')
-      FakeWebSocket.instances[0].simulateMessage({ type: 'task-update' })
+      FakeWebSocket.instances[0].simulateMessage({ type: 'task-update', taskId: 't-x' })
 
       expect(bad).toHaveBeenCalled()
       expect(good).toHaveBeenCalled()
@@ -187,7 +189,7 @@ describe('useGuildStore', () => {
       store.removeMessageHandler(h)
 
       store.connectWebSocket('g-1')
-      FakeWebSocket.instances[0].simulateMessage({ type: 'task-update' })
+      FakeWebSocket.instances[0].simulateMessage({ type: 'task-update', taskId: 't-x' })
 
       expect(h).not.toHaveBeenCalled()
     })

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -306,32 +306,36 @@ export const useAgentsStore = defineStore('agents', () => {
   }
 
   function handleWebSocketMessage(data: WSInbound) {
-    if (data.type === 'agent-joined') {
-      registerAgent(data)
-    } else if (data.type === 'agent-state') {
-      updateAgentState(
-        data.agentId,
-        data.state,
-        data.activity ?? undefined,
-        data.taskId ?? undefined,
-      )
-    } else if (data.type === 'task-complete') {
-      // The worker returns to its idle pool immediately after sending task-complete.
-      // Reset the agent proactively so the sidebar doesn't lag behind waiting for
-      // the separate agent-state:idle frame (which may be delayed for short tasks).
-      resetAgentForTask(data)
-    } else if (data.type === 'task-followup-done') {
-      // Same as task-complete: worker returns to idle after sending this.
-      resetAgentForTask(data)
-    } else if (data.type === 'terminal-output') {
-      // Route to per-agent log buffer (includes task logs for agent-tab view)
-      if (data.agentId) addLog(data.agentId, data.line, data.timestamp, data.detail, data.level)
-      // Route to per-worker log buffer; worker-wide lines may arrive with only
-      // workerId, while agent/task lines include both workerId and agentId.
-      const wid =
-        data.workerId ||
-        (data.agentId ? agents.value.find((a) => a.id === data.agentId)?.workerId : null)
-      if (wid) addWorkerLog(wid, data.line, data.timestamp, data.detail, data.level)
+    switch (data.type) {
+      case 'agent-joined':
+        registerAgent(data)
+        break
+      case 'agent-state':
+        updateAgentState(data.agentId, data.state, data.activity ?? undefined, data.taskId ?? undefined)
+        break
+      case 'task-complete':
+        // The worker returns to its idle pool immediately after sending task-complete.
+        // Reset the agent proactively so the sidebar doesn't lag behind waiting for
+        // the separate agent-state:idle frame (which may be delayed for short tasks).
+        resetAgentForTask(data)
+        break
+      case 'task-followup-done':
+        // Same as task-complete: worker returns to idle after sending this.
+        resetAgentForTask(data)
+        break
+      case 'terminal-output': {
+        // Route to per-agent log buffer (includes task logs for agent-tab view)
+        if (data.agentId) addLog(data.agentId, data.line, data.timestamp, data.detail, data.level)
+        // Route to per-worker log buffer; worker-wide lines may arrive with only
+        // workerId, while agent/task lines include both workerId and agentId.
+        const wid =
+          data.workerId ||
+          (data.agentId ? agents.value.find((a) => a.id === data.agentId)?.workerId : null)
+        if (wid) addWorkerLog(wid, data.line, data.timestamp, data.detail, data.level)
+        break
+      }
+      default:
+        break
     }
   }
 

--- a/frontend/src/stores/guild.ts
+++ b/frontend/src/stores/guild.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useAuthStore } from './auth'
 import { api } from '../utils/api'
 import type { ChatMessage, Guild, WSInbound, WSOutbound } from '../types'
+import { assertNever, parseWsMessage } from '../ws-schemas'
 
 type MessageHandler = (data: WSInbound) => void
 
@@ -108,28 +109,41 @@ export const useGuildStore = defineStore('guild', () => {
       reconnectAttempt.value = 0
     }
     socket.onmessage = (event) => {
-      let data: WSInbound
+      const data = parseWsMessage(event.data as string)
+      if (data === null) return
       try {
-        data = JSON.parse(event.data) as WSInbound
-      } catch (e) {
-        console.warn('Dropping non-JSON WS frame', e)
-        return
-      }
-      try {
-        if (data.type === 'chat') {
-          const chatMsg = data as ChatMessage
-          if ((chatMsg.from || chatMsg.from_agent) !== 'github') {
-            messages.value.push(chatMsg)
+        switch (data.type) {
+          case 'chat':
+            if ((data.from || data.from_agent) !== 'github')
+              messages.value.push(data as ChatMessage)
+            break
+          case 'guild-updated': {
+            if (currentGuild.value?.id === data.id)
+              currentGuild.value = { ...currentGuild.value, name: data.name }
+            const idx = guilds.value.findIndex((g) => g.id === data.id)
+            if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], name: data.name }
+            break
           }
+          // All remaining types are handled by registered message handlers below.
+          case 'agent-joined':
+          case 'agent-state':
+          case 'task-created':
+          case 'task-assigned':
+          case 'task-update':
+          case 'task-complete':
+          case 'task-followup-done':
+          case 'terminal-output':
+          case 'needs-input':
+          case 'claude-auth-required':
+          case 'claude-auth-success':
+          case 'claude-auth-cleared':
+          case 'foreman-poll-status':
+          case 'claude-usage':
+            break
+          default:
+            assertNever(data)
         }
-        if (data.type === 'guild-updated') {
-          if (currentGuild.value && currentGuild.value.id === data.id) {
-            currentGuild.value = { ...currentGuild.value, name: data.name }
-          }
-          const idx = guilds.value.findIndex((g) => g.id === data.id)
-          if (idx !== -1) guilds.value[idx] = { ...guilds.value[idx], name: data.name }
-        }
-        if (onMessage) onMessage(data)
+        onMessage?.(data)
         messageHandlers.value.forEach((h) => {
           try {
             h(data)

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -151,62 +151,76 @@ export const useTasksStore = defineStore('tasks', () => {
   }
 
   function handleWebSocketMessage(data: WSInbound) {
-    if (data.type === 'task-created') {
-      _upsertTask({
-        id: data.taskId,
-        name: data.name,
-        description: data.description,
-        phase: data.phase,
-        state: data.state,
-        worker_id: null,
-        created_at: data.createdAt,
-      })
-    } else if (data.type === 'task-assigned') {
-      const existing = tasks.value.find((t) => t.id === data.taskId)
-      _upsertTask({
-        id: data.taskId,
-        name: data.name || (data.description || '').slice(0, 60),
-        description: data.description,
-        phase: data.phase || 'execute',
-        state: 'pending',
-        worker_id: data.workerId,
-        parent_task_id: data.parentTaskId || null,
-        ...(existing ? {} : { created_at: new Date().toISOString() }),
-      })
-    } else if (data.type === 'task-update') {
-      const task = tasks.value.find((t) => t.id === data.taskId)
-      if (task) {
-        if (data.state) task.state = data.state
-        if (data.branch) task.branch = data.branch
-        if (data.prUrl) task.pr_url = data.prUrl
-        if (data.finishedAt) task.finished_at = data.finishedAt
-        if (data.worktreePath) task.worktree_path = data.worktreePath
-        if (data.deletedAt !== undefined) {
-          task.deleted_at = data.deletedAt
-          _scheduleExpiry(task.id, data.deletedAt)
-        }
-      }
-    } else if (data.type === 'task-complete') {
-      const task = tasks.value.find((t) => t.id === data.taskId)
-      if (task && !TERMINAL_STATES.has(task.state)) {
-        task.state = 'awaiting-review'
-        if (data.branch) task.branch = data.branch
-      }
-    } else if (data.type === 'task-followup-done') {
-      const task = tasks.value.find((t) => t.id === data.taskId)
-      if (task && !TERMINAL_STATES.has(task.state)) task.state = 'awaiting-review'
-    } else if (data.type === 'terminal-output' && data.taskId) {
-      const { taskId, line, timestamp, detail, level } = data
-      if (line) {
-        if (!taskLogs.value[taskId]) taskLogs.value[taskId] = []
-        taskLogs.value[taskId].push({
-          line,
-          timestamp,
-          detail: detail || null,
-          level: level || null,
+    switch (data.type) {
+      case 'task-created':
+        _upsertTask({
+          id: data.taskId,
+          name: data.name,
+          description: data.description,
+          phase: data.phase,
+          state: data.state,
+          worker_id: null,
+          created_at: data.createdAt,
         })
-        if (taskLogs.value[taskId].length > 2000) taskLogs.value[taskId].shift()
+        break
+      case 'task-assigned': {
+        const existing = tasks.value.find((t) => t.id === data.taskId)
+        _upsertTask({
+          id: data.taskId,
+          name: data.name || (data.description || '').slice(0, 60),
+          description: data.description,
+          phase: data.phase || 'execute',
+          state: 'pending',
+          worker_id: data.workerId,
+          parent_task_id: data.parentTaskId || null,
+          ...(existing ? {} : { created_at: new Date().toISOString() }),
+        })
+        break
       }
+      case 'task-update': {
+        const task = tasks.value.find((t) => t.id === data.taskId)
+        if (task) {
+          if (data.state) task.state = data.state
+          if (data.branch) task.branch = data.branch
+          if (data.prUrl) task.pr_url = data.prUrl
+          if (data.finishedAt) task.finished_at = data.finishedAt
+          if (data.worktreePath) task.worktree_path = data.worktreePath
+          if (data.deletedAt !== undefined) {
+            task.deleted_at = data.deletedAt
+            _scheduleExpiry(task.id, data.deletedAt)
+          }
+        }
+        break
+      }
+      case 'task-complete': {
+        const task = tasks.value.find((t) => t.id === data.taskId)
+        if (task && !TERMINAL_STATES.has(task.state)) {
+          task.state = 'awaiting-review'
+          if (data.branch) task.branch = data.branch
+        }
+        break
+      }
+      case 'task-followup-done': {
+        const task = tasks.value.find((t) => t.id === data.taskId)
+        if (task && !TERMINAL_STATES.has(task.state)) task.state = 'awaiting-review'
+        break
+      }
+      case 'terminal-output': {
+        const { taskId, line, timestamp, detail, level } = data
+        if (taskId && line) {
+          if (!taskLogs.value[taskId]) taskLogs.value[taskId] = []
+          taskLogs.value[taskId].push({
+            line,
+            timestamp,
+            detail: detail || null,
+            level: level || null,
+          })
+          if (taskLogs.value[taskId].length > 2000) taskLogs.value[taskId].shift()
+        }
+        break
+      }
+      default:
+        break
     }
   }
 

--- a/frontend/src/stores/usage.ts
+++ b/frontend/src/stores/usage.ts
@@ -102,9 +102,16 @@ export const useUsageStore = defineStore('usage', () => {
   }
 
   function handleWebSocketMessage(data: WSInbound) {
-    if (data.type !== 'claude-usage' || !data.taskId) return
-    const { type: _t, ...summary } = data
-    byTask.value = { ...byTask.value, [data.taskId]: summary }
+    switch (data.type) {
+      case 'claude-usage': {
+        if (!data.taskId) break
+        const { type: _t, ...summary } = data
+        byTask.value = { ...byTask.value, [data.taskId]: summary }
+        break
+      }
+      default:
+        break
+    }
   }
 
   function usageForTask(taskId: string): UsageSummary | null {

--- a/frontend/src/ws-schemas.ts
+++ b/frontend/src/ws-schemas.ts
@@ -1,0 +1,238 @@
+import { z } from 'zod'
+import type { WSInbound } from './types'
+
+// ─── Primitive enums ──────────────────────────────────────────────────────────
+
+const agentStateZ = z.enum(['idle', 'thinking', 'working', 'busy', 'error', 'offline'])
+const agentActivityZ = z.enum([
+  'reading',
+  'editing',
+  'running',
+  'searching',
+  'fetching',
+  'thinking',
+  'planning',
+])
+const taskStateZ = z.enum([
+  'pending',
+  'planning',
+  'working',
+  'awaiting-review',
+  'done',
+  'failed',
+  'followup',
+  'cancelled',
+])
+const logLevelZ = z.enum(['info', 'worker', 'auth', 'claude', 'thinking'])
+const logDetailZ = z
+  .object({
+    toolType: z.enum(['tool_use', 'tool_result', 'thinking']).optional(),
+    name: z.string().optional(),
+    input: z.union([z.record(z.unknown()), z.string()]).optional(),
+    output: z.string().optional(),
+    fullText: z.string().optional(),
+    summary: z.string().optional(),
+  })
+  .passthrough()
+
+// ─── Per-variant schemas ──────────────────────────────────────────────────────
+
+// passthrough() on chat so extra server fields survive into the ChatMessage store.
+const chatWSZ = z
+  .object({
+    type: z.literal('chat'),
+    from: z.string(),
+    to: z.string().optional(),
+    content: z.string(),
+    prUrl: z.string().nullable().optional(),
+    createdAt: z.string().optional(),
+    created_at: z.string().optional(),
+    role: z.string().optional(),
+    toolId: z.string().optional(),
+    toolName: z.string().optional(),
+    from_agent: z.string().optional(),
+  })
+  .passthrough()
+
+const guildUpdatedWSZ = z.object({
+  type: z.literal('guild-updated'),
+  id: z.string(),
+  name: z.string().optional(),
+})
+
+const agentJoinedWSZ = z.object({
+  type: z.literal('agent-joined'),
+  agentId: z.string(),
+  agentName: z.string().optional(),
+  agentType: z.string().optional(),
+  workerId: z.string().nullable().optional(),
+  workerName: z.string().optional(),
+  state: agentStateZ.optional(),
+  taskId: z.string().nullable().optional(),
+  joinedAt: z.string().optional(),
+})
+
+const agentStateWSZ = z.object({
+  type: z.literal('agent-state'),
+  agentId: z.string(),
+  workerId: z.string().nullable().optional(),
+  taskId: z.string().nullable().optional(),
+  state: agentStateZ,
+  activity: agentActivityZ.nullable().optional(),
+})
+
+const terminalOutputWSZ = z.object({
+  type: z.literal('terminal-output'),
+  agentId: z.string().optional(),
+  workerId: z.string().optional(),
+  taskId: z.string().optional(),
+  line: z.string(),
+  timestamp: z.string().optional(),
+  detail: logDetailZ.nullable().optional(),
+  level: logLevelZ.nullable().optional(),
+})
+
+const taskCreatedWSZ = z.object({
+  type: z.literal('task-created'),
+  taskId: z.string(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  phase: z.string().optional(),
+  state: taskStateZ,
+  createdAt: z.string().optional(),
+})
+
+const taskAssignedWSZ = z.object({
+  type: z.literal('task-assigned'),
+  taskId: z.string(),
+  workerId: z.string(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  phase: z.string().optional(),
+  parentTaskId: z.string().nullable().optional(),
+})
+
+const taskUpdateWSZ = z.object({
+  type: z.literal('task-update'),
+  taskId: z.string(),
+  agentId: z.string().nullable().optional(),
+  state: taskStateZ.optional(),
+  branch: z.string().optional(),
+  prUrl: z.string().optional(),
+  finishedAt: z.string().optional(),
+  worktreePath: z.string().optional(),
+  deletedAt: z.string().nullable().optional(),
+})
+
+const taskCompleteWSZ = z.object({
+  type: z.literal('task-complete'),
+  taskId: z.string(),
+  workerId: z.string().optional(),
+  agentId: z.string().nullable().optional(),
+  branch: z.string().optional(),
+  prUrl: z.string().nullable().optional(),
+})
+
+const taskFollowupDoneWSZ = z.object({
+  type: z.literal('task-followup-done'),
+  taskId: z.string(),
+  agentId: z.string().nullable().optional(),
+})
+
+const needsInputWSZ = z.object({
+  type: z.literal('needs-input'),
+  workerId: z.string(),
+  description: z.string().optional(),
+})
+
+const claudeAuthRequiredWSZ = z.object({
+  type: z.literal('claude-auth-required'),
+  workerId: z.string(),
+  url: z.string(),
+})
+
+const claudeAuthSuccessWSZ = z.object({
+  type: z.literal('claude-auth-success'),
+  workerId: z.string(),
+})
+
+const claudeAuthClearedWSZ = z.object({
+  type: z.literal('claude-auth-cleared'),
+  workerId: z.string(),
+})
+
+const foremanPollStatusWSZ = z.object({
+  type: z.literal('foreman-poll-status'),
+  nextCheckIn: z.number().optional(),
+})
+
+const claudeUsageWSZ = z.object({
+  type: z.literal('claude-usage'),
+  taskId: z.string().nullable(),
+  workerId: z.string().nullable().optional(),
+  sessionId: z.string().nullable().optional(),
+  model: z.string().nullable().optional(),
+  repo: z.string().nullable().optional(),
+  reporter: z.string().nullable().optional(),
+  apiCalls: z.number(),
+  summedInputTokens: z.number(),
+  summedOutputTokens: z.number(),
+  summedCacheReadTokens: z.number(),
+  summedCacheCreationTokens: z.number(),
+  reportedInputTokens: z.number().nullable().optional(),
+  reportedOutputTokens: z.number().nullable().optional(),
+  reportedCacheReadTokens: z.number().nullable().optional(),
+  reportedCacheCreationTokens: z.number().nullable().optional(),
+  costUsd: z.number().nullable().optional(),
+  numTurns: z.number().nullable().optional(),
+  stopReason: z.string().nullable().optional(),
+})
+
+// ─── Discriminated union ──────────────────────────────────────────────────────
+
+const wsMessageSchema = z.discriminatedUnion('type', [
+  chatWSZ,
+  guildUpdatedWSZ,
+  agentJoinedWSZ,
+  agentStateWSZ,
+  terminalOutputWSZ,
+  taskCreatedWSZ,
+  taskAssignedWSZ,
+  taskUpdateWSZ,
+  taskCompleteWSZ,
+  taskFollowupDoneWSZ,
+  needsInputWSZ,
+  claudeAuthRequiredWSZ,
+  claudeAuthSuccessWSZ,
+  claudeAuthClearedWSZ,
+  foremanPollStatusWSZ,
+  claudeUsageWSZ,
+])
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Parse and validate a raw WebSocket frame against the WSInbound union.
+ * Returns the typed payload on success, null for non-JSON or unrecognised-type frames.
+ */
+export function parseWsMessage(raw: string): WSInbound | null {
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch {
+    console.warn('Dropping non-JSON WS frame')
+    return null
+  }
+  const result = wsMessageSchema.safeParse(json)
+  if (result.success) return result.data as WSInbound
+  console.warn(
+    'Unrecognised WS message — dropped:',
+    typeof json === 'object' && json !== null ? (json as Record<string, unknown>).type : json,
+  )
+  return null
+}
+
+/** TypeScript exhaustiveness sentinel: call in `default` branches of WSInbound switches. */
+export function assertNever(x: never): never {
+  throw new Error(`Unhandled WS message type: ${(x as { type: string }).type}`)
+}

--- a/frontend/src/ws-schemas.ts
+++ b/frontend/src/ws-schemas.ts
@@ -28,7 +28,7 @@ const logDetailZ = z
   .object({
     toolType: z.enum(['tool_use', 'tool_result', 'thinking']).optional(),
     name: z.string().optional(),
-    input: z.union([z.record(z.unknown()), z.string()]).optional(),
+    input: z.union([z.record(z.string(), z.unknown()), z.string()]).optional(),
     output: z.string().optional(),
     fullText: z.string().optional(),
     summary: z.string().optional(),


### PR DESCRIPTION
## Summary

- **`frontend/src/ws-schemas.ts`** (new): Zod discriminated-union schema covering all 16 `WSInbound` variants. `parseWsMessage` validates the raw JSON at the single entry point and returns `WSInbound | null`; unknown-type frames are silently dropped. Exports `assertNever` for compile-time exhaustiveness.
- **`guild.ts`**: replaces `JSON.parse(…) as WSInbound` + bare `if/if` blocks with `parseWsMessage` + a full exhaustive `switch`. The `default: assertNever(data)` branch guarantees TypeScript will catch any future unhandled type.
- **`agents.ts`, `tasks.ts`, `usage.ts`**: `handleWebSocketMessage` converted from `if/else if` chains to typed `switch` statements (no `any` casts, no duplicate field coercions).
- **`ChatPane.vue`, `WorkerActions.vue`**: same `if/else if` → `switch` conversion in component-level WS handlers.
- **`guild.spec.ts`**: three tests updated to send valid messages (required fields added) so they still pass through Zod validation.

## Test plan

- [ ] `npm run type-check` — no errors
- [ ] `npm test` — all 94 tests pass
- [ ] `npm run lint:check` — no errors
- [ ] Manual: send each known WS message type from the backend and verify the frontend handles it identically to before

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)