### PR TITLE
Strongly type backend WebSocket messages with Pydantic v2

### DIFF
--- a/backend/events.py
+++ b/backend/events.py
@@ -124,15 +124,12 @@ async def broadcast_msg(
 
 async def emit_terminal_line(guild_id: str, agent_id: str, line: str):
     """Broadcast and persist a terminal output line."""
+    from ws_types import TerminalOutputMsg
+
     now = datetime.now(UTC)
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "terminal-output",
-            "agentId": agent_id,
-            "line": line,
-            "timestamp": now.isoformat(),
-        },
+        TerminalOutputMsg(agentId=agent_id, line=line, timestamp=now.isoformat()),
     )
     if line:
         db = await get_db()

--- a/backend/events.py
+++ b/backend/events.py
@@ -115,9 +115,7 @@ async def send_ws_message(ws: WebSocket, message: "_WS") -> None:
     await ws.send_text(ws_dumps(message.model_dump(by_alias=True)))
 
 
-async def broadcast_msg(
-    guild_id: str, message: "_WS", exclude: WebSocket | None = None
-) -> None:
+async def broadcast_msg(guild_id: str, message: "_WS", exclude: WebSocket | None = None) -> None:
     """Serialise a typed WS model and broadcast it to all guild connections."""
     await broadcast(guild_id, message.model_dump(by_alias=True), exclude)
 

--- a/backend/events.py
+++ b/backend/events.py
@@ -8,13 +8,16 @@ import asyncio
 import json
 import logging
 from datetime import UTC, date, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from database import get_db
 from fastapi import WebSocket, WebSocketDisconnect
 from models import Agent, TaskLog
 from sqlmodel import col, select
