### PR TITLE
fix(worker): prevent pi agent from getting stuck indefinitely

### DIFF
--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -156,7 +156,7 @@ async def run_pi_auto(
             proc.stdin.close()
         try:
             exit_code = await asyncio.wait_for(proc.wait(), timeout=_WAIT_TIMEOUT)
-        except (TimeoutError, asyncio.TimeoutError):
+        except TimeoutError:
             logger.warning(
                 "pi[%d] did not exit within %ds after stdin close; killing",
                 proc.pid,

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -11,6 +11,9 @@ logger = logging.getLogger(__name__)
 
 EmitFn = Callable[[str], Awaitable[None]]
 
+# Seconds to wait for pi to exit after stdin is closed before killing it.
+_WAIT_TIMEOUT = 30
+
 
 def _result_text(result: dict) -> str:
     """Join the text blocks of a tool result's content array."""
@@ -75,6 +78,8 @@ async def run_pi_auto(
     stop_reason = "no_events"
     event_count = 0
     agent_ended_ok = False
+    proc: asyncio.subprocess.Process | None = None
+    stderr_task: asyncio.Task[None] | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -90,10 +95,13 @@ async def run_pi_auto(
         await proc.stdin.drain()  # type: ignore[union-attr]
 
         async def _drain_stderr() -> None:
-            async for raw in proc.stderr:  # type: ignore[union-attr]
-                line = raw.decode(errors="replace").strip()
-                if line:
-                    await emit(f"[stderr] {line}")
+            try:
+                async for raw in proc.stderr:  # type: ignore[union-attr]
+                    line = raw.decode(errors="replace").strip()
+                    if line:
+                        await emit(f"[stderr] {line}")
+            except Exception:
+                logger.debug("pi[%d] stderr drain exited early", proc.pid, exc_info=True)  # type: ignore[union-attr]
 
         stderr_task = asyncio.create_task(_drain_stderr())
         accumulated = ""
@@ -144,7 +152,16 @@ async def run_pi_auto(
         # Closing stdin signals EOF so the RPC process exits cleanly.
         if proc.stdin and not proc.stdin.is_closing():
             proc.stdin.close()
-        exit_code = await proc.wait()
+        try:
+            exit_code = await asyncio.wait_for(proc.wait(), timeout=_WAIT_TIMEOUT)
+        except TimeoutError:
+            logger.warning(
+                "pi[%d] did not exit within %ds after stdin close; killing",
+                proc.pid,
+                _WAIT_TIMEOUT,
+            )
+            proc.kill()
+            exit_code = await proc.wait()
         await stderr_task
         if event_count == 0:
             logger.warning("pi[%d] produced no stdout events — check PATH/auth", proc.pid)
@@ -164,3 +181,29 @@ async def run_pi_auto(
         logger.exception("pi subprocess crashed: %s", exc)
         await emit(f"[pi] ✗ {exc}")
         return False, "error_during_execution", last_text
+    finally:
+        # Safety net: ensure the subprocess is gone even if we took an
+        # exception or were cancelled before the normal cleanup above ran.
+        if proc is not None and proc.returncode is None:
+            if proc.stdin and not proc.stdin.is_closing():
+                try:
+                    proc.stdin.close()
+                except Exception:
+                    pass
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            except Exception:
+                logger.debug("pi kill failed", exc_info=True)
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except Exception:
+                logger.debug("pi wait-after-kill failed", exc_info=True)
+        # Cancel the stderr drain task if it is still running.
+        if stderr_task is not None and not stderr_task.done():
+            stderr_task.cancel()
+            try:
+                await stderr_task
+            except BaseException:
+                pass

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -94,6 +94,8 @@ async def run_pi_auto(
         proc.stdin.write(rpc_msg.encode())  # type: ignore[union-attr]
         await proc.stdin.drain()  # type: ignore[union-attr]
 
+        pid = proc.pid
+
         async def _drain_stderr() -> None:
             try:
                 async for raw in proc.stderr:  # type: ignore[union-attr]
@@ -101,7 +103,7 @@ async def run_pi_auto(
                     if line:
                         await emit(f"[stderr] {line}")
             except Exception:
-                logger.debug("pi[%d] stderr drain exited early", proc.pid, exc_info=True)  # type: ignore[union-attr]
+                logger.debug("pi[%d] stderr drain exited early", pid, exc_info=True)
 
         stderr_task = asyncio.create_task(_drain_stderr())
         accumulated = ""
@@ -154,7 +156,7 @@ async def run_pi_auto(
             proc.stdin.close()
         try:
             exit_code = await asyncio.wait_for(proc.wait(), timeout=_WAIT_TIMEOUT)
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
             logger.warning(
                 "pi[%d] did not exit within %ds after stdin close; killing",
                 proc.pid,
@@ -198,7 +200,7 @@ async def run_pi_auto(
                 logger.debug("pi kill failed", exc_info=True)
             try:
                 await asyncio.wait_for(proc.wait(), timeout=5.0)
-            except Exception:
+            except BaseException:
                 logger.debug("pi wait-after-kill failed", exc_info=True)
         # Cancel the stderr drain task if it is still running.
         if stderr_task is not None and not stderr_task.done():

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -287,7 +287,7 @@ async def test_run_pi_auto_hung_process_is_killed(tmp_path, monkeypatch) -> None
     """Pi doesn't exit after agent_end + stdin close → timeout fires, SIGKILL sent."""
     import pioneer_worker.pi_runner as pi_runner_mod
 
-    monkeypatch.setattr(pi_runner_mod, "_WAIT_TIMEOUT", 1)
+    monkeypatch.setattr(pi_runner_mod, "_WAIT_TIMEOUT", 0.1)
 
     fake_pi = tmp_path / "fake-pi"
     fake_pi.write_text(

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -1,0 +1,344 @@
+"""Unit tests for pioneer_worker.pi_runner."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+from pioneer_worker.pi_runner import parse_pi_event, run_pi_auto
+
+# ---------------------------------------------------------------------------
+# parse_pi_event
+# ---------------------------------------------------------------------------
+
+
+def test_parse_agent_start():
+    text, last = parse_pi_event({"type": "agent_start"}, "")
+    assert text == "[pi] agent started"
+    assert last == ""
+
+
+def test_parse_message_update_full_text():
+    event = {
+        "type": "message_update",
+        "message": {"content": [{"type": "text", "text": "Hello world"}]},
+    }
+    text, last = parse_pi_event(event, "")
+    assert text == "Hello world"
+    assert last == "Hello world"
+
+
+def test_parse_message_update_delta_only():
+    event = {
+        "type": "message_update",
+        "message": {"content": [{"type": "text", "text": "Hello world extended"}]},
+    }
+    text, last = parse_pi_event(event, "Hello world")
+    # delta = " extended" (stripped) which has content
+    assert text is not None
+    assert "extended" in text
+    assert last == "Hello world extended"
+
+
+def test_parse_message_update_whitespace_delta_returns_none():
+    event = {
+        "type": "message_update",
+        "message": {"content": [{"type": "text", "text": "Hello world  "}]},
+    }
+    # delta is only whitespace → None
+    text, last = parse_pi_event(event, "Hello world  ")
+    assert text is None
+
+
+def test_parse_tool_execution_start_bash():
+    event = {
+        "type": "tool_execution_start",
+        "toolName": "bash",
+        "args": {"command": "ls -la"},
+    }
+    text, _ = parse_pi_event(event, "")
+    assert text == "▶ bash: ls -la"
+
+
+def test_parse_tool_execution_start_read():
+    event = {
+        "type": "tool_execution_start",
+        "toolName": "read",
+        "args": {"path": "/tmp/foo.py"},
+    }
+    text, _ = parse_pi_event(event, "")
+    assert text == "▶ read: /tmp/foo.py"
+
+
+def test_parse_tool_execution_start_edit():
+    event = {
+        "type": "tool_execution_start",
+        "toolName": "edit",
+        "args": {"file_path": "/tmp/bar.py"},
+    }
+    text, _ = parse_pi_event(event, "")
+    assert text == "▶ edit: /tmp/bar.py"
+
+
+def test_parse_tool_execution_start_unknown():
+    event = {
+        "type": "tool_execution_start",
+        "toolName": "custom_tool",
+        "args": {"key": "val"},
+    }
+    text, _ = parse_pi_event(event, "")
+    assert text is not None
+    assert "custom_tool" in text
+
+
+def test_parse_tool_execution_end_success():
+    event = {
+        "type": "tool_execution_end",
+        "result": {"content": [{"type": "text", "text": "output text"}]},
+        "isError": False,
+    }
+    text, _ = parse_pi_event(event, "")
+    assert text == "  → output text"
+
+
+def test_parse_tool_execution_end_error():
+    event = {
+        "type": "tool_execution_end",
+        "result": {"content": [{"type": "text", "text": "command failed"}]},
+        "isError": True,
+    }
+    text, _ = parse_pi_event(event, "")
+    assert text == "  ✗ command failed"
+
+
+def test_parse_tool_execution_end_empty_returns_none():
+    event = {
+        "type": "tool_execution_end",
+        "result": {"content": []},
+        "isError": False,
+    }
+    text, _ = parse_pi_event(event, "")
+    assert text is None
+
+
+def test_parse_tool_execution_end_multiline_shows_count():
+    event = {
+        "type": "tool_execution_end",
+        "result": {"content": [{"type": "text", "text": "line1\nline2\nline3"}]},
+        "isError": False,
+    }
+    text, _ = parse_pi_event(event, "")
+    assert text is not None
+    assert "+2 lines" in text
+
+
+def test_parse_unknown_event_returns_none():
+    text, last = parse_pi_event({"type": "unknown_type"}, "existing")
+    assert text is None
+    assert last == "existing"
+
+
+def test_parse_empty_event_returns_none():
+    text, last = parse_pi_event({}, "abc")
+    assert text is None
+    assert last == "abc"
+
+
+# ---------------------------------------------------------------------------
+# run_pi_auto — integration with fake pi scripts
+# ---------------------------------------------------------------------------
+
+
+async def test_run_pi_auto_success(tmp_path) -> None:
+    """Happy path: pi emits agent_start → message_update → agent_end and exits."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_start"}}), flush=True)
+print(json.dumps({{"type": "message_update", "message": {{"content": [{{"type": "text", "text": "Task done"}}]}}}}), flush=True)
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is True
+    assert stop_reason == "success"
+    assert "[pi] agent started" in emitted
+    assert last_text == "Task done"
+
+
+async def test_run_pi_auto_not_found(tmp_path) -> None:
+    """Missing pi binary → FileNotFoundError → returns (False, 'no_events', '')."""
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path="/nonexistent/pi-binary-xyz"
+    )
+
+    assert success is False
+    assert stop_reason == "no_events"
+    assert any("not found" in line for line in emitted)
+
+
+async def test_run_pi_auto_prompt_rejected(tmp_path) -> None:
+    """Pi sends a failed response event → saw_error=True, stop_reason='error_during_execution'."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "response", "command": "prompt", "success": False, "error": "auth failure"}}), flush=True)
+sys.exit(1)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is False
+    assert stop_reason == "error_during_execution"
+    assert any("auth failure" in line for line in emitted)
+
+
+async def test_run_pi_auto_non_json_stdout(tmp_path) -> None:
+    """Non-JSON stdout lines are emitted verbatim and don't crash the runner."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print("plain text line", flush=True)
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, _ = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert "plain text line" in emitted
+    assert stop_reason == "success"
+
+
+async def test_run_pi_auto_message_update_error(tmp_path) -> None:
+    """assistantMessageEvent error in message_update sets saw_error."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+event = {{
+    "type": "message_update",
+    "assistantMessageEvent": {{"type": "error", "reason": "context_limit"}},
+    "message": {{"content": []}}
+}}
+print(json.dumps(event), flush=True)
+sys.exit(1)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, _ = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is False
+    assert stop_reason == "error_during_execution"
+    assert any("context_limit" in line for line in emitted)
+
+
+async def test_run_pi_auto_hung_process_is_killed(tmp_path, monkeypatch) -> None:
+    """Pi doesn't exit after agent_end + stdin close → timeout fires, SIGKILL sent."""
+    import pioneer_worker.pi_runner as pi_runner_mod
+
+    monkeypatch.setattr(pi_runner_mod, "_WAIT_TIMEOUT", 1)
+
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys, signal, time
+
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+
+# Ignore SIGTERM so only SIGKILL (proc.kill()) will stop us.
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+while True:
+    time.sleep(0.05)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    # Should complete (not hang) even though pi refuses to exit on its own.
+    success, stop_reason, _ = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    # agent_end was received, so stop_reason should be success regardless of
+    # how the process was ultimately reaped.
+    assert stop_reason == "success"
+
+
+async def test_run_pi_auto_stderr_forwarded(tmp_path) -> None:
+    """Stderr lines from pi are forwarded to emit with [stderr] prefix."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print("warning from pi", file=sys.stderr, flush=True)
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    await run_pi_auto("do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi))
+
+    assert any("[stderr]" in line and "warning from pi" in line for line in emitted)


### PR DESCRIPTION
## Problem

`pi_runner.py` had three subprocess lifecycle bugs that caused the pi agent to hang the worker process indefinitely:

1. **No timeout on `proc.wait()`** — After breaking out of the stdout event loop and closing stdin, the code called `await proc.wait()` with no timeout. Pi runs in `--mode rpc` and stays alive waiting for more stdin; if it failed to notice the EOF (e.g. a signal-masked subprocess, a crash in pi's shutdown path, or a race), `proc.wait()` blocked forever and took the entire worker with it.

2. **No `finally` block** — If an exception (including `asyncio.CancelledError`) was raised during stdout reading, the `proc.stdin.close()` and `proc.wait()` lines were never reached. The pi subprocess was left running as an orphan with its stdin pipe still open, and the asyncio `StreamReader` for stderr was leaked.

3. **No error handling in `_drain_stderr`** — If `emit()` raised (e.g. because the WebSocket was broken), the exception propagated out of the `async for` loop inside the background task. When the caller later did `await stderr_task`, that exception was re-raised in an unexpected place, bypassing the structured error returns.

## Fix

- `_WAIT_TIMEOUT = 30` constant + `asyncio.wait_for(proc.wait(), timeout=_WAIT_TIMEOUT)`. If the timeout fires, `proc.kill()` (SIGKILL) is sent and the wait is retried, so the function always completes.
- `finally` block that: closes stdin if still open, sends SIGKILL if `proc.returncode is None` (meaning we never successfully waited), calls `proc.wait()` with a short 5 s timeout, and cancels/awaits the stderr drain task.
- `_drain_stderr` wraps its body in `try/except Exception` so emit failures are logged at DEBUG and don't surface as unhandled task exceptions.

## Tests

Added `worker/tests/test_pi_runner.py` with **21 tests**:
- `parse_pi_event` unit tests for all event types (agent_start, message_update, tool_execution_start/end, unknown)
- `run_pi_auto` integration tests using real fake-pi scripts:
  - Happy path (agent_end → success)
  - Missing binary (FileNotFoundError)
  - Prompt rejected (response.success=false)
  - Non-JSON stdout lines forwarded verbatim
  - `assistantMessageEvent` error sets saw_error
  - **Hung process**: pi ignores SIGTERM; with `_WAIT_TIMEOUT` monkeypatched to 1 s, the test completes in ~1 s via SIGKILL instead of hanging
  - Stderr lines forwarded with `[stderr]` prefix

## Test run

```
cd worker && python -m pytest tests/test_pi_runner.py -v   # 21 passed in 1.24s
cd worker && python -m pytest -x -q                         # 211 passed (no regressions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)