### PR TITLE
Replace .execute() with .exec() to remove test warnings

### DIFF
--- a/backend/oauth.py
+++ b/backend/oauth.py
@@ -179,7 +179,7 @@ async def create_session(code: str, state: str) -> dict:
                 "updated_at": stmt.excluded.updated_at,
             },
         )
-        await db.execute(stmt)
+        await db.exec(stmt)
 
         user_stmt = pg_insert(User).values(
             id=github_user_id,
@@ -201,7 +201,7 @@ async def create_session(code: str, state: str) -> dict:
                 "updated_at": user_stmt.excluded.updated_at,
             },
         )
-        await db.execute(user_stmt)
+        await db.exec(user_stmt)
         db.add(UserSession(token=login_token, github_user_id=github_user_id, created_at=now))
         await db.commit()
     finally:

--- a/backend/push.py
+++ b/backend/push.py
@@ -112,7 +112,7 @@ async def _delete_tokens(tokens: list[str]) -> None:
         return
     db = await get_db()
     try:
-        await db.execute(delete(PushToken).where(PushToken.token.in_(tokens)))
+        await db.exec(delete(PushToken).where(PushToken.token.in_(tokens)))
         await db.commit()
     finally:
         await db.close()
@@ -135,7 +135,7 @@ async def send_to_user(
 
     db = await get_db()
     try:
-        result = await db.execute(select(PushToken.token).where(PushToken.user_id == user_id))
+        result = await db.exec(select(PushToken.token).where(PushToken.user_id == user_id))
         tokens = [row[0] for row in result.all()]
     finally:
         await db.close()

--- a/backend/routes/push.py
+++ b/backend/routes/push.py
@@ -69,7 +69,7 @@ async def register_push_token(
             },
         )
     )
-    await db.execute(stmt)
+    await db.exec(stmt)
     await db.commit()
     return {"status": "ok"}
 
@@ -89,7 +89,7 @@ async def unregister_push_token(
     Only deletes when the token is owned by the authenticated user, so one
     user can't silence another's device by guessing its token.
     """
-    await db.execute(
+    await db.exec(
         delete(PushToken).where(
             PushToken.token == body.token,
             PushToken.user_id == github_user_id,
@@ -109,7 +109,7 @@ async def list_my_tokens(
     Useful for a future "logged-in devices" settings screen and for
     debugging — exposes only the caller's own rows.
     """
-    result = await db.execute(
+    result = await db.exec(
         select(
             PushToken.token,
             PushToken.platform,

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -669,7 +669,7 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
     # notify the foreman so it can decide how to handle them.
     if update_values.get("state") == "error" and task_id:
         queued_payloads: list[dict] = []
-        result = await ctx.db.execute(
+        result = await ctx.db.exec(
             select(TaskEvent.id, TaskEvent.payload_json)
             .where(TaskEvent.task_id == task_id, TaskEvent.event_type == "pending-followup")
             .order_by(TaskEvent.id)
@@ -678,7 +678,7 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
         if rows:
             event_ids = [r[0] for r in rows]
             queued_payloads = [json.loads(r[1]) for r in rows]
-            await ctx.db.execute(delete(TaskEvent).where(TaskEvent.id.in_(event_ids)))
+            await ctx.db.exec(delete(TaskEvent).where(TaskEvent.id.in_(event_ids)))
         worker_id_upd = data.get("workerId", "a worker")
         task_uid = await _task_user_id(ctx.db, task_id)
         if queued_payloads:


### PR DESCRIPTION
## Summary

- SQLModel's `AsyncSession.execute()` is decorated with `@deprecated` and generates `DeprecationWarning` at runtime whenever it's called, polluting test output with noise warnings
- Replaced all 9 call sites in application code with `AsyncSession.exec()`, which is SQLModel's recommended API and is not deprecated
- Files changed: `backend/push.py`, `backend/oauth.py`, `backend/ws_handlers.py`, `backend/routes/push.py`

## What was NOT changed

- `backend/alembic/env.py` — uses `await conn.execute()` on an Alembic `AsyncConnection`, not a SQLModel session
- `backend/alembic/versions/*.py` — all use `op.execute()` on Alembic's migration operations
- `backend/tests/helpers.py` and all test files — use `from sqlalchemy.orm import Session` (plain SQLAlchemy), whose `execute()` method is **not** deprecated

## Test plan

- [ ] Existing test suite should pass without the `DeprecationWarning: session.execute() is deprecated` warnings
- [ ] Result handling is preserved: `exec()` returns the same `Row`-like objects for multi-column `select()` expressions, so index access (`row[0]`) and named attribute access (`row.token`) both continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)