### PR TITLE
Pi runner: error reporting, cost tracking, remove no-session

### DIFF
--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -226,7 +226,7 @@ async def run_pi_auto(
                             "model": event.get("model"),
                             "cost_usd": cost,
                             "stop_reason": "success",
-                            **( usage_data or {}),
+                            **(usage_data or {}),
                         }
                         await on_usage(rec)
             if etype == "message_update":

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -37,23 +37,19 @@ def _parse_pi_usage(event: dict) -> dict | None:
     usage = event.get("usage") or event.get("tokenUsage")
     if not isinstance(usage, dict):
         return None
+    v = usage.get("inputTokens")
+    input_tokens = v if v is not None else usage.get("input_tokens", 0)
+    v = usage.get("outputTokens")
+    output_tokens = v if v is not None else usage.get("output_tokens", 0)
+    v = usage.get("cacheReadInputTokens")
+    cache_read = v if v is not None else usage.get("cache_read_input_tokens", 0)
+    v = usage.get("cacheCreationInputTokens")
+    cache_creation = v if v is not None else usage.get("cache_creation_input_tokens", 0)
     return {
-        "input_tokens": int(
-            usage.get("inputTokens") or usage.get("input_tokens") or 0
-        ),
-        "output_tokens": int(
-            usage.get("outputTokens") or usage.get("output_tokens") or 0
-        ),
-        "cache_read_input_tokens": int(
-            usage.get("cacheReadInputTokens")
-            or usage.get("cache_read_input_tokens")
-            or 0
-        ),
-        "cache_creation_input_tokens": int(
-            usage.get("cacheCreationInputTokens")
-            or usage.get("cache_creation_input_tokens")
-            or 0
-        ),
+        "input_tokens": int(input_tokens),
+        "output_tokens": int(output_tokens),
+        "cache_read_input_tokens": int(cache_read),
+        "cache_creation_input_tokens": int(cache_creation),
     }
 
 
