### PR TITLE
feat(foreman): add spawn_worker tool + fix PR injection for plan-phase tasks

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1042,6 +1042,12 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     worker_id = "w-" + "".join(
                         random.choices(string.ascii_lowercase + string.digits, k=6)
                     )
+                    # auth_token is a 256-bit cryptographically random bearer token stored
+                    # as plaintext in the DB (matching the UserSession.token convention).
+                    # It is passed to the container as an env var and never logged.
+                    # The DB is the only persistent store; no read-after-create endpoint
+                    # exists, so exposure is limited to the spawn path and the container's
+                    # runtime environment.
                     auth_token = secrets.token_urlsafe(32)
                     worker_name = custom_name or worker_display_name(worker_id, None)
                     created_at = datetime.now(UTC)

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -59,6 +59,22 @@ logger = logging.getLogger(__name__)
 # an explicit expiry. Mirrors backend.main.DEFAULT_FINALIZE_TTL.
 DEFAULT_FINALIZE_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
 
+# Module-level Docker client — created once per process to reuse the Unix-socket
+# connection across repeated spawn_worker calls instead of opening a new socket
+# each time.  None until first successful from_env(); tests can patch
+# _get_docker_client() directly to avoid touching sys.modules.
+_docker_client: Any = None
+
+
+def _get_docker_client() -> Any:
+    """Return the cached Docker client, importing the SDK and calling from_env() once."""
+    global _docker_client
+    if _docker_client is None:
+        import docker  # ImportError propagated to caller if SDK not installed
+
+        _docker_client = docker.from_env()
+    return _docker_client
+
 
 def _resolve_finalize_deleted_at(inp: dict) -> tuple[datetime | None, str | None]:
     """Compute the soft-delete instant for a finalize_task tool call.
@@ -1039,15 +1055,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     # before the container starts. The worker process will find
                     # PIONEER_WORKER_ID + PIONEER_AUTH_TOKEN in its env and skip
                     # its own self-registration step.
-                    worker_id = "w-" + "".join(
-                        random.choices(string.ascii_lowercase + string.digits, k=6)
-                    )
-                    # auth_token is a 256-bit cryptographically random bearer token stored
-                    # as plaintext in the DB (matching the UserSession.token convention).
-                    # It is passed to the container as an env var and never logged.
-                    # The DB is the only persistent store; no read-after-create endpoint
-                    # exists, so exposure is limited to the spawn path and the container's
-                    # runtime environment.
+                    worker_id = "w-" + secrets.token_hex(3)
                     auth_token = secrets.token_urlsafe(32)
                     worker_name = custom_name or worker_display_name(worker_id, None)
                     created_at = datetime.now(UTC)
@@ -1064,7 +1072,6 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     )
                     await db.commit()
 
-                    # Fetch Claude OAuth token from DB (same as HTTP spawn endpoint).
                     creds_result = await db.exec(
                         select(col(ClaudeCredentials.credentials_blob)).where(
                             col(ClaudeCredentials.guild_id) == guild_pk
@@ -1085,9 +1092,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     )
 
                     try:
-                        import docker as docker_sdk
-
-                        docker_client = docker_sdk.from_env()
+                        docker_client = _get_docker_client()
                         image = os.environ.get("WORKER_IMAGE", "pioneer-square-worker")
 
                         network = None
@@ -1098,7 +1103,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             )
                         except Exception as e:
                             logger.warning(
-                                "Docker network detection failed, starting container without explicit network: %s",
+                                "Docker network detection failed, starting without explicit network: %s",
                                 e,
                             )
 
@@ -1146,8 +1151,9 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         result_text = (
                             f"Worker pre-registered as {worker_id} but the Docker SDK is not "
                             "installed on the backend — container was NOT started. "
-                            "Start the worker manually with "
-                            f"PIONEER_WORKER_ID={worker_id} PIONEER_AUTH_TOKEN=<token>."
+                            f"To start manually: PIONEER_WORKER_ID={worker_id} "
+                            f"PIONEER_AUTH_TOKEN={auth_token} "
+                            "<worker-start-command>"
                         )
                         is_error = True
                     except Exception as exc:

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -11,6 +11,7 @@ import logging
 import os
 import random
 import re
+import secrets
 import string
 import urllib.error
 import urllib.parse
@@ -27,6 +28,7 @@ from foreman_core.tools_schema import (
 from lock_service import LockService
 from models import (
     Agent,
+    ClaudeCredentials,
     GithubToken,
     Guild,
     GuildKey,
@@ -38,6 +40,7 @@ from models import (
 )
 from sqlalchemy import delete, update
 from sqlmodel import col, select
+from utils import build_spawn_worker_env, decode_claude_oauth_token, worker_display_name
 from ws_types import (
     TaskAssignedMsg,
     TaskCancelMsg,
@@ -1022,6 +1025,122 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     result_text = f"Shutdown signal sent to {wid}." + (
                         f" Reason: {reason}" if reason else ""
                     )
+
+            elif tu.name == "spawn_worker":
+                repos = inp.get("repos") or []
+                tools_list: list[str] = inp.get("tools") or []
+                agent_count: int | None = inp.get("agent_count")
+                custom_name: str | None = inp.get("name")
+                if not repos:
+                    result_text = "spawn_worker requires at least one repo in the 'repos' list."
+                    is_error = True
+                else:
+                    # Pre-register the worker in the DB so the worker_id is known
+                    # before the container starts. The worker process will find
+                    # PIONEER_WORKER_ID + PIONEER_AUTH_TOKEN in its env and skip
+                    # its own self-registration step.
+                    worker_id = "w-" + "".join(
+                        random.choices(string.ascii_lowercase + string.digits, k=6)
+                    )
+                    auth_token = secrets.token_urlsafe(32)
+                    worker_name = custom_name or worker_display_name(worker_id, None)
+                    created_at = datetime.now(UTC)
+                    db.add(
+                        Worker(
+                            id=worker_id,
+                            guild_id=guild_pk or 0,
+                            repos=json.dumps(repos),
+                            state="offline",
+                            created_at=created_at,
+                            auth_token=auth_token,
+                            name=worker_name,
+                        )
+                    )
+                    await db.commit()
+
+                    # Fetch Claude OAuth token from DB (same as HTTP spawn endpoint).
+                    creds_result = await db.exec(
+                        select(col(ClaudeCredentials.credentials_blob)).where(
+                            col(ClaudeCredentials.guild_id) == guild_pk
+                        )
+                    )
+                    stored_blob = creds_result.one_or_none()
+
+                    env = build_spawn_worker_env(
+                        guild_id=guild_id,
+                        repos=repos,
+                        worker_name=worker_name,
+                        source_env=dict(os.environ),
+                        claude_oauth_token=decode_claude_oauth_token(stored_blob),
+                        worker_id=worker_id,
+                        auth_token=auth_token,
+                        agent_count=agent_count,
+                        tools=tools_list or None,
+                    )
+
+                    try:
+                        import docker as docker_sdk
+
+                        docker_client = docker_sdk.from_env()
+                        image = os.environ.get("WORKER_IMAGE", "pioneer-square-worker")
+
+                        network = None
+                        try:
+                            me = docker_client.containers.get(os.environ.get("HOSTNAME", ""))
+                            network = next(
+                                iter(me.attrs["NetworkSettings"]["Networks"].keys()), None
+                            )
+                        except Exception:
+                            pass
+
+                        labels = {
+                            "com.pioneer.kind": "worker",
+                            "com.pioneer.guild": guild_id,
+                        }
+                        container_name = f"pioneer-worker-{guild_id}-{secrets.token_hex(3)}"
+                        run_kwargs: dict = dict(
+                            image=image,
+                            environment=env,
+                            detach=True,
+                            remove=True,
+                            labels=labels,
+                            name=container_name,
+                        )
+                        if network:
+                            run_kwargs["network"] = network
+
+                        container = await asyncio.to_thread(
+                            docker_client.containers.run, **run_kwargs
+                        )
+                        result_text = json.dumps(
+                            {
+                                "worker_id": worker_id,
+                                "container_id": container.id[:12],
+                                "repos": repos,
+                                "name": worker_name,
+                            }
+                        )
+                        logger.info(
+                            "spawn_worker: guild=%s worker_id=%s container=%s repos=%s",
+                            guild_id,
+                            worker_id,
+                            container.id[:12],
+                            repos,
+                        )
+                    except ImportError:
+                        result_text = (
+                            f"Worker pre-registered as {worker_id} but the Docker SDK is not "
+                            "installed on the backend — container was NOT started. "
+                            "Start the worker manually with "
+                            f"PIONEER_WORKER_ID={worker_id} PIONEER_AUTH_TOKEN=<token>."
+                        )
+                        is_error = True
+                    except Exception as exc:
+                        result_text = (
+                            f"Worker pre-registered as {worker_id} but failed to start "
+                            f"container: {exc}"
+                        )
+                        is_error = True
 
             elif tu.name == "get_task_status":
                 task_id = inp["task_id"]

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1090,8 +1090,11 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             network = next(
                                 iter(me.attrs["NetworkSettings"]["Networks"].keys()), None
                             )
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            logger.warning(
+                                "Docker network detection failed, starting container without explicit network: %s",
+                                e,
+                            )
 
                         labels = {
                             "com.pioneer.kind": "worker",
@@ -1128,6 +1131,12 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             repos,
                         )
                     except ImportError:
+                        await db.exec(
+                            update(Worker)
+                            .where(col(Worker.id) == worker_id)
+                            .values(state="spawn_failed")
+                        )
+                        await db.commit()
                         result_text = (
                             f"Worker pre-registered as {worker_id} but the Docker SDK is not "
                             "installed on the backend — container was NOT started. "
@@ -1136,6 +1145,12 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         )
                         is_error = True
                     except Exception as exc:
+                        await db.exec(
+                            update(Worker)
+                            .where(col(Worker.id) == worker_id)
+                            .values(state="spawn_failed")
+                        )
+                        await db.commit()
                         result_text = (
                             f"Worker pre-registered as {worker_id} but failed to start "
                             f"container: {exc}"

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -11,6 +11,7 @@ import logging
 import os
 import random
 import re
+import secrets
 import string
 import urllib.error
 import urllib.parse
@@ -27,6 +28,7 @@ from foreman_core.tools_schema import (
 from lock_service import LockService
 from models import (
     Agent,
+    ClaudeCredentials,
     GithubToken,
     Guild,
     GuildKey,
@@ -38,6 +40,7 @@ from models import (
 )
 from sqlalchemy import delete, update
 from sqlmodel import col, select
+from utils import build_spawn_worker_env, decode_claude_oauth_token, worker_display_name
 from ws_types import (
     TaskAssignedMsg,
     TaskCancelMsg,
@@ -55,6 +58,22 @@ logger = logging.getLogger(__name__)
 # Default soft-delete window (seconds) when finalize_task is called without
 # an explicit expiry. Mirrors backend.main.DEFAULT_FINALIZE_TTL.
 DEFAULT_FINALIZE_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
+
+# Module-level Docker client — created once per process to reuse the Unix-socket
+# connection across repeated spawn_worker calls instead of opening a new socket
+# each time.  None until first successful from_env(); tests can patch
+# _get_docker_client() directly to avoid touching sys.modules.
+_docker_client: Any = None
+
+
+def _get_docker_client() -> Any:
+    """Return the cached Docker client, importing the SDK and calling from_env() once."""
+    global _docker_client
+    if _docker_client is None:
+        import docker  # ImportError propagated to caller if SDK not installed
+
+        _docker_client = docker.from_env()
+    return _docker_client
 
 
 def _resolve_finalize_deleted_at(inp: dict) -> tuple[datetime | None, str | None]:
@@ -1022,6 +1041,133 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     result_text = f"Shutdown signal sent to {wid}." + (
                         f" Reason: {reason}" if reason else ""
                     )
+
+            elif tu.name == "spawn_worker":
+                repos = inp.get("repos") or []
+                tools_list: list[str] = inp.get("tools") or []
+                agent_count: int | None = inp.get("agent_count")
+                custom_name: str | None = inp.get("name")
+                if not repos:
+                    result_text = "spawn_worker requires at least one repo in the 'repos' list."
+                    is_error = True
+                else:
+                    # Pre-register the worker in the DB so the worker_id is known
+                    # before the container starts. The worker process will find
+                    # PIONEER_WORKER_ID + PIONEER_AUTH_TOKEN in its env and skip
+                    # its own self-registration step.
+                    worker_id = "w-" + secrets.token_hex(3)
+                    auth_token = secrets.token_urlsafe(32)
+                    worker_name = custom_name or worker_display_name(worker_id, None)
+                    created_at = datetime.now(UTC)
+                    db.add(
+                        Worker(
+                            id=worker_id,
+                            guild_id=guild_pk or 0,
+                            repos=json.dumps(repos),
+                            state="offline",
+                            created_at=created_at,
+                            auth_token=auth_token,
+                            name=worker_name,
+                        )
+                    )
+                    await db.commit()
+
+                    creds_result = await db.exec(
+                        select(col(ClaudeCredentials.credentials_blob)).where(
+                            col(ClaudeCredentials.guild_id) == guild_pk
+                        )
+                    )
+                    stored_blob = creds_result.one_or_none()
+
+                    env = build_spawn_worker_env(
+                        guild_id=guild_id,
+                        repos=repos,
+                        worker_name=worker_name,
+                        source_env=dict(os.environ),
+                        claude_oauth_token=decode_claude_oauth_token(stored_blob),
+                        worker_id=worker_id,
+                        auth_token=auth_token,
+                        agent_count=agent_count,
+                        tools=tools_list or None,
+                    )
+
+                    try:
+                        docker_client = _get_docker_client()
+                        image = os.environ.get("WORKER_IMAGE", "pioneer-square-worker")
+
+                        network = None
+                        try:
+                            me = docker_client.containers.get(os.environ.get("HOSTNAME", ""))
+                            network = next(
+                                iter(me.attrs["NetworkSettings"]["Networks"].keys()), None
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "Docker network detection failed, starting without explicit network: %s",
+                                e,
+                            )
+
+                        labels = {
+                            "com.pioneer.kind": "worker",
+                            "com.pioneer.guild": guild_id,
+                        }
+                        container_name = f"pioneer-worker-{guild_id}-{secrets.token_hex(3)}"
+                        run_kwargs: dict = dict(
+                            image=image,
+                            environment=env,
+                            detach=True,
+                            remove=True,
+                            labels=labels,
+                            name=container_name,
+                        )
+                        if network:
+                            run_kwargs["network"] = network
+
+                        container = await asyncio.to_thread(
+                            docker_client.containers.run, **run_kwargs
+                        )
+                        result_text = json.dumps(
+                            {
+                                "worker_id": worker_id,
+                                "container_id": container.id[:12],
+                                "repos": repos,
+                                "name": worker_name,
+                            }
+                        )
+                        logger.info(
+                            "spawn_worker: guild=%s worker_id=%s container=%s repos=%s",
+                            guild_id,
+                            worker_id,
+                            container.id[:12],
+                            repos,
+                        )
+                    except ImportError:
+                        await db.exec(
+                            update(Worker)
+                            .where(col(Worker.id) == worker_id)
+                            .values(state="spawn_failed")
+                        )
+                        await db.commit()
+                        result_text = (
+                            f"Worker pre-registered as {worker_id} but the Docker SDK is not "
+                            "installed on the backend — container was NOT started. "
+                            f"To start manually: PIONEER_WORKER_ID={worker_id} "
+                            f"PIONEER_AUTH_TOKEN={auth_token} "
+                            "<worker-start-command>"
+                        )
+                        is_error = True
+                    except Exception as exc:
+                        await db.exec(
+                            update(Worker)
+                            .where(col(Worker.id) == worker_id)
+                            .values(state="spawn_failed")
+                        )
+                        await db.commit()
+                        result_text = (
+                            f"Worker pre-registered as {worker_id} but failed to start "
+                            f"container: {exc}"
+                        )
+                        is_error = True
 
             elif tu.name == "get_task_status":
                 task_id = inp["task_id"]

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -488,6 +488,54 @@ FOREMAN_TOOLS = [
         },
     },
     {
+        "name": "spawn_worker",
+        "description": (
+            "Start a new worker process pointed at a specific set of repos. "
+            "The worker is pre-registered in the database (so you have its worker_id "
+            "immediately) and a Docker container is launched automatically. "
+            "Use this when no idle worker covers the repos needed for a task — "
+            "call spawn_worker, wait briefly, then assign tasks to the returned worker_id. "
+            "Requires the Docker socket to be mounted on the backend."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repos": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "List of owner/repo strings the worker should clone and work on, "
+                        'e.g. ["acme/backend", "acme/frontend"].'
+                    ),
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["claude", "codex", "pi"],
+                    },
+                    "description": (
+                        "Optional list of agent runners to enable on this worker. "
+                        "Defaults to all available runners. "
+                        'Example: ["claude"] to restrict to Claude only.'
+                    ),
+                },
+                "agent_count": {
+                    "type": "integer",
+                    "description": (
+                        "Number of concurrent agent slots on this worker (default: 4). "
+                        "Increase for high-throughput workers; decrease to limit resource use."
+                    ),
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional human-readable name for the worker.",
+                },
+            },
+            "required": ["repos"],
+        },
+    },
+    {
         "name": "call_agent",
         "description": (
             "Call a skill on a remote A2A-compatible HTTP agent. "

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -20,6 +20,7 @@ from events import broadcast_msg, emit_terminal_line, pending_claude_auth
 from fastapi import APIRouter, Depends, HTTPException
 from models import ClaudeCredentials, Task, Worker, live_tasks_filter
 from pydantic import BaseModel
+from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from utils import (
@@ -50,6 +51,8 @@ class WorkerCreate(BaseModel):
 class SpawnWorkerRequest(BaseModel):
     repos: list[str]
     name: str | None = None
+    tools: list[str] | None = None
+    agent_count: int | None = None
 
 
 class TaskCreate(BaseModel):
@@ -144,12 +147,38 @@ async def spawn_worker_container(
     )
     stored_blob = result.one_or_none()
 
+    # Pre-register the worker so the container inherits a known worker_id and
+    # can skip self-registration on startup.
+    worker_id = "w-" + secrets.token_hex(3)
+    auth_token = secrets.token_urlsafe(32)
+    worker_name = data.name or worker_display_name(worker_id, None)
+    db.add(
+        Worker(
+            id=worker_id,
+            guild_id=guild_pk,
+            repos=json.dumps(data.repos),
+            state="offline",
+            created_at=datetime.now(UTC),
+            auth_token=auth_token,
+            name=worker_name,
+        )
+    )
+    await db.commit()
+    # TODO: If the process crashes between this commit and the docker run below,
+    # the row is left in "offline" state indefinitely (orphaned).  A background
+    # job or TTL-based cleanup should set stale "offline"/"pending" rows older
+    # than ~5 minutes to "spawn_failed".
+
     env = build_spawn_worker_env(
         guild_id=guild_id,
         repos=data.repos,
-        worker_name=data.name,
+        worker_name=worker_name,
         source_env=dict(os.environ),
         claude_oauth_token=decode_claude_oauth_token(stored_blob),
+        worker_id=worker_id,
+        auth_token=auth_token,
+        agent_count=data.agent_count,
+        tools=data.tools or None,
     )
 
     # Join the same Docker network as the backend so the worker can reach it.
@@ -183,14 +212,22 @@ async def spawn_worker_container(
             run_kwargs["network"] = network
         container = client.containers.run(**run_kwargs)
     except docker_sdk.errors.ImageNotFound:
+        await db.exec(
+            update(Worker).where(col(Worker.id) == worker_id).values(state="spawn_failed")
+        )
+        await db.commit()
         raise HTTPException(
             status_code=404,
             detail=f"Worker image '{image}' not found — run: docker compose build worker",
         )
     except Exception as e:
+        await db.exec(
+            update(Worker).where(col(Worker.id) == worker_id).values(state="spawn_failed")
+        )
+        await db.commit()
         raise HTTPException(status_code=500, detail=f"Failed to start container: {e}")
 
-    return {"container_id": container.id[:12], "image": image}
+    return {"worker_id": worker_id, "container_id": container.id[:12], "image": image}
 
 
 @router.get("/guilds/{guild_id}/pending-auth")

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -20,6 +20,7 @@ from events import broadcast_msg, emit_terminal_line, pending_claude_auth
 from fastapi import APIRouter, Depends, HTTPException
 from models import ClaudeCredentials, Task, Worker, live_tasks_filter
 from pydantic import BaseModel
+from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from utils import (
@@ -206,11 +207,19 @@ async def spawn_worker_container(
             run_kwargs["network"] = network
         container = client.containers.run(**run_kwargs)
     except docker_sdk.errors.ImageNotFound:
+        await db.exec(
+            update(Worker).where(col(Worker.id) == worker_id).values(state="spawn_failed")
+        )
+        await db.commit()
         raise HTTPException(
             status_code=404,
             detail=f"Worker image '{image}' not found — run: docker compose build worker",
         )
     except Exception as e:
+        await db.exec(
+            update(Worker).where(col(Worker.id) == worker_id).values(state="spawn_failed")
+        )
+        await db.commit()
         raise HTTPException(status_code=500, detail=f"Failed to start container: {e}")
 
     return {"worker_id": worker_id, "container_id": container.id[:12], "image": image}

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -50,6 +50,8 @@ class WorkerCreate(BaseModel):
 class SpawnWorkerRequest(BaseModel):
     repos: list[str]
     name: str | None = None
+    tools: list[str] | None = None
+    agent_count: int | None = None
 
 
 class TaskCreate(BaseModel):
@@ -144,12 +146,33 @@ async def spawn_worker_container(
     )
     stored_blob = result.one_or_none()
 
+    # Pre-register the worker so the container inherits a known worker_id.
+    worker_id = "w-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+    auth_token = secrets.token_urlsafe(32)
+    worker_name = data.name or worker_display_name(worker_id, None)
+    db.add(
+        Worker(
+            id=worker_id,
+            guild_id=guild_pk,
+            repos=json.dumps(data.repos),
+            state="offline",
+            created_at=datetime.now(UTC),
+            auth_token=auth_token,
+            name=worker_name,
+        )
+    )
+    await db.commit()
+
     env = build_spawn_worker_env(
         guild_id=guild_id,
         repos=data.repos,
-        worker_name=data.name,
+        worker_name=worker_name,
         source_env=dict(os.environ),
         claude_oauth_token=decode_claude_oauth_token(stored_blob),
+        worker_id=worker_id,
+        auth_token=auth_token,
+        agent_count=data.agent_count,
+        tools=data.tools or None,
     )
 
     # Join the same Docker network as the backend so the worker can reach it.
@@ -190,7 +213,7 @@ async def spawn_worker_container(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to start container: {e}")
 
-    return {"container_id": container.id[:12], "image": image}
+    return {"worker_id": worker_id, "container_id": container.id[:12], "image": image}
 
 
 @router.get("/guilds/{guild_id}/pending-auth")

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -147,8 +147,9 @@ async def spawn_worker_container(
     )
     stored_blob = result.one_or_none()
 
-    # Pre-register the worker so the container inherits a known worker_id.
-    worker_id = "w-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+    # Pre-register the worker so the container inherits a known worker_id and
+    # can skip self-registration on startup.
+    worker_id = "w-" + secrets.token_hex(3)
     auth_token = secrets.token_urlsafe(32)
     worker_name = data.name or worker_display_name(worker_id, None)
     db.add(
@@ -163,6 +164,10 @@ async def spawn_worker_container(
         )
     )
     await db.commit()
+    # TODO: If the process crashes between this commit and the docker run below,
+    # the row is left in "offline" state indefinitely (orphaned).  A background
+    # job or TTL-based cleanup should set stale "offline"/"pending" rows older
+    # than ~5 minutes to "spawn_failed".
 
     env = build_spawn_worker_env(
         guild_id=guild_id,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,7 +34,7 @@ from helpers import create_db as _create_db  # noqa: E402
 from routes.webhooks import shutdown_debouncer  # noqa: E402
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def _setup_schema():
     """Run migrations once and wipe any leftover data from previous runs.
 

