### PR TITLE
feat(spawn): save env var values in DB, not localStorage

### DIFF
--- a/backend/alembic/versions/20260603_000000_create_user_spawn_settings.py
+++ b/backend/alembic/versions/20260603_000000_create_user_spawn_settings.py
@@ -1,0 +1,36 @@
+"""Create user_spawn_settings table.
+
+Revision ID: 20260603_000000_create_user_spawn_settings
+Revises: 20260530_000000_add_level_to_task_logs
+Create Date: 2026-06-03
+
+Stores per-user, per-guild spawn-worker preferences (repos, tools, env var
+key-value pairs) in the database so that env var values are not exposed in
+browser localStorage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260603_000000_create_user_spawn_settings"
+down_revision: str | Sequence[str] | None = "20260530_000000_add_level_to_task_logs"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_spawn_settings",
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), primary_key=True),
+        sa.Column("user_id", sa.Text(), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("settings_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_spawn_settings")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from sqlalchemy import Column, DateTime, Index, or_, text
+from sqlalchemy import Column, DateTime, Index, Text, or_, text
 from sqlmodel import Field, SQLModel, col
 
 
@@ -378,7 +378,8 @@ class UserSpawnSettings(SQLModel, table=True):
     # SECURITY: this column may contain sensitive values (API tokens, credentials,
     # secret env vars). Operators must restrict DB-level read access to this table.
     # TODO: add application-layer encryption for envVars before storing.
-    settings_json: str = Field(default="{}")
+    # TODO: tracked in issue #537
+    settings_json: str = Field(default="{}", sa_column=Column(Text, server_default="{}"))
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),

--- a/backend/models.py
+++ b/backend/models.py
@@ -363,6 +363,22 @@ class ClaudeUsage(SQLModel, table=True):
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
+class UserSpawnSettings(SQLModel, table=True):
+    """Per-user, per-guild spawn-worker preferences (repos, tools, env vars).
+
+    Stored server-side so env var values survive browser sessions without
+    being exposed in localStorage.
+    """
+
+    __tablename__ = "user_spawn_settings"  # type: ignore[assignment]
+
+    guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
+    user_id: str = Field(foreign_key="users.id", primary_key=True)
+    # JSON blob: {repos: [...], tools: [...], envVars: [{key, value}, ...]}
+    settings_json: str = Field(default="{}")
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
 class PushToken(SQLModel, table=True):
     """APNs (or, in the future, FCM) device token registered by the iOS app.
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -379,7 +379,10 @@ class UserSpawnSettings(SQLModel, table=True):
     # secret env vars). Operators must restrict DB-level read access to this table.
     # TODO: add application-layer encryption for envVars before storing.
     settings_json: str = Field(default="{}")
-    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
 
 
 class PushToken(SQLModel, table=True):

--- a/backend/models.py
+++ b/backend/models.py
@@ -375,6 +375,9 @@ class UserSpawnSettings(SQLModel, table=True):
     guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
     user_id: str = Field(foreign_key="users.id", primary_key=True)
     # JSON blob: {repos: [...], tools: [...], envVars: [{key, value}, ...]}
+    # SECURITY: this column may contain sensitive values (API tokens, credentials,
+    # secret env vars). Operators must restrict DB-level read access to this table.
+    # TODO: add application-layer encryption for envVars before storing.
     settings_json: str = Field(default="{}")
     updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -378,15 +378,15 @@ class EnvVarPair(BaseModel):
 
 
 class SaveSpawnSettingsRequest(BaseModel):
-    repos: list[str] | None = None
-    tools: list[str] | None = None
-    envVars: list[EnvVarPair] | None = None
+    # All fields default to empty so a PUT always replaces the full settings object
+    # (no partial-update / PATCH semantics).
+    repos: list[str] = []
+    tools: list[str] = []
+    envVars: list[EnvVarPair] = []
 
     @field_validator("envVars")
     @classmethod
-    def validate_env_var_keys(cls, v: list[EnvVarPair] | None) -> list[EnvVarPair] | None:
-        if v is None:
-            return v
+    def validate_env_var_keys(cls, v: list[EnvVarPair]) -> list[EnvVarPair]:
         if len(v) > _MAX_SETTINGS_ENV_VARS:
             raise ValueError(f"Too many env vars (max {_MAX_SETTINGS_ENV_VARS})")
         for pair in v:
@@ -449,19 +449,25 @@ async def save_spawn_settings(
         )
     )
     row = result.one_or_none()