@@ -285,13 +281,15 @@ async def run_pi_auto(
             stop_reason = "success"
         # Emit an explicit error when the subprocess exits non-zero without a
         # clean agent_end so callers see a failure rather than a silent EOF.
+        # Guard with `not saw_error` to avoid emitting a second error when the
+        # message_update handler already forwarded one.
         agent_ended_ok = saw_agent_end and not saw_error
-        if exit_code != 0 and not agent_ended_ok:
+        if exit_code != 0 and not agent_ended_ok and not saw_error:
             msg = f"[pi] ✗ process exited with non-zero code {exit_code}"
             logger.error("pi[%d] %s", proc.pid if proc else "?", msg)
             await emit(msg)
-            if not saw_error:
-                stop_reason = "error_during_execution"
+        if exit_code != 0 and not agent_ended_ok:
+            stop_reason = "error_during_execution"
         return (exit_code == 0 and agent_ended_ok), stop_reason, last_text, session_id
     except FileNotFoundError:
         logger.error("`pi` CLI not found on PATH")

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -1,4 +1,4 @@
-"""Run `pi --mode rpc --no-session` on a task and stream output."""
+"""Run `pi --mode rpc` on a task and stream output."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from collections.abc import Awaitable, Callable
 logger = logging.getLogger(__name__)
 
 EmitFn = Callable[[str], Awaitable[None]]
+UsageFn = Callable[[dict], Awaitable[None]]  # on_usage(record: dict)
 
 # Seconds to wait for pi to exit after stdin is closed before killing it.
 _WAIT_TIMEOUT = 30
@@ -25,6 +26,35 @@ def _result_text(result: dict) -> str:
         if isinstance(blk, dict) and blk.get("type") == "text":
             parts.append(blk.get("text", ""))
     return "".join(parts)
+
+
+def _parse_pi_usage(event: dict) -> dict | None:
+    """Extract token counts from a pi event's usage block, if present.
+
+    Pi may use camelCase or snake_case field names depending on version.
+    Returns None when no usage block is found.
+    """
+    usage = event.get("usage") or event.get("tokenUsage")
+    if not isinstance(usage, dict):
+        return None
+    return {
+        "input_tokens": int(
+            usage.get("inputTokens") or usage.get("input_tokens") or 0
+        ),
+        "output_tokens": int(
+            usage.get("outputTokens") or usage.get("output_tokens") or 0
+        ),
+        "cache_read_input_tokens": int(
+            usage.get("cacheReadInputTokens")
+            or usage.get("cache_read_input_tokens")
+            or 0
+        ),
+        "cache_creation_input_tokens": int(
+            usage.get("cacheCreationInputTokens")
+            or usage.get("cache_creation_input_tokens")
+            or 0
+        ),
+    }
 
 
 def parse_pi_event(event: dict, last_text: str) -> tuple[str | None, str]:
@@ -68,12 +98,28 @@ async def run_pi_auto(
     cwd: str,
     *,
     emit: EmitFn,
+    on_usage: UsageFn | None = None,
     pi_path: str = "pi",
     model: str | None = None,
     provider: str | None = None,
-) -> tuple[bool, str, str]:
-    """Run pi on *description* in *cwd*. Returns (success, stop_reason, last_text)."""
-    cmd = [pi_path, "--mode", "rpc", "--no-session"]
+) -> tuple[bool, str, str, str | None]:
+    """Run pi on *description* in *cwd*.
+
+    Returns (success, stop_reason, last_text, session_id).
+
+    Session tracking is enabled by default (no ``--no-session`` flag).
+    Pi emits a ``session_id`` field in ``agent_start`` (or a dedicated
+    ``session`` event); the value is extracted and returned so callers can
+    resume or reference the session.
+
+    If *on_usage* is provided it is called with usage-record dicts following
+    the same shape used by claude_runner:
+      - ``{"kind": "api_call", "model": ..., "input_tokens": ..., ...}`` for
+        per-message token counts emitted in ``message_update`` events.
+      - ``{"kind": "result", "model": ..., "cost_usd": ..., ...}`` for the
+        final summary emitted in ``agent_end``.
+    """
+    cmd = [pi_path, "--mode", "rpc"]
     if provider:
         cmd += ["--provider", provider]
     if model:
@@ -87,6 +133,7 @@ async def run_pi_auto(
     stop_reason = "no_events"
     event_count = 0
     agent_ended_ok = False
+    session_id: str | None = None
     proc: asyncio.subprocess.Process | None = None
     stderr_task: asyncio.Task[None] | None = None
     try:
@@ -151,6 +198,14 @@ async def run_pi_auto(
                 await emit(line_str)
                 continue
             etype = event.get("type")
+
+            # Extract session_id from agent_start or a dedicated session event.
+            if etype in ("agent_start", "session"):
+                sid = event.get("session_id") or event.get("sessionId")
+                if sid:
+                    session_id = sid
+                    logger.info("pi[%d] session_id=%s", proc.pid, session_id)
+
             if (
                 etype == "response"
                 and event.get("command") == "prompt"
@@ -165,12 +220,36 @@ async def run_pi_auto(
                 if accumulated.strip():
                     last_text = accumulated
                 accumulated = ""
+                # Emit final usage record if pi includes cost/token data here.
+                if on_usage is not None:
+                    usage_data = _parse_pi_usage(event)
+                    cost = event.get("cost_usd") or event.get("costUsd")
+                    if usage_data or cost is not None:
+                        rec: dict = {
+                            "kind": "result",
+                            "model": event.get("model"),
+                            "cost_usd": cost,
+                            "stop_reason": "success",
+                            **( usage_data or {}),
+                        }
+                        await on_usage(rec)
             if etype == "message_update":
                 ame = event.get("assistantMessageEvent", {})
                 if ame.get("type") == "error":
                     saw_error = True
                     reason = ame.get("reason", "error")
                     await emit(f"[pi] ✗ {reason}")
+                # Emit per-message token counts if present.
+                if on_usage is not None:
+                    usage_data = _parse_pi_usage(event)
+                    if usage_data:
+                        await on_usage(
+                            {
+                                "kind": "api_call",
+                                "model": event.get("model"),
+                                **usage_data,
+                            }
+                        )
             text, accumulated = parse_pi_event(event, accumulated)
             if text:
                 await emit(text)
@@ -204,16 +283,24 @@ async def run_pi_auto(
             stop_reason = "success"
         elif exit_code == 0:
             stop_reason = "success"
+        # Emit an explicit error when the subprocess exits non-zero without a
+        # clean agent_end so callers see a failure rather than a silent EOF.
         agent_ended_ok = saw_agent_end and not saw_error
-        return (exit_code == 0 and agent_ended_ok), stop_reason, last_text
+        if exit_code != 0 and not agent_ended_ok:
+            msg = f"[pi] ✗ process exited with non-zero code {exit_code}"
+            logger.error("pi[%d] %s", proc.pid if proc else "?", msg)
+            await emit(msg)
+            if not saw_error:
+                stop_reason = "error_during_execution"
+        return (exit_code == 0 and agent_ended_ok), stop_reason, last_text, session_id
     except FileNotFoundError:
         logger.error("`pi` CLI not found on PATH")
         await emit("[pi] ✗ `pi` CLI not found on PATH")
-        return False, "no_events", last_text
+        return False, "no_events", last_text, session_id
     except Exception as exc:  # pragma: no cover
         logger.exception("pi subprocess crashed: %s", exc)
         await emit(f"[pi] ✗ {exc}")
-        return False, "error_during_execution", last_text
+        return False, "error_during_execution", last_text, session_id
     finally:
         # Safety net: ensure the subprocess is gone even if we took an
         # exception or were cancelled before the normal cleanup above ran.

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -2032,14 +2032,17 @@ class Worker:
                         _pi_model,
                         _pi_provider,
                     )
-                    success, stop_reason, last_msg = await pi_runner.run_pi_auto(
+                    success, stop_reason, last_msg, _pi_session_id = await pi_runner.run_pi_auto(
                         current_desc,
                         primary_wt,
                         emit=emit,
                         pi_path=self.cfg.pi_path,
                         model=_pi_model,
                         provider=_pi_provider,
+                        on_usage=_collect_usage,
                     )
+                    if _pi_session_id:
+                        resume_session_id = _pi_session_id
                 else:
                     logger.info(
                         "Task %s: launching claude in %s (max_turns=%d, resume=%s)",

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -2041,8 +2041,7 @@ class Worker:
                         provider=_pi_provider,
                         on_usage=_collect_usage,
                     )
-                    if _pi_session_id:
-                        resume_session_id = _pi_session_id
+                    resume_session_id = _pi_session_id
                 else:
                     logger.info(
                         "Task %s: launching claude in %s (max_turns=%d, resume=%s)",

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -750,6 +750,53 @@ sys.exit(0)
     assert success is True
 
 
+async def test_parse_pi_usage_zero_input_tokens_not_ignored() -> None:
+    """inputTokens=0 must not fall through to input_tokens via or-chaining."""
+    from pioneer_worker.pi_runner import _parse_pi_usage
+
+    # If or-chaining is used, 0 (falsy) would cause fallthrough to input_tokens=99.
+    event = {"usage": {"inputTokens": 0, "input_tokens": 99, "outputTokens": 5}}
+    result = _parse_pi_usage(event)
+    assert result is not None
+    assert result["input_tokens"] == 0
+    assert result["output_tokens"] == 5
+
+
+async def test_run_pi_auto_no_double_error_when_saw_error(tmp_path) -> None:
+    """When a message_update error is already forwarded, a non-zero exit must not
+    emit a second error chunk (double-error bug)."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+event = {{
+    "type": "message_update",
+    "assistantMessageEvent": {{"type": "error", "reason": "context_limit"}},
+    "message": {{"content": []}}
+}}
+print(json.dumps(event), flush=True)
+sys.exit(1)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, _, _sid = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is False
+    assert stop_reason == "error_during_execution"
+    assert any("context_limit" in line for line in emitted)
+    # No second error chunk about the non-zero exit code.
+    assert not any("non-zero" in line for line in emitted), emitted
+
+
 async def test_run_pi_auto_snake_case_usage_fields(tmp_path) -> None:
     """Snake_case usage fields (input_tokens/output_tokens) are parsed correctly."""
     fake_pi = tmp_path / "fake-pi"

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -172,7 +172,7 @@ sys.exit(0)
     async def emit(line: str) -> None:
         emitted.append(line)
 