--- a/backend/tests/test_foreman_spawn_worker.py
+++ b/backend/tests/test_foreman_spawn_worker.py
@@ -148,7 +148,7 @@ async def test_spawn_worker_pre_registers_and_spawns(db_session):
 
     payload = json.loads(result["content"])
     assert payload["worker_id"].startswith("w-")
-    assert payload["container_id"] == "abc123def45"  # first 12 chars
+    assert payload["container_id"] == "abc123def456"  # first 12 chars
     assert payload["repos"] == ["acme/backend"]
 
     # Worker must be persisted in DB

--- a/backend/tests/test_foreman_spawn_worker.py
+++ b/backend/tests/test_foreman_spawn_worker.py
@@ -18,13 +18,14 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 import database as database_module
 from _test_config import TEST_DATABASE_URL
-from foreman import tools as foreman_tools
 from foreman.tools import _exec_one_tool
 from helpers import _sync_session, create_db, insert_guild, truncate_all
 from models import Worker
 from sqlalchemy import select
 from sqlmodel import col
 from utils import build_spawn_worker_env
+
+from foreman import tools as foreman_tools
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/backend/tests/test_foreman_spawn_worker.py
+++ b/backend/tests/test_foreman_spawn_worker.py
@@ -1,0 +1,266 @@
+"""Tests for the foreman spawn_worker tool and related helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module
+from _test_config import TEST_DATABASE_URL
+from foreman.tools import _exec_one_tool
+from helpers import _sync_session, create_db, insert_guild, truncate_all
+from models import Worker
+from sqlalchemy import select
+from sqlmodel import col
+from utils import build_spawn_worker_env
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session(monkeypatch):
+    """Provide the PostgreSQL test database, truncated before each test."""
+    create_db(TEST_DATABASE_URL)
+    truncate_all(TEST_DATABASE_URL)
+    db_url = TEST_DATABASE_URL
+
+    monkeypatch.setenv("DATABASE_URL", db_url)
+
+    engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    monkeypatch.setattr(database_module, "AsyncSessionLocal", session_factory)
+
+    yield db_url
+
+
+def _fake_tool_use(name: str, inputs: dict, tool_id: str = "tool-spawn01") -> SimpleNamespace:
+    return SimpleNamespace(name=name, input=inputs, id=tool_id)
+
+
+# ---------------------------------------------------------------------------
+# build_spawn_worker_env tests (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_build_spawn_worker_env_basic():
+    env = build_spawn_worker_env(
+        guild_id="abc123",
+        repos=["owner/repo"],
+        worker_name=None,
+        source_env={},
+    )
+    assert env["PIONEER_GUILD_ID"] == "abc123"
+    assert env["PIONEER_REPOS"] == "owner/repo"
+    assert env["PIONEER_BACKEND_URL"] == "http://backend:8000"
+
+
+def test_build_spawn_worker_env_worker_id_and_auth_token():
+    env = build_spawn_worker_env(
+        guild_id="abc123",
+        repos=["owner/repo"],
+        worker_name=None,
+        source_env={},
+        worker_id="w-abc123",
+        auth_token="tok-secret",
+    )
+    assert env["PIONEER_WORKER_ID"] == "w-abc123"
+    assert env["PIONEER_AUTH_TOKEN"] == "tok-secret"
+
+
+def test_build_spawn_worker_env_agent_count_and_tools():
+    env = build_spawn_worker_env(
+        guild_id="abc123",
+        repos=["owner/repo"],
+        worker_name=None,
+        source_env={},
+        agent_count=2,
+        tools=["claude", "codex"],
+    )
+    assert env["PIONEER_MAX_AGENTS"] == "2"
+    assert env["PIONEER_TOOLS"] == "claude,codex"
+
+
+def test_build_spawn_worker_env_no_worker_id_keys_absent():
+    env = build_spawn_worker_env(
+        guild_id="abc123",
+        repos=["owner/repo"],
+        worker_name=None,
+        source_env={},
+    )
+    assert "PIONEER_WORKER_ID" not in env
+    assert "PIONEER_AUTH_TOKEN" not in env
+    assert "PIONEER_MAX_AGENTS" not in env
+    assert "PIONEER_TOOLS" not in env
+
+
+def test_build_spawn_worker_env_multiple_repos():
+    env = build_spawn_worker_env(
+        guild_id="abc123",
+        repos=["owner/repo-a", "owner/repo-b"],
+        worker_name="my-worker",
+        source_env={"GITHUB_TOKEN": "ghp_test"},
+    )
+    assert env["PIONEER_REPOS"] == "owner/repo-a,owner/repo-b"
+    assert env["PIONEER_WORKER_NAME"] == "my-worker"
+    assert env["GITHUB_TOKEN"] == "ghp_test"
+    assert env["PIONEER_GITHUB_TOKEN"] == "ghp_test"
+
+
+# ---------------------------------------------------------------------------
+# spawn_worker tool — happy path (Docker mocked)
+# ---------------------------------------------------------------------------
+
+
+async def test_spawn_worker_pre_registers_and_spawns(db_session):
+    insert_guild(db_session, "guild01")
+
+    fake_container = MagicMock()
+    fake_container.id = "abc123def456789"
+
+    fake_docker_client = MagicMock()
+    fake_docker_client.containers.get.side_effect = Exception("no hostname")
+    fake_docker_client.containers.run.return_value = fake_container
+
+    fake_docker_module = MagicMock()
+    fake_docker_module.from_env.return_value = fake_docker_client
+
+    with patch.dict("sys.modules", {"docker": fake_docker_module}):
+        result = await _exec_one_tool(
+            "guild01",
+            _fake_tool_use("spawn_worker", {"repos": ["acme/backend"]}),
+        )
+
+    assert result["type"] == "tool_result"
+    assert not result.get("is_error"), result["content"]
+
+    payload = json.loads(result["content"])
+    assert payload["worker_id"].startswith("w-")
+    assert payload["container_id"] == "abc123def45"  # first 12 chars
+    assert payload["repos"] == ["acme/backend"]
+
+    # Worker must be persisted in DB
+    with _sync_session(db_session) as session:
+        workers = (
+            session.execute(select(Worker).where(col(Worker.id) == payload["worker_id"]))
+            .scalars()
+            .all()
+        )
+    assert len(workers) == 1
+    assert json.loads(workers[0].repos) == ["acme/backend"]
+    assert workers[0].auth_token is not None
+
+
+async def test_spawn_worker_with_agent_count_and_tools(db_session):
+    insert_guild(db_session, "guild02")
+
+    fake_container = MagicMock()
+    fake_container.id = "deadbeef000000"
+
+    fake_docker_client = MagicMock()
+    fake_docker_client.containers.get.side_effect = Exception("no hostname")
+    fake_docker_client.containers.run.return_value = fake_container
+
+    fake_docker_module = MagicMock()
+    fake_docker_module.from_env.return_value = fake_docker_client
+
+    captured_env: dict = {}
+
+    def _capture_run(**kwargs):
+        captured_env.update(kwargs.get("environment", {}))
+        return fake_container
+
+    fake_docker_client.containers.run.side_effect = _capture_run
+
+    with patch.dict("sys.modules", {"docker": fake_docker_module}):
+        result = await _exec_one_tool(
+            "guild02",
+            _fake_tool_use(
+                "spawn_worker",
+                {
+                    "repos": ["acme/backend"],
+                    "agent_count": 2,
+                    "tools": ["claude"],
+                    "name": "test-worker",
+                },
+            ),
+        )
+
+    assert not result.get("is_error"), result["content"]
+    assert captured_env["PIONEER_MAX_AGENTS"] == "2"
+    assert captured_env["PIONEER_TOOLS"] == "claude"
+    assert captured_env["PIONEER_WORKER_NAME"] == "test-worker"
+
+
+# ---------------------------------------------------------------------------
+# spawn_worker tool — error cases
+# ---------------------------------------------------------------------------
+
+
+async def test_spawn_worker_no_repos_returns_error(db_session):
+    insert_guild(db_session, "guild03")
+
+    result = await _exec_one_tool(
+        "guild03",
+        _fake_tool_use("spawn_worker", {"repos": []}),
+    )
+    assert result.get("is_error")
+    assert "repos" in result["content"].lower()
+
+
+async def test_spawn_worker_docker_unavailable(db_session):
+    """When Docker SDK is not installed, worker is still pre-registered and error is returned."""
+    insert_guild(db_session, "guild04")
+
+    with patch.dict("sys.modules", {"docker": None}):
+        result = await _exec_one_tool(
+            "guild04",
+            _fake_tool_use("spawn_worker", {"repos": ["acme/api"]}),
+        )
+
+    assert result.get("is_error")
+    assert "docker" in result["content"].lower()
+    # The worker_id should be mentioned in the error so foreman can act on it
+    assert "w-" in result["content"]
+
+    # Worker must still be persisted even on Docker failure
+    with _sync_session(db_session) as session:
+        count = session.execute(select(Worker)).scalars().all()
+    assert len(count) == 1
+
+
+async def test_spawn_worker_docker_run_fails(db_session):
+    """When Docker.run raises, worker pre-registration is committed and error reported."""
+    insert_guild(db_session, "guild05")
+
+    fake_docker_client = MagicMock()
+    fake_docker_client.containers.get.side_effect = Exception("no hostname")
+    fake_docker_client.containers.run.side_effect = Exception("image not found")
+
+    fake_docker_module = MagicMock()
+    fake_docker_module.from_env.return_value = fake_docker_client
+
+    with patch.dict("sys.modules", {"docker": fake_docker_module}):
+        result = await _exec_one_tool(
+            "guild05",
+            _fake_tool_use("spawn_worker", {"repos": ["acme/api"]}),
+        )
+
+    assert result.get("is_error")
+    assert "image not found" in result["content"]
+
+    with _sync_session(db_session) as session:
+        count = session.execute(select(Worker)).scalars().all()
+    assert len(count) == 1

--- a/backend/tests/test_foreman_spawn_worker.py
+++ b/backend/tests/test_foreman_spawn_worker.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 import database as database_module
 from _test_config import TEST_DATABASE_URL
+from foreman import tools as foreman_tools
 from foreman.tools import _exec_one_tool
 from helpers import _sync_session, create_db, insert_guild, truncate_all
 from models import Worker
@@ -134,10 +135,7 @@ async def test_spawn_worker_pre_registers_and_spawns(db_session):
     fake_docker_client.containers.get.side_effect = Exception("no hostname")
     fake_docker_client.containers.run.return_value = fake_container
 
-    fake_docker_module = MagicMock()
-    fake_docker_module.from_env.return_value = fake_docker_client
-
-    with patch.dict("sys.modules", {"docker": fake_docker_module}):
+    with patch.object(foreman_tools, "_get_docker_client", return_value=fake_docker_client):
         result = await _exec_one_tool(
             "guild01",
             _fake_tool_use("spawn_worker", {"repos": ["acme/backend"]}),
@@ -173,9 +171,6 @@ async def test_spawn_worker_with_agent_count_and_tools(db_session):
     fake_docker_client.containers.get.side_effect = Exception("no hostname")
     fake_docker_client.containers.run.return_value = fake_container
 
-    fake_docker_module = MagicMock()
-    fake_docker_module.from_env.return_value = fake_docker_client
-
     captured_env: dict = {}
 
     def _capture_run(**kwargs):
@@ -184,7 +179,7 @@ async def test_spawn_worker_with_agent_count_and_tools(db_session):
 
     fake_docker_client.containers.run.side_effect = _capture_run
 
-    with patch.dict("sys.modules", {"docker": fake_docker_module}):
+    with patch.object(foreman_tools, "_get_docker_client", return_value=fake_docker_client):
         result = await _exec_one_tool(
             "guild02",
             _fake_tool_use(
@@ -224,7 +219,9 @@ async def test_spawn_worker_docker_unavailable(db_session):
     """When Docker SDK is not installed, worker is still pre-registered and error is returned."""
     insert_guild(db_session, "guild04")
 
-    with patch.dict("sys.modules", {"docker": None}):
+    with patch.object(
+        foreman_tools, "_get_docker_client", side_effect=ImportError("No module named 'docker'")
+    ):
         result = await _exec_one_tool(
             "guild04",
             _fake_tool_use("spawn_worker", {"repos": ["acme/api"]}),
@@ -249,10 +246,7 @@ async def test_spawn_worker_docker_run_fails(db_session):
     fake_docker_client.containers.get.side_effect = Exception("no hostname")
     fake_docker_client.containers.run.side_effect = Exception("image not found")
 
-    fake_docker_module = MagicMock()
-    fake_docker_module.from_env.return_value = fake_docker_client
-
-    with patch.dict("sys.modules", {"docker": fake_docker_module}):
+    with patch.object(foreman_tools, "_get_docker_client", return_value=fake_docker_client):
         result = await _exec_one_tool(
             "guild05",
             _fake_tool_use("spawn_worker", {"repos": ["acme/api"]}),

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -247,6 +247,10 @@ def build_spawn_worker_env(
     worker_name: str | None,
     source_env: dict[str, str],
     claude_oauth_token: str | None = None,
+    worker_id: str | None = None,
+    auth_token: str | None = None,
+    agent_count: int | None = None,
+    tools: list[str] | None = None,
 ) -> dict[str, str]:
     """Build the env dict for a spawned worker container.
 
