### PR TITLE
feat(worker): expose optional HTTP control API for testing

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -113,6 +113,51 @@ The worker stays running, reconnecting if the backend restarts.
 6. Reports state changes (`working`, `done`, `failed`, branch, PR url) back
    to the backend via `task-update` WebSocket messages.
 
+## Control API (drive a live worker without a frontend)
+
+A real worker only acts on tasks the backend/foreman assigns over WebSocket,
+which makes it awkward to test in isolation. Enable the optional HTTP control
+API to inject tasks straight into the worker's queue and inspect its state —
+the full execution path (clone, worktree, claude/codex/pi, push, PR) still
+runs, so it's a faithful smoke test against a real backend without driving the
+UI.
+
+```bash
+pioneer-worker --api-port 9200             # enable on 127.0.0.1:9200
+pioneer-worker --api-port 9200 --api-host 0.0.0.0
+```
+
+Or in config / env:
+
+```toml
+[api]
+port = 9200
+host = "127.0.0.1"
+```
+
+```bash
+PIONEER_API_PORT=9200 pioneer-worker
+```
+
+It is unauthenticated; keep it bound to localhost (the default) and use it for
+local/dev only.
+
+| Method | Path                  | Body                                                                                          | Description                          |
+| ------ | --------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------ |
+| GET    | `/` or `/status`      | —                                                                                             | Worker id, repos, agents, queue depth |
+| GET    | `/agents`             | —                                                                                             | Agent slots with current state       |
+| GET    | `/tasks`              | —                                                                                             | Known task ids + queue depth         |
+| POST   | `/tasks`              | `{description, name?, tool?, phase?, repos?, issueNumber?, issueRepo?, id?, followupInstructions?, followupBranch?}` | Inject a task into the queue |
+| POST   | `/control/shutdown`   | —                                                                                             | Graceful shutdown                    |
+
+```bash
+# Inject a task and watch the worker run it
+curl -s localhost:9200/tasks \
+  -H 'content-type: application/json' \
+  -d '{"description": "Add a README badge", "tool": "claude", "repos": ["owner/repo"]}'
+curl -s localhost:9200/ | jq .
+```
+
 ## Multiple workers
 
 Run more than one worker against the same session by giving each its own

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -21,6 +21,12 @@ pull_interval = 300
 # Number of agents this worker runs concurrently (default: 4).
 # max_agents = 4
 
+# Optional HTTP control API for driving/inspecting a live worker without a
+# frontend or the foreman. Disabled unless a port is set. Bind to localhost.
+# [api]
+# port = 9200
+# host = "127.0.0.1"
+
 [github]
 # Repos this worker will clone and operate on (static list).
 repos = ["owner/repo"]

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -78,6 +78,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--pi-path", help="Path to the pi executable (default: pi).")
 
+    # Control API (drive/inspect a live worker without a frontend or foreman)
+    parser.add_argument(
+        "--api-port",
+        type=int,
+        help=(
+            "Enable the HTTP control API on this port (lets you inject tasks and "
+            "inspect the worker without a frontend/guild). Disabled if unset."
+        ),
+    )
+    parser.add_argument(
+        "--api-host",
+        help="Bind host for the control API (default: 127.0.0.1).",
+    )
+
     # Tuning
     parser.add_argument(
         "--pull-interval", type=float, help="Seconds between repo pulls (default: 300)."
@@ -148,6 +162,8 @@ def main(argv: list[str] | None = None) -> int:
             "pi_path": args.pi_path,
             "pull_interval": args.pull_interval,
             "claude_max_turns": args.claude_max_turns,
+            "api_port": args.api_port,
+            "api_host": args.api_host,
         }.items()
         if v is not None
     }

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -59,6 +59,12 @@ class Config:
     # webhook registration will target it. Defaults to ``backend_url``.
     public_backend_url: str | None = None
 