-    incoming = data.model_dump(exclude_none=True)
+    # model_dump() without exclude_none gives full-replace PUT semantics: every field
+    # is always written, so callers cannot do partial updates through this endpoint.
+    incoming = data.model_dump()
     now = datetime.now(UTC)
+    # TODO: encrypt env var values at rest before production use (tracked in GH issue #537).
+    # Currently stored as plaintext JSON — an improvement over localStorage but not
+    # suitable for highly sensitive credentials until encryption is added.
+    settings_blob = json.dumps(incoming)
     if row is None:
         db.add(
             UserSpawnSettings(
                 guild_id=guild_pk,
                 user_id=github_user_id,
-                settings_json=json.dumps(incoming),
+                settings_json=settings_blob,
                 updated_at=now,
             )
         )
     else:
-        row.settings_json = json.dumps(incoming)
+        row.settings_json = settings_blob
         row.updated_at = now
     await db.commit()
     return {"status": "saved"}

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -365,9 +365,9 @@ async def list_tasks(
     return [row_to_dict(t) for t in result.all()]
 
 
-_MAX_SETTINGS_ENV_VARS = 100
-_MAX_SETTINGS_ENV_KEY_LEN = 1000
-_MAX_SETTINGS_ENV_VALUE_LEN = 1000
+_MAX_SETTINGS_ENV_VARS = 50
+_MAX_SETTINGS_ENV_KEY_LEN = 256
+_MAX_SETTINGS_ENV_VALUE_LEN = 1024
 
 
 class EnvVarPair(BaseModel):

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -19,7 +19,7 @@ from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg, emit_terminal_line, pending_claude_auth
 from fastapi import APIRouter, Depends, HTTPException
-from models import ClaudeCredentials, Task, Worker, live_tasks_filter
+from models import ClaudeCredentials, Task, UserSpawnSettings, Worker, live_tasks_filter
 from pydantic import BaseModel, field_validator
 from sqlalchemy import update
 from sqlmodel import col, select
@@ -363,6 +363,90 @@ async def list_tasks(
         .order_by(col(Task.created_at).desc())
     )
     return [row_to_dict(t) for t in result.all()]
+
+
+class EnvVarPair(BaseModel):
+    key: str
+    value: str
+
+
+class SaveSpawnSettingsRequest(BaseModel):
+    repos: list[str] | None = None
+    tools: list[str] | None = None
+    envVars: list[EnvVarPair] | None = None
+
+    @field_validator("envVars")
+    @classmethod
+    def validate_env_var_keys(cls, v: list[EnvVarPair] | None) -> list[EnvVarPair] | None:
+        if v is None:
+            return v
+        for pair in v:
+            if pair.key and not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", pair.key):
+                raise ValueError(
+                    f"Invalid env var key: {pair.key!r}. Must match ^[A-Za-z_][A-Za-z0-9_]*$"
+                )
+        return v
+
+
+@router.get("/guilds/{guild_id}/spawn-settings")
+async def get_spawn_settings(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Return the current user's saved spawn-worker settings for this guild."""
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    result = await db.exec(
+        select(UserSpawnSettings).where(
+            col(UserSpawnSettings.guild_id) == guild_pk,
+            col(UserSpawnSettings.user_id) == github_user_id,
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        return {}
+    try:
+        return json.loads(row.settings_json)
+    except json.JSONDecodeError:
+        return {}
+
+
+@router.put("/guilds/{guild_id}/spawn-settings")
+async def save_spawn_settings(
+    guild_id: str,
+    data: SaveSpawnSettingsRequest,
+    github_user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Persist the current user's spawn-worker settings for this guild."""
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    result = await db.exec(
+        select(UserSpawnSettings).where(
+            col(UserSpawnSettings.guild_id) == guild_pk,
+            col(UserSpawnSettings.user_id) == github_user_id,
+        )
+    )
+    row = result.one_or_none()
+    settings_json = json.dumps(data.model_dump(exclude_none=True))
+    now = datetime.now(UTC)
+    if row is None:
+        db.add(
+            UserSpawnSettings(
+                guild_id=guild_pk,
+                user_id=github_user_id,
+                settings_json=settings_json,
+                updated_at=now,
+            )
+        )
+    else:
+        row.settings_json = settings_json
+        row.updated_at = now
+    await db.commit()
+    return {"status": "saved"}
 
 
 @router.post("/guilds/{guild_id}/workers/{worker_id}/message")

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -8,6 +8,7 @@ the worker process connects via WebSocket (``join`` message in ws_handlers.py).
 from __future__ import annotations
 
 import json
+import logging
 import os
 import random
 import re
@@ -33,6 +34,7 @@ from utils import (
 from ws_handlers import _resolve_user_identifier
 from ws_types import TaskAssignedMsg, WorkerMessageMsg
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
@@ -393,9 +395,7 @@ class SaveSpawnSettingsRequest(BaseModel):
                     f"Env var key exceeds max length ({_MAX_SETTINGS_ENV_KEY_LEN} chars)"
                 )
             if len(pair.value) > _MAX_SETTINGS_ENV_VALUE_LEN:
-                raise ValueError(
-                    f"Env var value for {pair.key!r} exceeds max length ({_MAX_SETTINGS_ENV_VALUE_LEN} chars)"
-                )
+                raise ValueError("An env var value exceeds the maximum allowed length")
             if pair.key and not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", pair.key):
                 raise ValueError(
                     f"Invalid env var key: {pair.key!r}. Must match ^[A-Za-z_][A-Za-z0-9_]*$"
@@ -424,7 +424,10 @@ async def get_spawn_settings(
         return {}
     try:
         return json.loads(row.settings_json)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Corrupt settings_json for user %s guild %s: %s", github_user_id, guild_pk, exc
+        )
         return {}
 
 
@@ -458,12 +461,7 @@ async def save_spawn_settings(
             )
         )
     else:
-        try:
-            existing = json.loads(row.settings_json)
-        except json.JSONDecodeError:
-            existing = {}
-        existing.update(incoming)
-        row.settings_json = json.dumps(existing)
+        row.settings_json = json.dumps(incoming)
         row.updated_at = now
     await db.commit()
     return {"status": "saved"}

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -365,6 +365,11 @@ async def list_tasks(
     return [row_to_dict(t) for t in result.all()]
 
 
+_MAX_SETTINGS_ENV_VARS = 100
+_MAX_SETTINGS_ENV_KEY_LEN = 1000
+_MAX_SETTINGS_ENV_VALUE_LEN = 1000
+
+
 class EnvVarPair(BaseModel):
     key: str
     value: str
@@ -380,7 +385,17 @@ class SaveSpawnSettingsRequest(BaseModel):
     def validate_env_var_keys(cls, v: list[EnvVarPair] | None) -> list[EnvVarPair] | None:
         if v is None:
             return v
+        if len(v) > _MAX_SETTINGS_ENV_VARS:
+            raise ValueError(f"Too many env vars (max {_MAX_SETTINGS_ENV_VARS})")
         for pair in v:
+            if len(pair.key) > _MAX_SETTINGS_ENV_KEY_LEN:
+                raise ValueError(
+                    f"Env var key exceeds max length ({_MAX_SETTINGS_ENV_KEY_LEN} chars)"
+                )
+            if len(pair.value) > _MAX_SETTINGS_ENV_VALUE_LEN:
+                raise ValueError(
+                    f"Env var value for {pair.key!r} exceeds max length ({_MAX_SETTINGS_ENV_VALUE_LEN} chars)"
+                )
             if pair.key and not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", pair.key):
                 raise ValueError(
                     f"Invalid env var key: {pair.key!r}. Must match ^[A-Za-z_][A-Za-z0-9_]*$"
@@ -431,19 +446,24 @@ async def save_spawn_settings(
         )
     )
     row = result.one_or_none()
-    settings_json = json.dumps(data.model_dump(exclude_none=True))
+    incoming = data.model_dump(exclude_none=True)
     now = datetime.now(UTC)
     if row is None:
         db.add(
             UserSpawnSettings(
                 guild_id=guild_pk,
                 user_id=github_user_id,
-                settings_json=settings_json,
+                settings_json=json.dumps(incoming),
                 updated_at=now,
             )
         )
     else:
-        row.settings_json = settings_json
+        try:
+            existing = json.loads(row.settings_json)
+        except json.JSONDecodeError:
+            existing = {}
+        existing.update(incoming)
+        row.settings_json = json.dumps(existing)
         row.updated_at = now
     await db.commit()
     return {"status": "saved"}

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -181,7 +181,14 @@ onMounted(async () => {
   if (saved && (saved.repos?.length || saved.tools?.length || saved.envVars?.length)) {
     if (saved.repos?.length) {
       const availableRepoNames = new Set(ghStore.repos.map((r) => r.full_name))
-      selectedRepos.value = saved.repos.filter((r) => availableRepoNames.has(r))
+      if (availableRepoNames.size === 0) {
+        console.warn(
+          '[SpawnWorkerForm] repo list is empty after fetch — skipping filter, preserving saved repos',
+        )
+        selectedRepos.value = saved.repos
+      } else {
+        selectedRepos.value = saved.repos.filter((r) => availableRepoNames.has(r))
+      }
     }
     if (saved.tools?.length) selectedTools.value = saved.tools
     if (saved.envVars?.length) envVars.value = saved.envVars

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -172,8 +172,11 @@ onMounted(async () => {
 
   if (ghStore.repos.length === 0 && ghStore.token) {
     loadingRepos.value = true
-    await ghStore.fetchRepos()
-    loadingRepos.value = false
+    try {
+      await ghStore.fetchRepos()
+    } finally {
+      loadingRepos.value = false
+    }
   }
 
   const saved = guild ? await loadSavedSettings(guild.id) : null

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -70,7 +70,7 @@
         placeholder="4"
       />
       <label class="spawn-label">Env Vars <span class="spawn-hint">(optional)</span></label>
-      <p class="spawn-env-hint">Keys are remembered between sessions; values must be re-entered each time (not saved for security).</p>
+      <p class="spawn-env-hint">Key-value pairs are saved to the server and restored each session.</p>
       <div class="spawn-env-list">
         <div v-for="(pair, idx) in envVars" :key="idx" class="spawn-env-row">
           <input
@@ -131,8 +131,6 @@ interface SpawnSettings {
   envVars?: EnvPair[]
 }
 
-const SETTINGS_KEY = (guildId: string) => `pioneer_square:spawn_settings:${guildId}`
-
 const selectedRepos = ref<string[]>([])
 const name = ref('')
 const selectedTools = ref<string[]>([])
@@ -146,32 +144,41 @@ const launchedWorkerId = ref('')
 
 const groupedRepos = computed(() => groupAndSortRepos(ghStore.repos))
 
-function loadSavedSettings(guildId: string): SpawnSettings | null {
+async function loadSavedSettings(guildId: string): Promise<SpawnSettings | null> {
   try {
-    const raw = localStorage.getItem(SETTINGS_KEY(guildId))
-    return raw ? (JSON.parse(raw) as SpawnSettings) : null
+    return await api<SpawnSettings>(`/guilds/${guildId}/spawn-settings`)
   } catch {
     return null
   }
 }
 
-function saveSettings(guildId: string) {
-  const settings: SpawnSettings = {
-    repos: selectedRepos.value,
-    tools: selectedTools.value,
-    // Save only keys (not values) — values may contain secrets/tokens.
-    envVars: envVars.value
-      .filter((e) => e.key.trim() !== '')
-      .map((e) => ({ key: e.key.trim(), value: '' })), // value intentionally blank: secrets must be re-entered each session
+async function saveSettings(guildId: string) {
+  try {
+    await api(`/guilds/${guildId}/spawn-settings`, {
+      method: 'PUT',
+      json: {
+        repos: selectedRepos.value,
+        tools: selectedTools.value,
+        envVars: envVars.value.filter((e) => e.key.trim() !== ''),
+      },
+    })
+  } catch {
+    // Settings persistence failure is non-fatal — the spawn already succeeded.
   }
-  localStorage.setItem(SETTINGS_KEY(guildId), JSON.stringify(settings))
 }
 
 onMounted(async () => {
   const guild = guildStore.currentGuild
-  const saved = guild ? loadSavedSettings(guild.id) : null
 
-  if (saved) {
+  if (ghStore.repos.length === 0 && ghStore.token) {
+    loadingRepos.value = true
+    await ghStore.fetchRepos()
+    loadingRepos.value = false
+  }
+
+  const saved = guild ? await loadSavedSettings(guild.id) : null
+
+  if (saved && (saved.repos?.length || saved.tools?.length || saved.envVars?.length)) {
     if (saved.repos?.length) {
       const availableRepoNames = new Set(ghStore.repos.map((r) => r.full_name))
       selectedRepos.value = saved.repos.filter((r) => availableRepoNames.has(r))
@@ -180,12 +187,6 @@ onMounted(async () => {
     if (saved.envVars?.length) envVars.value = saved.envVars
   } else {
     selectedRepos.value = [...ghStore.selectedRepos]
-  }
-
-  if (ghStore.repos.length === 0 && ghStore.token) {
-    loadingRepos.value = true
-    await ghStore.fetchRepos()
-    loadingRepos.value = false
   }
 })
 
@@ -264,7 +265,7 @@ async function launch() {
         env_vars: Object.keys(envVarsPayload).length ? envVarsPayload : undefined,
       },
     })
-    saveSettings(guild.id)
+    await saveSettings(guild.id)
     launchedWorkerId.value = result?.worker_id ?? ''
     launched.value = true
     setTimeout(() => emit('launched'), 2500)

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -7,6 +7,9 @@
     <template v-else>
       <label class="spawn-label">Repos</label>
       <div v-if="loadingRepos" class="spawn-hint-text">Loading repos…</div>
+      <div v-else-if="repoFetchFailed" class="spawn-error">
+        Failed to load repos — saved selection cleared.
+      </div>
       <div v-else-if="ghStore.repos.length === 0" class="spawn-hint-text">
         No repos found — configure GitHub first.
       </div>
@@ -139,6 +142,7 @@ const envVars = ref<EnvPair[]>([])
 const spawning = ref(false)
 const error = ref('')
 const loadingRepos = ref(false)
+const repoFetchFailed = ref(false)
 const launched = ref(false)
 const launchedWorkerId = ref('')
 
@@ -174,6 +178,8 @@ onMounted(async () => {
     loadingRepos.value = true
     try {
       await ghStore.fetchRepos()
+    } catch {
+      repoFetchFailed.value = true
     } finally {
       loadingRepos.value = false
     }
@@ -183,20 +189,19 @@ onMounted(async () => {
 
   if (saved && (saved.repos?.length || saved.tools?.length || saved.envVars?.length)) {
     if (saved.repos?.length) {
-      const availableRepoNames = new Set(ghStore.repos.map((r) => r.full_name))
-      if (availableRepoNames.size === 0) {
-        console.warn(
-          '[SpawnWorkerForm] repo list is empty after fetch — skipping filter, preserving saved repos',
-        )
-        selectedRepos.value = saved.repos
+      if (repoFetchFailed.value) {
+        // Fetch failed — cannot validate saved repos against available ones.
+        selectedRepos.value = []
       } else {
+        const availableRepoNames = new Set(ghStore.repos.map((r) => r.full_name))
+        // If fetch succeeded but returned no repos, the filter yields [] — correct.
         selectedRepos.value = saved.repos.filter((r) => availableRepoNames.has(r))
       }
     }
     if (saved.tools?.length) selectedTools.value = saved.tools
     if (saved.envVars?.length) envVars.value = saved.envVars
   } else {
-    selectedRepos.value = [...ghStore.selectedRepos]
+    selectedRepos.value = repoFetchFailed.value ? [] : [...ghStore.selectedRepos]
   }
 })
 


### PR DESCRIPTION
## Problem

PR #533 added env var passthrough to the spawn-worker form but intentionally blanked env var values before saving to localStorage (security concern: tokens could sit in browser storage). This meant users had to re-enter all env var values every session.

## Solution

Move spawn-worker form settings (repos, tools, **full** env var key-value pairs) to the database, scoped per guild × user.

## Changes

### Backend
- **`backend/models.py`**: New `UserSpawnSettings` table (`user_spawn_settings`) with columns `guild_id` (FK), `user_id` (FK), `settings_json` (JSON text), `updated_at`. Composite PK on `(guild_id, user_id)`.
- **`backend/alembic/versions/20260603_000000_create_user_spawn_settings.py`**: Alembic migration.
- **`backend/routes/workers.py`**: Two new authenticated endpoints:
  - `GET /guilds/{guild_id}/spawn-settings` — returns saved settings dict (or `{}` if none)
  - `PUT /guilds/{guild_id}/spawn-settings` — upserts settings with full-replace (PUT) semantics; validates env var key format (same `^[A-Za-z_][A-Za-z0-9_]*$` regex as spawn)

### Frontend (`SpawnWorkerForm.vue`)
- Replaced `localStorage` read/write with `api()` calls to the new endpoints.
- Removed the `.map((e) => ({ key: e.key.trim(), value: '' }))` stripping that blanked env var values.
- Fetch repos before loading saved settings so the available-repo filter has data.
- Updated hint text: values are now persisted server-side.

## Known Limitations / Security Notes

**Env var values (including secrets/tokens) are stored as plaintext JSON in the database.**

This is an improvement over localStorage (browser-local, easily inspectable by any JS on the page, cleared on logout) but it is **not a final solution** for sensitive credentials:

- Anyone with DB read access can see the values.
- There is a `TODO` comment in `backend/routes/workers.py` at the `save_spawn_settings` endpoint marking this for follow-up.

**Encryption at rest is a required follow-up before this feature is used with production secrets.** Until then, treat the DB column as only marginally safer than localStorage — better isolation, worse if the DB is compromised.

## Test plan
- [ ] Spawn a worker with env vars → refresh the page → form should restore keys **and** values
- [ ] Env vars with invalid keys (e.g. `123bad`, `has space`) should be rejected by PUT with 422
- [ ] `ruff check . && ruff format .` — clean
- [ ] Backend tests: `cd backend && python -m pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)