+
+if TYPE_CHECKING:
+    from ws_types import _WS
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +108,18 @@ async def broadcast(guild_id: str, message: dict, exclude: WebSocket | None = No
             dead.append(ws)
     for ws in dead:
         connections[guild_id].remove(ws)
+
+
+async def send_ws_message(ws: WebSocket, message: "_WS") -> None:
+    """Serialise a typed WS model and send it to a single WebSocket."""
+    await ws.send_text(ws_dumps(message.model_dump(by_alias=True)))
+
+
+async def broadcast_msg(
+    guild_id: str, message: "_WS", exclude: WebSocket | None = None
+) -> None:
+    """Serialise a typed WS model and broadcast it to all guild connections."""
+    await broadcast(guild_id, message.model_dump(by_alias=True), exclude)
 
 
 async def emit_terminal_line(guild_id: str, agent_id: str, line: str):

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -7,7 +7,8 @@ from datetime import UTC, datetime
 
 from auth_deps import get_guild_pk
 from database import get_db
-from events import broadcast
+from events import broadcast_msg
+from ws_types import ChatMsg, ForemanPollStatusMsg
 from foreman.prompt import build_state_preamble, build_system_blocks, build_system_prompt
 from foreman.tools import exec_tools
 from foreman_core.constants import (
@@ -205,10 +206,7 @@ async def _poll_loop(guild_id: str) -> None:
                     "guild=%s external foreman connected, skipping embedded poll", guild_id
                 )
                 interval = next_interval
-                await broadcast(
-                    guild_id,
-                    {"type": "foreman-poll-status", "nextCheckIn": interval},
-                )
+                await broadcast_msg(guild_id, ForemanPollStatusMsg(nextCheckIn=interval))
                 continue
 
             db = await get_db()
@@ -246,10 +244,7 @@ async def _poll_loop(guild_id: str) -> None:
 
             # Announce next check interval so the UI can display a countdown.
             interval = next_interval
-            await broadcast(
-                guild_id,
-                {"type": "foreman-poll-status", "nextCheckIn": interval},
-            )
+            await broadcast_msg(guild_id, ForemanPollStatusMsg(nextCheckIn=interval))
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -304,15 +299,14 @@ async def run_foreman_ai(
     """Process a human message (or system escalation) through the Claude foreman AI."""
     if not HAS_ANTHROPIC:
         now = datetime.now(UTC).isoformat()
-        await broadcast(
+        await broadcast_msg(
             guild_id,
-            {
-                "type": "chat",
-                "from": "foreman",
-                "to": "user",
-                "content": "Foreman AI offline (install `anthropic` package to enable).",
-                "createdAt": now,
-            },
+            ChatMsg(
+                from_="foreman",
+                to="user",
+                content="Foreman AI offline (install `anthropic` package to enable).",
+                createdAt=now,
+            ),
         )
         return
 
@@ -465,15 +459,14 @@ async def run_foreman_ai(
             for b in resp.content:
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
-                    await broadcast(
+                    await broadcast_msg(
                         guild_id,
-                        {
-                            "type": "chat",
-                            "from": "foreman",
-                            "to": "user",
-                            "content": b.text.strip(),
-                            "createdAt": _now.isoformat(),
-                        },
+                        ChatMsg(
+                            from_="foreman",
+                            to="user",
+                            content=b.text.strip(),
+                            createdAt=_now.isoformat(),
+                        ),
                     )
 
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
@@ -482,19 +475,18 @@ async def run_foreman_ai(
 
             # Broadcast tool-use events so the frontend chat shows them live
             for tu in tool_uses:
-                await broadcast(
+                await broadcast_msg(
                     guild_id,
-                    {
-                        "type": "chat",
-                        "from": "foreman",
-                        "role": "tool_use",
-                        "to": "user",
-                        "content": f"▶ {tu.name}",
-                        "toolName": tu.name,
-                        "toolInput": dict(tu.input) if tu.input else {},
-                        "toolId": tu.id,
-                        "createdAt": _now.isoformat(),
-                    },
+                    ChatMsg(
+                        from_="foreman",
+                        role="tool_use",
+                        to="user",
+                        content=f"▶ {tu.name}",
+                        toolName=tu.name,
+                        toolInput=dict(tu.input) if tu.input else {},
+                        toolId=tu.id,
+                        createdAt=_now.isoformat(),
+                    ),
                 )
 
             _tool_use_ts = _now  # capture before exec_tools may raise
@@ -512,19 +504,18 @@ async def run_foreman_ai(
             # Broadcast tool-result events
             _now = datetime.now(UTC)
             for result in trimmed:
-                await broadcast(
+                await broadcast_msg(
                     guild_id,
-                    {
-                        "type": "chat",
-                        "from": "foreman",
-                        "role": "tool_result",
-                        "to": "user",
-                        "content": result.get("content", ""),
-                        "toolId": result.get("tool_use_id"),
-                        "toolOutput": result.get("content", ""),
-                        "isError": result.get("is_error", False),
-                        "createdAt": _now.isoformat(),
-                    },
+                    ChatMsg(
+                        from_="foreman",
+                        role="tool_result",
+                        to="user",
+                        content=result.get("content", ""),
+                        toolId=result.get("tool_use_id"),
+                        toolOutput=result.get("content", ""),
+                        isError=result.get("is_error", False),
+                        createdAt=_now.isoformat(),
+                    ),
                 )
 
             # Persist tool_use and tool_result together in one transaction
@@ -637,27 +628,15 @@ async def run_foreman_ai(
             for b in wrap_resp.content:
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
-                    await broadcast(
+                    await broadcast_msg(
                         guild_id,
-                        {
-                            "type": "chat",
-                            "from": "foreman",
-                            "to": "user",
-                            "content": b.text.strip(),
-                            "createdAt": _now,
-                        },
+                        ChatMsg(from_="foreman", to="user", content=b.text.strip(), createdAt=_now),
                     )
             cap_note = f"_(Foreman hit {MAX_FOREMAN_ROUNDS}-round safety cap and stopped.)_"
             text_parts.append(cap_note)
-            await broadcast(
+            await broadcast_msg(
                 guild_id,
-                {
-                    "type": "chat",
-                    "from": "foreman",
-                    "to": "user",
-                    "content": cap_note,
-                    "createdAt": _now,
-                },
+                ChatMsg(from_="foreman", to="user", content=cap_note, createdAt=_now),
             )
 
         response_text = "\n".join(text_parts).strip()
@@ -677,15 +656,9 @@ async def run_foreman_ai(
 
     except Exception as exc:
         now = datetime.now(UTC).isoformat()
-        await broadcast(
+        await broadcast_msg(
             guild_id,
-            {
-                "type": "chat",
-                "from": "foreman",
-                "to": "user",
-                "content": f"Foreman error: {exc}",
-                "createdAt": now,
-            },
+            ChatMsg(from_="foreman", to="user", content=f"Foreman error: {exc}", createdAt=now),
         )
     finally:
         await db.close()

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -8,7 +8,6 @@ from datetime import UTC, datetime
 from auth_deps import get_guild_pk
 from database import get_db
 from events import broadcast_msg
-from ws_types import ChatMsg, ForemanPollStatusMsg
 from foreman.prompt import build_state_preamble, build_system_blocks, build_system_prompt
 from foreman.tools import exec_tools
 from foreman_core.constants import (
@@ -32,6 +31,7 @@ from models import Agent, ForemanTurn, Guild, GuildMember, Message, Task, Worker
 from sqlalchemy import delete, func
 from sqlmodel import col, select
 from util.tasks import spawn
+from ws_types import ChatMsg, ForemanPollStatusMsg
 
 logger = logging.getLogger(__name__)
 

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from database import get_db
-from events import broadcast_msg, emit_terminal_line
+from events import broadcast, emit_terminal_line
 from foreman_core.llm import get_foreman_model
 from foreman_core.tools_schema import (
     FOREMAN_TOOLS,  # noqa: F401 — re-exported for test compatibility
@@ -601,7 +601,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     )
                 )
                 await db.commit()
-                await broadcast_msg(
+                await broadcast(
                     guild_id,
                     TaskCreatedMsg(
                         taskId=task_id,
@@ -610,7 +610,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         phase=phase,
                         state="pending",
                         createdAt=created_at.isoformat(),
-                    ),
+                    ).model_dump(by_alias=True, exclude_none=True),
                 )
                 result_text = (
                     f"Task {task_id} created: '{name}'. Reference this task_id in assign_task."
@@ -688,7 +688,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     )
                     task_name = name_result.one_or_none() or desc[:60]
                     task_id = existing_task_id
-                    await broadcast_msg(
+                    await broadcast(
                         guild_id,
                         TaskAssignedMsg(
                             workerId=wid,
@@ -700,7 +700,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             issueNumber=inp.get("issue_number"),
                             issueRepo=inp.get("issue_repo"),
                             repos=repos,
-                        ),
+                        ).model_dump(by_alias=True, exclude_none=True),
                     )
                     result_text = f"Task {task_id} assigned to {wid}."
                 elif not is_error:
@@ -728,7 +728,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         )
                     )
                     await db.commit()
-                    await broadcast_msg(
+                    await broadcast(
                         guild_id,
                         TaskAssignedMsg(
                             workerId=wid,
@@ -741,7 +741,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             issueNumber=inp.get("issue_number"),
                             issueRepo=inp.get("issue_repo"),
                             repos=repos,
-                        ),
+                        ).model_dump(by_alias=True, exclude_none=True),
                     )
                     result_text = f"Task {task_id} queued for {wid}."
 
@@ -841,7 +841,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 update(Task).where(col(Task.id) == task_id).values(**update_vals)
                             )
                             await db.commit()
-                            await broadcast_msg(
+                            await broadcast(
                                 guild_id,
                                 TaskUpdateMsg(
                                     taskId=task_id,
@@ -849,9 +849,9 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     workerId=target_worker_id,
                                     deletedAt=None,
                                     finishedAt=None,
-                                ),
+                                ).model_dump(by_alias=True, exclude_none=True),
                             )
-                            await broadcast_msg(
+                            await broadcast(
                                 guild_id,
                                 TaskFollowupMsg(
                                     workerId=target_worker_id,
@@ -863,7 +863,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     instructions=instructions,
                                     issueNumber=task_issue_number,
                                     issueRepo=task_issue_repo,
-                                ),
+                                ).model_dump(by_alias=True, exclude_none=True),
                             )
                             if target_worker_id != original_worker_id and original_worker_id:
                                 result_text = (

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -20,17 +20,6 @@ from typing import Any
 
 from database import get_db
 from events import broadcast_msg, emit_terminal_line
-from ws_types import (
-    TaskAssignedMsg,
-    TaskCancelMsg,
-    TaskCreatedMsg,
-    TaskFinalizeMsg,
-    TaskFollowupMsg,
-    TaskRedirectMsg,
-    TaskUpdateMsg,
-    WorkerMessageMsg,
-    WorkerShutdownMsg,
-)
 from foreman_core.llm import get_foreman_model
 from foreman_core.tools_schema import (
     FOREMAN_TOOLS,  # noqa: F401 — re-exported for test compatibility
@@ -49,6 +38,17 @@ from models import (
 )
 from sqlalchemy import delete, update
 from sqlmodel import col, select
+from ws_types import (
+    TaskAssignedMsg,
+    TaskCancelMsg,
+    TaskCreatedMsg,
+    TaskFinalizeMsg,
+    TaskFollowupMsg,
+    TaskRedirectMsg,
+    TaskUpdateMsg,
+    WorkerMessageMsg,
+    WorkerShutdownMsg,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -914,7 +914,9 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 taskId=task_id,
                                 state="done",
                                 finishedAt=finished_at.isoformat(),
-                                deletedAt=deleted_at.isoformat() if deleted_at is not None else None,
+                                deletedAt=deleted_at.isoformat()
+                                if deleted_at is not None
+                                else None,
                             ),
                         )
                         result_text = (
@@ -987,22 +989,17 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         )
                         await LockService(db).release(f"task:{task_id}")
                         await db.commit()
-                        await broadcast(
+                        await broadcast_msg(
                             guild_id,
-                            {
-                                "type": "task-cancel",
-                                "workerId": worker_id_val,
-                                "taskId": task_id,
-                            },
+                            TaskCancelMsg(workerId=worker_id_val, taskId=task_id),
                         )
-                        await broadcast(
+                        await broadcast_msg(
                             guild_id,
-                            {
-                                "type": "task-update",
-                                "taskId": task_id,
-                                "state": "cancelled",
-                                "finishedAt": finished_at.isoformat(),
-                            },
+                            TaskUpdateMsg(
+                                taskId=task_id,
+                                state="cancelled",
+                                finishedAt=finished_at.isoformat(),
+                            ),
                         )
                         result_text = f"Task {task_id} cancelled." + (
                             f" Reason: {reason}" if reason else ""

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from database import get_db
-from events import broadcast, emit_terminal_line
+from events import broadcast, broadcast_msg, emit_terminal_line
 from foreman_core.llm import get_foreman_model
 from foreman_core.tools_schema import (
     FOREMAN_TOOLS,  # noqa: F401 — re-exported for test compatibility

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -19,7 +19,18 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from database import get_db
-from events import broadcast, emit_terminal_line
+from events import broadcast_msg, emit_terminal_line
+from ws_types import (
+    TaskAssignedMsg,
+    TaskCancelMsg,
+    TaskCreatedMsg,
+    TaskFinalizeMsg,
+    TaskFollowupMsg,
+    TaskRedirectMsg,
+    TaskUpdateMsg,
+    WorkerMessageMsg,
+    WorkerShutdownMsg,
+)
 from foreman_core.llm import get_foreman_model
 from foreman_core.tools_schema import (
     FOREMAN_TOOLS,  # noqa: F401 — re-exported for test compatibility
@@ -590,17 +601,16 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     )
                 )
                 await db.commit()
-                await broadcast(
+                await broadcast_msg(
                     guild_id,
-                    {
-                        "type": "task-created",
-                        "taskId": task_id,
-                        "name": name,
-                        "description": desc,
-                        "phase": phase,
-                        "state": "pending",
-                        "createdAt": created_at.isoformat(),
-                    },
+                    TaskCreatedMsg(
+                        taskId=task_id,
+                        name=name,
+                        description=desc,
+                        phase=phase,
+                        state="pending",
+                        createdAt=created_at.isoformat(),
+                    ),
                 )
                 result_text = (
                     f"Task {task_id} created: '{name}'. Reference this task_id in assign_task."
@@ -678,20 +688,19 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     )
                     task_name = name_result.one_or_none() or desc[:60]
                     task_id = existing_task_id
-                    await broadcast(
+                    await broadcast_msg(
                         guild_id,
-                        {
-                            "type": "task-assigned",
-                            "workerId": wid,
-                            "taskId": task_id,
-                            "name": task_name,
-                            "description": desc,
-                            "tool": tool,
-                            "phase": phase,
-                            "issueNumber": inp.get("issue_number"),
-                            "issueRepo": inp.get("issue_repo"),
-                            "repos": repos,
-                        },
+                        TaskAssignedMsg(
+                            workerId=wid,
+                            taskId=task_id,
+                            name=task_name,
+                            description=desc,
+                            tool=tool,
+                            phase=phase,
+                            issueNumber=inp.get("issue_number"),
+                            issueRepo=inp.get("issue_repo"),
+                            repos=repos,
+                        ),
                     )
                     result_text = f"Task {task_id} assigned to {wid}."
                 elif not is_error:
@@ -719,21 +728,20 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         )
                     )
                     await db.commit()
-                    await broadcast(
+                    await broadcast_msg(
                         guild_id,
-                        {
-                            "type": "task-assigned",
-                            "workerId": wid,
-                            "taskId": task_id,
-                            "name": name,
-                            "description": desc,
-                            "tool": tool,
-                            "phase": phase,
-                            "parentTaskId": parent_task_id,
-                            "issueNumber": inp.get("issue_number"),
-                            "issueRepo": inp.get("issue_repo"),
-                            "repos": repos,
-                        },
+                        TaskAssignedMsg(
+                            workerId=wid,
+                            taskId=task_id,
+                            name=name,
+                            description=desc,
+                            tool=tool,
+                            phase=phase,
+                            parentTaskId=parent_task_id,
+                            issueNumber=inp.get("issue_number"),
+                            issueRepo=inp.get("issue_repo"),
+                            repos=repos,
+                        ),
                     )
                     result_text = f"Task {task_id} queued for {wid}."
 
@@ -833,31 +841,29 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 update(Task).where(col(Task.id) == task_id).values(**update_vals)
                             )
                             await db.commit()
-                            await broadcast(
+                            await broadcast_msg(
                                 guild_id,
-                                {
-                                    "type": "task-update",
-                                    "taskId": task_id,
-                                    "state": "working",
-                                    "workerId": target_worker_id,
-                                    "deletedAt": None,
-                                    "finishedAt": None,
-                                },
+                                TaskUpdateMsg(
+                                    taskId=task_id,
+                                    state="working",
+                                    workerId=target_worker_id,
+                                    deletedAt=None,
+                                    finishedAt=None,
+                                ),
                             )
-                            await broadcast(
+                            await broadcast_msg(
                                 guild_id,
-                                {
-                                    "type": "task-followup",
-                                    "workerId": target_worker_id,
-                                    "taskId": task_id,
-                                    "name": task_name or "",
-                                    "description": task_desc or "",
-                                    "tool": task_tool or "claude",
-                                    "branch": branch,
-                                    "instructions": instructions,
-                                    "issueNumber": task_issue_number,
-                                    "issueRepo": task_issue_repo,
-                                },
+                                TaskFollowupMsg(
+                                    workerId=target_worker_id,
+                                    taskId=task_id,
+                                    name=task_name or "",
+                                    description=task_desc or "",
+                                    tool=task_tool or "claude",
+                                    branch=branch,
+                                    instructions=instructions,
+                                    issueNumber=task_issue_number,
+                                    issueRepo=task_issue_repo,
+                                ),
                             )
                             if target_worker_id != original_worker_id and original_worker_id:
                                 result_text = (
@@ -898,25 +904,18 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
                         await LockService(db).release(f"task:{task_id}")
                         await db.commit()
-                        await broadcast(
+                        await broadcast_msg(
                             guild_id,
-                            {
-                                "type": "task-finalize",
-                                "workerId": task.worker_id,
-                                "taskId": task_id,
-                            },
+                            TaskFinalizeMsg(workerId=task.worker_id, taskId=task_id),
                         )
-                        await broadcast(
+                        await broadcast_msg(
                             guild_id,
-                            {
-                                "type": "task-update",
-                                "taskId": task_id,
-                                "state": "done",
-                                "finishedAt": finished_at.isoformat(),
-                                "deletedAt": deleted_at.isoformat()
-                                if deleted_at is not None
-                                else None,
-                            },
+                            TaskUpdateMsg(
+                                taskId=task_id,
+                                state="done",
+                                finishedAt=finished_at.isoformat(),
+                                deletedAt=deleted_at.isoformat() if deleted_at is not None else None,
+                            ),
                         )
                         result_text = (
                             f"Task {task_id} finalized; soft-delete at "
@@ -927,14 +926,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 wid = inp["worker_id"]
                 msg = inp["message"]
                 await emit_terminal_line(guild_id, wid, f"[foreman] {msg}")
-                await broadcast(
-                    guild_id,
-                    {
-                        "type": "worker-message",
-                        "workerId": wid,
-                        "message": msg,
-                    },
-                )
+                await broadcast_msg(guild_id, WorkerMessageMsg(workerId=wid, message=msg))
                 result_text = f"Message delivered to {wid}."
 
             elif tu.name == "redirect_task":
@@ -957,22 +949,14 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             update(Task).where(col(Task.id) == task_id).values(state="working")
                         )
                         await db.commit()
-                        await broadcast(
+                        await broadcast_msg(
                             guild_id,
-                            {
-                                "type": "task-redirect",
-                                "workerId": worker_id_val,
-                                "taskId": task_id,
-                                "instructions": instructions,
-                            },
+                            TaskRedirectMsg(
+                                workerId=worker_id_val, taskId=task_id, instructions=instructions
+                            ),
                         )
-                        await broadcast(
-                            guild_id,
-                            {
-                                "type": "task-update",
-                                "taskId": task_id,
-                                "state": "working",
-                            },
+                        await broadcast_msg(
+                            guild_id, TaskUpdateMsg(taskId=task_id, state="working")
                         )
                         result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
 
@@ -1035,10 +1019,9 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 if worker_result.one_or_none() is None:
                     result_text = f"Worker {wid} not found."
                 else:
-                    message: dict = {"type": "worker-shutdown", "workerId": wid}
-                    if reason:
-                        message["reason"] = reason
-                    await broadcast(guild_id, message)
+                    await broadcast_msg(
+                        guild_id, WorkerShutdownMsg(workerId=wid, reason=reason or None)
+                    )
                     result_text = f"Shutdown signal sent to {wid}." + (
                         f" Reason: {reason}" if reason else ""
                     )

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -35,7 +35,8 @@ from datetime import UTC, datetime
 
 from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
 from database import get_db_dep
-from events import broadcast
+from events import broadcast_msg
+from ws_types import ChatMsg, TaskCreatedMsg, TaskUpdateMsg
 from fastapi import APIRouter, Depends, HTTPException, Query
 from foreman.runner import _fetch_online_workers
 from models import (
@@ -395,17 +396,16 @@ async def create_foreman_task(
     )
     await db.commit()
 
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "task-created",
-            "taskId": task_id,
-            "name": name,
-            "description": body.description,
-            "phase": body.phase,
-            "state": "pending",
-            "createdAt": created_at.isoformat(),
-        },
+        TaskCreatedMsg(
+            taskId=task_id,
+            name=name,
+            description=body.description,
+            phase=body.phase,
+            state="pending",
+            createdAt=created_at.isoformat(),
+        ),
     )
     return {"task_id": task_id, "created_at": created_at}
 
@@ -495,11 +495,11 @@ async def patch_task(
         "deleted_at": "deletedAt",
         "phase": "phase",
     }
-    ws_payload: dict = {"type": "task-update", "taskId": task_id}
+    ws_data: dict = {"taskId": task_id}
     for col_name, ws_key in _KEY_MAP.items():
         if col_name in update_values:
-            ws_payload[ws_key] = update_values[col_name]
-    await broadcast(guild_id, ws_payload)
+            ws_data[ws_key] = update_values[col_name]
+    await broadcast_msg(guild_id, TaskUpdateMsg.model_validate(ws_data))
 
     return {"task_id": task_id, "updated": update_values}
 
@@ -550,16 +550,15 @@ async def create_message(
     await db.refresh(msg)
     msg_id = msg.id
 
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "chat",
-            "from": body.from_agent,
-            "to": body.to_agent,
-            "content": body.content,
-            "createdAt": created_at.isoformat(),
-            **({"userId": body.user_id} if body.user_id else {}),
-        },
+        ChatMsg(
+            from_=body.from_agent,
+            to=body.to_agent,
+            content=body.content,
+            createdAt=created_at.isoformat(),
+            userId=body.user_id,
+        ),
     )
     return {"message_id": msg_id, "created_at": created_at}
 

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -36,7 +36,6 @@ from datetime import UTC, datetime
 from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
 from database import get_db_dep
 from events import broadcast_msg
-from ws_types import ChatMsg, TaskCreatedMsg, TaskUpdateMsg
 from fastapi import APIRouter, Depends, HTTPException, Query
 from foreman.runner import _fetch_online_workers
 from models import (
@@ -52,6 +51,7 @@ from pydantic import BaseModel
 from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from ws_types import ChatMsg, TaskCreatedMsg, TaskUpdateMsg
 
 from foreman import clear_foreman_history, get_foreman_history
 
@@ -557,7 +557,7 @@ async def create_message(
             to=body.to_agent,
             content=body.content,
             createdAt=created_at.isoformat(),
-            userId=body.user_id,
+            **({"userId": body.user_id} if body.user_id else {}),
         ),
     )
     return {"message_id": msg_id, "created_at": created_at}

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -13,7 +13,8 @@ from datetime import UTC, datetime
 
 from auth_deps import get_guild_pk, require_member, require_user, require_worker_or_member_path
 from database import get_db_dep
-from events import broadcast
+from events import broadcast_msg
+from ws_types import GuildUpdatedMsg
 from fastapi import APIRouter, Depends, HTTPException
 from models import Agent, Guild, GuildMember, Message, User, Worker
 from pydantic import BaseModel
@@ -156,17 +157,16 @@ async def update_guild(
     if "version" in data.model_fields_set:
         guild.version = data.version
     await db.commit()
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "guild-updated",
-            "id": guild_id,
-            "name": guild.name,
-            "primary_repo": guild.primary_repo,
-            "description": guild.description,
-            "url": guild.url,
-            "version": guild.version,
-        },
+        GuildUpdatedMsg(
+            id=guild_id,
+            name=guild.name,
+            primary_repo=guild.primary_repo,
+            description=guild.description,
+            url=guild.url,
+            version=guild.version,
+        ),
     )
     return {
         "id": guild_id,

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -14,7 +14,6 @@ from datetime import UTC, datetime
 from auth_deps import get_guild_pk, require_member, require_user, require_worker_or_member_path
 from database import get_db_dep
 from events import broadcast_msg
-from ws_types import GuildUpdatedMsg
 from fastapi import APIRouter, Depends, HTTPException
 from models import Agent, Guild, GuildMember, Message, User, Worker
 from pydantic import BaseModel
@@ -25,6 +24,7 @@ from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from utils import generate_guild_id, row_to_dict
 from ws_handlers import _resolve_user_identifier
+from ws_types import GuildUpdatedMsg
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -13,7 +13,6 @@ from datetime import UTC, datetime, timedelta
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg
-from ws_types import TaskCancelMsg, TaskFinalizeMsg, TaskRedirectMsg, TaskUpdateMsg
 from fastapi import APIRouter, Depends, HTTPException
 from lock_service import LockService
 from models import Guild, Task, TaskLog, live_tasks_filter
@@ -22,6 +21,7 @@ from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from util.tasks import spawn
+from ws_types import TaskCancelMsg, TaskFinalizeMsg, TaskRedirectMsg, TaskUpdateMsg
 
 from foreman import run_foreman_ai
 

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -12,7 +12,8 @@ from datetime import UTC, datetime, timedelta
 
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
-from events import broadcast
+from events import broadcast_msg
+from ws_types import TaskCancelMsg, TaskFinalizeMsg, TaskRedirectMsg, TaskUpdateMsg
 from fastapi import APIRouter, Depends, HTTPException
 from lock_service import LockService
 from models import Guild, Task, TaskLog, live_tasks_filter
@@ -267,23 +268,15 @@ async def finalize_task_endpoint(
         .values(state="done", finished_at=finished_at, deleted_at=deleted_at)
     )
     await db.commit()
-    await broadcast(
+    await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=task_id))
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "task-finalize",
-            "workerId": worker_id,
-            "taskId": task_id,
-        },
-    )
-    await broadcast(
-        guild_id,
-        {
-            "type": "task-update",
-            "taskId": task_id,
-            "state": "done",
-            "finishedAt": finished_at.isoformat(),
-            "deletedAt": deleted_at.isoformat(),
-        },
+        TaskUpdateMsg(
+            taskId=task_id,
+            state="done",
+            finishedAt=finished_at.isoformat(),
+            deletedAt=deleted_at.isoformat(),
+        ),
     )
     # Return raw datetime — FastAPI's jsonable_encoder handles ISO-8601 serialisation.
     return {"status": "finalized", "taskId": task_id, "deletedAt": deleted_at}
@@ -319,22 +312,10 @@ async def cancel_task_endpoint(
     )
     await LockService(db).release(f"task:{task_id}")
     await db.commit()
-    await broadcast(
+    await broadcast_msg(guild_id, TaskCancelMsg(workerId=worker_id, taskId=task_id))
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "task-cancel",
-            "workerId": worker_id,
-            "taskId": task_id,
-        },
-    )
-    await broadcast(
-        guild_id,
-        {
-            "type": "task-update",
-            "taskId": task_id,
-            "state": "cancelled",
-            "finishedAt": finished_at.isoformat(),
-        },
+        TaskUpdateMsg(taskId=task_id, state="cancelled", finishedAt=finished_at.isoformat()),
     )
     return {"status": "cancelled", "taskId": task_id}
 
@@ -367,21 +348,8 @@ async def redirect_task_endpoint(
         raise HTTPException(status_code=409, detail=f"Task is already {state}")
     await db.exec(update(Task).where(col(Task.id) == task_id).values(state="working"))
     await db.commit()
-    await broadcast(
-        guild_id,
-        {
-            "type": "task-redirect",
-            "workerId": worker_id,
-            "taskId": task_id,
-            "instructions": instructions,
-        },
+    await broadcast_msg(
+        guild_id, TaskRedirectMsg(workerId=worker_id, taskId=task_id, instructions=instructions)
     )
-    await broadcast(
-        guild_id,
-        {
-            "type": "task-update",
-            "taskId": task_id,
-            "state": "working",
-        },
-    )
+    await broadcast_msg(guild_id, TaskUpdateMsg(taskId=task_id, state="working"))
     return {"status": "redirected", "taskId": task_id}

--- a/backend/routes/usage.py
+++ b/backend/routes/usage.py
@@ -8,20 +8,22 @@ frontend can surface live token/cost figures per task.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 
 from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
 from database import get_db_dep
 from events import broadcast_msg
-from ws_types import ClaudeUsageMsg
 from fastapi import APIRouter, Depends, HTTPException
 from models import ClaudeUsage
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from utils import row_to_dict
+from ws_types import ClaudeUsageMsg
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class UsageRecord(BaseModel):
@@ -110,20 +112,20 @@ async def report_usage(
         )
     await db.commit()
 
-    await broadcast_msg(
-        guild_id,
-        ClaudeUsageMsg.model_validate(
-            {
-                "taskId": data.task_id,
-                "workerId": data.worker_id,
-                "sessionId": data.session_id,
-                "model": next((r.model for r in data.records if r.model), None),
-                "repo": data.repo,
-                "reporter": data.reporter,
-                **_summarize(data.records),
-            }
-        ),
-    )
+    try:
+        usage_msg = ClaudeUsageMsg(
+            taskId=data.task_id,
+            workerId=data.worker_id,
+            sessionId=data.session_id,
+            model=next((r.model for r in data.records if r.model), None),
+            repo=data.repo,
+            reporter=data.reporter,
+            **_summarize(data.records),
+        )
+    except ValidationError as exc:
+        logger.error("Failed to construct ClaudeUsageMsg for guild %s: %s", guild_id, exc)
+        return {"stored": len(data.records)}
+    await broadcast_msg(guild_id, usage_msg)
     return {"stored": len(data.records)}
 
 

--- a/backend/routes/usage.py
+++ b/backend/routes/usage.py
@@ -12,7 +12,8 @@ from datetime import UTC, datetime
 
 from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
 from database import get_db_dep
-from events import broadcast
+from events import broadcast_msg
+from ws_types import ClaudeUsageMsg
 from fastapi import APIRouter, Depends, HTTPException
 from models import ClaudeUsage
 from pydantic import BaseModel
@@ -109,18 +110,19 @@ async def report_usage(
         )
     await db.commit()
 
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "claude-usage",
-            "taskId": data.task_id,
-            "workerId": data.worker_id,
-            "sessionId": data.session_id,
-            "model": next((r.model for r in data.records if r.model), None),
-            "repo": data.repo,
-            "reporter": data.reporter,
-            **_summarize(data.records),
-        },
+        ClaudeUsageMsg.model_validate(
+            {
+                "taskId": data.task_id,
+                "workerId": data.worker_id,
+                "sessionId": data.session_id,
+                "model": next((r.model for r in data.records if r.model), None),
+                "repo": data.repo,
+                "reporter": data.reporter,
+                **_summarize(data.records),
+            }
+        ),
     )
     return {"stored": len(data.records)}
 

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -24,7 +24,6 @@ from datetime import UTC, datetime
 
 from database import get_db_dep
 from events import broadcast_msg
-from ws_types import ChatMsg, GithubEventMsg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from models import GithubEvent, Guild, Message, Task
 from pydantic import BaseModel
@@ -33,6 +32,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from ws_types import ChatMsg, GithubEventMsg
 
 from foreman import reset_foreman_poll, run_foreman_ai
 

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -23,7 +23,8 @@ import os
 from datetime import UTC, datetime
 
 from database import get_db_dep
-from events import broadcast
+from events import broadcast_msg
+from ws_types import ChatMsg, GithubEventMsg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from models import GithubEvent, Guild, Message, Task
 from pydantic import BaseModel
@@ -605,32 +606,30 @@ async def github_webhook(
         task_id,
     )
 
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "github-event",
-            "deliveryId": delivery_id,
-            "event": event_type,
-            "action": action,
-            "repo": repo,
-            "prNumber": pr_number,
-            "prUrl": pr_url,
-            "taskId": task_id,
-            "sender": sender_login,
-        },
+        GithubEventMsg(
+            deliveryId=delivery_id,
+            event=event_type,
+            action=action,
+            repo=repo,
+            prNumber=pr_number,
+            prUrl=pr_url,
+            taskId=task_id,
+            sender=sender_login,
+        ),
     )
 
     chat_line = _build_chat_line(event_type, action, repo, pr_number, payload, task_id)
     chat_now = datetime.now(UTC)
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "chat",
-            "from": "github",
-            "to": "foreman",
-            "content": chat_line,
-            "createdAt": chat_now.isoformat(),
-        },
+        ChatMsg(
+            from_="github",
+            to="foreman",
+            content=chat_line,
+            createdAt=chat_now.isoformat(),
+        ),
     )
     db.add(
         Message(
@@ -744,15 +743,14 @@ async def ci_notify(
         )
     )
     await db.commit()
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "chat",
-            "from": "github",
-            "to": "foreman",
-            "content": content,
-            "createdAt": created_at.isoformat(),
-        },
+        ChatMsg(
+            from_="github",
+            to="foreman",
+            content=content,
+            createdAt=created_at.isoformat(),
+        ),
     )
     logger.info(
         "ci-notify guild=%s repo=%s pr=%s task=%s conclusion=%s",

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -14,13 +14,19 @@ from datetime import UTC, datetime
 import anyio
 import ws_handlers
 from database import get_db
-from events import agent_owner_lock, agent_owners, broadcast, broadcast_msg, connections, foreman_connections
-from ws_types import AgentStateMsg
+from events import (
+    agent_owner_lock,
+    agent_owners,
+    broadcast_msg,
+    connections,
+    foreman_connections,
+)
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from models import Agent, Guild, UserSession, Worker
 from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from ws_types import AgentStateMsg
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -14,7 +14,8 @@ from datetime import UTC, datetime
 import anyio
 import ws_handlers
 from database import get_db
-from events import agent_owner_lock, agent_owners, broadcast, connections, foreman_connections
+from events import agent_owner_lock, agent_owners, broadcast, broadcast_msg, connections, foreman_connections
+from ws_types import AgentStateMsg
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from models import Agent, Guild, UserSession, Worker
 from sqlalchemy import update
@@ -217,13 +218,9 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                             exc_info=True,
                         )
                 for agent_id in stale_agents:
-                    await broadcast(
+                    await broadcast_msg(
                         guild_id,
-                        {
-                            "type": "agent-state",
-                            "agentId": agent_id,
-                            "state": "offline",
-                        },
+                        AgentStateMsg(agentId=agent_id, state="offline"),
                     )
                 # Batch all stale-worker notifications into a single foreman
                 # trigger so a simultaneous mass-disconnect doesn't stampede

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -16,7 +16,8 @@ from datetime import UTC, datetime
 
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
-from events import broadcast, emit_terminal_line, pending_claude_auth
+from events import broadcast_msg, emit_terminal_line, pending_claude_auth
+from ws_types import TaskAssignedMsg, WorkerMessageMsg
 from fastapi import APIRouter, Depends, HTTPException
 from models import ClaudeCredentials, Task, Worker, live_tasks_filter
 from pydantic import BaseModel
@@ -262,21 +263,20 @@ async def assign_task(
     )
     await db.commit()
 
-    await broadcast(
+    await broadcast_msg(
         guild_id,
-        {
-            "type": "task-assigned",
-            "workerId": worker_id,
-            "taskId": task_id,
-            "name": name,
-            "description": data.description,
-            "tool": data.tool,
-            "phase": data.phase or "execute",
-            "parentTaskId": data.parent_task_id,
-            "issueNumber": data.issue_number,
-            "issueRepo": data.issue_repo,
-            "repos": data.repos,
-        },
+        TaskAssignedMsg(
+            workerId=worker_id,
+            taskId=task_id,
+            name=name,
+            description=data.description,
+            tool=data.tool,
+            phase=data.phase or "execute",
+            parentTaskId=data.parent_task_id,
+            issueNumber=data.issue_number,
+            issueRepo=data.issue_repo,
+            repos=data.repos,
+        ),
     )
 
     return {"id": task_id, "worker_id": worker_id, "state": "pending"}
@@ -316,12 +316,5 @@ async def message_worker(
         raise HTTPException(status_code=400, detail="Empty message")
 
     await emit_terminal_line(guild_id, worker_id, f"[foreman → worker] {text_msg}")
-    await broadcast(
-        guild_id,
-        {
-            "type": "worker-message",
-            "workerId": worker_id,
-            "message": text_msg,
-        },
-    )
+    await broadcast_msg(guild_id, WorkerMessageMsg(workerId=worker_id, message=text_msg))
     return {"status": "delivered"}

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -17,7 +17,6 @@ from datetime import UTC, datetime
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg, emit_terminal_line, pending_claude_auth
-from ws_types import TaskAssignedMsg, WorkerMessageMsg
 from fastapi import APIRouter, Depends, HTTPException
 from models import ClaudeCredentials, Task, Worker, live_tasks_filter
 from pydantic import BaseModel
@@ -30,6 +29,7 @@ from utils import (
     worker_display_name,
 )
 from ws_handlers import _resolve_user_identifier
+from ws_types import TaskAssignedMsg, WorkerMessageMsg
 
 router = APIRouter()
 

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -561,7 +561,7 @@ class TestExecToolsDispatching:
             broadcast_calls.append(msg)
 
         with (
-            patch("foreman.tools.broadcast", side_effect=capture),
+            patch("foreman.tools.broadcast_msg", side_effect=capture),
             patch("foreman.tools.emit_terminal_line", new_callable=AsyncMock),
         ):
             results = await exec_tools(
@@ -573,9 +573,9 @@ class TestExecToolsDispatching:
                 ],
             )
         assert "delivered" in results[0]["content"].lower()
-        worker_msgs = [m for m in broadcast_calls if m.get("type") == "worker-message"]
+        worker_msgs = [m for m in broadcast_calls if m.type == "worker-message"]
         assert len(worker_msgs) == 1
-        assert worker_msgs[0]["message"] == "Hello worker"
+        assert worker_msgs[0].message == "Hello worker"
 
     async def test_redirect_task_not_found(self, db_session):
         insert_guild(db_session, "g-redirect-missing")

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -670,7 +670,7 @@ class TestExecToolsDispatching:
     async def test_shutdown_worker_broadcasts_signal(self, db_session):
         insert_guild(db_session, "g-sd-ok")
         _insert_worker(db_session, "g-sd-ok", "w-sd")
-        with patch("foreman.tools.broadcast", new_callable=AsyncMock) as mock_bcast:
+        with patch("foreman.tools.broadcast_msg", new_callable=AsyncMock) as mock_bcast:
             results = await exec_tools(
                 "g-sd-ok",
                 [
@@ -684,26 +684,26 @@ class TestExecToolsDispatching:
         assert "winding down" in results[0]["content"]
         # The handler must broadcast a worker-shutdown message targeting the worker.
         shutdown_calls = [
-            c for c in mock_bcast.await_args_list if c.args[1].get("type") == "worker-shutdown"
+            c for c in mock_bcast.await_args_list if c.args[1].type == "worker-shutdown"
         ]
         assert len(shutdown_calls) == 1
         payload = shutdown_calls[0].args[1]
-        assert payload["workerId"] == "w-sd"
-        assert payload.get("reason") == "winding down"
+        assert payload.workerId == "w-sd"
+        assert payload.reason == "winding down"
 
     async def test_shutdown_worker_omits_reason_when_blank(self, db_session):
         insert_guild(db_session, "g-sd-noreason")
         _insert_worker(db_session, "g-sd-noreason", "w-sd2")
-        with patch("foreman.tools.broadcast", new_callable=AsyncMock) as mock_bcast:
+        with patch("foreman.tools.broadcast_msg", new_callable=AsyncMock) as mock_bcast:
             await exec_tools(
                 "g-sd-noreason",
                 [_fake_tool_use("shutdown_worker", {"worker_id": "w-sd2"})],
             )
         shutdown_calls = [
-            c for c in mock_bcast.await_args_list if c.args[1].get("type") == "worker-shutdown"
+            c for c in mock_bcast.await_args_list if c.args[1].type == "worker-shutdown"
         ]
         assert len(shutdown_calls) == 1
-        assert "reason" not in shutdown_calls[0].args[1]
+        assert shutdown_calls[0].args[1].reason is None
 
     async def test_get_task_status_not_found(self, db_session):
         insert_guild(db_session, "g-status-missing")

--- a/backend/tests/test_usage_api.py
+++ b/backend/tests/test_usage_api.py
@@ -55,10 +55,6 @@ def test_report_usage_stores_rows_and_broadcasts(client, monkeypatch):
         captured.append((guild_id, message))
 
     monkeypatch.setattr(events_module, "broadcast", _fake_broadcast)
-    # routes.usage imported broadcast by name, so patch it there too.
-    import routes.usage as usage_module
-
-    monkeypatch.setattr(usage_module, "broadcast", _fake_broadcast)
 
     resp = test_client.post(
         "/guilds/guseu1/usage",

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -18,13 +18,40 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import ValidationError
+
 from events import (
     agent_owner_lock,
     agent_owners,
     broadcast,
+    broadcast_msg,
     connections,
     foreman_connections,
     pending_claude_auth,
+    send_ws_message,
+)
+from ws_types import (
+    AgentJoinedMsg,
+    AgentStateMsg,
+    AnswerMsg,
+    ChatMsg,
+    ClaudeAuthRequiredMsg,
+    ForemanDisconnectMsg,
+    ForemanEvictedMsg,
+    ForemanRegisteredMsg,
+    ForemanTriggerMsg,
+    IceCandidateMsg,
+    KNOWN_INBOUND_TYPES,
+    NeedsInputMsg,
+    OfferMsg,
+    PongMsg,
+    TaskAssignedMsg,
+    TaskCompleteMsg,
+    TaskFollowupDoneMsg,
+    TaskUpdateMsg,
+    TerminalOutputMsg,
+    WorkerAuthResponseMsg,
+    parse_inbound_message,
 )
 from fastapi import WebSocket
 from lock_service import LockService
@@ -148,18 +175,15 @@ async def _trigger_foreman(
     """
     ws = foreman_connections.get(guild_id)
     if ws is not None:
-        payload: dict = {
-            "type": "foreman-trigger",
-            "event": event,
-            "guildId": guild_id,
-            "humanMessage": human_message,
-        }
-        if user_id:
-            payload["userId"] = user_id
-        if task_id:
-            payload["taskId"] = task_id
+        msg = ForemanTriggerMsg(
+            event=event,
+            guildId=guild_id,
+            humanMessage=human_message,
+            userId=user_id if user_id else None,
+            taskId=task_id if task_id else None,
+        )
         try:
-            await ws.send_json(payload)
+            await send_ws_message(ws, msg)
             logger.debug(
                 "guild=%s foreman-trigger dispatched to external foreman: event=%s",
                 guild_id,
@@ -209,7 +233,7 @@ class WSContext:
 async def handle_ping(ctx: WSContext, data: dict) -> None:
     """Application-level heartbeat. Reply with pong so the worker can detect a
     half-open socket too."""
-    await ctx.websocket.send_json({"type": "pong", "timestamp": datetime.now(UTC).isoformat()})
+    await send_ws_message(ctx.websocket, PongMsg(timestamp=datetime.now(UTC).isoformat()))
 
 
 async def handle_join(ctx: WSContext, data: dict) -> None:
@@ -275,24 +299,21 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
                 ctx.guild_id,
             )
             try:
-                await existing_ws.send_json(
-                    {
-                        "type": "foreman-evicted",
-                        "guildId": ctx.guild_id,
-                        "reason": "superseded by new foreman connection",
-                    }
+                await send_ws_message(
+                    existing_ws,
+                    ForemanEvictedMsg(
+                        guildId=ctx.guild_id,
+                        reason="superseded by new foreman connection",
+                    ),
                 )
             except Exception:
                 pass
         foreman_connections[ctx.guild_id] = ctx.websocket
         logger.info("guild=%s external foreman registered: agentId=%s", ctx.guild_id, agent_id)
         # Acknowledge registration so the foreman knows it is the active one.
-        await ctx.websocket.send_json(
-            {
-                "type": "foreman-registered",
-                "guildId": ctx.guild_id,
-                "agentId": agent_id,
-            }
+        await send_ws_message(
+            ctx.websocket,
+            ForemanRegisteredMsg(guildId=ctx.guild_id, agentId=agent_id),
         )
     elif agent_type == "worker":
         reset_foreman_poll(ctx.guild_id)
@@ -318,27 +339,25 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
                     pt.id,
                     worker_id,
                 )
-                await ctx.websocket.send_json(
-                    {
-                        "type": "task-assigned",
-                        "workerId": worker_id,
-                        "taskId": pt.id,
-                        "name": pt.name or "",
-                        "description": pt.description or "",
-                        "tool": pt.tool or "claude",
-                        "issueNumber": pt.issue_number,
-                        "issueRepo": pt.issue_repo,
-                    }
+                await send_ws_message(
+                    ctx.websocket,
+                    TaskAssignedMsg(
+                        workerId=worker_id,
+                        taskId=pt.id,
+                        name=pt.name or "",
+                        description=pt.description or "",
+                        tool=pt.tool or "claude",
+                        issueNumber=pt.issue_number,
+                        issueRepo=pt.issue_repo,
+                    ),
                 )
-    broadcast_payload: dict = {
-        "type": "agent-joined",
-        "agentId": agent_id,
-        "agentName": agent_name,
-        "agentType": agent_type,
-        "workerId": worker_id,
-        "state": "idle",
-        "joinedAt": joined_at.isoformat(),
-    }
+    joined_msg = AgentJoinedMsg(
+        agentId=agent_id,
+        agentName=agent_name,
+        agentType=agent_type,
+        workerId=worker_id,
+        joinedAt=joined_at.isoformat(),
+    )
     if worker_id:
         r = await ctx.db.exec(
             select(col(Worker.name)).where(
@@ -346,8 +365,8 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
             )
         )
         stored_name = r.one_or_none()
-        broadcast_payload["workerName"] = stored_name or worker_display_name(worker_id)
-    await broadcast(ctx.guild_id, broadcast_payload)
+        joined_msg.workerName = stored_name or worker_display_name(worker_id)
+    await broadcast_msg(ctx.guild_id, joined_msg)
 
 
 # States that indicate the agent is no longer actively running a task and
@@ -418,14 +437,16 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
             await LockService(ctx.db).release(f"task:{task_id_to_release}")
 
     await ctx.db.commit()
-    msg: dict = {"type": "agent-state", "agentId": agent_id, "state": state}
-    if worker_id:
-        msg["workerId"] = worker_id
-    if "activity" in update_vals:
-        msg["activity"] = update_vals["activity"]
-    if "current_task_id" in update_vals:
-        msg["taskId"] = update_vals["current_task_id"]
-    await broadcast(ctx.guild_id, msg)
+    await broadcast_msg(
+        ctx.guild_id,
+        AgentStateMsg(
+            agentId=agent_id,
+            state=state,
+            workerId=worker_id if worker_id else None,
+            activity=update_vals.get("activity"),
+            taskId=update_vals.get("current_task_id"),
+        ),
+    )
     reset_foreman_poll(ctx.guild_id)
 
 
@@ -453,16 +474,15 @@ async def handle_chat(ctx: WSContext, data: dict) -> None:
         )
     )
     await ctx.db.commit()
-    await broadcast(
+    await broadcast_msg(
         ctx.guild_id,
-        {
-            "type": "chat",
-            "from": from_agent,
-            "to": to_agent,
-            "content": content,
-            "createdAt": created_at.isoformat(),
-            **({"userId": ctx.ws_user_id} if ctx.ws_user_id and from_agent == "user" else {}),
-        },
+        ChatMsg(
+            **{"from": from_agent},
+            to=to_agent,
+            content=content,
+            createdAt=created_at.isoformat(),
+            userId=ctx.ws_user_id if ctx.ws_user_id and from_agent == "user" else None,
+        ),
     )
     if not (from_agent == "user" and to_agent == "foreman" and content):
         return
@@ -477,13 +497,9 @@ async def handle_chat(ctx: WSContext, data: dict) -> None:
             ctx.guild_id,
             len(content),
         )
-        await broadcast(
+        await broadcast_msg(
             ctx.guild_id,
-            {
-                "type": "worker-auth-response",
-                "workerId": pending_worker_id,
-                "code": content,
-            },
+            WorkerAuthResponseMsg(workerId=pending_worker_id, code=content),
         )
     else:
         await _trigger_foreman(
@@ -523,18 +539,17 @@ async def handle_terminal_output(ctx: WSContext, data: dict) -> None:
             )
         )
         await ctx.db.commit()
-    await broadcast(
+    await broadcast_msg(
         ctx.guild_id,
-        {
-            "type": "terminal-output",
-            "agentId": msg_agent_id,
-            "workerId": worker_id_for_log,
-            "taskId": task_id,
-            "line": line,
-            "timestamp": created_at.isoformat(),
-            **({"detail": detail} if detail else {}),
-            **({"level": level} if level else {}),
-        },
+        TerminalOutputMsg(
+            agentId=msg_agent_id,
+            workerId=worker_id_for_log,
+            taskId=task_id,
+            line=line,
+            timestamp=created_at.isoformat(),
+            detail=detail if detail else None,
+            level=level if level else None,
+        ),
     )
 
 
@@ -592,9 +607,9 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
     if ctx.joined_agents or worker_id:
         await ctx.db.commit()
     for agent_id in ctx.joined_agents:
-        await broadcast(
+        await broadcast_msg(
             ctx.guild_id,
-            {"type": "agent-state", "agentId": agent_id, "state": "offline"},
+            AgentStateMsg(agentId=agent_id, state="offline"),
         )
     if worker_id:
         await _trigger_foreman(
@@ -643,7 +658,7 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
         if update_values.get("state") in _TERMINAL_STATES:
             await LockService(ctx.db).release(f"task:{task_id}")
         await ctx.db.commit()
-    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    await broadcast_msg(ctx.guild_id, TaskUpdateMsg.model_validate(data), exclude=ctx.websocket)
     if "state" in update_values:
         reset_foreman_poll(ctx.guild_id)
     # Drain any pending-followup events queued while the task was locked, and
@@ -715,7 +730,9 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
         )
         await LockService(ctx.db).release(f"task:{task_id}")
         await ctx.db.commit()
-    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    await broadcast_msg(
+        ctx.guild_id, TaskCompleteMsg.model_validate(data), exclude=ctx.websocket
+    )
     if task_id:
         spawn(
             maybe_post_plan_comment(ctx.guild_id, task_id, last_text),
@@ -785,7 +802,9 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
             )
         await LockService(ctx.db).release(f"task:{task_id}")
         await ctx.db.commit()
-    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    await broadcast_msg(
+        ctx.guild_id, TaskFollowupDoneMsg.model_validate(data), exclude=ctx.websocket
+    )
     if not task_id:
         return
 
@@ -844,7 +863,9 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
 
 
 async def handle_needs_input(ctx: WSContext, data: dict) -> None:
-    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    await broadcast_msg(
+        ctx.guild_id, NeedsInputMsg.model_validate(data), exclude=ctx.websocket
+    )
     wid = data.get("workerId", "a worker")
     task_id = data.get("taskId", "")
     description = data.get("description", "")
@@ -876,7 +897,9 @@ async def handle_claude_auth_required(ctx: WSContext, data: dict) -> None:
         ctx.guild_id,
         auth_url[:80],
     )
-    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    await broadcast_msg(
+        ctx.guild_id, ClaudeAuthRequiredMsg.model_validate(data), exclude=ctx.websocket
+    )
     pending_claude_auth.setdefault(ctx.guild_id, {})[worker_id] = auth_url
     logger.info(
         "pending_claude_auth now has %d entries for guild %s",
@@ -909,9 +932,9 @@ async def handle_foreman_disconnect(ctx: WSContext, data: dict) -> None:
             "guild=%s external foreman disconnected gracefully",
             ctx.guild_id,
         )
-    await broadcast(
+    await broadcast_msg(
         ctx.guild_id,
-        {"type": "foreman-disconnect", "guildId": ctx.guild_id},
+        ForemanDisconnectMsg(guildId=ctx.guild_id),
         exclude=ctx.websocket,
     )
 
@@ -932,7 +955,7 @@ async def handle_worker_auth_response(ctx: WSContext, data: dict) -> None:
         peer_count,
         ctx.guild_id,
     )
-    await broadcast(ctx.guild_id, data)
+    await broadcast_msg(ctx.guild_id, WorkerAuthResponseMsg.model_validate(data))
 
 
 async def handle_foreman_broadcast(ctx: WSContext, data: dict) -> None:
@@ -951,7 +974,11 @@ async def handle_foreman_broadcast(ctx: WSContext, data: dict) -> None:
 
 async def handle_webrtc_signal(ctx: WSContext, data: dict) -> None:
     """offer/answer/ice-candidate — forward to all peers in the guild."""
-    await broadcast(ctx.guild_id, data, exclude=ctx.websocket)
+    rtc_type = data.get("type", "offer")
+    cls = {"offer": OfferMsg, "answer": AnswerMsg, "ice-candidate": IceCandidateMsg}.get(
+        rtc_type, OfferMsg
+    )
+    await broadcast_msg(ctx.guild_id, cls.model_validate(data), exclude=ctx.websocket)
 
 
 HANDLERS: dict[str, Any] = {
@@ -979,11 +1006,24 @@ HANDLERS: dict[str, Any] = {
 async def dispatch(ctx: WSContext, data: dict) -> None:
     """Route an inbound WS message to its handler.
 
-    Unknown types fall through to a generic broadcast (legacy behaviour).
+    Known types are validated with Pydantic before the handler is called;
+    malformed frames are dropped with a warning. Unknown types fall through
+    to a generic broadcast (legacy pass-through behaviour).
     """
     msg_type = data.get("type") or ""
     handler = HANDLERS.get(msg_type)
     if handler is None:
         await broadcast(ctx.guild_id, data)
         return
+    if msg_type in KNOWN_INBOUND_TYPES:
+        try:
+            parse_inbound_message(data)
+        except ValidationError as exc:
+            logger.warning(
+                "guild=%s dropping malformed inbound WS message type=%s: %s",
+                ctx.guild_id,
+                msg_type,
+                exc,
+            )
+            return
     await handler(ctx, data)

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -18,8 +18,6 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import ValidationError
-
 from events import (
     agent_owner_lock,
     agent_owners,
@@ -30,7 +28,18 @@ from events import (
     pending_claude_auth,
     send_ws_message,
 )
+from fastapi import WebSocket
+from lock_service import LockService
+from models import Agent, Message, Task, TaskEvent, TaskLog, User, Worker
+from pydantic import ValidationError
+from sqlalchemy import delete, func, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from util.tasks import spawn
+from utils import worker_display_name
 from ws_types import (
+    KNOWN_INBOUND_TYPES,
     AgentJoinedMsg,
     AgentStateMsg,
     AnswerMsg,
@@ -41,7 +50,6 @@ from ws_types import (
     ForemanRegisteredMsg,
     ForemanTriggerMsg,
     IceCandidateMsg,
-    KNOWN_INBOUND_TYPES,
     NeedsInputMsg,
     OfferMsg,
     PongMsg,
@@ -53,15 +61,6 @@ from ws_types import (
     WorkerAuthResponseMsg,
     parse_inbound_message,
 )
-from fastapi import WebSocket
-from lock_service import LockService
-from models import Agent, Message, Task, TaskEvent, TaskLog, User, Worker
-from sqlalchemy import delete, func, update
-from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlmodel import col, select
-from sqlmodel.ext.asyncio.session import AsyncSession
-from util.tasks import spawn
-from utils import worker_display_name
 
 from foreman import maybe_post_plan_comment, reset_foreman_poll, run_foreman_ai
 
@@ -179,8 +178,8 @@ async def _trigger_foreman(
             event=event,
             guildId=guild_id,
             humanMessage=human_message,
-            userId=user_id if user_id else None,
-            taskId=task_id if task_id else None,
+            userId=user_id or None,  # coerce empty string to None
+            taskId=task_id or None,  # coerce empty string to None
         )
         try:
             await send_ws_message(ws, msg)
@@ -730,9 +729,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
         )
         await LockService(ctx.db).release(f"task:{task_id}")
         await ctx.db.commit()
-    await broadcast_msg(
-        ctx.guild_id, TaskCompleteMsg.model_validate(data), exclude=ctx.websocket
-    )
+    await broadcast_msg(ctx.guild_id, TaskCompleteMsg.model_validate(data), exclude=ctx.websocket)
     if task_id:
         spawn(
             maybe_post_plan_comment(ctx.guild_id, task_id, last_text),
@@ -863,9 +860,7 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
 
 
 async def handle_needs_input(ctx: WSContext, data: dict) -> None:
-    await broadcast_msg(
-        ctx.guild_id, NeedsInputMsg.model_validate(data), exclude=ctx.websocket
-    )
+    await broadcast_msg(ctx.guild_id, NeedsInputMsg.model_validate(data), exclude=ctx.websocket)
     wid = data.get("workerId", "a worker")
     task_id = data.get("taskId", "")
     description = data.get("description", "")

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -1,0 +1,461 @@
+"""Pydantic v2 discriminated-union models for the Pioneer Square WebSocket protocol.
+
+Two unions are exported:
+  - ``OutboundWSMessage``: all message types the *backend* sends to browsers/workers
+  - ``InboundWSMessage``:  all message types *received* from workers or the foreman
+
+Bidirectional types (inbound echo → outbound) appear once under a shared name.
+
+Usage in handlers::
+
+    from ws_types import AgentStateMsg, TaskAssignedMsg
+    from events import broadcast_msg, send_ws_message
+
+    await broadcast_msg(guild_id, AgentStateMsg(agentId=aid, state="offline"))
+    await send_ws_message(ws, TaskAssignedMsg(workerId=wid, taskId=tid, ...))
+
+Inbound validation in dispatch::
+
+    from ws_types import parse_inbound_message
+    from pydantic import ValidationError
+
+    try:
+        parsed = parse_inbound_message(data)
+    except ValidationError as exc:
+        logger.warning("Invalid inbound WS message: %s", exc)
+        return
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+
+
+# ---------------------------------------------------------------------------
+# Base
+# ---------------------------------------------------------------------------
+
+
+class _WS(BaseModel):
+    """Shared base for all WS message models."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+# ---------------------------------------------------------------------------
+# Outbound: backend → browser / worker
+# ---------------------------------------------------------------------------
+
+
+class PongMsg(_WS):
+    type: Literal["pong"] = "pong"
+    timestamp: str
+
+
+class AgentJoinedMsg(_WS):
+    type: Literal["agent-joined"] = "agent-joined"
+    agentId: str | None = None
+    agentName: str
+    agentType: str
+    workerId: str | None = None
+    state: str = "idle"
+    joinedAt: str
+    workerName: str | None = None
+
+
+class AgentStateMsg(_WS):
+    """Bidirectional: received from worker, echoed to all clients."""
+
+    type: Literal["agent-state"] = "agent-state"
+    agentId: str | None = None
+    state: str
+    workerId: str | None = None
+    activity: str | None = None
+    taskId: str | None = None
+
+
+class ChatMsg(_WS):
+    """Chat message – bidirectional; outbound adds createdAt/userId/role fields."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: Literal["chat"] = "chat"
+    from_: str = Field("user", alias="from")
+    to: str = "foreman"
+    content: str = ""
+    createdAt: str | None = None
+    userId: str | None = None
+    role: str | None = None
+    toolName: str | None = None
+    toolInput: dict[str, Any] | None = None
+    toolId: str | None = None
+    toolOutput: str | None = None
+    isError: bool | None = None
+
+
+class TerminalOutputMsg(_WS):
+    """Terminal log line – bidirectional; outbound adds timestamp."""
+
+    type: Literal["terminal-output"] = "terminal-output"
+    agentId: str | None = None
+    workerId: str | None = None
+    taskId: str | None = None
+    line: str = ""
+    timestamp: str | None = None
+    detail: dict[str, Any] | None = None
+    level: str | None = None
+
+
+class TaskAssignedMsg(_WS):
+    type: Literal["task-assigned"] = "task-assigned"
+    workerId: str
+    taskId: str
+    name: str = ""
+    description: str = ""
+    tool: str = "claude"
+    phase: str | None = None
+    parentTaskId: str | None = None
+    issueNumber: int | None = None
+    issueRepo: str | None = None
+    repos: list[str] | None = None
+
+
+class TaskCreatedMsg(_WS):
+    type: Literal["task-created"] = "task-created"
+    taskId: str
+    name: str
+    description: str
+    phase: str
+    state: str
+    createdAt: str
+
+
+class TaskUpdateMsg(_WS):
+    """Task state patch – bidirectional; exact fields vary by source."""
+
+    type: Literal["task-update"] = "task-update"
+    taskId: str
+    state: str | None = None
+    workerId: str | None = None
+    branch: str | None = None
+    worktreePath: str | None = None
+    prUrl: str | None = None
+    finishedAt: str | None = None
+    deletedAt: str | None = None
+    phase: str | None = None
+
+
+class TaskCompleteMsg(_WS):
+    """Echoed outbound from inbound worker message."""
+
+    type: Literal["task-complete"] = "task-complete"
+    taskId: str | None = None
+    workerId: str | None = None
+    description: str | None = None
+    branch: str | None = None
+    prUrl: str | None = None
+    lastText: str | None = None
+    stopReason: str = "success"
+
+
+class TaskFollowupMsg(_WS):
+    """Follow-up instructions dispatched to a worker."""
+
+    type: Literal["task-followup"] = "task-followup"
+    workerId: str
+    taskId: str
+    name: str = ""
+    description: str = ""
+    tool: str = "claude"
+    branch: str
+    instructions: str
+    issueNumber: int | None = None
+    issueRepo: str | None = None
+
+
+class TaskFollowupDoneMsg(_WS):
+    """Echoed outbound from inbound worker message."""
+
+    type: Literal["task-followup-done"] = "task-followup-done"
+    taskId: str | None = None
+    workerId: str | None = None
+    stopReason: str = "success"
+    lastText: str | None = None
+    prUrl: str | None = None
+
+
+class TaskFinalizeMsg(_WS):
+    type: Literal["task-finalize"] = "task-finalize"
+    workerId: str | None = None
+    taskId: str
+
+
+class TaskCancelMsg(_WS):
+    type: Literal["task-cancel"] = "task-cancel"
+    workerId: str | None = None
+    taskId: str
+
+
+class TaskRedirectMsg(_WS):
+    type: Literal["task-redirect"] = "task-redirect"
+    workerId: str | None = None
+    taskId: str
+    instructions: str
+
+
+class NeedsInputMsg(_WS):
+    """Bidirectional – echoed outbound."""
+
+    type: Literal["needs-input"] = "needs-input"
+    workerId: str = ""
+    taskId: str | None = None
+    description: str | None = None
+    stopReason: str | None = None
+    lastMessage: str | None = None
+
+
+class ClaudeAuthRequiredMsg(_WS):
+    """Bidirectional – echoed outbound."""
+
+    type: Literal["claude-auth-required"] = "claude-auth-required"
+    workerId: str = ""
+    url: str = ""
+
+
+class WorkerAuthResponseMsg(_WS):
+    """Bidirectional – echoed outbound."""
+
+    type: Literal["worker-auth-response"] = "worker-auth-response"
+    workerId: str = ""
+    code: str = ""
+
+
+class WorkerMessageMsg(_WS):
+    type: Literal["worker-message"] = "worker-message"
+    workerId: str
+    message: str
+
+
+class WorkerShutdownMsg(_WS):
+    type: Literal["worker-shutdown"] = "worker-shutdown"
+    workerId: str
+    reason: str | None = None
+
+
+class ForemanTriggerMsg(_WS):
+    type: Literal["foreman-trigger"] = "foreman-trigger"
+    event: str
+    guildId: str
+    humanMessage: str
+    userId: str | None = None
+    taskId: str | None = None
+
+
+class ForemanRegisteredMsg(_WS):
+    type: Literal["foreman-registered"] = "foreman-registered"
+    guildId: str
+    agentId: str | None = None
+
+
+class ForemanEvictedMsg(_WS):
+    type: Literal["foreman-evicted"] = "foreman-evicted"
+    guildId: str
+    reason: str
+
+
+class ForemanDisconnectMsg(_WS):
+    type: Literal["foreman-disconnect"] = "foreman-disconnect"
+    guildId: str | None = None
+
+
+class ForemanPollStatusMsg(_WS):
+    type: Literal["foreman-poll-status"] = "foreman-poll-status"
+    nextCheckIn: int | float
+
+
+class GuildUpdatedMsg(_WS):
+    type: Literal["guild-updated"] = "guild-updated"
+    id: str
+    name: str | None = None
+    primary_repo: str | None = None
+    description: str | None = None
+    url: str | None = None
+    version: str | None = None
+
+
+class GithubEventMsg(_WS):
+    type: Literal["github-event"] = "github-event"
+    deliveryId: str | None = None
+    event: str | None = None
+    action: str | None = None
+    repo: str | None = None
+    prNumber: int | None = None
+    prUrl: str | None = None
+    taskId: str | None = None
+    sender: str | None = None
+
+
+class ClaudeUsageMsg(_WS):
+    """Claude session usage stats. Extra fields from _summarize() are allowed."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    type: Literal["claude-usage"] = "claude-usage"
+    taskId: str | None = None
+    workerId: str | None = None
+    sessionId: str | None = None
+    model: str | None = None
+    repo: str | None = None
+    reporter: str | None = None
+
+
+# WebRTC signaling – forwarded verbatim; extra fields allowed
+class OfferMsg(_WS):
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    type: Literal["offer"] = "offer"
+
+
+class AnswerMsg(_WS):
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    type: Literal["answer"] = "answer"
+
+
+class IceCandidateMsg(_WS):
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    type: Literal["ice-candidate"] = "ice-candidate"
+
+
+# ---------------------------------------------------------------------------
+# Inbound-only types (received from workers / browser / external foreman)
+# ---------------------------------------------------------------------------
+
+
+class PingMsg(_WS):
+    type: Literal["ping"] = "ping"
+
+
+class JoinMsg(_WS):
+    type: Literal["join"] = "join"
+    agentId: str | None = None
+    agentName: str = "Unknown"
+    agentType: str = "worker"
+    workerId: str | None = None
+    external: bool | None = None
+
+
+class WorkerRegisterMsg(_WS):
+    type: Literal["worker-register"] = "worker-register"
+    workerId: str | None = None
+    repos: list[str] | None = None
+    user: str | None = None
+
+
+class WorkerDisconnectMsg(_WS):
+    type: Literal["worker-disconnect"] = "worker-disconnect"
+    workerId: str | None = None
+
+
+class ForemanBroadcastMsg(_WS):
+    type: Literal["foreman-broadcast"] = "foreman-broadcast"
+    payload: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Discriminated unions
+# ---------------------------------------------------------------------------
+
+OutboundWSMessage = Annotated[
+    Union[
+        PongMsg,
+        AgentJoinedMsg,
+        AgentStateMsg,
+        ChatMsg,
+        TerminalOutputMsg,
+        TaskAssignedMsg,
+        TaskCreatedMsg,
+        TaskUpdateMsg,
+        TaskCompleteMsg,
+        TaskFollowupMsg,
+        TaskFollowupDoneMsg,
+        TaskFinalizeMsg,
+        TaskCancelMsg,
+        TaskRedirectMsg,
+        NeedsInputMsg,
+        ClaudeAuthRequiredMsg,
+        WorkerAuthResponseMsg,
+        WorkerMessageMsg,
+        WorkerShutdownMsg,
+        ForemanTriggerMsg,
+        ForemanRegisteredMsg,
+        ForemanEvictedMsg,
+        ForemanDisconnectMsg,
+        ForemanPollStatusMsg,
+        GuildUpdatedMsg,
+        GithubEventMsg,
+        ClaudeUsageMsg,
+        OfferMsg,
+        AnswerMsg,
+        IceCandidateMsg,
+    ],
+    Field(discriminator="type"),
+]
+
+InboundWSMessage = Annotated[
+    Union[
+        PingMsg,
+        JoinMsg,
+        AgentStateMsg,
+        ChatMsg,
+        TerminalOutputMsg,
+        WorkerRegisterMsg,
+        WorkerDisconnectMsg,
+        TaskUpdateMsg,
+        TaskCompleteMsg,
+        TaskFollowupDoneMsg,
+        NeedsInputMsg,
+        ClaudeAuthRequiredMsg,
+        ForemanDisconnectMsg,
+        ForemanBroadcastMsg,
+        WorkerAuthResponseMsg,
+        OfferMsg,
+        AnswerMsg,
+        IceCandidateMsg,
+    ],
+    Field(discriminator="type"),
+]
+
+_inbound_adapter: TypeAdapter[InboundWSMessage] = TypeAdapter(InboundWSMessage)
+
+# Set of type strings that are known inbound message types
+KNOWN_INBOUND_TYPES: frozenset[str] = frozenset(
+    {
+        "ping",
+        "join",
+        "agent-state",
+        "chat",
+        "terminal-output",
+        "worker-register",
+        "worker-disconnect",
+        "task-update",
+        "task-complete",
+        "task-followup-done",
+        "needs-input",
+        "claude-auth-required",
+        "foreman-disconnect",
+        "foreman-broadcast",
+        "worker-auth-response",
+        "offer",
+        "answer",
+        "ice-candidate",
+    }
+)
+
+
+def parse_inbound_message(data: dict[str, Any]) -> InboundWSMessage:
+    """Parse and validate a raw inbound WS frame into a typed model.
+
+    Raises ``pydantic.ValidationError`` when the message is malformed.
+    """
+    return _inbound_adapter.validate_python(data)

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -28,10 +28,9 @@ Inbound validation in dispatch::
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Union
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
-
 
 # ---------------------------------------------------------------------------
 # Base
@@ -367,62 +366,58 @@ class ForemanBroadcastMsg(_WS):
 # ---------------------------------------------------------------------------
 
 OutboundWSMessage = Annotated[
-    Union[
-        PongMsg,
-        AgentJoinedMsg,
-        AgentStateMsg,
-        ChatMsg,
-        TerminalOutputMsg,
-        TaskAssignedMsg,
-        TaskCreatedMsg,
-        TaskUpdateMsg,
-        TaskCompleteMsg,
-        TaskFollowupMsg,
-        TaskFollowupDoneMsg,
-        TaskFinalizeMsg,
-        TaskCancelMsg,
-        TaskRedirectMsg,
-        NeedsInputMsg,
-        ClaudeAuthRequiredMsg,
-        WorkerAuthResponseMsg,
-        WorkerMessageMsg,
-        WorkerShutdownMsg,
-        ForemanTriggerMsg,
-        ForemanRegisteredMsg,
-        ForemanEvictedMsg,
-        ForemanDisconnectMsg,
-        ForemanPollStatusMsg,
-        GuildUpdatedMsg,
-        GithubEventMsg,
-        ClaudeUsageMsg,
-        OfferMsg,
-        AnswerMsg,
-        IceCandidateMsg,
-    ],
+    PongMsg
+    | AgentJoinedMsg
+    | AgentStateMsg
+    | ChatMsg
+    | TerminalOutputMsg
+    | TaskAssignedMsg
+    | TaskCreatedMsg
+    | TaskUpdateMsg
+    | TaskCompleteMsg
+    | TaskFollowupMsg
+    | TaskFollowupDoneMsg
+    | TaskFinalizeMsg
+    | TaskCancelMsg
+    | TaskRedirectMsg
+    | NeedsInputMsg
+    | ClaudeAuthRequiredMsg
+    | WorkerAuthResponseMsg
+    | WorkerMessageMsg
+    | WorkerShutdownMsg
+    | ForemanTriggerMsg
+    | ForemanRegisteredMsg
+    | ForemanEvictedMsg
+    | ForemanDisconnectMsg
+    | ForemanPollStatusMsg
+    | GuildUpdatedMsg
+    | GithubEventMsg
+    | ClaudeUsageMsg
+    | OfferMsg
+    | AnswerMsg
+    | IceCandidateMsg,
     Field(discriminator="type"),
 ]
 
 InboundWSMessage = Annotated[
-    Union[
-        PingMsg,
-        JoinMsg,
-        AgentStateMsg,
-        ChatMsg,
-        TerminalOutputMsg,
-        WorkerRegisterMsg,
-        WorkerDisconnectMsg,
-        TaskUpdateMsg,
-        TaskCompleteMsg,
-        TaskFollowupDoneMsg,
-        NeedsInputMsg,
-        ClaudeAuthRequiredMsg,
-        ForemanDisconnectMsg,
-        ForemanBroadcastMsg,
-        WorkerAuthResponseMsg,
-        OfferMsg,
-        AnswerMsg,
-        IceCandidateMsg,
-    ],
+    PingMsg
+    | JoinMsg
+    | AgentStateMsg
+    | ChatMsg
+    | TerminalOutputMsg
+    | WorkerRegisterMsg
+    | WorkerDisconnectMsg
+    | TaskUpdateMsg
+    | TaskCompleteMsg
+    | TaskFollowupDoneMsg
+    | NeedsInputMsg
+    | ClaudeAuthRequiredMsg
+    | ForemanDisconnectMsg
+    | ForemanBroadcastMsg
+    | WorkerAuthResponseMsg
+    | OfferMsg
+    | AnswerMsg
+    | IceCandidateMsg,
     Field(discriminator="type"),
 ]
 

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -803,9 +803,7 @@ class Worker:
     def _start_control_api(self) -> None:
         if self.cfg.api_port is None:
             return
-        self._control_server = ControlServer(
-            self, host=self.cfg.api_host, port=self.cfg.api_port
-        )
+        self._control_server = ControlServer(self, host=self.cfg.api_host, port=self.cfg.api_port)
         try:
             self._control_server.start()
         except OSError:


### PR DESCRIPTION
## Summary

- Adds `backend/ws_types.py` with Pydantic v2 discriminated union models covering all inbound and outbound WebSocket message types
- Replaces bare `dict` payloads in `send_json`/`send_text` calls with `.model_dump()` on typed models throughout `ws_handlers.py`, `events.py`, `foreman/runner.py`, `foreman/tools.py`, and all route files
- Adds a centralised `send_ws_message(ws, msg)` helper in `events.py` so serialisation and validation are in one place
- Validates inbound WS messages at each entry point using `model_validate` / a `parse_ws_message` dispatcher

Closes #522

## Test plan

- [ ] All existing backend pytest tests pass (`python -m pytest` in `backend/`)
- [ ] Run `ruff check . --fix && ruff format .` from repo root — no errors
- [ ] Manually verify WS message flow: worker connects, task assigned, task-complete received, foreman triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)