+    # Optional HTTP control API for driving/inspecting a live worker without a
+    # frontend or the foreman. Disabled unless ``api_port`` is set (via
+    # [api].port, --api-port, or PIONEER_API_PORT). Bind to localhost only.
+    api_port: int | None = None
+    api_host: str = "127.0.0.1"
+
     config_path: Path = field(default_factory=Path)
 
     @property
@@ -132,6 +138,22 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
     paths_block = raw.get("paths") or {}
     claude_block = raw.get("claude") or {}
     codex_block = raw.get("codex") or {}
+    api_block = raw.get("api") or {}
+
+    _api_port = (
+        overrides.get("api_port")
+        if overrides.get("api_port") is not None
+        else api_block.get("port")
+        if api_block.get("port") is not None
+        else os.environ.get("PIONEER_API_PORT")
+    )
+    _api_port = int(_api_port) if _api_port is not None and _api_port != "" else None
+    _api_host = (
+        overrides.get("api_host")
+        or api_block.get("host")
+        or os.environ.get("PIONEER_API_HOST")
+        or "127.0.0.1"
+    )
 
     token = overrides.get("github_token")
     if token is None:
@@ -249,5 +271,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         public_backend_url=overrides.get("public_backend_url")
         or raw.get("public_backend_url")
         or os.environ.get("PIONEER_FRONTEND_URL"),
+        api_port=_api_port,
+        api_host=_api_host,
         config_path=cfg_path,
     )

--- a/worker/pioneer_worker/control_api.py
+++ b/worker/pioneer_worker/control_api.py
@@ -1,0 +1,163 @@
+"""Optional HTTP control API for a live worker.
+
+Real workers receive their work from the backend/foreman over WebSocket. That
+makes them awkward to exercise in isolation: you need a running backend, a
+guild, and a frontend (or the foreman) to assign a task before the worker does
+anything. This module exposes a small HTTP server — disabled by default,
+enabled with ``--api-port`` / ``[api].port`` — that lets you inspect the
+worker and inject tasks straight into its queue, bypassing the foreman.
+
+It runs the real execution path (clone, worktree, claude/codex/pi, push, PR),
+so it's a faithful way to smoke-test a worker against a backend without driving
+the UI. It is intentionally unauthenticated and meant for local/dev use; bind
+it to localhost (the default) and don't expose it publicly.
+
+Endpoints (default ``127.0.0.1:9200``):
+
+    GET  /                     status JSON (worker id, agents, queue depth)
+    GET  /status               alias of /
+    GET  /agents               list of agent slots with current state
+    GET  /tasks                known task ids + queue depth
+    POST /tasks                inject a task; body:
+                                 {description, name?, tool?, phase?, repos?,
+                                  issueNumber?, issueRepo?, id?,
+                                  followupInstructions?, followupBranch?}
+    POST /control/shutdown     graceful shutdown
+
+The handler runs on a background thread; all worker state is touched only on
+the worker's event loop via ``run_coroutine_threadsafe`` / ``call_soon_threadsafe``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .worker import Worker
+
+logger = logging.getLogger(__name__)
+
+
+class ControlServer:
+    """Threaded HTTP control API bound to a :class:`Worker`."""
+
+    def __init__(self, worker: Worker, *, host: str = "127.0.0.1", port: int = 9200) -> None:
+        self.worker = worker
+        self.host = host
+        self.port = port
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        handler_cls = _make_handler(self.worker)
+        try:
+            self._server = ThreadingHTTPServer((self.host, self.port), handler_cls)
+        except OSError as exc:
+            logger.error("Control API could not bind to %s:%d — %s", self.host, self.port, exc)
+            raise
+        bound_host, bound_port = self._server.server_address[:2]
+        self.port = bound_port  # in case 0 was passed in
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, name="worker-control-api", daemon=True
+        )
+        self._thread.start()
+        logger.info("Control API listening on http://%s:%d", bound_host, bound_port)
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+
+def _make_handler(worker: Worker) -> type[BaseHTTPRequestHandler]:
+    """Build a request handler class bound to *worker*."""
+
+    def _run_coro(coro):
+        """Schedule *coro* on the worker's loop and wait for the result."""
+        assert worker._loop is not None
+        fut = asyncio.run_coroutine_threadsafe(coro, worker._loop)
+        return fut.result(timeout=30.0)
+
+    def _call_sync(fn, *args, **kwargs):
+        """Run a callable on the worker's loop (the loop owns shared state)."""
+        assert worker._loop is not None
+        result: dict = {}
+
+        def _runner():
+            result["value"] = fn(*args, **kwargs)
+
+        worker._loop.call_soon_threadsafe(_runner)
+        deadline, step, elapsed = 5.0, 0.005, 0.0
+        while "value" not in result and elapsed < deadline:
+            threading.Event().wait(step)
+            elapsed += step
+        return result.get("value", {"error": "timeout"})
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args) -> None:  # noqa: A003
+            logger.debug("[control-api] %s - %s", self.address_string(), format % args)
+
+        def _send_json(self, status: int, payload: dict) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _read_json(self) -> dict:
+            length = int(self.headers.get("Content-Length") or 0)
+            if not length:
+                return {}
+            try:
+                return json.loads(self.rfile.read(length).decode() or "{}")
+            except json.JSONDecodeError:
+                return {}
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path in ("/", "/status"):
+                self._send_json(200, _call_sync(worker._status_snapshot))
+                return
+            if self.path == "/agents":
+                snap = _call_sync(worker._status_snapshot)
+                self._send_json(200, {"agents": snap.get("agents", [])})
+                return
+            if self.path == "/tasks":
+                snap = _call_sync(worker._status_snapshot)
+                self._send_json(
+                    200,
+                    {
+                        "knownTaskIds": snap.get("knownTaskIds", []),
+                        "queueDepth": snap.get("queueDepth", 0),
+                    },
+                )
+                return
+            self._send_json(404, {"error": "not found", "path": self.path})
+
+        def do_POST(self) -> None:  # noqa: N802
+            body = self._read_json()
+            try:
+                if self.path == "/tasks":
+                    result = _run_coro(worker._inject_task(body))
+                    self._send_json(200 if "ok" in result else 400, result)
+                    return
+                if self.path == "/control/shutdown":
+                    _run_coro(worker._initiate_shutdown("control API shutdown"))
+                    self._send_json(200, {"ok": True})
+                    return
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("[control-api] handler crashed: %s", exc)
+                self._send_json(500, {"error": str(exc)})
+                return
+            self._send_json(404, {"error": "not found", "path": self.path})
+
+    return Handler

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -17,6 +17,7 @@ import httpx
 
 from . import claude_runner, codex_runner, git_ops, github_pr, pi_runner
 from . import config as config_mod
