### PR TITLE
Fix pi_runner asyncio buffer overflow (#542)

### DIFF
--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -128,11 +128,12 @@ async def run_pi_auto(
                     exc,
                 )
                 await emit(f"[pi] ✗ stdout line too large, skipping: {exc}")
-                # Consume the rest of the oversized line so the stream stays usable.
+                # Drain the rest of the oversized line one byte at a time so we
+                # stop exactly at the \n and don't consume bytes from the next line.
                 try:
                     while True:
-                        chunk = await proc.stdout.read(65536)  # type: ignore[union-attr]
-                        if not chunk or b"\n" in chunk:
+                        byte = await proc.stdout.read(1)  # type: ignore[union-attr]
+                        if not byte or byte == b"\n":
                             break
                 except Exception:
                     pass

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -96,8 +96,13 @@ async def run_pi_auto(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            limit=_STREAM_LIMIT,
         )
+        # asyncio.create_subprocess_exec silently ignores the `limit` kwarg, so
+        # patch the StreamReader directly after creation.
+        if proc.stdout:
+            proc.stdout._limit = _STREAM_LIMIT
+        if proc.stderr:
+            proc.stderr._limit = _STREAM_LIMIT
         logger.info("pi subprocess started pid=%s", proc.pid)
 
         rpc_msg = json.dumps({"type": "prompt", "message": description}) + "\n"

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -93,6 +93,7 @@ async def run_pi_auto(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            limit=10 * 1024 * 1024,  # 10 MB — prevents LimitOverrunError on large lines
         )
         logger.info("pi subprocess started pid=%s", proc.pid)
 
@@ -114,48 +115,54 @@ async def run_pi_auto(
         stderr_task = asyncio.create_task(_drain_stderr())
         accumulated = ""
 
-        async for raw in proc.stdout:  # type: ignore[union-attr]
-            line_str = raw.decode(errors="replace").strip()
-            if not line_str:
-                continue
-            event_count += 1
-            logger.debug("pi[%d] stdout#%d: %s", proc.pid, event_count, line_str)
-            try:
-                event = json.loads(line_str)
-            except json.JSONDecodeError:
-                await emit(line_str)
-                continue
-            etype = event.get("type")
-            if (
-                etype == "response"
-                and event.get("command") == "prompt"
-                and not event.get("success", True)
-            ):
-                # Prompt was rejected before acceptance.
-                err = event.get("error", "prompt rejected")
-                await emit(f"[pi] ✗ {err}")
-                saw_error = True
-            if etype == "agent_end":
-                saw_agent_end = True
-                if accumulated.strip():
-                    last_text = accumulated
-                accumulated = ""
-            if etype == "message_update":
-                ame = event.get("assistantMessageEvent", {})
-                if ame.get("type") == "error":
+        try:
+            async for raw in proc.stdout:  # type: ignore[union-attr]
+                line_str = raw.decode(errors="replace").strip()
+                if not line_str:
+                    continue
+                event_count += 1
+                logger.debug("pi[%d] stdout#%d: %s", proc.pid, event_count, line_str)
+                try:
+                    event = json.loads(line_str)
+                except json.JSONDecodeError:
+                    await emit(line_str)
+                    continue
+                etype = event.get("type")
+                if (
+                    etype == "response"
+                    and event.get("command") == "prompt"
+                    and not event.get("success", True)
+                ):
+                    # Prompt was rejected before acceptance.
+                    err = event.get("error", "prompt rejected")
+                    await emit(f"[pi] ✗ {err}")
                     saw_error = True
-                    reason = ame.get("reason", "error")
-                    await emit(f"[pi] ✗ {reason}")
-            text, accumulated = parse_pi_event(event, accumulated)
-            if text:
-                await emit(text)
-            if etype == "message_update" and accumulated.strip():
-                last_text = accumulated
-            # We only send a single prompt; pi RPC mode stays alive waiting
-            # for more stdin after the run completes, so stop reading once the
-            # agent (or a fatal error) has finished.
-            if saw_agent_end or saw_error:
-                break
+                if etype == "agent_end":
+                    saw_agent_end = True
+                    if accumulated.strip():
+                        last_text = accumulated
+                    accumulated = ""
+                if etype == "message_update":
+                    ame = event.get("assistantMessageEvent", {})
+                    if ame.get("type") == "error":
+                        saw_error = True
+                        reason = ame.get("reason", "error")
+                        await emit(f"[pi] ✗ {reason}")
+                text, accumulated = parse_pi_event(event, accumulated)
+                if text:
+                    await emit(text)
+                if etype == "message_update" and accumulated.strip():
+                    last_text = accumulated
+                # We only send a single prompt; pi RPC mode stays alive waiting
+                # for more stdin after the run completes, so stop reading once the
+                # agent (or a fatal error) has finished.
+                if saw_agent_end or saw_error:
+                    break
+        except (asyncio.LimitOverrunError, ValueError) as exc:
+            logger.error(
+                "pi[%d] stdout line exceeded StreamReader limit: %s", proc.pid, exc
+            )
+            await emit(f"[pi] ✗ stdout line too large, skipping remainder: {exc}")
 
         # Closing stdin signals EOF so the RPC process exits cleanly.
         if proc.stdin and not proc.stdin.is_closing():

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -14,6 +14,9 @@ EmitFn = Callable[[str], Awaitable[None]]
 # Seconds to wait for pi to exit after stdin is closed before killing it.
 _WAIT_TIMEOUT = 30
 
+# StreamReader buffer size — large enough to handle big tool outputs.
+_STREAM_LIMIT = 10 * 1024 * 1024  # 10 MB
+
 
 def _result_text(result: dict) -> str:
     """Join the text blocks of a tool result's content array."""
@@ -93,7 +96,7 @@ async def run_pi_auto(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            limit=10 * 1024 * 1024,  # 10 MB — prevents LimitOverrunError on large lines
+            limit=_STREAM_LIMIT,
         )
         logger.info("pi subprocess started pid=%s", proc.pid)
 
@@ -115,54 +118,68 @@ async def run_pi_auto(
         stderr_task = asyncio.create_task(_drain_stderr())
         accumulated = ""
 
-        try:
-            async for raw in proc.stdout:  # type: ignore[union-attr]
-                line_str = raw.decode(errors="replace").strip()
-                if not line_str:
-                    continue
-                event_count += 1
-                logger.debug("pi[%d] stdout#%d: %s", proc.pid, event_count, line_str)
+        while True:
+            try:
+                raw = await proc.stdout.readline()  # type: ignore[union-attr]
+            except (asyncio.LimitOverrunError, ValueError) as exc:
+                logger.error(
+                    "pi[%d] stdout line exceeded StreamReader limit, skipping line: %s",
+                    proc.pid,
+                    exc,
+                )
+                await emit(f"[pi] ✗ stdout line too large, skipping: {exc}")
+                # Consume the rest of the oversized line so the stream stays usable.
                 try:
-                    event = json.loads(line_str)
-                except json.JSONDecodeError:
-                    await emit(line_str)
-                    continue
-                etype = event.get("type")
-                if (
-                    etype == "response"
-                    and event.get("command") == "prompt"
-                    and not event.get("success", True)
-                ):
-                    # Prompt was rejected before acceptance.
-                    err = event.get("error", "prompt rejected")
-                    await emit(f"[pi] ✗ {err}")
-                    saw_error = True
-                if etype == "agent_end":
-                    saw_agent_end = True
-                    if accumulated.strip():
-                        last_text = accumulated
-                    accumulated = ""
-                if etype == "message_update":
-                    ame = event.get("assistantMessageEvent", {})
-                    if ame.get("type") == "error":
-                        saw_error = True
-                        reason = ame.get("reason", "error")
-                        await emit(f"[pi] ✗ {reason}")
-                text, accumulated = parse_pi_event(event, accumulated)
-                if text:
-                    await emit(text)
-                if etype == "message_update" and accumulated.strip():
+                    while True:
+                        chunk = await proc.stdout.read(65536)  # type: ignore[union-attr]
+                        if not chunk or b"\n" in chunk:
+                            break
+                except Exception:
+                    pass
+                continue
+            if not raw:  # EOF
+                break
+            line_str = raw.decode(errors="replace").strip()
+            if not line_str:
+                continue
+            event_count += 1
+            logger.debug("pi[%d] stdout#%d: %s", proc.pid, event_count, line_str)
+            try:
+                event = json.loads(line_str)
+            except json.JSONDecodeError:
+                await emit(line_str)
+                continue
+            etype = event.get("type")
+            if (
+                etype == "response"
+                and event.get("command") == "prompt"
+                and not event.get("success", True)
+            ):
+                # Prompt was rejected before acceptance.
+                err = event.get("error", "prompt rejected")
+                await emit(f"[pi] ✗ {err}")
+                saw_error = True
+            if etype == "agent_end":
+                saw_agent_end = True
+                if accumulated.strip():
                     last_text = accumulated
-                # We only send a single prompt; pi RPC mode stays alive waiting
-                # for more stdin after the run completes, so stop reading once the
-                # agent (or a fatal error) has finished.
-                if saw_agent_end or saw_error:
-                    break
-        except (asyncio.LimitOverrunError, ValueError) as exc:
-            logger.error(
-                "pi[%d] stdout line exceeded StreamReader limit: %s", proc.pid, exc
-            )
-            await emit(f"[pi] ✗ stdout line too large, skipping remainder: {exc}")
+                accumulated = ""
+            if etype == "message_update":
+                ame = event.get("assistantMessageEvent", {})
+                if ame.get("type") == "error":
+                    saw_error = True
+                    reason = ame.get("reason", "error")
+                    await emit(f"[pi] ✗ {reason}")
+            text, accumulated = parse_pi_event(event, accumulated)
+            if text:
+                await emit(text)
+            if etype == "message_update" and accumulated.strip():
+                last_text = accumulated
+            # We only send a single prompt; pi RPC mode stays alive waiting
+            # for more stdin after the run completes, so stop reading once the
+            # agent (or a fatal error) has finished.
+            if saw_agent_end or saw_error:
+                break
 
         # Closing stdin signals EOF so the RPC process exits cleanly.
         if proc.stdin and not proc.stdin.is_closing():

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -96,13 +96,8 @@ async def run_pi_auto(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            limit=_STREAM_LIMIT,
         )
-        # asyncio.create_subprocess_exec silently ignores the `limit` kwarg, so
-        # patch the StreamReader directly after creation.
-        if proc.stdout:
-            proc.stdout._limit = _STREAM_LIMIT
-        if proc.stderr:
-            proc.stderr._limit = _STREAM_LIMIT
         logger.info("pi subprocess started pid=%s", proc.pid)
 
         rpc_msg = json.dumps({"type": "prompt", "message": description}) + "\n"

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -346,14 +346,11 @@ sys.exit(0)
         "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
     )
 
-    # The runner must not crash; success is acceptable if the limit is raised,
-    # but a logged error is also fine as long as it returns cleanly.
-    assert stop_reason in ("success", "error_during_execution", "no_events")
+    # The 2 MB line is below the 10 MB _STREAM_LIMIT, so the runner completes cleanly.
+    assert stop_reason == "success"
 
 
-async def test_run_pi_auto_oversized_line_continues_to_agent_end(
-    tmp_path, monkeypatch
-) -> None:
+async def test_run_pi_auto_oversized_line_continues_to_agent_end(tmp_path, monkeypatch) -> None:
     """After an oversized line (LimitOverrunError), subsequent lines including
     agent_end must still be processed — the runner must not hang or lose events."""
     import pioneer_worker.pi_runner as pi_runner_mod

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -179,6 +180,8 @@ sys.exit(0)
     assert stop_reason == "success"
     assert "[pi] agent started" in emitted
     assert last_text == "Task done"
+    for line in emitted:
+        assert not line.endswith("\n"), f"trailing newline in emitted line: {line!r}"
 
 
 async def test_run_pi_auto_not_found(tmp_path) -> None:
@@ -350,41 +353,83 @@ sys.exit(0)
     assert stop_reason == "success"
 
 
-async def test_run_pi_auto_oversized_line_continues_to_agent_end(tmp_path, monkeypatch) -> None:
-    """After an oversized line (LimitOverrunError), subsequent lines including
-    agent_end must still be processed — the runner must not hang or lose events."""
-    import pioneer_worker.pi_runner as pi_runner_mod
+async def test_run_pi_auto_limit_overrun_skips_and_continues() -> None:
+    """LimitOverrunError on the first readline is logged and skipped; the
+    following agent_end line is still processed and stop_reason is success.
+    Uses a fully-mocked subprocess so no real process is spawned."""
+    from unittest.mock import AsyncMock, MagicMock, patch
 
-    # Set a tiny limit so a 256-byte line triggers LimitOverrunError.
-    monkeypatch.setattr(pi_runner_mod, "_STREAM_LIMIT", 128)
+    # --- stdout behaviour ---
+    # readline: first call raises LimitOverrunError; second returns agent_end; third is EOF.
+    readline_queue = [
+        asyncio.LimitOverrunError("line too long", 0),
+        b'{"type":"agent_end"}\n',
+        b"",
+    ]
+    readline_pos = [0]
 
-    fake_pi = tmp_path / "fake-pi"
-    fake_pi.write_text(
-        f"""#!{sys.executable}
-import json, sys
-# This 256-byte line exceeds the patched 128-byte limit.
-print("x" * 256, flush=True)
-# agent_end must still be received even after the oversized line.
-print(json.dumps({{"type": "agent_end"}}), flush=True)
-sys.exit(0)
-""",
-        encoding="utf-8",
-    )
-    fake_pi.chmod(0o755)
+    async def _readline() -> bytes:
+        idx = readline_pos[0]
+        readline_pos[0] += 1
+        val = readline_queue[idx] if idx < len(readline_queue) else b""
+        if isinstance(val, BaseException):
+            raise val
+        return val
+
+    # read(1): drain loop reads two bytes — 'x' then '\n' — to simulate the
+    # tail of the oversized line, stopping exactly at the newline.
+    read_queue = [b"x", b"\n"]
+    read_pos = [0]
+
+    async def _read(n: int) -> bytes:
+        idx = read_pos[0]
+        read_pos[0] += 1
+        return read_queue[idx] if idx < len(read_queue) else b""
+
+    fake_stdout = MagicMock()
+    fake_stdout.readline = _readline
+    fake_stdout.read = _read
+
+    # --- stderr: empty async generator ---
+    async def _empty_stderr():
+        return
+        yield  # make it an async generator
+
+    # --- stdin ---
+    fake_stdin = MagicMock()
+    fake_stdin.write = MagicMock()
+    fake_stdin.drain = AsyncMock()
+    fake_stdin.close = MagicMock()
+    fake_stdin.is_closing = MagicMock(return_value=False)
+
+    # --- process ---
+    fake_proc = MagicMock()
+    fake_proc.pid = 99999
+    fake_proc.returncode = 0  # already exited — finally block skips kill
+    fake_proc.stdout = fake_stdout
+    fake_proc.stderr = _empty_stderr()
+    fake_proc.stdin = fake_stdin
+    fake_proc.wait = AsyncMock(return_value=0)
+
+    async def _fake_create(*args: object, **kwargs: object):
+        return fake_proc
 
     emitted: list[str] = []
 
     async def emit(line: str) -> None:
         emitted.append(line)
 
-    success, stop_reason, _ = await run_pi_auto(
-        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
-    )
+    with patch("asyncio.create_subprocess_exec", new=_fake_create):
+        success, stop_reason, _ = await run_pi_auto("/tmp", "/tmp", emit=emit)
 
-    # The oversized line error must have been reported.
+    # The oversized-line error must have been reported.
     assert any("too large" in line for line in emitted)
-    # agent_end must have been received → stop_reason is success, not no_events.
+    # agent_end was processed → success is True (not merely exit_code==0).
+    assert success is True
     assert stop_reason == "success"
+    # No emitted line should carry a spurious trailing newline.
+    for line in emitted:
+        assert not line.endswith("\n"), f"trailing newline in emitted line: {line!r}"
 
 
 async def test_run_pi_auto_stderr_forwarded(tmp_path) -> None:

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -323,7 +323,8 @@ while True:
 async def test_run_pi_auto_large_line_does_not_crash(tmp_path) -> None:
     """A stdout line larger than the default 64 KB limit must not crash the runner."""
     fake_pi = tmp_path / "fake-pi"
-    # Write a line that is 2 MB long (well above asyncio's default 64 KB limit).
+    # Write a line that is 2 MB long (well above asyncio's default 64 KB limit but
+    # within the 10 MB _STREAM_LIMIT, so it succeeds cleanly).
     fake_pi.write_text(
         f"""#!{sys.executable}
 import json, sys
@@ -348,6 +349,45 @@ sys.exit(0)
     # The runner must not crash; success is acceptable if the limit is raised,
     # but a logged error is also fine as long as it returns cleanly.
     assert stop_reason in ("success", "error_during_execution", "no_events")
+
+
+async def test_run_pi_auto_oversized_line_continues_to_agent_end(
+    tmp_path, monkeypatch
+) -> None:
+    """After an oversized line (LimitOverrunError), subsequent lines including
+    agent_end must still be processed — the runner must not hang or lose events."""
+    import pioneer_worker.pi_runner as pi_runner_mod
+
+    # Set a tiny limit so a 256-byte line triggers LimitOverrunError.
+    monkeypatch.setattr(pi_runner_mod, "_STREAM_LIMIT", 128)
+
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+# This 256-byte line exceeds the patched 128-byte limit.
+print("x" * 256, flush=True)
+# agent_end must still be received even after the oversized line.
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, _ = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    # The oversized line error must have been reported.
+    assert any("too large" in line for line in emitted)
+    # agent_end must have been received → stop_reason is success, not no_events.
+    assert stop_reason == "success"
 
 
 async def test_run_pi_auto_stderr_forwarded(tmp_path) -> None:

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -320,6 +320,36 @@ while True:
     assert stop_reason == "success"
 
 
+async def test_run_pi_auto_large_line_does_not_crash(tmp_path) -> None:
+    """A stdout line larger than the default 64 KB limit must not crash the runner."""
+    fake_pi = tmp_path / "fake-pi"
+    # Write a line that is 2 MB long (well above asyncio's default 64 KB limit).
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print("x" * 2 * 1024 * 1024, flush=True)
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    # Should complete without raising — either success or graceful error.
+    success, stop_reason, _ = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    # The runner must not crash; success is acceptable if the limit is raised,
+    # but a logged error is also fine as long as it returns cleanly.
+    assert stop_reason in ("success", "error_during_execution", "no_events")
+
+
 async def test_run_pi_auto_stderr_forwarded(tmp_path) -> None:
     """Stderr lines from pi are forwarded to emit with [stderr] prefix."""
     fake_pi = tmp_path / "fake-pi"


### PR DESCRIPTION
## Summary

- Passes `limit=10 * 1024 * 1024` (10 MB) to `asyncio.create_subprocess_exec` so the subprocess `StreamReader` can handle stdout lines larger than asyncio's default 64 KB limit.
- Wraps the `async for raw in proc.stdout` loop in a `try/except (asyncio.LimitOverrunError, ValueError)` block — if a line still somehow exceeds the limit, the error is logged and emitted to the caller rather than crashing the whole runner.
- Adds `test_run_pi_auto_large_line_does_not_crash`: a fake pi script that writes a 2 MB line followed by `agent_end`, verifying the runner completes cleanly.

Closes #542