-    success, stop_reason, last_text = await run_pi_auto(
+    success, stop_reason, last_text, session_id = await run_pi_auto(
         "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
     )
 
@@ -180,23 +180,25 @@ sys.exit(0)
     assert stop_reason == "success"
     assert "[pi] agent started" in emitted
     assert last_text == "Task done"
+    assert session_id is None  # no session event emitted by this fake
     for line in emitted:
         assert not line.endswith("\n"), f"trailing newline in emitted line: {line!r}"
 
 
 async def test_run_pi_auto_not_found(tmp_path) -> None:
-    """Missing pi binary → FileNotFoundError → returns (False, 'no_events', '')."""
+    """Missing pi binary → FileNotFoundError → returns (False, 'no_events', '', None)."""
     emitted: list[str] = []
 
     async def emit(line: str) -> None:
         emitted.append(line)
 
-    success, stop_reason, last_text = await run_pi_auto(
+    success, stop_reason, last_text, session_id = await run_pi_auto(
         "do the work", str(tmp_path), emit=emit, pi_path="/nonexistent/pi-binary-xyz"
     )
 
     assert success is False
     assert stop_reason == "no_events"
+    assert session_id is None
     assert any("not found" in line for line in emitted)
 
 
@@ -218,7 +220,7 @@ sys.exit(1)
     async def emit(line: str) -> None:
         emitted.append(line)
 
-    success, stop_reason, last_text = await run_pi_auto(
+    success, stop_reason, last_text, session_id = await run_pi_auto(
         "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
     )
 
@@ -246,7 +248,7 @@ sys.exit(0)
     async def emit(line: str) -> None:
         emitted.append(line)
 
-    success, stop_reason, _ = await run_pi_auto(
+    success, stop_reason, _, _sid = await run_pi_auto(
         "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
     )
 
@@ -277,7 +279,7 @@ sys.exit(1)
     async def emit(line: str) -> None:
         emitted.append(line)
 
-    success, stop_reason, _ = await run_pi_auto(
+    success, stop_reason, _, _sid = await run_pi_auto(
         "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
     )
 
@@ -314,7 +316,7 @@ while True:
         emitted.append(line)
 
     # Should complete (not hang) even though pi refuses to exit on its own.
-    success, stop_reason, _ = await run_pi_auto(
+    success, stop_reason, _, _sid = await run_pi_auto(
         "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
     )
 
@@ -345,7 +347,7 @@ sys.exit(0)
         emitted.append(line)
 
     # Should complete without raising — either success or graceful error.
-    success, stop_reason, _ = await run_pi_auto(
+    success, stop_reason, _, _sid = await run_pi_auto(
         "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
     )
 
@@ -420,7 +422,7 @@ async def test_run_pi_auto_limit_overrun_skips_and_continues() -> None:
         emitted.append(line)
 
     with patch("asyncio.create_subprocess_exec", new=_fake_create):
-        success, stop_reason, _ = await run_pi_auto("/tmp", "/tmp", emit=emit)
+        success, stop_reason, _, _sid = await run_pi_auto("/tmp", "/tmp", emit=emit)
 
     # The oversized-line error must have been reported.
     assert any("too large" in line for line in emitted)
@@ -454,3 +456,328 @@ sys.exit(0)
     await run_pi_auto("do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi))
 
     assert any("[stderr]" in line and "warning from pi" in line for line in emitted)
+
+
+# ---------------------------------------------------------------------------
+# Goal 1: Error & Crash Reporting
+# ---------------------------------------------------------------------------
+
+
+async def test_run_pi_auto_nonzero_exit_emits_error(tmp_path) -> None:
+    """Pi exits non-zero without agent_end → error chunk emitted, success=False."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_start"}}), flush=True)
+print(json.dumps({{"type": "message_update", "message": {{"content": [{{"type": "text", "text": "partial"}}]}}}}), flush=True)
+sys.exit(2)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is False
+    assert stop_reason == "error_during_execution"
+    # Partial text should be preserved
+    assert last_text == "partial"
+    # An explicit error message about the exit code must be emitted
+    assert any("non-zero" in line and "2" in line for line in emitted), emitted
+
+
+async def test_run_pi_auto_crash_with_stderr(tmp_path) -> None:
+    """Pi crashes (non-zero + stderr) → both stderr and exit-code error are surfaced."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print("fatal: segfault", file=sys.stderr, flush=True)
+sys.exit(139)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is False
+    assert stop_reason == "error_during_execution"
+    # Stderr forwarded
+    assert any("[stderr]" in line and "fatal" in line for line in emitted), emitted
+    # Non-zero exit explicitly reported
+    assert any("non-zero" in line for line in emitted), emitted
+
+
+async def test_run_pi_auto_zero_exit_no_agent_end(tmp_path) -> None:
+    """Pi exits 0 but never emits agent_end → not treated as success (no clean agent_end)."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_start"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    # exit_code == 0 but agent_ended_ok is False → success must be False
+    assert success is False
+    # stop_reason is "success" because exit_code==0 path sets it, but agent_ended_ok
+    # gate prevents returning success=True
+    assert stop_reason in ("success", "no_events")
+
+
+# ---------------------------------------------------------------------------
+# Goal 2: No "no-session" mode — session_id extraction
+# ---------------------------------------------------------------------------
+
+
+async def test_run_pi_auto_extracts_session_id_from_agent_start(tmp_path) -> None:
+    """Session ID in agent_start is returned from run_pi_auto."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_start", "session_id": "sess-abc123"}}), flush=True)
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is True
+    assert session_id == "sess-abc123"
+
+
+async def test_run_pi_auto_extracts_session_id_camel_case(tmp_path) -> None:
+    """sessionId (camelCase) in agent_start is also accepted."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_start", "sessionId": "sess-xyz999"}}), flush=True)
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is True
+    assert session_id == "sess-xyz999"
+
+
+async def test_run_pi_auto_no_session_flag_absent(tmp_path) -> None:
+    """The --no-session flag must NOT appear in the pi command invocation."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+# Fail if --no-session is passed so the test catches regression
+if "--no-session" in sys.argv:
+    print(json.dumps({{"type": "response", "command": "prompt", "success": False,
+                       "error": "--no-session flag was passed"}}), flush=True)
+    sys.exit(1)
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+
+    assert success is True, f"emitted: {emitted}"
+    assert not any("--no-session" in line for line in emitted)
+
+
+# ---------------------------------------------------------------------------
+# Goal 3: Cost Tracking via on_usage callback
+# ---------------------------------------------------------------------------
+
+
+async def test_run_pi_auto_usage_from_agent_end(tmp_path) -> None:
+    """Usage data in agent_end is forwarded to on_usage as a 'result' record."""
+    fake_pi = tmp_path / "fake-pi"
+    usage = {"inputTokens": 100, "outputTokens": 50}
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_end", "usage": {json.dumps(usage)}, "cost_usd": 0.0042, "model": "pi-1"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+    usage_records: list[dict] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    async def on_usage(rec: dict) -> None:
+        usage_records.append(rec)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi), on_usage=on_usage
+    )
+
+    assert success is True
+    assert len(usage_records) == 1
+    rec = usage_records[0]
+    assert rec["kind"] == "result"
+    assert rec["input_tokens"] == 100
+    assert rec["output_tokens"] == 50
+    assert rec["cost_usd"] == pytest.approx(0.0042)
+    assert rec["model"] == "pi-1"
+
+
+async def test_run_pi_auto_usage_from_message_update(tmp_path) -> None:
+    """Per-message token counts in message_update are forwarded as 'api_call' records."""
+    fake_pi = tmp_path / "fake-pi"
+    usage = {"inputTokens": 20, "outputTokens": 10}
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{
+    "type": "message_update",
+    "usage": {json.dumps(usage)},
+    "model": "pi-1",
+    "message": {{"content": [{{"type": "text", "text": "hello"}}]}}
+}}), flush=True)
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+    usage_records: list[dict] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    async def on_usage(rec: dict) -> None:
+        usage_records.append(rec)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi), on_usage=on_usage
+    )
+
+    assert success is True
+    api_calls = [r for r in usage_records if r.get("kind") == "api_call"]
+    assert len(api_calls) == 1
+    assert api_calls[0]["input_tokens"] == 20
+    assert api_calls[0]["output_tokens"] == 10
+
+
+async def test_run_pi_auto_no_usage_callback_still_works(tmp_path) -> None:
+    """Passing no on_usage callback is fine — runner completes without error."""
+    fake_pi = tmp_path / "fake-pi"
+    usage = {"inputTokens": 5, "outputTokens": 3}
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_end", "usage": {json.dumps(usage)}}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi)
+    )
+    assert success is True
+
+
+async def test_run_pi_auto_snake_case_usage_fields(tmp_path) -> None:
+    """Snake_case usage fields (input_tokens/output_tokens) are parsed correctly."""
+    fake_pi = tmp_path / "fake-pi"
+    usage = {"input_tokens": 77, "output_tokens": 33}
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_end", "usage": {json.dumps(usage)}}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    emitted: list[str] = []
+    usage_records: list[dict] = []
+
+    async def emit(line: str) -> None:
+        emitted.append(line)
+
+    async def on_usage(rec: dict) -> None:
+        usage_records.append(rec)
+
+    success, stop_reason, last_text, session_id = await run_pi_auto(
+        "do the work", str(tmp_path), emit=emit, pi_path=os.fspath(fake_pi), on_usage=on_usage
+    )
+
+    assert success is True
+    assert len(usage_records) == 1
+    assert usage_records[0]["input_tokens"] == 77
+    assert usage_records[0]["output_tokens"] == 33