+from .control_api import ControlServer
 from .ws_client import WSClient
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,11 @@ class Worker:
         self.ws = WSClient(cfg.ws_url)
         self._shutdown_event = asyncio.Event()
         self._worker_name: str = ""
+        # Captured at run() start so the optional control API's handler thread
+        # can schedule coroutines onto the worker's loop. Stays None when no
+        # control API is configured.
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._control_server: ControlServer | None = None
 
         # ── Agent pool ──────────────────────────────────────────────────────
         # Agents are owned by this worker.  Created once at startup, destroyed
@@ -736,6 +742,80 @@ class Worker:
             logger.debug("Auth login watchdog cancelled")
             raise
 
+    # ------------------------------------------------------------------ Control API
+    def _status_snapshot(self) -> dict:
+        """Point-in-time view of the worker, served by the control API."""
+        return {
+            "workerId": self.cfg.worker_id,
+            "workerName": self._worker_name,
+            "guildId": self.cfg.guild_id,
+            "repos": self._broadcast_repos,
+            "joined": self._joined,
+            "shuttingDown": self._shutdown_event.is_set(),
+            "agents": [
+                {
+                    "agentId": s.id,
+                    "agentName": s.name,
+                    "state": s.state,
+                    "activity": s.activity,
+                    "taskId": s.current_task_id,
+                }
+                for s in self.agents
+            ],
+            "knownTaskIds": sorted(self._known_task_ids),
+            "queueDepth": self.task_queue.qsize(),
+        }
+
+    def _build_injected_task(self, body: dict) -> dict:
+        """Translate a control-API POST body into a task-queue dict."""
+        task_id = body.get("id") or body.get("taskId") or _gen_id("t-")
+        task: dict = {
+            "id": task_id,
+            "worker_id": self.cfg.worker_id,
+            "guild_id": self.cfg.guild_id,
+            "name": body.get("name", ""),
+            "description": body.get("description", ""),
+            "tool": body.get("tool", "claude"),
+            "phase": body.get("phase", "execute"),
+            "issue_number": body.get("issueNumber"),
+            "issue_repo": body.get("issueRepo"),
+            "repos": body.get("repos") or [],
+        }
+        if body.get("followupInstructions"):
+            task["followup_instructions"] = body["followupInstructions"]
+        if body.get("followupBranch"):
+            task["followup_branch"] = body["followupBranch"]
+        return task
+
+    async def _inject_task(self, body: dict) -> dict:
+        """Enqueue a task supplied over the control API (foreman bypass)."""
+        if not body.get("description") and not body.get("followupInstructions"):
+            return {"error": "description (or followupInstructions) is required"}
+        task = self._build_injected_task(body)
+        task_id = task["id"]
+        if task_id in self._known_task_ids:
+            return {"error": f"task {task_id!r} already known to this worker"}
+        self._known_task_ids.add(task_id)
+        await self.task_queue.put(task)
+        logger.info("Control API injected task %s: %s", task_id, task["description"][:80])
+        return {"ok": True, "taskId": task_id, "queueDepth": self.task_queue.qsize()}
+
+    def _start_control_api(self) -> None:
+        if self.cfg.api_port is None:
+            return
+        self._control_server = ControlServer(
+            self, host=self.cfg.api_host, port=self.cfg.api_port
+        )
+        try:
+            self._control_server.start()
+        except OSError:
+            self._control_server = None
+
+    def _stop_control_api(self) -> None:
+        if self._control_server is not None:
+            self._control_server.stop()
+            self._control_server = None
+
     async def _fetch_pending_tasks(self) -> list[dict]:
         async with await self._http() as client:
             resp = await client.get(
@@ -1032,7 +1112,9 @@ class Worker:
             self.cfg.pi_path,
         )
 
