### PR TITLE
Include tools in worker-online event (#540)

### DIFF
--- a/backend/alembic/versions/20260603_000001_add_tools_to_workers.py
+++ b/backend/alembic/versions/20260603_000001_add_tools_to_workers.py
@@ -1,0 +1,32 @@
+"""Add tools column to workers table.
+
+Revision ID: 20260603_000001_add_tools_to_workers
+Revises: 20260603_000000_create_user_spawn_settings
+Create Date: 2026-06-03
+
+Stores the JSON-serialised list of available tool runners (e.g. ["claude", "codex", "pi"])
+that the worker reported at registration time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260603_000001_add_tools_to_workers"
+down_revision: str | Sequence[str] | None = "20260603_000000_create_user_spawn_settings"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workers",
+        sa.Column("tools", sa.Text(), nullable=False, server_default="'[]'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "tools")

--- a/backend/alembic/versions/20260603_000001_add_tools_to_workers.py
+++ b/backend/alembic/versions/20260603_000001_add_tools_to_workers.py
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260603_000001_add_tools_to_workers"
-down_revision: str | Sequence[str] | None = "20260603_000000_create_user_spawn_settings"
+down_revision: str | Sequence[str] | None = "20260601_000000_add_model_provider_to_tasks"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -276,6 +276,7 @@ async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
         select(
             col(Worker.id),
             col(Worker.repos),
+            col(Worker.tools),
             col(Worker.org),
             col(Worker.state).label("worker_state"),
             func.count(col(Agent.id)).label("agent_count"),
@@ -363,6 +364,7 @@ async def run_foreman_ai(
                     "repos": json.loads(r["repos"] or "[]"),
                     **({"org": r["org"]} if r.get("org") else {}),
                     "agent_count": r["agent_count"] or 0,
+                    "tools": json.loads(r["tools"] or "[]"),
                 }
                 for r in worker_rows
             ],

--- a/backend/models.py
+++ b/backend/models.py
@@ -96,6 +96,8 @@ class Worker(SQLModel, table=True):
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
     repos: str = Field(default="[]", sa_column_kwargs={"server_default": "'[]'"})
+    # JSON-serialised list of tool runner names available on this worker (e.g. ["claude", "codex"]).
+    tools: str = Field(default="[]", sa_column_kwargs={"server_default": "'[]'"})
     # Optional GitHub org; when set the worker accepts any task targeting <org>/*
     # and clones repos lazily. NULL for workers that use an explicit repos list only.
     org: str | None = None

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -177,6 +177,7 @@ async def get_foreman_state(
             **({"org": r["org"]} if r.get("org") else {}),
             "agent_count": r["agent_count"] or 0,
             "agents": r["agents"] or "",
+            "tools": json.loads(r["tools"] or "[]"),
         }
         for r in worker_rows
     ]

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -70,7 +70,7 @@ def _make_trigger_spy():
 
 
 def test_worker_online_notifies_foreman(client):
-    """worker-register triggers [worker-online] with worker_id, repos, and agent_count."""
+    """worker-register triggers [worker-online] with worker_id, repos, agent_count, and tools."""
     test_client, db_url = client
     guild_id = "nfy001"
     worker_id = "w-nfy001"
@@ -99,6 +99,7 @@ def test_worker_online_notifies_foreman(client):
                     "type": "worker-register",
                     "workerId": worker_id,
                     "repos": ["org/repo1", "org/repo2"],
+                    "tools": ["claude", "codex"],
                 }
             )
             # Sync: ping/pong ensures the server has fully processed
@@ -116,6 +117,7 @@ def test_worker_online_notifies_foreman(client):
     assert f"worker_id={worker_id}" in msg, msg
     assert "repos=org/repo1,org/repo2" in msg, msg
     assert "agent_count=1" in msg, msg
+    assert "tools=claude,codex" in msg, msg
 
 
 def test_worker_graceful_offline_notifies_foreman(client):

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -559,8 +559,9 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
     if not worker_id:
         return
     repos = data.get("repos") or []
+    tools = data.get("tools") or []
     user_ident = data.get("user")
-    update_vals: dict = {"repos": json.dumps(repos)}
+    update_vals: dict = {"repos": json.dumps(repos), "tools": json.dumps(tools)}
     if user_ident:
         resolved = await _resolve_user_identifier(ctx.db, user_ident)
         if resolved:
@@ -572,6 +573,7 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
     )
     await ctx.db.commit()
     repos_str = ",".join(repos) if repos else ""
+    tools_str = ",".join(tools) if tools else ""
     # Query the DB for agents belonging to this specific worker so the count
     # is accurate even when multiple workers share the same WS connection or
     # agents from previous sessions are still tracked in joined_agents.
@@ -583,10 +585,11 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
         )
     )
     agent_count = count_res.one()
+    tools_suffix = f" tools={tools_str}" if tools_str else ""
     await _trigger_foreman(
         ctx.guild_id,
         "worker-online",
-        f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}",
+        f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}{tools_suffix}",
         task_name=f"foreman.worker-online:{worker_id}",
     )
 

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -151,6 +151,7 @@ async def run_foreman_ai(
                     "repos": r.get("repos") or [],
                     **({"org": r["org"]} if r.get("org") else {}),
                     "agent_count": r.get("agent_count") or 0,
+                    "tools": r.get("tools") or [],
                 }
                 for r in worker_rows
             ],

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -77,6 +77,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Skip `codex doctor` startup diagnostics.",
     )
     parser.add_argument("--pi-path", help="Path to the pi executable (default: pi).")
+    parser.add_argument(
+        "--tools",
+        help=(
+            "Comma-separated list of tool runners to enable (e.g. claude,codex,pi). "
+            "Each name is verified against its binary on PATH; tools not found are excluded "
+            "with a warning. Omit to auto-detect all known tools."
+        ),
+    )
 
     # Control API (drive/inspect a live worker without a frontend or foreman)
     parser.add_argument(
@@ -160,6 +168,11 @@ def main(argv: list[str] | None = None) -> int:
             "codex_args": args.codex_args,
             "codex_doctor": args.codex_doctor,
             "pi_path": args.pi_path,
+            "tools": (
+                [t.strip() for t in args.tools.split(",") if t.strip()]
+                if args.tools is not None
+                else None
+            ),
             "pull_interval": args.pull_interval,
             "claude_max_turns": args.claude_max_turns,
             "api_port": args.api_port,

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -70,6 +70,11 @@ class Config:
     api_port: int | None = None
     api_host: str = "127.0.0.1"
 
+    # Explicit allow-list of tool runners to report.  When None (default) the worker
+    # auto-detects by probing every known tool binary.  When set to a list the worker
+    # only checks the listed names and warns about any that are absent from PATH.
+    tools: list[str] | None = None
+
     config_path: Path = field(default_factory=Path)
 
     @property
@@ -238,6 +243,19 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         else raw.get("max_agents", _default_max_agents)
     )
 
+    # tools: override list > TOML list > PIONEER_TOOLS env var (comma-separated) > None (auto-detect)
+    _tools_override = overrides.get("tools")
+    _tools_raw = raw.get("tools")
+    _tools_env = os.environ.get("PIONEER_TOOLS", "").strip()
+    if _tools_override is not None:
+        _tools_val: list[str] | None = list(_tools_override)
+    elif _tools_raw is not None:
+        _tools_val = list(_tools_raw)
+    elif _tools_env:
+        _tools_val = [t.strip() for t in _tools_env.split(",") if t.strip()]
+    else:
+        _tools_val = None
+
     return Config(
         backend_url=backend_url.rstrip("/"),
         guild_id=guild_id,
@@ -301,5 +319,6 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         or os.environ.get("PIONEER_FRONTEND_URL"),
         api_port=_api_port,
         api_host=_api_host,
+        tools=_tools_val,
         config_path=cfg_path,
     )

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -367,7 +367,22 @@ class Worker:
         on PATH are excluded with a warning.  When cfg.tools is None (default), all
         known tool binaries are probed automatically.
         """
+        import os
         import shutil
+
+        def _is_executable(path: str) -> bool:
+            """Return True if *path* resolves to an executable file.
+
+            For bare names (no path separator) uses shutil.which to search PATH.
+            For paths containing a separator, falls back to a direct file check
+            when shutil.which returns None (handles relative and absolute paths
+            that aren't on PATH).
+            """
+            if shutil.which(path):
+                return True
+            if os.sep in path or (os.altsep and os.altsep in path):
+                return os.path.isfile(path) and os.access(path, os.X_OK)
+            return False
 
         tool_paths = {
             "claude": self.cfg.claude_path,
@@ -382,7 +397,7 @@ class Worker:
             if binary is None:
                 logger.warning("Unknown tool %r in --tools list; skipping", name)
                 continue
-            if shutil.which(binary):
+            if _is_executable(binary):
                 tools.append(name)
             else:
                 logger.warning(

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -164,6 +164,8 @@ class Worker:
         # plus API-discovered repos). Never used for task execution — only for
         # telling the backend/UI how many repos this worker can see.
         self._broadcast_repos: list[str] = list(cfg.repos)
+        # Available tool runners detected at startup (e.g. ["claude", "codex", "pi"]).
+        self._available_tools: list[str] = []
 
     # ------------------------------------------------------------------ HTTP
     async def _http(self, *, authed: bool = False) -> httpx.AsyncClient:
@@ -357,6 +359,20 @@ class Worker:
                 "OPENAI_API_KEY not configured — Codex tasks will fail. "
                 "Set openai_api_key in the [codex] config block or the OPENAI_API_KEY env var."
             )
+
+    def _detect_available_tools(self) -> None:
+        """Populate self._available_tools based on which runner binaries are on PATH."""
+        import shutil
+
+        tools: list[str] = []
+        if shutil.which(self.cfg.claude_path):
+            tools.append("claude")
+        if shutil.which(self.cfg.codex_path):
+            tools.append("codex")
+        if shutil.which(self.cfg.pi_path):
+            tools.append("pi")
+        self._available_tools = tools
+        logger.info("Available tools: %s", tools or ["(none)"])
 
     async def _claude_is_authenticated(self) -> bool:
         """Return True if `claude auth status --json` reports loggedIn=true.
@@ -931,6 +947,7 @@ class Worker:
                 "type": "worker-register",
                 "workerId": self.cfg.worker_id,
                 "repos": self._broadcast_repos,
+                "tools": self._available_tools,
                 **({"user": self.cfg.user} if self.cfg.user else {}),
             }
         )
@@ -1144,6 +1161,7 @@ class Worker:
         # be visible to the foreman until Claude is ready to accept tasks.
         listener = asyncio.create_task(self._listen())
         await self._check_claude_auth()
+        self._detect_available_tools()
 
         await self._join()
         self._joined = True
@@ -1541,6 +1559,7 @@ class Worker:
                     "type": "worker-register",
                     "workerId": self.cfg.worker_id,
                     "repos": self._broadcast_repos,
+                    "tools": self._available_tools,
                     **({"user": self.cfg.user} if self.cfg.user else {}),
                 }
             )

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -361,16 +361,35 @@ class Worker:
             )
 
     def _detect_available_tools(self) -> None:
-        """Populate self._available_tools based on which runner binaries are on PATH."""
+        """Populate self._available_tools based on which runner binaries are on PATH.
+
+        When cfg.tools is set, only the listed names are probed; any that aren't found
+        on PATH are excluded with a warning.  When cfg.tools is None (default), all
+        known tool binaries are probed automatically.
+        """
         import shutil
 
+        tool_paths = {
+            "claude": self.cfg.claude_path,
+            "codex": self.cfg.codex_path,
+            "pi": self.cfg.pi_path,
+        }
+        candidates = self.cfg.tools if self.cfg.tools is not None else list(tool_paths)
+
         tools: list[str] = []
-        if shutil.which(self.cfg.claude_path):
-            tools.append("claude")
-        if shutil.which(self.cfg.codex_path):
-            tools.append("codex")
-        if shutil.which(self.cfg.pi_path):
-            tools.append("pi")
+        for name in candidates:
+            binary = tool_paths.get(name)
+            if binary is None:
+                logger.warning("Unknown tool %r in --tools list; skipping", name)
+                continue
+            if shutil.which(binary):
+                tools.append(name)
+            else:
+                logger.warning(
+                    "Tool %r not found on PATH (checked %r); excluding from available tools",
+                    name,
+                    binary,
+                )
         self._available_tools = tools
         logger.info("Available tools: %s", tools or ["(none)"])
 

--- a/worker/tests/test_config.py
+++ b/worker/tests/test_config.py
@@ -308,7 +308,9 @@ def test_load_auth_token_from_env(tmp_path, monkeypatch):
     assert cfg.auth_token == "tok-secret"
 
 
-def test_load_worker_id_none_by_default(tmp_path):
+def test_load_worker_id_none_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("PIONEER_WORKER_ID", raising=False)
+    monkeypatch.delenv("PIONEER_AUTH_TOKEN", raising=False)
     cfg = load(
         str(tmp_path / "missing.toml"),
         overrides={"backend_url": "ws://x:1", "guild_id": "g"},

--- a/worker/tests/test_tools_detection.py
+++ b/worker/tests/test_tools_detection.py
@@ -117,6 +117,41 @@ class TestDetectAvailableTools:
         assert worker._available_tools == ["claude", "pi"]
         assert "codex" not in worker._available_tools
 
+    def test_absolute_path_detected_via_file_check(self, tmp_path):
+        """An absolute path to an executable must be detected even when shutil.which returns None."""
+        exe = tmp_path / "my-claude"
+        exe.write_text("#!/bin/sh\n")
+        exe.chmod(0o755)
+
+        cfg = _make_cfg(tools=["claude"], claude_path=str(exe))
+        worker = Worker(cfg)
+        with patch("shutil.which", return_value=None):
+            worker._detect_available_tools()
+
+        assert "claude" in worker._available_tools
+
+    def test_absolute_path_nonexistent_excluded(self, tmp_path):
+        """An absolute path that doesn't exist must be excluded."""
+        cfg = _make_cfg(tools=["claude"], claude_path=str(tmp_path / "no-such-binary"))
+        worker = Worker(cfg)
+        with patch("shutil.which", return_value=None):
+            worker._detect_available_tools()
+
+        assert "claude" not in worker._available_tools
+
+    def test_absolute_path_non_executable_excluded(self, tmp_path):
+        """An absolute path to a non-executable file must be excluded."""
+        non_exe = tmp_path / "claude-data"
+        non_exe.write_text("not a script")
+        non_exe.chmod(0o644)
+
+        cfg = _make_cfg(tools=["claude"], claude_path=str(non_exe))
+        worker = Worker(cfg)
+        with patch("shutil.which", return_value=None):
+            worker._detect_available_tools()
+
+        assert "claude" not in worker._available_tools
+
 
 class TestToolsCLIFlag:
     """Tests for the --tools CLI flag wiring through cli.main()."""

--- a/worker/tests/test_tools_detection.py
+++ b/worker/tests/test_tools_detection.py
@@ -1,0 +1,187 @@
+"""Tests for --tools CLI flag and _detect_available_tools() path validation."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pioneer_worker import cli
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_cfg(**kwargs) -> Config:
+    defaults = dict(
+        backend_url="ws://localhost:8000",
+        guild_id="g12345",
+        repos=["owner/repo"],
+    )
+    defaults.update(kwargs)
+    return Config(**defaults)
+
+
+class TestDetectAvailableTools:
+    """Unit tests for Worker._detect_available_tools."""
+
+    def test_tool_on_path_is_included(self):
+        """A tool whose binary is found on PATH must appear in _available_tools."""
+        cfg = _make_cfg(tools=["claude"], claude_path="claude")
+        worker = Worker(cfg)
+        with patch("shutil.which", side_effect=lambda x: x if x == "claude" else None):
+            worker._detect_available_tools()
+        assert "claude" in worker._available_tools
+
+    def test_tool_not_on_path_is_excluded(self):
+        """A tool whose binary is absent from PATH must be excluded, not raise."""
+        cfg = _make_cfg(tools=["codex"], codex_path="codex")
+        worker = Worker(cfg)
+        with patch("shutil.which", return_value=None):
+            worker._detect_available_tools()
+        assert "codex" not in worker._available_tools
+
+    def test_tool_not_on_path_logs_warning(self, caplog):
+        """Absence from PATH must produce a warning log."""
+        import logging
+
+        cfg = _make_cfg(tools=["pi"], pi_path="pi")
+        worker = Worker(cfg)
+        with caplog.at_level(logging.WARNING, logger="pioneer_worker.worker"):
+            with patch("shutil.which", return_value=None):
+                worker._detect_available_tools()
+        assert any("pi" in r.message and "not found" in r.message for r in caplog.records)
+
+    def test_only_specified_tools_are_checked(self):
+        """When cfg.tools is set, unlisted tools are not probed even if on PATH."""
+        cfg = _make_cfg(tools=["claude"], claude_path="claude", codex_path="codex")
+        worker = Worker(cfg)
+        checked: list[str] = []
+
+        def _fake_which(path: str):
+            checked.append(path)
+            return path  # pretend everything is present
+
+        with patch("shutil.which", side_effect=_fake_which):
+            worker._detect_available_tools()
+
+        assert "claude" in worker._available_tools
+        assert "codex" not in worker._available_tools
+        assert "codex" not in checked
+
+    def test_auto_detect_checks_all_known_tools(self):
+        """When cfg.tools is None all known tool binaries must be probed."""
+        cfg = _make_cfg(tools=None, claude_path="claude", codex_path="codex", pi_path="pi")
+        worker = Worker(cfg)
+        checked: list[str] = []
+
+        def _fake_which(path: str):
+            checked.append(path)
+            return path
+
+        with patch("shutil.which", side_effect=_fake_which):
+            worker._detect_available_tools()
+
+        assert "claude" in checked
+        assert "codex" in checked
+        assert "pi" in checked
+        assert worker._available_tools == ["claude", "codex", "pi"]
+
+    def test_unknown_tool_name_logs_warning_and_is_skipped(self, caplog):
+        """An unrecognised tool name in cfg.tools must be skipped with a warning."""
+        import logging
+
+        cfg = _make_cfg(tools=["magic_tool"])
+        worker = Worker(cfg)
+        with caplog.at_level(logging.WARNING, logger="pioneer_worker.worker"):
+            with patch("shutil.which", return_value="/usr/bin/magic_tool"):
+                worker._detect_available_tools()
+
+        assert "magic_tool" not in worker._available_tools
+        assert any("magic_tool" in r.message for r in caplog.records)
+
+    def test_mixed_present_and_absent_tools(self):
+        """Only tools actually present on PATH are included; absent ones are silently dropped."""
+        cfg = _make_cfg(
+            tools=["claude", "codex", "pi"],
+            claude_path="claude",
+            codex_path="codex",
+            pi_path="pi",
+        )
+        worker = Worker(cfg)
+
+        def _fake_which(path: str):
+            return path if path in ("claude", "pi") else None
+
+        with patch("shutil.which", side_effect=_fake_which):
+            worker._detect_available_tools()
+
+        assert worker._available_tools == ["claude", "pi"]
+        assert "codex" not in worker._available_tools
+
+
+class TestToolsCLIFlag:
+    """Tests for the --tools CLI flag wiring through cli.main()."""
+
+    def _write_toml(self, tmp_path, body: str):
+        p = tmp_path / "pioneer-worker.toml"
+        p.write_text(body)
+        return p
+
+    def test_tools_flag_passed_to_config(self, tmp_path, monkeypatch):
+        """--tools claude,codex must arrive in cfg.tools as a list."""
+        toml_path = self._write_toml(
+            tmp_path,
+            'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\nrepos = ["owner/repo"]\n',
+        )
+        captured = {}
+
+        class _FakeWorker:
+            def __init__(self, cfg):
+                captured["tools"] = cfg.tools
+
+            async def run(self):
+                return None
+
+        monkeypatch.setattr(cli, "Worker", _FakeWorker)
+        rc = cli.main(["--config", str(toml_path), "--tools", "claude,codex"])
+        assert rc == 0
+        assert captured["tools"] == ["claude", "codex"]
+
+    def test_no_tools_flag_gives_none(self, tmp_path, monkeypatch):
+        """Omitting --tools must leave cfg.tools as None (auto-detect mode)."""
+        toml_path = self._write_toml(
+            tmp_path,
+            'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\nrepos = ["owner/repo"]\n',
+        )
+        captured = {}
+
+        class _FakeWorker:
+            def __init__(self, cfg):
+                captured["tools"] = cfg.tools
+
+            async def run(self):
+                return None
+
+        monkeypatch.setattr(cli, "Worker", _FakeWorker)
+        rc = cli.main(["--config", str(toml_path)])
+        assert rc == 0
+        assert captured["tools"] is None
+
+    def test_tools_flag_strips_whitespace(self, tmp_path, monkeypatch):
+        """Spaces around commas in --tools must be stripped."""
+        toml_path = self._write_toml(
+            tmp_path,
+            'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\nrepos = ["owner/repo"]\n',
+        )
+        captured = {}
+
+        class _FakeWorker:
+            def __init__(self, cfg):
+                captured["tools"] = cfg.tools
+
+            async def run(self):
+                return None
+
+        monkeypatch.setattr(cli, "Worker", _FakeWorker)
+        rc = cli.main(["--config", str(toml_path), "--tools", " claude , pi "])
+        assert rc == 0
+        assert captured["tools"] == ["claude", "pi"]


### PR DESCRIPTION
## Summary

- **Worker**: At startup, after auth checks, calls `_detect_available_tools()` which uses `shutil.which()` to detect which runner binaries (claude/codex/pi) are on PATH and stores the result in `self._available_tools`. Both `worker-register` sends (initial join and repo-refresh) now include a `tools` field.
- **Backend model**: Added `tools: str` column to the `workers` table (JSON array, defaults to `[]`), with a new Alembic migration (`20260603_000001_add_tools_to_workers`).
- **WS handler**: `handle_worker_register` now reads the `tools` field from the message, persists it to the DB, and appends `tools=claude,codex,pi` to the `[worker-online]` foreman event string (omitted when empty for backwards compatibility).
- **Foreman state**: Both the embedded foreman (`backend/foreman/runner.py`) and the standalone foreman (`foreman/pioneer_foreman/runner.py`) now include `tools` in the workers JSON block passed to the Foreman AI. The `foreman/state` API endpoint also exposes the field.
- **Test**: `test_worker_online_notifies_foreman` now sends `"tools": ["claude", "codex"]` in the `worker-register` message and asserts `tools=claude,codex` appears in the triggered foreman message.

## Test plan

- [ ] `cd backend && python -m pytest tests/test_worker_foreman_notify.py -v`
- [ ] Start a worker and confirm the `[worker-online]` log line shows `tools=claude` (or whichever runners are installed)

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)