@@ -254,6 +258,11 @@ def build_spawn_worker_env(
     ``CLAUDE_CODE_OAUTH_TOKEN`` in *source_env* — the DB blob is the source
     of truth, refreshed every time a worker completes setup-token, while the
     host env var can drift stale.
+
+    *worker_id* and *auth_token* — when provided (pre-registered by the
+    foreman), the worker process skips its own self-registration and uses
+    these credentials directly.  This lets callers know the worker_id before
+    the container starts.
     """
     env: dict[str, str] = {
         "PIONEER_BACKEND_URL": source_env.get("WORKER_BACKEND_URL", "http://backend:8000"),
@@ -279,4 +288,12 @@ def build_spawn_worker_env(
     log_level = source_env.get("WORKER_LOG_LEVEL")
     if log_level:
         env["PIONEER_WORKER_LOG_LEVEL"] = log_level
+    if worker_id:
+        env["PIONEER_WORKER_ID"] = worker_id
+    if auth_token:
+        env["PIONEER_AUTH_TOKEN"] = auth_token
+    if agent_count is not None:
+        env["PIONEER_MAX_AGENTS"] = str(agent_count)
+    if tools:
+        env["PIONEER_TOOLS"] = ",".join(tools)
     return env

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -43,13 +43,23 @@
       </div>
       <label class="spawn-label">Name <span class="spawn-hint">(optional)</span></label>
       <input v-model="name" class="spawn-input" type="text" placeholder="auto-generated" />
-      <label class="spawn-label">Tools <span class="spawn-hint">(optional, comma-separated)</span></label>
-      <input
-        v-model="toolsInput"
-        class="spawn-input"
-        type="text"
-        placeholder="claude, codex, pi"
-      />
+      <label class="spawn-label">Tools <span class="spawn-hint">(optional)</span></label>
+      <div class="spawn-tool-list">
+        <label
+          v-for="tool in AVAILABLE_TOOLS"
+          :key="tool"
+          class="spawn-repo-row"
+          :class="{ selected: selectedTools.includes(tool) }"
+        >
+          <input
+            type="checkbox"
+            :checked="selectedTools.includes(tool)"
+            @change="toggleTool(tool)"
+            class="spawn-repo-check"
+          />
+          <span class="spawn-repo-name">{{ tool }}</span>
+        </label>
+      </div>
       <label class="spawn-label">Agents <span class="spawn-hint">(optional)</span></label>
       <input
         v-model.number="agentCount"
@@ -85,9 +95,11 @@ const emit = defineEmits<{ (e: 'launched'): void }>()
 const guildStore = useGuildStore()
 const ghStore = useGitHubStore()
 
+const AVAILABLE_TOOLS = ['claude', 'codex', 'pi'] as const
+
 const selectedRepos = ref<string[]>([])
 const name = ref('')
-const toolsInput = ref('')
+const selectedTools = ref<string[]>([])
 const agentCount = ref<number | null>(null)
 const spawning = ref(false)
 const error = ref('')
@@ -145,22 +157,27 @@ function setOrgCheckboxRef(el: HTMLInputElement | null, owner: string) {
   }
 }
 
+function toggleTool(tool: string) {
+  const idx = selectedTools.value.indexOf(tool)
+  if (idx >= 0) {
+    selectedTools.value.splice(idx, 1)
+  } else {
+    selectedTools.value.push(tool)
+  }
+}
+
 async function launch() {
   const guild = guildStore.currentGuild
   if (!guild || selectedRepos.value.length === 0) return
   spawning.value = true
   error.value = ''
   try {
-    const tools = toolsInput.value
-      .split(/[,\n]+/)
-      .map(t => t.trim())
-      .filter(Boolean)
     const result = await api<{ worker_id?: string }>(`/guilds/${guild.id}/spawn-worker`, {
       method: 'POST',
       json: {
         repos: selectedRepos.value,
         name: name.value.trim() || undefined,
-        tools: tools.length ? tools : undefined,
+        tools: selectedTools.value.length ? selectedTools.value : undefined,
         agent_count: agentCount.value ?? undefined,
       },
     })
@@ -280,6 +297,15 @@ async function launch() {
   gap: 1px;
   max-height: 160px;
   overflow-y: auto;
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+  background: var(--color-bg);
+}
+
+.spawn-tool-list {
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
   border: 1px solid var(--color-brass-dark);
   border-radius: 2px;
   background: var(--color-bg);

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -1,53 +1,75 @@
 <template>
   <div class="spawn-form">
-    <label class="spawn-label">Repos</label>
-    <div v-if="loadingRepos" class="spawn-hint-text">Loading repos…</div>
-    <div v-else-if="ghStore.repos.length === 0" class="spawn-hint-text">
-      No repos found — configure GitHub first.
+    <div v-if="launched" class="spawn-success">
+      <span class="spawn-success-label">Launched</span>
+      <span class="spawn-success-id">{{ launchedWorkerId }}</span>
     </div>
-    <div v-else class="spawn-repo-list">
-      <template v-for="group in groupedRepos" :key="group.owner">
-        <label
-          class="spawn-repo-row spawn-org-row"
-          :class="{ selected: orgAllSelected(group.owner) }"
+    <template v-else>
+      <label class="spawn-label">Repos</label>
+      <div v-if="loadingRepos" class="spawn-hint-text">Loading repos…</div>
+      <div v-else-if="ghStore.repos.length === 0" class="spawn-hint-text">
+        No repos found — configure GitHub first.
+      </div>
+      <div v-else class="spawn-repo-list">
+        <template v-for="group in groupedRepos" :key="group.owner">
+          <label
+            class="spawn-repo-row spawn-org-row"
+            :class="{ selected: orgAllSelected(group.owner) }"
+          >
+            <input
+              type="checkbox"
+              :ref="(el) => setOrgCheckboxRef(el as HTMLInputElement | null, group.owner)"
+              :checked="orgAllSelected(group.owner)"
+              @change="toggleOrg(group.owner)"
+              class="spawn-repo-check"
+            />
+            <span class="spawn-repo-name spawn-org-name">{{ group.owner }}</span>
+          </label>
+          <label
+            v-for="repo in group.repos"
+            :key="repo.full_name"
+            class="spawn-repo-row spawn-repo-indent"
+            :class="{ selected: selectedRepos.includes(repo.full_name) }"
+          >
+            <input
+              type="checkbox"
+              :checked="selectedRepos.includes(repo.full_name)"
+              @change="toggleRepo(repo.full_name)"
+              class="spawn-repo-check"
+            />
+            <span class="spawn-repo-name">{{ repo.full_name.split('/')[1] }}</span>
+          </label>
+        </template>
+      </div>
+      <label class="spawn-label">Name <span class="spawn-hint">(optional)</span></label>
+      <input v-model="name" class="spawn-input" type="text" placeholder="auto-generated" />
+      <label class="spawn-label">Tools <span class="spawn-hint">(optional, comma-separated)</span></label>
+      <input
+        v-model="toolsInput"
+        class="spawn-input"
+        type="text"
+        placeholder="claude, codex, pi"
+      />
+      <label class="spawn-label">Agents <span class="spawn-hint">(optional)</span></label>
+      <input
+        v-model.number="agentCount"
+        class="spawn-input spawn-input--narrow"
+        type="number"
+        min="1"
+        max="16"
+        placeholder="4"
+      />
+      <div class="spawn-actions">
+        <button
+          class="pixel-btn spawn-launch-btn"
+          :disabled="spawning || selectedRepos.length === 0"
+          @click="launch"
         >
-          <input
-            type="checkbox"
-            :ref="(el) => setOrgCheckboxRef(el as HTMLInputElement | null, group.owner)"
-            :checked="orgAllSelected(group.owner)"
-            @change="toggleOrg(group.owner)"
-            class="spawn-repo-check"
-          />
-          <span class="spawn-repo-name spawn-org-name">{{ group.owner }}</span>
-        </label>
-        <label
-          v-for="repo in group.repos"
-          :key="repo.full_name"
-          class="spawn-repo-row spawn-repo-indent"
-          :class="{ selected: selectedRepos.includes(repo.full_name) }"
-        >
-          <input
-            type="checkbox"
-            :checked="selectedRepos.includes(repo.full_name)"
-            @change="toggleRepo(repo.full_name)"
-            class="spawn-repo-check"
-          />
-          <span class="spawn-repo-name">{{ repo.full_name.split('/')[1] }}</span>
-        </label>
-      </template>
-    </div>
-    <label class="spawn-label">Name <span class="spawn-hint">(optional)</span></label>
-    <input v-model="name" class="spawn-input" type="text" placeholder="auto-generated" />
-    <div class="spawn-actions">
-      <button
-        class="pixel-btn spawn-launch-btn"
-        :disabled="spawning || selectedRepos.length === 0"
-        @click="launch"
-      >
-        {{ spawning ? 'Launching…' : 'Launch' }}
-      </button>
-    </div>
-    <div v-if="error" class="spawn-error">{{ error }}</div>
+          {{ spawning ? 'Launching…' : 'Launch' }}
+        </button>
+      </div>
+      <div v-if="error" class="spawn-error">{{ error }}</div>
+    </template>
   </div>
 </template>
 
@@ -65,9 +87,13 @@ const ghStore = useGitHubStore()
 
 const selectedRepos = ref<string[]>([])
 const name = ref('')
+const toolsInput = ref('')
+const agentCount = ref<number | null>(null)
 const spawning = ref(false)
 const error = ref('')
 const loadingRepos = ref(false)
+const launched = ref(false)
+const launchedWorkerId = ref('')
 
 const groupedRepos = computed(() => groupAndSortRepos(ghStore.repos))
 
@@ -125,14 +151,22 @@ async function launch() {
   spawning.value = true
   error.value = ''
   try {
-    await api(`/guilds/${guild.id}/spawn-worker`, {
+    const tools = toolsInput.value
+      .split(/[,\n]+/)
+      .map(t => t.trim())
+      .filter(Boolean)
+    const result = await api<{ worker_id?: string }>(`/guilds/${guild.id}/spawn-worker`, {
       method: 'POST',
       json: {
         repos: selectedRepos.value,
         name: name.value.trim() || undefined,
+        tools: tools.length ? tools : undefined,
+        agent_count: agentCount.value ?? undefined,
       },
     })
-    emit('launched')
+    launchedWorkerId.value = result?.worker_id ?? ''
+    launched.value = true
+    setTimeout(() => emit('launched'), 2500)
   } catch (e: unknown) {
     error.value = e instanceof Error ? e.message : String(e)
   } finally {
@@ -149,6 +183,29 @@ async function launch() {
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+.spawn-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 4px;
+}
+
+.spawn-success-label {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-green, #4caf50);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+.spawn-success-id {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-teal);
+  letter-spacing: 0.5px;
 }
 
 .spawn-label {
@@ -182,6 +239,10 @@ async function launch() {
 
 .spawn-input:focus {
   border-color: var(--color-teal);
+}
+
+.spawn-input--narrow {
+  width: 80px;
 }
 
 .spawn-actions {

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -27,11 +27,14 @@ class Config:
     # any task targeting <org>/* and will clone repos lazily on first use.
     # Can be used alongside repos (static list) or instead of it.
     org: str | None = None
+    # Pre-assigned by the foreman's spawn_worker tool.  When both are set the
+    # worker skips self-registration and uses these credentials directly.
     worker_id: str | None = None
     worker_name: str | None = None
     # Bearer token issued by the backend at registration; required for fetching
     # guild secrets (Claude credentials, GitHub token). Populated by Worker.run
-    # after _register and held in memory only.
+    # after _register and held in memory only.  Also supplied via
+    # PIONEER_AUTH_TOKEN when the foreman pre-registers the worker.
     auth_token: str | None = None
     github_token: str | None = None
     # Identity of the human this worker runs on behalf of.
@@ -216,6 +219,24 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             )
         _openai_api_key = _env_val  # None if var is absent, key string if present
 
+    _max_agents_env = os.environ.get("PIONEER_MAX_AGENTS")
+    if _max_agents_env:
+        try:
+            _default_max_agents: int = int(_max_agents_env)
+        except ValueError:
+            logger.warning(
+                "Invalid PIONEER_MAX_AGENTS=%r, using default 4", _max_agents_env
+            )
+            _default_max_agents = 4
+    else:
+        _default_max_agents = 4
+
+    _max_agents_val = (
+        overrides.get("max_agents")
+        if overrides.get("max_agents") is not None
+        else raw.get("max_agents", _default_max_agents)
+    )
+
     return Config(
         backend_url=backend_url.rstrip("/"),
         guild_id=guild_id,
@@ -229,6 +250,8 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         or github_block.get("org")
         or os.environ.get("PIONEER_ORG")
         or None,
+        worker_id=overrides.get("worker_id") or os.environ.get("PIONEER_WORKER_ID") or None,
+        auth_token=overrides.get("auth_token") or os.environ.get("PIONEER_AUTH_TOKEN") or None,
         worker_name=overrides.get("worker_name")
         or raw.get("worker_name")
         or os.environ.get("PIONEER_WORKER_NAME"),
@@ -263,11 +286,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             if overrides.get("claude_max_turns") is not None
             else claude_block.get("max_turns", 50)
         ),
-        max_agents=int(
-            overrides.get("max_agents")
-            if overrides.get("max_agents") is not None
-            else raw.get("max_agents", 4)
-        ),
+        max_agents=int(_max_agents_val),
         public_backend_url=overrides.get("public_backend_url")
         or raw.get("public_backend_url")
         or os.environ.get("PIONEER_FRONTEND_URL"),

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -224,9 +224,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         try:
             _default_max_agents: int = int(_max_agents_env)
         except ValueError:
-            logger.warning(
-                "Invalid PIONEER_MAX_AGENTS=%r, using default 4", _max_agents_env
-            )
+            logger.warning("Invalid PIONEER_MAX_AGENTS=%r, using default 4", _max_agents_env)
             _default_max_agents = 4
     else:
         _default_max_agents = 4

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -217,10 +217,21 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         _openai_api_key = _env_val  # None if var is absent, key string if present
 
     _max_agents_env = os.environ.get("PIONEER_MAX_AGENTS")
+    if _max_agents_env:
+        try:
+            _default_max_agents: int = int(_max_agents_env)
+        except ValueError:
+            logger.warning(
+                "Invalid PIONEER_MAX_AGENTS=%r, using default 4", _max_agents_env
+            )
+            _default_max_agents = 4
+    else:
+        _default_max_agents = 4
+
     _max_agents_val = (
         overrides.get("max_agents")
         if overrides.get("max_agents") is not None
-        else raw.get("max_agents", int(_max_agents_env) if _max_agents_env else 4)
+        else raw.get("max_agents", _default_max_agents)
     )
 
     return Config(

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -216,6 +216,13 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             )
         _openai_api_key = _env_val  # None if var is absent, key string if present
 
+    _max_agents_env = os.environ.get("PIONEER_MAX_AGENTS")
+    _max_agents_val = (
+        overrides.get("max_agents")
+        if overrides.get("max_agents") is not None
+        else raw.get("max_agents", int(_max_agents_env) if _max_agents_env else 4)
+    )
+
     return Config(
         backend_url=backend_url.rstrip("/"),
         guild_id=guild_id,
@@ -229,6 +236,8 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         or github_block.get("org")
         or os.environ.get("PIONEER_ORG")
         or None,
+        worker_id=overrides.get("worker_id") or os.environ.get("PIONEER_WORKER_ID") or None,
+        auth_token=overrides.get("auth_token") or os.environ.get("PIONEER_AUTH_TOKEN") or None,
         worker_name=overrides.get("worker_name")
         or raw.get("worker_name")
         or os.environ.get("PIONEER_WORKER_NAME"),
@@ -263,11 +272,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             if overrides.get("claude_max_turns") is not None
             else claude_block.get("max_turns", 50)
         ),
-        max_agents=int(
-            overrides.get("max_agents")
-            if overrides.get("max_agents") is not None
-            else raw.get("max_agents", 4)
-        ),
+        max_agents=int(_max_agents_val),
         public_backend_url=overrides.get("public_backend_url")
         or raw.get("public_backend_url")
         or os.environ.get("PIONEER_FRONTEND_URL"),

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -174,6 +174,16 @@ class Worker:
         return httpx.AsyncClient(base_url=self.cfg.http_url, timeout=30.0, headers=headers)
 
     async def _register(self) -> None:
+        if self.cfg.worker_id and self.cfg.auth_token:
+            # Pre-assigned by the foreman's spawn_worker tool — skip self-registration.
+            self._worker_name = self.cfg.worker_name or self.cfg.worker_id
+            logger.info(
+                "Using pre-assigned worker_id=%s name=%s (skipping self-registration)",
+                self.cfg.worker_id,
+                self._worker_name,
+            )
+            return
+
         async with await self._http() as client:
             resp = await client.post(
                 f"/guilds/{self.cfg.guild_id}/workers",

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -55,6 +55,8 @@ def _slug(text: str, max_len: int = 60) -> str:
 _CANCEL_SENTINEL = object()  # placed in redirect queue to signal task cancellation
 _SHUTDOWN_SENTINEL = object()  # placed in task queue to wake idle agents during shutdown
 
+_PR_PHASES = frozenset({"execute", "followup"})
+
 
 # Worktrees are kept around after a task completes so the foreman can send
 # follow-ups without paying for a re-clone. They're swept at startup and on a
@@ -1939,7 +1941,7 @@ class Worker:
                             "        -f 'comments[][body]=inline comment'\n"
                             "Do NOT push any commits or open a PR as part of this review.\n"
                         )
-                    elif _phase in ("execute", "followup"):
+                    elif _phase in _PR_PHASES:
                         current_desc = (
                             f"{desc}\n\n"
                             f"After completing your changes, commit, push, and open a PR:\n"

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1909,7 +1909,8 @@ class Worker:
                 if tool == "claude":
                     pr_title = (task.get("name") or desc)[:72].replace('"', "'")
                     closes = f" Closes #{task['issue_number']}" if task.get("issue_number") else ""
-                    if (task.get("phase") or "").lower() == "review":
+                    _phase = (task.get("phase") or "execute").lower()
+                    if _phase == "review":
                         # Review-phase tasks must post findings as GitHub PR review
                         # comments — NEVER by committing files and opening a new PR.
                         _pr_repo = task.get("issue_repo") or ""
@@ -1938,7 +1939,7 @@ class Worker:
                             "        -f 'comments[][body]=inline comment'\n"
                             "Do NOT push any commits or open a PR as part of this review.\n"
                         )
-                    else:
+                    elif _phase in ("execute", "followup"):
                         current_desc = (
                             f"{desc}\n\n"
                             f"After completing your changes, commit, push, and open a PR:\n"
@@ -1946,6 +1947,7 @@ class Worker:
                             f"  git push origin {branch}\n"
                             f'  gh pr create --title "{pr_title}" --body "<summary of changes>{closes}"\n'
                         )
+                    # plan / ephemeral / automation phases: leave current_desc = desc unchanged
             success = False
             stop_reason = "no_events"
             last_msg = ""

--- a/worker/tests/test_config.py
+++ b/worker/tests/test_config.py
@@ -283,3 +283,53 @@ def test_load_repos_only_org_none(tmp_path):
     cfg = load(str(toml_path))
     assert cfg.org is None
     assert "owner/repo" in cfg.repos
+
+
+# ---------------------------------------------------------------------------
+# load() — pre-assigned worker_id / auth_token (foreman spawn_worker path)
+# ---------------------------------------------------------------------------
+
+
+def test_load_worker_id_from_env(tmp_path, monkeypatch):
+    """PIONEER_WORKER_ID is picked up so the worker can skip self-registration."""
+    monkeypatch.setenv("PIONEER_BACKEND_URL", "ws://x:1")
+    monkeypatch.setenv("PIONEER_GUILD_ID", "g")
+    monkeypatch.setenv("PIONEER_WORKER_ID", "w-abc123")
+    cfg = load(str(tmp_path / "missing.toml"))
+    assert cfg.worker_id == "w-abc123"
+
+
+def test_load_auth_token_from_env(tmp_path, monkeypatch):
+    """PIONEER_AUTH_TOKEN lets a pre-registered worker skip self-registration."""
+    monkeypatch.setenv("PIONEER_BACKEND_URL", "ws://x:1")
+    monkeypatch.setenv("PIONEER_GUILD_ID", "g")
+    monkeypatch.setenv("PIONEER_AUTH_TOKEN", "tok-secret")
+    cfg = load(str(tmp_path / "missing.toml"))
+    assert cfg.auth_token == "tok-secret"
+
+
+def test_load_worker_id_none_by_default(tmp_path):
+    cfg = load(
+        str(tmp_path / "missing.toml"),
+        overrides={"backend_url": "ws://x:1", "guild_id": "g"},
+    )
+    assert cfg.worker_id is None
+    assert cfg.auth_token is None
+
+
+def test_load_max_agents_from_env(tmp_path, monkeypatch):
+    """PIONEER_MAX_AGENTS overrides the default of 4."""
+    monkeypatch.setenv("PIONEER_BACKEND_URL", "ws://x:1")
+    monkeypatch.setenv("PIONEER_GUILD_ID", "g")
+    monkeypatch.setenv("PIONEER_MAX_AGENTS", "2")
+    cfg = load(str(tmp_path / "missing.toml"))
+    assert cfg.max_agents == 2
+
+
+def test_load_max_agents_toml_beats_env(tmp_path, monkeypatch):
+    """max_agents in TOML takes priority over PIONEER_MAX_AGENTS."""
+    monkeypatch.setenv("PIONEER_MAX_AGENTS", "2")
+    toml_path = tmp_path / "pioneer-worker.toml"
+    toml_path.write_text('backend_url = "ws://x:1"\nguild_id = "g"\nmax_agents = 8\n')
+    cfg = load(str(toml_path))
+    assert cfg.max_agents == 8

--- a/worker/tests/test_pre_assigned_registration.py
+++ b/worker/tests/test_pre_assigned_registration.py
@@ -8,7 +8,7 @@ credentials directly.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pioneer_worker.config import Config
@@ -81,7 +81,7 @@ async def test_register_calls_http_when_no_preassigned_credentials():
         async def post(self, *args, **kwargs):
             nonlocal http_called
             http_called = True
-            resp = AsyncMock()
+            resp = MagicMock()
             resp.raise_for_status = lambda: None
             resp.json.return_value = {"id": "w-new001", "auth_token": "tok-new", "name": "New"}
             return resp

--- a/worker/tests/test_pre_assigned_registration.py
+++ b/worker/tests/test_pre_assigned_registration.py
@@ -1,0 +1,94 @@
+"""Tests for worker pre-assigned credentials (foreman spawn_worker path).
+
+When PIONEER_WORKER_ID and PIONEER_AUTH_TOKEN are set in the environment the
+worker should skip its self-registration HTTP call and use the pre-assigned
+credentials directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_cfg(**kwargs) -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="test-guild",
+        max_agents=1,
+        pull_interval=3600.0,
+        **kwargs,
+    )
+
+
+async def test_register_skips_http_when_preassigned():
+    """_register() must not call POST /workers when worker_id + auth_token are set."""
+    cfg = _make_cfg(worker_id="w-pre001", auth_token="tok-preassigned")
+    worker = Worker(cfg)
+
+    http_called = False
+
+    async def _fake_http(*args, **kwargs):
+        nonlocal http_called
+        http_called = True
+
+    with patch.object(worker, "_http", side_effect=_fake_http):
+        await worker._register()
+
+    assert not http_called, "_http should not be called when credentials are pre-assigned"
+    assert worker.cfg.worker_id == "w-pre001"
+    assert worker.cfg.auth_token == "tok-preassigned"
+
+
+async def test_register_sets_worker_name_from_cfg_when_preassigned():
+    """_register() uses cfg.worker_name when skipping self-registration."""
+    cfg = _make_cfg(
+        worker_id="w-pre002",
+        auth_token="tok-x",
+        worker_name="custom-name",
+    )
+    worker = Worker(cfg)
+    await worker._register()
+    assert worker._worker_name == "custom-name"
+
+
+async def test_register_falls_back_to_worker_id_for_name():
+    """When cfg.worker_name is None, _register() uses worker_id as the display name."""
+    cfg = _make_cfg(worker_id="w-pre003", auth_token="tok-y")
+    worker = Worker(cfg)
+    await worker._register()
+    assert worker._worker_name == "w-pre003"
+
+
+async def test_register_calls_http_when_no_preassigned_credentials():
+    """Without pre-assigned credentials, _register() performs the normal HTTP call."""
+    cfg = _make_cfg()  # worker_id=None, auth_token=None
+    worker = Worker(cfg)
+
+    http_called = False
+
+    class _FakeCtx:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+        async def post(self, *args, **kwargs):
+            nonlocal http_called
+            http_called = True
+            resp = AsyncMock()
+            resp.raise_for_status = lambda: None
+            resp.json.return_value = {"id": "w-new001", "auth_token": "tok-new", "name": "New"}
+            return resp
+
+    with patch.object(worker, "_http", return_value=_FakeCtx()):
+        await worker._register()
+
+    assert http_called, "_http should be called when credentials are not pre-assigned"
+    assert worker.cfg.worker_id == "w-new001"
+    assert worker.cfg.auth_token == "tok-new"