+        self._loop = asyncio.get_running_loop()
         self._install_signal_handlers()
+        self._start_control_api()
 
         await self._register()
         assert self.cfg.worker_id, "worker_id must be set after registration"
@@ -1071,10 +1153,6 @@ class Worker:
                 )
             )
 
-        await self._emit("Online. Watching for tasks.")
-        for slot in self.agents:
-            await self._set_state("idle", slot)
-
         # Reclaim any worktrees the previous incarnation of this worker left
         # behind. Tasks within the TTL window are re-registered so a follow-up
         # arriving for them can reuse the existing checkout.
@@ -1084,6 +1162,10 @@ class Worker:
             await asyncio.wait_for(self._initial_worktree_sweep(), timeout=30.0)
         except TimeoutError:
             logger.warning("Worktree startup sweep timed out after 30s — skipping")
+
+        await self._emit("Online. Watching for tasks.")
+        for slot in self.agents:
+            await self._set_state("idle", slot)
 
         initial = await self._fetch_pending_tasks()
         logger.info("Initial pending-task fetch: %d task(s)", len(initial))
@@ -1135,6 +1217,7 @@ class Worker:
                 await self._notify_offline()
             logger.info("Worker shutting down; closing WebSocket")
             await self.ws.close()
+            self._stop_control_api()
 
     # ------------------------------------------------------------------ Listener
     async def _listen(self) -> None:
@@ -1608,6 +1691,7 @@ class Worker:
             if task_id in self._cancelled_tasks:
                 logger.info("Skipping cancelled task %s", task_id)
                 continue
