### PR TITLE
fix(foreman): correct task lifecycle and add error handling for PR events

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1114,6 +1114,8 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
 
             elif tu.name == "finalize_task":
                 task_id = inp["task_id"]
+                raw_outcome = inp.get("outcome", "done")
+                outcome = raw_outcome if raw_outcome in ("done", "failed") else "done"
                 deleted_at, err = _resolve_finalize_deleted_at(inp)
                 if err:
                     result_text = err
@@ -1131,12 +1133,12 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             update(Task)
                             .where(col(Task.id) == task_id)
                             .values(
-                                state="done",
+                                state=outcome,
                                 finished_at=finished_at,
                                 deleted_at=deleted_at,
                             )
                         )
-                        # Discard any queued follow-up events — the task is done.
+                        # Discard any queued follow-up events — the task is closed.
                         await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
                         await LockService(db).release(f"task:{task_id}")
                         await db.commit()
@@ -1148,7 +1150,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             guild_id,
                             TaskUpdateMsg(
                                 taskId=task_id,
-                                state="done",
+                                state=outcome,
                                 finishedAt=finished_at.isoformat(),
                                 deletedAt=deleted_at.isoformat()
                                 if deleted_at is not None
@@ -1156,7 +1158,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             ),
                         )
                         result_text = (
-                            f"Task {task_id} finalized; soft-delete at "
+                            f"Task {task_id} finalized as {outcome}; soft-delete at "
                             f"{deleted_at.isoformat() if deleted_at is not None else 'unknown'}."
                         )
 

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1116,13 +1116,19 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 task_id = inp["task_id"]
                 raw_outcome = inp.get("outcome", "done")
                 outcome = raw_outcome if raw_outcome in ("done", "failed") else "done"
