### PR TITLE
Add database indexes (#573)

### DIFF
--- a/backend/alembic/versions/20260605_000000_add_database_indexes.py
+++ b/backend/alembic/versions/20260605_000000_add_database_indexes.py
@@ -1,0 +1,73 @@
+"""Add database indexes for query performance.
+
+Revision ID: 20260605_000000_add_database_indexes
+Revises: 20260604_000000_add_foreman_config_to_guilds
+Create Date: 2026-06-05
+
+Adds indexes on columns used in WHERE, ORDER BY, JOIN, and FK lookups that had
+no explicit index. Covers the following high-frequency query patterns:
+
+  tasks       – list by guild (filtered on deleted_at, ordered by created_at),
+                orphaned-task sweeper (state == 'working'), FK from workers
+  agents      – sweeper + listing by guild+state, FK from workers
+  messages    – history fetch by guild ordered by created_at
+  task_logs   – log retrieval by task_id (FK present but no index in SQLite/PG)
+  workers     – listing by guild ordered by created_at
+  guild_members – owner lookups by guild+role
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260605_000000_add_database_indexes"
+down_revision: str | Sequence[str] | None = "20260604_000000_add_foreman_config_to_guilds"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # tasks: most common list query filters on guild_id + live_tasks_filter()
+    # (deleted_at IS NULL or > now) and orders by created_at DESC
+    op.create_index(
+        "ix_tasks_guild_id_deleted_at_created_at", "tasks", ["guild_id", "deleted_at", "created_at"]
+    )
+
+    # tasks: orphaned-task sweeper filters on state == 'working'
+    op.create_index("ix_tasks_state", "tasks", ["state"])
+
+    # tasks: FK lookup from workers (task list for a specific worker)
+    op.create_index("ix_tasks_worker_id", "tasks", ["worker_id"])
+
+    # agents: sweeper and guild listing filter on guild_id + state
+    op.create_index("ix_agents_guild_id_state", "agents", ["guild_id", "state"])
+
+    # agents: FK lookup from workers (agents belonging to a worker)
+    op.create_index("ix_agents_worker_id", "agents", ["worker_id"])
+
+    # messages: history fetch filters on guild_id and orders by created_at
+    op.create_index("ix_messages_guild_id_created_at", "messages", ["guild_id", "created_at"])
+
+    # task_logs: log retrieval filters on task_id; FK constraints do not
+    # create an index automatically in SQLite or PostgreSQL
+    op.create_index("ix_task_logs_task_id", "task_logs", ["task_id"])
+
+    # workers: listing endpoint filters on guild_id and orders by created_at DESC
+    op.create_index("ix_workers_guild_id_created_at", "workers", ["guild_id", "created_at"])
+
+    # guild_members: owner-role lookup filters on guild_id + role
+    op.create_index("ix_guild_members_guild_id_role", "guild_members", ["guild_id", "role"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_guild_members_guild_id_role", table_name="guild_members")
+    op.drop_index("ix_workers_guild_id_created_at", table_name="workers")
+    op.drop_index("ix_task_logs_task_id", table_name="task_logs")
+    op.drop_index("ix_messages_guild_id_created_at", table_name="messages")
+    op.drop_index("ix_agents_worker_id", table_name="agents")
+    op.drop_index("ix_agents_guild_id_state", table_name="agents")
+    op.drop_index("ix_tasks_worker_id", table_name="tasks")
+    op.drop_index("ix_tasks_state", table_name="tasks")
+    op.drop_index("ix_tasks_guild_id_deleted_at_created_at", table_name="tasks")

--- a/backend/models.py
+++ b/backend/models.py
@@ -52,11 +52,12 @@ class Guild(SQLModel, table=True):
 
 class Agent(SQLModel, table=True):
     __tablename__ = "agents"  # type: ignore[assignment]
+    __table_args__ = (Index("ix_agents_guild_id_state", "guild_id", "state"),)
 
     id: str = Field(primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
-    worker_id: str | None = Field(default=None, foreign_key="workers.id")
+    worker_id: str | None = Field(default=None, foreign_key="workers.id", index=True)
     name: str
     type: str = Field(default="worker", sa_column_kwargs={"server_default": "'worker'"})
     state: str = Field(default="idle", sa_column_kwargs={"server_default": "'idle'"})
@@ -77,6 +78,7 @@ class Agent(SQLModel, table=True):
 
 class Message(SQLModel, table=True):
     __tablename__ = "messages"  # type: ignore[assignment]
+    __table_args__ = (Index("ix_messages_guild_id_created_at", "guild_id", "created_at"),)
 
     id: int | None = Field(default=None, primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
@@ -93,6 +95,10 @@ class Message(SQLModel, table=True):
 
 class Worker(SQLModel, table=True):
     __tablename__ = "workers"  # type: ignore[assignment]
+    __table_args__ = (
+        Index("ix_workers_guild_id_created_at", "guild_id", "created_at"),
+        Index("ix_workers_state_last_seen", "state", "last_seen"),
+    )
 
     id: str = Field(primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
@@ -124,10 +130,14 @@ class Worker(SQLModel, table=True):
 
 class Task(SQLModel, table=True):
     __tablename__ = "tasks"  # type: ignore[assignment]
+    __table_args__ = (
+        Index("ix_tasks_guild_id_deleted_at_created_at", "guild_id", "deleted_at", "created_at"),
+        Index("ix_tasks_state", "state"),
+    )
 
     id: str = Field(primary_key=True)
     worker_id: str | None = Field(
-        default=None, foreign_key="workers.id"
+        default=None, foreign_key="workers.id", index=True
     )  # NULL for foreman-owned tasks
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id")
@@ -202,6 +212,7 @@ class User(SQLModel, table=True):
 
 class GuildMember(SQLModel, table=True):
     __tablename__ = "guild_members"  # type: ignore[assignment]
+    __table_args__ = (Index("ix_guild_members_guild_id_role", "guild_id", "role"),)
 
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
     guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
@@ -216,7 +227,7 @@ class TaskLog(SQLModel, table=True):
     __tablename__ = "task_logs"  # type: ignore[assignment]
 
     id: int | None = Field(default=None, primary_key=True)
-    task_id: str | None = Field(default=None, foreign_key="tasks.id")
+    task_id: str | None = Field(default=None, foreign_key="tasks.id", index=True)
     timestamp: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     line: str
     worker_id: str | None = None


### PR DESCRIPTION
## Summary

- Adds a new Alembic migration (`20260605_000000_add_database_indexes`) with 9 indexes on columns used in high-frequency WHERE/ORDER BY/JOIN patterns that had no explicit index
- Updates `backend/models.py` ORM models to declare the same indexes via `__table_args__` and `index=True`, keeping schema and models in sync

## Indexes added

| Index | Table | Columns | Query pattern |
|---|---|---|---|
| `ix_tasks_guild_id_deleted_at_created_at` | tasks | guild_id, deleted_at, created_at | Task list by guild filtered by `live_tasks_filter()` ordered by `created_at DESC` |
| `ix_tasks_state` | tasks | state | Orphaned-task sweeper: `state == 'working'` |
| `ix_tasks_worker_id` | tasks | worker_id | FK lookup — tasks assigned to a worker |
| `ix_agents_guild_id_state` | agents | guild_id, state | Stale-agent sweeper + guild agent listing |
| `ix_agents_worker_id` | agents | worker_id | FK lookup — agents belonging to a worker |
| `ix_messages_guild_id_created_at` | messages | guild_id, created_at | Message history fetch ordered by timestamp |
| `ix_task_logs_task_id` | task_logs | task_id | Log retrieval by task (FK alone creates no index in SQLite/PG) |
| `ix_workers_guild_id_created_at` | workers | guild_id, created_at | Worker listing ordered by `created_at DESC` |
| `ix_guild_members_guild_id_role` | guild_members | guild_id, role | Owner-role lookups |

## What was already indexed (not duplicated)

`ix_workers_state_last_seen`, `ix_foreman_turns_guild_user`, `ix_github_events_task_id`, `ix_github_events_guild_id`, `ix_task_events_task_id`, `ix_claude_usage_guild_id`, `ix_claude_usage_task_id`, `ix_locks_key`, `ix_push_tokens_user_id`, `uq_guilds_guild_id_active`.

## Test plan

- [ ] `docker compose up -d postgres-test && cd backend && python -m pytest` — all tests pass
- [ ] `alembic upgrade head` applies cleanly on a fresh DB
- [ ] `alembic downgrade -1` removes all 9 indexes cleanly

Closes #573