### PR DESCRIPTION
## Summary

- **Error & crash reporting**: `run_pi_auto` now emits an explicit `[pi] ✗ process exited with non-zero code N` chunk whenever `pi` exits non-zero without a clean `agent_end`. Stderr was already forwarded via `[stderr]` prefix. Partial output before a crash is preserved in `last_text`.
- **Remove no-session mode**: Dropped `--no-session` from the `pi` command. `run_pi_auto` now extracts `session_id` from `agent_start` and `session` events (both `session_id` and `sessionId` spellings). The return type is now a 4-tuple `(success, stop_reason, last_text, session_id)` matching `claude_runner`. `worker.py` captures the session ID into `resume_session_id` so it appears in task-completion messages and usage reports.
- **Cost tracking**: Added `on_usage: UsageFn | None` parameter to `run_pi_auto`. Per-message token counts from `message_update` events are forwarded as `{"kind": "api_call", ...}` records; final cost/token data from `agent_end` is forwarded as `{"kind": "result", ...}`. Both camelCase (`inputTokens`) and snake_case (`input_tokens`) field names are supported. `worker.py` passes `on_usage=_collect_usage` so pi usage is included in the existing usage-reporting pipeline.
- **Tests**: All 14 existing tests updated for the new 4-tuple return value; 10 new tests added covering crash/non-zero exit, session ID extraction (both field spellings), absence of `--no-session` flag, and cost/usage callback for `agent_end`, `message_update`, snake_case fields, and the no-callback path.

## Test plan

- [x] `pytest worker/tests/test_pi_runner.py` — 33/33 passed
- [x] `python -c "from pioneer_worker import worker"` — imports cleanly

Closes #544