+                if outcome != raw_outcome:
+                    logger.warning(
+                        "finalize_task: unknown outcome %r, defaulting to 'done'", raw_outcome
+                    )
                 deleted_at, err = _resolve_finalize_deleted_at(inp)
                 if err:
                     result_text = err
                     is_error = True
                 else:
                     result = await db.exec(
-                        select(Task).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+                        select(Task)
+                        .where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+                        .with_for_update()
                     )
                     task = result.one_or_none()
                     if not task:

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -145,21 +145,34 @@ FOREMAN_TOOLS = [
     {
         "name": "finalize_task",
         "description": (
-            "Mark a task complete with no further follow-up needed. "
-            "Call after reviewing a completed task when no additional work is required. "
-            "Tasks are soft-deleted after their expiry window so the table doesn't "
-            "accumulate cruft. Pick the window by task type:\n"
+            "Close a task with no further follow-up needed. "
+            "Call after reviewing a completed or errored task when no additional work is required. "
+            "Use outcome='failed' when the task did not succeed (push errors, agent errors, "
+            "abandoned work). Tasks are soft-deleted after their expiry window so the table "
+            "doesn't accumulate cruft. Pick the window by task type:\n"
             "  - Ephemeral tasks (periodic-check, status-poll, automated health "
             "checks): expires_in_seconds = 1200 (20 minutes)\n"
             "  - Code tasks (execute / review / followup phases): omit the field "
             "to use the default 3 days, or pass expires_in_seconds = 259200\n"
             "  - Error / failed tasks: expires_in_seconds = 86400 (1 day)\n"
-            "Pass deleted_at instead if you need an exact ISO-8601 timestamp."
+            "Pass deleted_at instead if you need an exact ISO-8601 timestamp.\n"
+            "NOTE: Do NOT call finalize_task for tasks that have an open PR — those are "
+            "automatically finalized when the PR is merged (or failed when the PR is closed "
+            "without merging) via the GitHub webhook."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "task_id": {"type": "string", "description": "Task ID to finalize."},
+                "outcome": {
+                    "type": "string",
+                    "enum": ["done", "failed"],
+                    "description": (
+                        "Final state to set on the task. "
+                        "'done' (default) for successful completion; "
+                        "'failed' for tasks that errored, hit push failures, or were abandoned."
+                    ),
+                },
                 "expires_in_seconds": {
                     "type": "integer",
                     "description": (

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -241,28 +241,40 @@ async def _auto_finalize_task_on_pr_merge(
 ) -> bool:
     """Directly transition a task to 'done' when its PR is merged.
 
-    Skips tasks already in a terminal state. Returns True if finalization occurred.
+    Uses a single conditional UPDATE to prevent TOCTOU races with concurrent
+    state transitions. Returns True if finalization occurred.
     Releases any in-progress lock, discards queued follow-up events, and broadcasts
     TaskFinalizeMsg + TaskUpdateMsg so the frontend reflects the change immediately.
     """
-    result = await db.exec(
-        select(col(Task.worker_id), col(Task.state)).where(
+    # Fetch worker_id for the broadcast; existence check only — state filtering
+    # is delegated entirely to the conditional UPDATE to eliminate SELECT→UPDATE TOCTOU.
+    row_result = await db.exec(
+        select(col(Task.id), col(Task.worker_id)).where(
             col(Task.id) == task_id, col(Task.guild_id) == guild_pk
         )
     )
-    row = result.one_or_none()
-    if not row or row[1] in _WEBHOOK_TERMINAL_STATES:
+    task_row = row_result.one_or_none()
+    if task_row is None:
         return False
+    worker_id = task_row[1]
 
-    worker_id = row[0]
     now = datetime.now(UTC)
     deleted_at = now + timedelta(seconds=_DEFAULT_FINALIZE_TTL_SECS)
 
-    await db.exec(
+    # Single conditional UPDATE — only fires if task is not already in a terminal
+    # state, eliminating the race between two concurrent state transitions.
+    upd = await db.exec(
         update(Task)
-        .where(col(Task.id) == task_id)
+        .where(
+            col(Task.id) == task_id,
+            col(Task.guild_id) == guild_pk,
+            col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
+        )
         .values(state="done", finished_at=now, deleted_at=deleted_at)
     )
+    if (getattr(upd, "rowcount", 0) or 0) == 0:
+        return False
+
     await LockService(db).release(f"task:{task_id}")
     await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
     await db.commit()
@@ -288,27 +300,45 @@ async def _auto_fail_task_on_pr_close(
 ) -> bool:
     """Directly transition a task to 'failed' when its PR is closed without merging.
 
-    Skips tasks already in a terminal state. Returns True if the transition occurred.
-    Releases any in-progress lock and broadcasts TaskUpdateMsg so the frontend updates.
+    Uses a single conditional UPDATE to prevent TOCTOU races with concurrent
+    state transitions. Returns True if the transition occurred.
+    Releases any in-progress lock, discards queued follow-up events, and broadcasts
+    TaskFinalizeMsg + TaskUpdateMsg so the frontend updates.
     """
-    state = await db.exec(
-        select(col(Task.state)).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+    # Fetch worker_id for TaskFinalizeMsg; state filtering is delegated to the
+    # conditional UPDATE to eliminate the SELECT→UPDATE TOCTOU.
+    row_result = await db.exec(
+        select(col(Task.id), col(Task.worker_id)).where(
+            col(Task.id) == task_id, col(Task.guild_id) == guild_pk
+        )
     )
-    current_state = state.one_or_none()
-    if current_state is None or current_state in _WEBHOOK_TERMINAL_STATES:
+    task_row = row_result.one_or_none()
+    if task_row is None:
         return False
+    worker_id = task_row[1]
 
     now = datetime.now(UTC)
     deleted_at = now + timedelta(seconds=_DEFAULT_FAIL_TTL_SECS)
 
-    await db.exec(
+    # Single conditional UPDATE — only fires if task is not already in a terminal
+    # state, eliminating the race between two concurrent state transitions.
+    upd = await db.exec(
         update(Task)
-        .where(col(Task.id) == task_id)
+        .where(
+            col(Task.id) == task_id,
+            col(Task.guild_id) == guild_pk,
+            col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
+        )
         .values(state="failed", finished_at=now, deleted_at=deleted_at)
     )
+    if (getattr(upd, "rowcount", 0) or 0) == 0:
+        return False
+
     await LockService(db).release(f"task:{task_id}")
+    await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
     await db.commit()
 
+    await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=task_id))
     await broadcast_msg(
         guild_id,
         TaskUpdateMsg(

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -20,19 +20,20 @@ import hmac
 import json
 import logging
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from database import get_db_dep
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from models import GithubEvent, Guild, Message, Task
+from lock_service import LockService
+from models import GithubEvent, Guild, Message, Task, TaskEvent
 from pydantic import BaseModel
-from sqlalchemy import update
+from sqlalchemy import delete, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
-from ws_types import ChatMsg, GithubEventMsg
+from ws_types import ChatMsg, GithubEventMsg, TaskFinalizeMsg, TaskUpdateMsg
 
 from foreman import reset_foreman_poll, run_foreman_ai
 
@@ -227,6 +228,98 @@ class DebounceQueue:
 
 _debounce_queue = DebounceQueue()
 
+_DEFAULT_FINALIZE_TTL_SECS = 3 * 24 * 60 * 60  # 3 days
+_DEFAULT_FAIL_TTL_SECS = 24 * 60 * 60  # 1 day
+_WEBHOOK_TERMINAL_STATES = frozenset({"done", "failed", "cancelled"})
+
+
+async def _auto_finalize_task_on_pr_merge(
+    db: AsyncSession,
+    guild_pk: int,
+    guild_id: str,
+    task_id: str,
+) -> bool:
+    """Directly transition a task to 'done' when its PR is merged.
+
+    Skips tasks already in a terminal state. Returns True if finalization occurred.
+    Releases any in-progress lock, discards queued follow-up events, and broadcasts
+    TaskFinalizeMsg + TaskUpdateMsg so the frontend reflects the change immediately.
+    """
+    result = await db.exec(
+        select(col(Task.worker_id), col(Task.state)).where(
+            col(Task.id) == task_id, col(Task.guild_id) == guild_pk
+        )
+    )
+    row = result.one_or_none()
+    if not row or row[1] in _WEBHOOK_TERMINAL_STATES:
+        return False
+
+    worker_id = row[0]
+    now = datetime.now(UTC)
+    deleted_at = now + timedelta(seconds=_DEFAULT_FINALIZE_TTL_SECS)
+
+    await db.exec(
+        update(Task)
+        .where(col(Task.id) == task_id)
+        .values(state="done", finished_at=now, deleted_at=deleted_at)
+    )
+    await LockService(db).release(f"task:{task_id}")
+    await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
+    await db.commit()
+
+    await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=task_id))
+    await broadcast_msg(
+        guild_id,
+        TaskUpdateMsg(
+            taskId=task_id,
+            state="done",
+            finishedAt=now.isoformat(),
+            deletedAt=deleted_at.isoformat(),
+        ),
+    )
+    return True
+
+
+async def _auto_fail_task_on_pr_close(
+    db: AsyncSession,
+    guild_pk: int,
+    guild_id: str,
+    task_id: str,
+) -> bool:
+    """Directly transition a task to 'failed' when its PR is closed without merging.
+
+    Skips tasks already in a terminal state. Returns True if the transition occurred.
+    Releases any in-progress lock and broadcasts TaskUpdateMsg so the frontend updates.
+    """
+    state = await db.exec(
+        select(col(Task.state)).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+    )
+    current_state = state.one_or_none()
+    if current_state is None or current_state in _WEBHOOK_TERMINAL_STATES:
+        return False
+
+    now = datetime.now(UTC)
+    deleted_at = now + timedelta(seconds=_DEFAULT_FAIL_TTL_SECS)
+
+    await db.exec(
+        update(Task)
+        .where(col(Task.id) == task_id)
+        .values(state="failed", finished_at=now, deleted_at=deleted_at)
+    )
+    await LockService(db).release(f"task:{task_id}")
+    await db.commit()
+
+    await broadcast_msg(
+        guild_id,
+        TaskUpdateMsg(
+            taskId=task_id,
+            state="failed",
+            finishedAt=now.isoformat(),
+            deletedAt=deleted_at.isoformat(),
+        ),
+    )
+    return True
+
 
 async def shutdown_debouncer() -> None:
     """Cancel all in-flight debounce timers and wait for them to complete.
@@ -361,14 +454,14 @@ def _build_foreman_summary(
         merged = pr.get("merged")
         if action == "closed" and merged:
             detail = (
-                "PR was merged. Call finalize_task — "
-                "the work has landed and no follow-up is needed."
+                "PR was merged. The task has been automatically finalized (state=done). "
+                "No action needed — this message is informational."
             )
         elif action == "closed":
             detail = (
-                "PR was closed without merging. Investigate why "
-                "(check_pr_status, get_task_status), then either send_followup "
-                "to address the rejection or finalize_task if the work is being abandoned."
+                "PR was closed without merging. The task has been automatically marked as failed. "
+                "If the work should be retried, use send_followup or assign_task to create "
+                "a new task on a fresh branch."
             )
         else:
             detail = (
@@ -594,6 +687,28 @@ async def github_webhook(
             .values(pr_url=pr_url)
         )
         await db.commit()
+
+    # Deterministic lifecycle transitions: finalize on merge, fail on close-without-merge.
+    # These happen directly — no AI decision needed for these clear-cut outcomes.
+    if task_id and event_type == "pull_request" and action == "closed":
+        pr = payload.get("pull_request") or {}
+        merged = pr.get("merged")
+        if merged:
+            finalized = await _auto_finalize_task_on_pr_merge(db, guild_pk, guild_id, task_id)
+            if finalized:
+                logger.info(
+                    "github webhook auto-finalized task=%s on PR merge guild=%s",
+                    task_id,
+                    guild_id,
+                )
+        else:
+            failed = await _auto_fail_task_on_pr_close(db, guild_pk, guild_id, task_id)
+            if failed:
+                logger.info(
+                    "github webhook auto-failed task=%s on unmerged PR close guild=%s",
+                    task_id,
+                    guild_id,
+                )
 
     logger.info(
         "github webhook accepted guild=%s delivery=%s event=%s action=%s repo=%s pr=%s task=%s",

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -552,6 +552,39 @@ class TestExecToolsDispatching:
             state = session.scalar(select(col(Task.state)).where(col(Task.id) == "t-fin1"))
         assert state == "done"
 
+    async def test_finalize_task_marks_failed_with_outcome(self, db_session):
+        """finalize_task with outcome='failed' sets task state to 'failed', not 'done'."""
+        insert_guild(db_session, "g-finalize-fail")
+        _insert_worker(db_session, "g-finalize-fail", "w-fin-fail")
+        _insert_task(db_session, "t-fin-fail", "g-finalize-fail", "w-fin-fail")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-finalize-fail",
+                [_fake_tool_use("finalize_task", {"task_id": "t-fin-fail", "outcome": "failed"})],
+            )
+        assert "finalized" in results[0]["content"].lower()
+        assert "failed" in results[0]["content"].lower()
+
+        with _sync_session(db_session) as session:
+            state = session.scalar(select(col(Task.state)).where(col(Task.id) == "t-fin-fail"))
+        assert state == "failed"
+
+    async def test_finalize_task_invalid_outcome_defaults_to_done(self, db_session):
+        """An unrecognised outcome value must not break finalize_task — it falls back to 'done'."""
+        insert_guild(db_session, "g-finalize-inv")
+        _insert_worker(db_session, "g-finalize-inv", "w-fin-inv")
+        _insert_task(db_session, "t-fin-inv", "g-finalize-inv", "w-fin-inv")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-finalize-inv",
+                [_fake_tool_use("finalize_task", {"task_id": "t-fin-inv", "outcome": "bogus"})],
+            )
+        assert not results[0].get("is_error")
+
+        with _sync_session(db_session) as session:
+            state = session.scalar(select(col(Task.state)).where(col(Task.id) == "t-fin-inv"))
+        assert state == "done"
+
     async def test_message_worker_dispatches(self, db_session):
         insert_guild(db_session, "g-msgwkr")
         _insert_worker(db_session, "g-msgwkr", "w-msgwkr")

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -33,13 +33,16 @@ import database as database_module  # noqa: E402
 from _test_config import TEST_DATABASE_URL  # noqa: E402
 from foreman.tools import exec_tools  # noqa: E402
 from helpers import _sync_session, create_db, insert_guild, insert_task, insert_worker  # noqa: E402
-from models import Guild  # noqa: E402
+from models import (
+    Guild,  # noqa: E402
+    Task,  # noqa: E402
+)
 from routes.webhooks import (  # noqa: E402
     _build_foreman_summary,
     _should_dispatch_to_foreman,
 )
 from sqlalchemy import update  # noqa: E402
-from sqlmodel import col  # noqa: E402
+from sqlmodel import col, select  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers (mirror test_github_webhooks.py to keep these focused on Phase 2)
@@ -169,7 +172,7 @@ class TestBuildSummary:
         )
         assert "[github-event] pull_request/closed on owner/repo#42 (task t-1)" in s
         assert "merged" in s.lower()
-        assert "finalize_task" in s
+        assert "automatically finalized" in s
 
     def test_pr_closed_unmerged(self):
         payload = {"pull_request": {"merged": False}}
@@ -177,7 +180,7 @@ class TestBuildSummary:
             "pull_request", "closed", payload, "owner/repo", 42, "t-1", "human"
         )
         assert "without merging" in s.lower()
-        assert "send_followup" in s
+        assert "automatically marked as failed" in s
 
     def test_review_changes_requested(self):
         payload = {"review": {"state": "changes_requested", "body": "needs work"}}
@@ -263,6 +266,91 @@ def test_webhook_dispatches_to_foreman_when_task_matches(client):
     assert guild_arg == "gd1"
     assert "pull_request" in summary_arg
     assert user_arg == "user-42"
+
+
+def _get_task_state(db_url: str, task_id: str) -> str | None:
+    """Read a task's current state directly from the DB."""
+    with _sync_session(db_url) as session:
+        return session.scalar(select(col(Task.state)).where(col(Task.id) == task_id))
+
+
+def test_pr_merge_webhook_auto_finalizes_task(client):
+    """PR merge webhook must directly set task state to 'done' without AI involvement."""
+    test_client, db_url = client
+    insert_guild(db_url, "gd-merge-1")
+    _set_webhook_secret(db_url, "gd-merge-1", "secret-m1")
+    _insert_task_with_worker(
+        db_url,
+        task_id="t-merge-1",
+        guild_id="gd-merge-1",
+        pr_url="https://github.com/o/r/pull/10",
+        pr_number=10,
+        pr_repo="o/r",
+    )
+    payload = _pr_payload(
+        action="closed", repo="o/r", number=10, pull_request_extra={"merged": True}
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-m1", body, event="pull_request", delivery="d-merge-1")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-merge-1", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert _get_task_state(db_url, "t-merge-1") == "done"
+
+
+def test_pr_close_unmerged_webhook_auto_fails_task(client):
+    """PR closed without merge must directly set task state to 'failed'."""
+    test_client, db_url = client
+    insert_guild(db_url, "gd-close-1")
+    _set_webhook_secret(db_url, "gd-close-1", "secret-c1")
+    _insert_task_with_worker(
+        db_url,
+        task_id="t-close-1",
+        guild_id="gd-close-1",
+        pr_url="https://github.com/o/r/pull/11",
+        pr_number=11,
+        pr_repo="o/r",
+    )
+    payload = _pr_payload(
+        action="closed", repo="o/r", number=11, pull_request_extra={"merged": False}
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-c1", body, event="pull_request", delivery="d-close-1")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-close-1", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert _get_task_state(db_url, "t-close-1") == "failed"
+
+
+def test_pr_merge_skips_already_terminal_task(client):
+    """Auto-finalize on PR merge must not overwrite a task already in a terminal state."""
+    test_client, db_url = client
+    insert_guild(db_url, "gd-term-1")
+    _set_webhook_secret(db_url, "gd-term-1", "secret-t1")
+    insert_worker(db_url, "gd-term-1", "w-term-1", state="online")
+    insert_task(
+        db_url,
+        "gd-term-1",
+        "t-term-1",
+        worker_id="w-term-1",
+        state="cancelled",
+        pr_url="https://github.com/o/r/pull/12",
+        pr_number=12,
+        pr_repo="o/r",
+    )
+    payload = _pr_payload(
+        action="closed", repo="o/r", number=12, pull_request_extra={"merged": True}
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-t1", body, event="pull_request", delivery="d-term-1")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-term-1", content=body, headers=headers)
+    assert resp.status_code == 202
+    # State must remain cancelled — not overwritten to done
+    assert _get_task_state(db_url, "t-term-1") == "cancelled"
 
 
 def test_webhook_skips_foreman_when_no_task_match(client):

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -690,12 +690,14 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
                 f"While the task was locked, {len(queued_payloads)} follow-up request(s) were queued:\n"
                 f"{queued_summary}\n"
                 "The queued follow-ups were NOT dispatched because the task errored. "
-                "Decide: call send_followup to retry, or call finalize_task to mark it failed."
+                "Decide: call send_followup to retry, or call finalize_task with "
+                "outcome='failed' to mark it failed."
             )
         else:
             human_msg = (
                 f"[task-error] Worker {worker_id_upd} reported task {task_id} as errored. "
-                "Decide: call send_followup to retry the task, or call finalize_task to mark it failed."
+                "Decide: call send_followup to retry the task, or call finalize_task with "
+                "outcome='failed' to mark it failed."
             )
         await _trigger_foreman(
             ctx.guild_id,
@@ -745,12 +747,33 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
 
     task_uid = await _task_user_id(ctx.db, task_id)
     pr_line = f" PR: {pr_url}." if pr_url else ""
-    if stop_reason == "max_turns":
-        last_text_snippet = f' Last output: "{last_text[:200]}".' if last_text else ""
+    last_text_snippet = f' Last output: "{last_text[:200]}".' if last_text else ""
+    if pr_url:
+        # PR exists: lifecycle is driven by GitHub webhooks, not the foreman.
+        # The task will be auto-finalized on merge or auto-failed on close without merge.
+        if stop_reason == "max_turns":
+            foreman_message = (
+                f"[task-complete/max-turns] Worker {worker_id_msg} task {task_id}: "
+                f'"{desc[:80]}" — branch: {branch}.{pr_line} '
+                f"Claude hit its max-turns limit before finishing. Partial work committed.{last_text_snippet} "
+                "IMPORTANT: DO NOT call finalize_task — the task will be automatically "
+                "finalized when the PR is merged (or marked failed if the PR is closed without "
+                "merging). Use send_followup to continue work on the same branch/worktree."
+            )
+        else:
+            foreman_message = (
+                f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
+                f'"{desc[:80]}" — branch: {branch}.{pr_line} '
+                "IMPORTANT: DO NOT call finalize_task now. The task will be automatically "
+                "finalized when the PR is merged (or automatically marked failed if the PR "
+                "is closed without merging). Only call send_followup if CI fails or reviewers "
+                "request changes."
+            )
+    elif stop_reason == "max_turns":
         foreman_message = (
             f"[task-complete/max-turns] Worker {worker_id_msg} task {task_id}: "
-            f'"{desc[:80]}" — branch: {branch}.{pr_line} '
-            f"IMPORTANT: Claude hit its max-turns limit and stopped before finishing. "
+            f'"{desc[:80]}" — branch: {branch}. '
+            f"Claude hit its max-turns limit and stopped before finishing. "
             f"Partial work has been committed and the branch pushed.{last_text_snippet} "
             "Call send_followup with a continuation prompt so the worker can resume on the "
             "same branch/worktree. Only call finalize_task if the partial work is sufficient "
@@ -759,14 +782,9 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
     else:
         foreman_message = (
             f"[task-complete] Worker {worker_id_msg} finished task {task_id}: "
-            f'"{desc[:80]}" — branch: {branch}.{pr_line} '
-            "The worker has returned to its idle pool; the task is parked in "
-            "awaiting-review for human review. "
-            "Default behaviour: leave PR-bearing tasks open so reviewers can "
-            "comment — call send_followup if a comment or CI failure asks for "
-            "an iteration on the same branch (any idle worker can pick it up). "
-            "Only call finalize_task when the work is genuinely closed (PR "
-            "merged, task abandoned, or it was an ephemeral/automation task)."
+            f'"{desc[:80]}" — branch: {branch}. '
+            "No PR was opened. Call send_followup for more work, or finalize_task to close "
+            "this task (use outcome='failed' if the task did not succeed)."
         )
     await _trigger_foreman(
         ctx.guild_id,


### PR DESCRIPTION
## Summary

Fixes two related issues with how the foreman manages task lifecycle and errors (closes #570).

**Issue 1 — Tasks marked complete too early:**
- `finalize_task` was being called by the AI as soon as the coding agent finished, before any PR was opened or merged
- Added deterministic auto-finalization in the GitHub webhook handler: when a `pull_request/closed` event arrives with `merged=true`, the task is immediately transitioned to `done` without requiring an AI decision
- Updated the foreman summary message for merged/closed PRs to reflect that the transition is automatic, so the AI no longer tries to call `finalize_task` itself

**Issue 2 — Errors not surfaced:**
- Unmerged PR closures now automatically transition the task to `failed` (via `_auto_fail_task_on_pr_close` in the webhook handler)
- `finalize_task` now accepts an `outcome` parameter (`"done"` | `"failed"`) so the foreman AI can explicitly mark errored/abandoned tasks as failed
- Invalid `outcome` values fall back to `"done"` to avoid breaking existing callers
- The `finalize_task` tool description now warns the AI not to call it for tasks with an open PR (those are handled by webhooks)

Both lifecycle helpers (`_auto_finalize_task_on_pr_merge`, `_auto_fail_task_on_pr_close`) release task locks, discard queued follow-up events, and broadcast `TaskUpdateMsg` / `TaskFinalizeMsg` so the frontend updates immediately.

## Test plan
- [ ] `test_finalize_task_marks_failed_with_outcome` — `finalize_task(outcome="failed")` sets `state=failed`
- [ ] `test_finalize_task_invalid_outcome_defaults_to_done` — bogus outcome value falls back to `done`
- [ ] `test_pr_merge_webhook_auto_finalizes_task` — merged PR webhook sets task `state=done`
- [ ] `test_pr_close_unmerged_webhook_auto_fails_task` — closed-without-merge webhook sets task `state=failed`
- [ ] Existing webhook and foreman tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)