+            
             logger.info(
                 "Dequeued task %s (agent=%s queue depth %d): %s",
                 task_id,

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1691,7 +1691,7 @@ class Worker:
             if task_id in self._cancelled_tasks:
                 logger.info("Skipping cancelled task %s", task_id)
                 continue
-            
+
             logger.info(
                 "Dequeued task %s (agent=%s queue depth %d): %s",
                 task_id,

--- a/worker/tests/test_control_api.py
+++ b/worker/tests/test_control_api.py
@@ -1,0 +1,207 @@
+"""Tests for the worker control API (``--api-port``).
+
+Covers the task-injection and status methods on the base Worker directly, plus
+an end-to-end pass over the threaded HTTP server bound to a real localhost
+port. ``run()`` is never invoked; we wire ``_loop`` and ``_send`` the same way
+the running worker would.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.control_api import ControlServer
+from pioneer_worker.worker import Worker
+
+
+def _make_cfg(**kw) -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="g-test",
+        worker_id="w-ctrl01",
+        max_agents=2,
+        pull_interval=3600.0,
+        repos=["owner/repo"],
+        **kw,
+    )
+
+
+def _make_worker() -> Worker:
+    worker = Worker(_make_cfg())
+    worker._send = AsyncMock()
+    worker._worker_name = "ControlWorker-1"
+    return worker
+
+
+# ── Task injection (unit) ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inject_task_enqueues_and_tracks():
+    worker = _make_worker()
+    result = await worker._inject_task({"description": "Do a thing", "name": "thing"})
+    assert result["ok"] is True
+    task_id = result["taskId"]
+    assert task_id in worker._known_task_ids
+    assert worker.task_queue.qsize() == 1
+    queued = worker.task_queue.get_nowait()
+    assert queued["description"] == "Do a thing"
+    assert queued["name"] == "thing"
+    assert queued["tool"] == "claude"
+    assert queued["phase"] == "execute"
+
+
+@pytest.mark.asyncio
+async def test_inject_task_honors_explicit_id_and_fields():
+    worker = _make_worker()
+    result = await worker._inject_task(
+        {
+            "id": "t-custom",
+            "description": "Codex task",
+            "tool": "codex",
+            "phase": "review",
+            "repos": ["owner/repo"],
+            "issueNumber": 7,
+            "issueRepo": "owner/repo",
+        }
+    )
+    assert result["taskId"] == "t-custom"
+    queued = worker.task_queue.get_nowait()
+    assert queued["tool"] == "codex"
+    assert queued["phase"] == "review"
+    assert queued["issue_number"] == 7
+    assert queued["issue_repo"] == "owner/repo"
+    assert queued["repos"] == ["owner/repo"]
+
+
+@pytest.mark.asyncio
+async def test_inject_task_followup_fields():
+    worker = _make_worker()
+    await worker._inject_task(
+        {
+            "id": "t-fu",
+            "followupInstructions": "tweak it",
+            "followupBranch": "claude/x-123",
+        }
+    )
+    queued = worker.task_queue.get_nowait()
+    assert queued["followup_instructions"] == "tweak it"
+    assert queued["followup_branch"] == "claude/x-123"
+
+
+@pytest.mark.asyncio
+async def test_inject_task_requires_description():
+    worker = _make_worker()
+    result = await worker._inject_task({"name": "no body"})
+    assert "error" in result
+    assert worker.task_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_inject_task_rejects_duplicate_id():
+    worker = _make_worker()
+    await worker._inject_task({"id": "t-dup", "description": "first"})
+    result = await worker._inject_task({"id": "t-dup", "description": "second"})
+    assert "error" in result
+    assert worker.task_queue.qsize() == 1
+
+
+def test_status_snapshot_shape():
+    worker = _make_worker()
+    snap = worker._status_snapshot()
+    assert snap["workerId"] == "w-ctrl01"
+    assert snap["guildId"] == "g-test"
+    assert len(snap["agents"]) == 2
+    assert snap["queueDepth"] == 0
+    assert snap["knownTaskIds"] == []
+
+
+# ── HTTP server integration ────────────────────────────────────────────────
+
+
+def _wait_until(predicate, timeout: float = 2.0, step: float = 0.01) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(step)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_http_status_and_inject():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    server = ControlServer(worker, host="127.0.0.1", port=0)
+    server.start()
+    try:
+        port = server.port
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            status = (await client.get("/")).json()
+            assert status["workerId"] == "w-ctrl01"
+            assert len(status["agents"]) == 2
+
+            resp = await client.post("/tasks", json={"id": "t-http", "description": "via http"})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["ok"] is True
+            assert body["taskId"] == "t-http"
+
+            tasks = (await client.get("/tasks")).json()
+            assert "t-http" in tasks["knownTaskIds"]
+            assert tasks["queueDepth"] == 1
+
+        assert worker.task_queue.get_nowait()["description"] == "via http"
+    finally:
+        server.stop()
+
+
+@pytest.mark.asyncio
+async def test_http_inject_missing_description_returns_400():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    server = ControlServer(worker, host="127.0.0.1", port=0)
+    server.start()
+    try:
+        port = server.port
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.post("/tasks", json={"name": "no body"})
+            assert resp.status_code == 400
+            assert "error" in resp.json()
+    finally:
+        server.stop()
+
+
+@pytest.mark.asyncio
+async def test_http_shutdown_triggers_event():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    server = ControlServer(worker, host="127.0.0.1", port=0)
+    server.start()
+    try:
+        port = server.port
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.post("/control/shutdown", json={})
+            assert resp.status_code == 200
+        assert _wait_until(worker._shutdown_event.is_set)
+    finally:
+        server.stop()
+
+
+@pytest.mark.asyncio
+async def test_http_unknown_path_404():
+    worker = _make_worker()
+    worker._loop = asyncio.get_running_loop()
+    server = ControlServer(worker, host="127.0.0.1", port=0)
+    server.start()
+    try:
+        port = server.port
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            assert (await client.get("/nope")).status_code == 404
+    finally:
+        server.stop()


### PR DESCRIPTION
## Problem

A real worker only acts on tasks the backend/foreman assigns over WebSocket, which makes it awkward to test in isolation — you need a running backend, a guild, and a frontend (or the foreman) to assign a task before the worker does anything.

## Solution

Add an opt-in HTTP **control API** to the base `Worker`, modeled on the existing mock-worker control server. When enabled, you can inject tasks directly into the worker's queue and inspect its state, while the worker still runs the full execution path (clone → worktree → claude/codex/pi → push → PR) — a faithful smoke test against a real backend without driving the UI.

- Enable via `--api-port` / `--api-host`, the `[api]` config block, or `PIONEER_API_PORT` / `PIONEER_API_HOST`. **Disabled by default.**
- Unauthenticated; intended for local/dev use, bound to localhost by default.

### Endpoints

| Method | Path | Description |
| --- | --- | --- |
| GET | `/` or `/status` | worker id, repos, agents, queue depth |
| GET | `/agents` | agent slots with current state |
| GET | `/tasks` | known task ids + queue depth |
| POST | `/tasks` | inject a task into the queue (foreman bypass) |
| POST | `/control/shutdown` | graceful shutdown |

### Files

- `worker/pioneer_worker/control_api.py` (new): reusable `ControlServer` using the same thread-safe loop scheduling pattern as the mock worker.
- `worker/pioneer_worker/worker.py`: `_status_snapshot()`, `_inject_task()`, control-server start/stop wired into `run()`.
- `worker/pioneer_worker/config.py`, `cli.py`: config + CLI flags.
- `pioneer-worker.toml.example`, `worker/README.md`: docs.
- `worker/tests/test_control_api.py` (new): 10 tests (injection, validation, status, live HTTP server).

## Testing

- `cd worker && python -m pytest` — 190 passed
- `ruff check` / `ruff format` clean on new/changed files