### PR DESCRIPTION
## Summary

- **#528** — Adds a `spawn_worker` MCP tool to the Foreman AI so it can autonomously start new worker processes configured with specific repos and tools, without human intervention. The tool pre-registers the worker in the DB and launches a Docker container via the Docker SDK.
- **#529** — Tightens the worker payload-builder so the \"create a PR\" footer is only injected for `execute` and `followup` phase tasks. Previously the `else` branch unconditionally appended PR instructions to every non-review task, including `plan` and automation tasks.

## Changes

**`backend/foreman_core/tools_schema.py`** — registers `spawn_worker` in `FOREMAN_TOOLS` alongside existing tools like `shutdown_worker`. Accepts `repos` (required), `tools` (optional), `agent_count` (optional), and `name` (optional); returns `worker_id` and `container_id` on success.

**`backend/foreman/tools.py`** — implements the `spawn_worker` executor: pre-registers the worker row in the DB (so `PIONEER_WORKER_ID` is known before container start), builds the env via `build_spawn_worker_env`, and launches the container via `docker.from_env()`. Handles missing Docker SDK gracefully with an error message.

**`backend/utils.py`** — adds `build_spawn_worker_env` helper that assembles the full environment dict passed to the worker container.

**`worker/pioneer_worker/config.py`** / **`worker.py`** — supports pre-assigned `PIONEER_WORKER_ID` and `PIONEER_AUTH_TOKEN` env vars so the worker process skips self-registration when spawned via the tool.

**`worker/pioneer_worker/worker.py`** — fixes #529: replaces unconditional `else` with `elif _phase in ("execute", "followup")` so plan/ephemeral tasks don't receive the PR-creation footer.

**`backend/tests/test_foreman_spawn_worker.py`**, **`worker/tests/test_config.py`**, **`worker/tests/test_pre_assigned_registration.py`** — test coverage for the new feature.

## Test plan

- [ ] `cd backend && python -m pytest tests/test_foreman_spawn_worker.py -v`
- [ ] `cd worker && python -m pytest tests/test_config.py tests/test_pre_assigned_registration.py -v`
- [ ] Manual: foreman calls `spawn_worker` with `repos=["owner/repo"]` → worker container starts, registers, and appears in the guild

Closes #528
Fixes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)