### PR TITLE
feat(foreman): capture API request IDs and response metadata in foreman turns

### DIFF
--- a/backend/alembic/versions/20260605_000001_add_api_calls_to_foreman_turns.py
+++ b/backend/alembic/versions/20260605_000001_add_api_calls_to_foreman_turns.py
@@ -1,0 +1,33 @@
+"""Add api_calls_json column to foreman_turns.
+
+Revision ID: 20260605_000001_add_api_calls_to_foreman_turns
+Revises: 20260605_000000_add_database_indexes
+Create Date: 2026-06-05
+
+Stores per-HTTP-call metadata (GitHub request IDs, status codes, timestamps)
+captured during foreman tool execution. Attached to the tool_result turn
+(is_tool_response=1) so failures can be correlated with provider-side logs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260605_000001_add_api_calls_to_foreman_turns"
+down_revision: str | Sequence[str] | None = "20260605_000000_add_database_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "foreman_turns",
+        sa.Column("api_calls_json", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("foreman_turns", "api_calls_json")

--- a/backend/alembic/versions/20260605_000001_add_api_calls_to_foreman_turns.py
+++ b/backend/alembic/versions/20260605_000001_add_api_calls_to_foreman_turns.py
@@ -4,9 +4,9 @@ Revision ID: 20260605_000001_add_api_calls_to_foreman_turns
 Revises: 20260605_000000_add_database_indexes
 Create Date: 2026-06-05
 
-Stores per-HTTP-call metadata (GitHub request IDs, status codes, timestamps)
-captured during foreman tool execution. Attached to the tool_result turn
-(is_tool_response=1) so failures can be correlated with provider-side logs.
+Stores Anthropic API call metadata (request IDs, model, token counts, timestamps)
+captured from each messages.create() call. Attached to the assistant turn so
+failures can be correlated with Anthropic-side logs via the request-id header.
 """
 
 from __future__ import annotations

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -156,6 +156,7 @@ async def _save_turn(
     *,
     is_tool_response: bool = False,
     parent_id: int | None = None,
+    api_calls: list | None = None,
 ) -> int:
     """Persist one turn to the DB. Returns the new row's id."""
     db = await get_db()
@@ -169,6 +170,7 @@ async def _save_turn(
             is_tool_response=1 if is_tool_response else 0,
             parent_id=parent_id,
             created_at=datetime.now(UTC),
+            api_calls_json=json.dumps(api_calls) if api_calls else None,
         )
         db.add(turn)
         await db.commit()
@@ -574,12 +576,20 @@ async def _run_foreman_ai(
             tool_results = await exec_tools(guild_id, tool_uses, user_id=user_id)
             # Truncate verbose results; filter to only IDs in the current batch so
             # stale results that survived history trimming are never persisted.
+            # Extract api_calls metadata before building trimmed — the Anthropic API
+            # only accepts {type, tool_use_id, content, is_error} in tool_result blocks.
             current_tool_use_ids = {tu.id for tu in tool_uses}
-            trimmed = [
-                {**r, "content": truncate_tool_result(r["content"])} if r.get("content") else r
-                for r in tool_results
-                if r.get("tool_use_id") in current_tool_use_ids
-            ]
+            all_api_calls: list[dict] = []
+            trimmed: list[dict] = []
+            for r in tool_results:
+                if r.get("tool_use_id") not in current_tool_use_ids:
+                    continue
+                for call in r.get("api_calls") or []:
+                    all_api_calls.append({"tool_use_id": r["tool_use_id"], **call})
+                entry = {k: v for k, v in r.items() if k != "api_calls"}
+                if entry.get("content"):
+                    entry = {**entry, "content": truncate_tool_result(entry["content"])}
+                trimmed.append(entry)
 
             # Broadcast tool-result events
             _now = datetime.now(UTC)
@@ -651,6 +661,7 @@ async def _run_foreman_ai(
                 trimmed,
                 is_tool_response=True,
                 parent_id=asst_turn_id,
+                api_calls=all_api_calls if all_api_calls else None,
             )
             logger.info(
                 "guild=%s round %d: %d tool call(s) dispatched: %s",
@@ -662,6 +673,21 @@ async def _run_foreman_ai(
                         "tool_use_id": r["tool_use_id"],
                         "name": r.get("name"),
                         "is_error": r.get("is_error", False),
+                        **(
+                            {
+                                "x_github_request_id": next(
+                                    (
+                                        c["x_github_request_id"]
+                                        for c in all_api_calls
+                                        if c.get("tool_use_id") == r["tool_use_id"]
+                                        and c.get("x_github_request_id")
+                                    ),
+                                    None,
+                                )
+                            }
+                            if r.get("is_error", False)
+                            else {}
+                        ),
                     }
                     for r in trimmed
                 ],
@@ -805,6 +831,7 @@ async def get_foreman_history(guild_id: str, user_id: str) -> dict:
             "created_at": t.created_at,
             "input_tokens": t.input_tokens,
             "output_tokens": t.output_tokens,
+            "api_calls": json.loads(t.api_calls_json) if t.api_calls_json else None,
         }
         for t in turns
         if t.role != "system"

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -505,31 +505,48 @@ async def _run_foreman_ai(
                 round_num,
                 len(messages),
             )
-            resp = await client.messages.create(
+            _raw = await client.messages.with_raw_response.create(
                 model=foreman_model,
                 max_tokens=1024,
                 system=system_blocks,  # type: ignore[arg-type]
                 messages=messages,  # type: ignore[arg-type]
                 tools=FOREMAN_TOOLS,  # type: ignore[arg-type]
             )
+            resp = _raw.parse()
             usage = resp.usage
             _input_tokens = getattr(usage, "input_tokens", 0) or 0
             _output_tokens = getattr(usage, "output_tokens", 0) or 0
+            _cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
+            _cache_write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+            _anthropic_request_id = _raw.headers.get("request-id")
             logger.info(
                 "guild=%s run_foreman_ai round %d: stop_reason=%s content_blocks=%d "
-                "input=%d cache_read=%d cache_write=%d output=%d",
+                "input=%d cache_read=%d cache_write=%d output=%d request_id=%s",
                 guild_id,
                 round_num,
                 resp.stop_reason,
                 len(resp.content),
                 _input_tokens,
-                getattr(usage, "cache_read_input_tokens", 0) or 0,
-                getattr(usage, "cache_creation_input_tokens", 0) or 0,
+                _cache_read,
+                _cache_write,
                 _output_tokens,
+                _anthropic_request_id,
             )
 
+            _api_call_meta = {
+                "request_id": _anthropic_request_id,
+                "model": foreman_model,
+                "input_tokens": _input_tokens,
+                "output_tokens": _output_tokens,
+                "cache_read_tokens": _cache_read,
+                "cache_write_tokens": _cache_write,
+                "ts": datetime.now(UTC).isoformat(),
+            }
+
             # Persist assistant turn and append to local messages
-            asst_turn_id = await _save_turn(guild_id, user_id, "assistant", resp.content)
+            asst_turn_id = await _save_turn(
+                guild_id, user_id, "assistant", resp.content, api_calls=[_api_call_meta]
+            )
             await _update_turn_tokens(asst_turn_id, _input_tokens, _output_tokens)
             messages.append({"role": "assistant", "content": _serialize_content(resp.content)})
             # Re-parse so messages stays as plain dicts (not SDK objects)
@@ -576,16 +593,11 @@ async def _run_foreman_ai(
             tool_results = await exec_tools(guild_id, tool_uses, user_id=user_id)
             # Truncate verbose results; filter to only IDs in the current batch so
             # stale results that survived history trimming are never persisted.
-            # Extract api_calls metadata before building trimmed — the Anthropic API
-            # only accepts {type, tool_use_id, content, is_error} in tool_result blocks.
             current_tool_use_ids = {tu.id for tu in tool_uses}
-            all_api_calls: list[dict] = []
             trimmed: list[dict] = []
             for r in tool_results:
                 if r.get("tool_use_id") not in current_tool_use_ids:
                     continue
-                for call in r.get("api_calls") or []:
-                    all_api_calls.append({"tool_use_id": r["tool_use_id"], **call})
                 entry = {k: v for k, v in r.items() if k != "api_calls"}
                 if entry.get("content"):
                     entry = {**entry, "content": truncate_tool_result(entry["content"])}
@@ -661,7 +673,6 @@ async def _run_foreman_ai(
                 trimmed,
                 is_tool_response=True,
                 parent_id=asst_turn_id,
-                api_calls=all_api_calls if all_api_calls else None,
             )
             logger.info(
                 "guild=%s round %d: %d tool call(s) dispatched: %s",
@@ -669,26 +680,7 @@ async def _run_foreman_ai(
                 round_num,
                 len(trimmed),
                 [
-                    {
-                        "tool_use_id": r["tool_use_id"],
-                        "name": r.get("name"),
-                        "is_error": r.get("is_error", False),
-                        **(
-                            {
-                                "x_github_request_id": next(
-                                    (
-                                        c["x_github_request_id"]
-                                        for c in all_api_calls
-                                        if c.get("tool_use_id") == r["tool_use_id"]
-                                        and c.get("x_github_request_id")
-                                    ),
-                                    None,
-                                )
-                            }
-                            if r.get("is_error", False)
-                            else {}
-                        ),
-                    }
+                    {"tool_use_id": r["tool_use_id"], "is_error": r.get("is_error", False)}
                     for r in trimmed
                 ],
             )
@@ -707,7 +699,7 @@ async def _run_foreman_ai(
             messages = prune_history(messages)
             messages = strip_orphaned_tool_results(messages)
             _stamp_message_cache_breakpoint(messages)
-            wrap_resp = await client.messages.create(
+            _wrap_raw = await client.messages.with_raw_response.create(
                 model=foreman_model,
                 max_tokens=1024,
                 system=system_blocks,  # type: ignore[arg-type]
@@ -715,20 +707,36 @@ async def _run_foreman_ai(
                 tools=FOREMAN_TOOLS,  # type: ignore[arg-type]
                 tool_choice={"type": "none"},  # type: ignore[arg-type]
             )
+            wrap_resp = _wrap_raw.parse()
             wrap_usage = wrap_resp.usage
             _wrap_input = getattr(wrap_usage, "input_tokens", 0) or 0
             _wrap_output = getattr(wrap_usage, "output_tokens", 0) or 0
+            _wrap_cache_read = getattr(wrap_usage, "cache_read_input_tokens", 0) or 0
+            _wrap_cache_write = getattr(wrap_usage, "cache_creation_input_tokens", 0) or 0
+            _wrap_request_id = _wrap_raw.headers.get("request-id")
             logger.info(
                 "guild=%s run_foreman_ai wrap-up: stop_reason=%s "
-                "input=%d cache_read=%d cache_write=%d output=%d",
+                "input=%d cache_read=%d cache_write=%d output=%d request_id=%s",
                 guild_id,
                 wrap_resp.stop_reason,
                 _wrap_input,
-                getattr(wrap_usage, "cache_read_input_tokens", 0) or 0,
-                getattr(wrap_usage, "cache_creation_input_tokens", 0) or 0,
+                _wrap_cache_read,
+                _wrap_cache_write,
                 _wrap_output,
+                _wrap_request_id,
             )
-            wrap_turn_id = await _save_turn(guild_id, user_id, "assistant", wrap_resp.content)
+            _wrap_api_meta = {
+                "request_id": _wrap_request_id,
+                "model": foreman_model,
+                "input_tokens": _wrap_input,
+                "output_tokens": _wrap_output,
+                "cache_read_tokens": _wrap_cache_read,
+                "cache_write_tokens": _wrap_cache_write,
+                "ts": datetime.now(UTC).isoformat(),
+            }
+            wrap_turn_id = await _save_turn(
+                guild_id, user_id, "assistant", wrap_resp.content, api_calls=[_wrap_api_meta]
+            )
             await _update_turn_tokens(wrap_turn_id, _wrap_input, _wrap_output)
             _now = datetime.now(UTC).isoformat()
             for b in wrap_resp.content:

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -6,6 +6,7 @@ of truth shared with the standalone foreman.  This module owns the embedded exec
 """
 
 import asyncio
+import contextvars
 import json
 import logging
 import os
@@ -75,6 +76,30 @@ CONTAINER_RUN_TIMEOUT = 600
 # each time.  None until first successful from_env(); tests can patch
 # _get_docker_client() directly to avoid touching sys.modules.
 _docker_client: Any = None
+
+# Per-tool-call collector for GitHub API response metadata (request IDs, status codes).
+# Each _exec_one_tool invocation sets a fresh list via _api_calls_ctx.set([]) using the
+# token-reset pattern so concurrent coroutines never share a list.  asyncio.to_thread
+# copies the context so thread-pool calls can also append to the same list.
+_api_calls_ctx: contextvars.ContextVar[list | None] = contextvars.ContextVar(
+    "_api_calls_ctx", default=None
+)
+
+
+def _record_api_call(path: str, status: int, headers: Any) -> None:
+    """Append one HTTP-call record to the per-tool-call collector (no-op if unset)."""
+    calls = _api_calls_ctx.get(None)
+    if calls is None:
+        return
+    entry: dict = {"path": path, "status": status, "ts": datetime.now(UTC).isoformat()}
+    if headers:
+        rid = headers.get("x-request-id")
+        ghrid = headers.get("x-github-request-id")
+        if rid:
+            entry["x_request_id"] = rid
+        if ghrid:
+            entry["x_github_request_id"] = ghrid
+    calls.append(entry)
 
 
 async def _get_docker_client() -> Any:
@@ -147,8 +172,14 @@ def _gh_api(path: str, token: str) -> Any:
             "Accept": "application/vnd.github.v3+json",
         },
     )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            _record_api_call(path, resp.status, resp.headers)
+            return data
+    except urllib.error.HTTPError as exc:
+        _record_api_call(path, exc.code, exc.headers)
+        raise
 
 
 def _gh_api_post(path: str, token: str, payload: dict, method: str = "POST") -> Any:
@@ -164,8 +195,14 @@ def _gh_api_post(path: str, token: str, payload: dict, method: str = "POST") -> 
         },
         method=method,
     )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            _record_api_call(path, resp.status, resp.headers)
+            return data
+    except urllib.error.HTTPError as exc:
+        _record_api_call(path, exc.code, exc.headers)
+        raise
 
 
 def _gh_api_diff(path: str, token: str) -> str:
@@ -177,8 +214,14 @@ def _gh_api_diff(path: str, token: str) -> str:
             "Accept": "application/vnd.github.v3.diff",
         },
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return resp.read().decode("utf-8", errors="replace")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            text = resp.read().decode("utf-8", errors="replace")
+            _record_api_call(path, resp.status, resp.headers)
+            return text
+    except urllib.error.HTTPError as exc:
+        _record_api_call(path, exc.code, exc.headers)
+        raise
 
 
 def _gh_graphql(token: str, query: str, variables: dict) -> dict:
@@ -194,8 +237,14 @@ def _gh_graphql(token: str, query: str, variables: dict) -> dict:
         },
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            _record_api_call("/graphql", resp.status, resp.headers)
+            return data
+    except urllib.error.HTTPError as exc:
+        _record_api_call("/graphql", exc.code, exc.headers)
+        raise
 
 
 def _parse_review_from_claude(text: str) -> dict:
@@ -746,6 +795,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
     inp = tu.input
     result_text = ""
     is_error = False
+    _ctx_token = _api_calls_ctx.set([])
     try:
         db = await get_db()
         try:
@@ -1844,8 +1894,20 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
     except Exception as exc:
         result_text = f"Tool {tu.name} failed: {exc}"
         is_error = True
+    finally:
+        _api_call_log = _api_calls_ctx.get([])
+        _api_calls_ctx.reset(_ctx_token)
+
+    # Surface GitHub request IDs in error responses so failures can be correlated
+    # with provider-side logs without digging through the database.
+    if is_error and _api_call_log:
+        req_ids = [c["x_github_request_id"] for c in _api_call_log if c.get("x_github_request_id")]
+        if req_ids:
+            result_text = f"{result_text}\n[x-github-request-id: {', '.join(req_ids)}]"
 
     block: dict = {"type": "tool_result", "tool_use_id": tu.id, "content": result_text}
     if is_error:
         block["is_error"] = True
+    if _api_call_log:
+        block["api_calls"] = _api_call_log
     return block

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -6,7 +6,6 @@ of truth shared with the standalone foreman.  This module owns the embedded exec
 """
 
 import asyncio
-import contextvars
 import json
 import logging
 import os
@@ -76,30 +75,6 @@ CONTAINER_RUN_TIMEOUT = 600
 # each time.  None until first successful from_env(); tests can patch
 # _get_docker_client() directly to avoid touching sys.modules.
 _docker_client: Any = None
-
-# Per-tool-call collector for GitHub API response metadata (request IDs, status codes).
-# Set to a fresh list at the start of each _exec_one_tool invocation; each _gh_api*
-# function appends one entry per HTTP call.  asyncio.to_thread copies the context so
-# threads see the same list and mutations propagate back to the coroutine.
-_api_calls_ctx: contextvars.ContextVar[list | None] = contextvars.ContextVar(
-    "_api_calls_ctx", default=None
-)
-
-
-def _record_api_call(path: str, status: int, headers: Any) -> None:
-    """Append one HTTP-call record to the per-tool-call collector (no-op if unset)."""
-    calls = _api_calls_ctx.get(None)
-    if calls is None:
-        return
-    entry: dict = {"path": path, "status": status, "ts": datetime.now(UTC).isoformat()}
-    if headers:
-        rid = headers.get("x-request-id")
-        ghrid = headers.get("x-github-request-id")
-        if rid:
-            entry["x_request_id"] = rid
-        if ghrid:
-            entry["x_github_request_id"] = ghrid
-    calls.append(entry)
 
 
 async def _get_docker_client() -> Any:
@@ -172,14 +147,8 @@ def _gh_api(path: str, token: str) -> Any:
             "Accept": "application/vnd.github.v3+json",
         },
     )
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read())
-            _record_api_call(path, resp.status, resp.headers)
-            return data
-    except urllib.error.HTTPError as exc:
-        _record_api_call(path, exc.code, exc.headers)
-        raise
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
 
 
 def _gh_api_post(path: str, token: str, payload: dict, method: str = "POST") -> Any:
@@ -195,14 +164,8 @@ def _gh_api_post(path: str, token: str, payload: dict, method: str = "POST") -> 
         },
         method=method,
     )
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read())
-            _record_api_call(path, resp.status, resp.headers)
-            return data
-    except urllib.error.HTTPError as exc:
-        _record_api_call(path, exc.code, exc.headers)
-        raise
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
 
 
 def _gh_api_diff(path: str, token: str) -> str:
@@ -214,14 +177,8 @@ def _gh_api_diff(path: str, token: str) -> str:
             "Accept": "application/vnd.github.v3.diff",
         },
     )
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            text = resp.read().decode("utf-8", errors="replace")
-            _record_api_call(path, resp.status, resp.headers)
-            return text
-    except urllib.error.HTTPError as exc:
-        _record_api_call(path, exc.code, exc.headers)
-        raise
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8", errors="replace")
 
 
 def _gh_graphql(token: str, query: str, variables: dict) -> dict:
@@ -237,14 +194,8 @@ def _gh_graphql(token: str, query: str, variables: dict) -> dict:
         },
         method="POST",
     )
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read())
-            _record_api_call("/graphql", resp.status, resp.headers)
-            return data
-    except urllib.error.HTTPError as exc:
-        _record_api_call("/graphql", exc.code, exc.headers)
-        raise
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
 
 
 def _parse_review_from_claude(text: str) -> dict:
@@ -795,11 +746,6 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
     inp = tu.input
     result_text = ""
     is_error = False
-    # Set up a fresh per-call collector for GitHub API response metadata.
-    # _api_calls_ctx is a ContextVar so each concurrent task gets its own list;
-    # asyncio.to_thread copies the context so thread-pool calls can also append.
-    _api_call_log: list = []
-    _api_calls_ctx.set(_api_call_log)
     try:
         db = await get_db()
         try:
@@ -1899,16 +1845,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
         result_text = f"Tool {tu.name} failed: {exc}"
         is_error = True
 
-    # Surface GitHub request IDs in error responses so failures are easy to
-    # correlate with provider-side logs without digging through the database.
-    if is_error and _api_call_log:
-        req_ids = [c["x_github_request_id"] for c in _api_call_log if c.get("x_github_request_id")]
-        if req_ids:
-            result_text = f"{result_text}\n[x-github-request-id: {', '.join(req_ids)}]"
-
     block: dict = {"type": "tool_result", "tool_use_id": tu.id, "content": result_text}
     if is_error:
         block["is_error"] = True
-    if _api_call_log:
-        block["api_calls"] = _api_call_log
     return block

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -6,6 +6,7 @@ of truth shared with the standalone foreman.  This module owns the embedded exec
 """
 
 import asyncio
+import contextvars
 import json
 import logging
 import os
@@ -75,6 +76,30 @@ CONTAINER_RUN_TIMEOUT = 600
 # each time.  None until first successful from_env(); tests can patch
 # _get_docker_client() directly to avoid touching sys.modules.
 _docker_client: Any = None
+
+# Per-tool-call collector for GitHub API response metadata (request IDs, status codes).
+# Set to a fresh list at the start of each _exec_one_tool invocation; each _gh_api*
+# function appends one entry per HTTP call.  asyncio.to_thread copies the context so
+# threads see the same list and mutations propagate back to the coroutine.
+_api_calls_ctx: contextvars.ContextVar[list | None] = contextvars.ContextVar(
+    "_api_calls_ctx", default=None
+)
+
+
+def _record_api_call(path: str, status: int, headers: Any) -> None:
+    """Append one HTTP-call record to the per-tool-call collector (no-op if unset)."""
+    calls = _api_calls_ctx.get(None)
+    if calls is None:
+        return
+    entry: dict = {"path": path, "status": status, "ts": datetime.now(UTC).isoformat()}
+    if headers:
+        rid = headers.get("x-request-id")
+        ghrid = headers.get("x-github-request-id")
+        if rid:
+            entry["x_request_id"] = rid
+        if ghrid:
+            entry["x_github_request_id"] = ghrid
+    calls.append(entry)
 
 
 async def _get_docker_client() -> Any:
@@ -147,8 +172,14 @@ def _gh_api(path: str, token: str) -> Any:
             "Accept": "application/vnd.github.v3+json",
         },
     )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            _record_api_call(path, resp.status, resp.headers)
+            return data
+    except urllib.error.HTTPError as exc:
+        _record_api_call(path, exc.code, exc.headers)
+        raise
 
 
 def _gh_api_post(path: str, token: str, payload: dict, method: str = "POST") -> Any:
@@ -164,8 +195,14 @@ def _gh_api_post(path: str, token: str, payload: dict, method: str = "POST") -> 
         },
         method=method,
     )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            _record_api_call(path, resp.status, resp.headers)
+            return data
+    except urllib.error.HTTPError as exc:
+        _record_api_call(path, exc.code, exc.headers)
+        raise
 
 
 def _gh_api_diff(path: str, token: str) -> str:
@@ -177,8 +214,14 @@ def _gh_api_diff(path: str, token: str) -> str:
             "Accept": "application/vnd.github.v3.diff",
         },
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return resp.read().decode("utf-8", errors="replace")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            text = resp.read().decode("utf-8", errors="replace")
+            _record_api_call(path, resp.status, resp.headers)
+            return text
+    except urllib.error.HTTPError as exc:
+        _record_api_call(path, exc.code, exc.headers)
+        raise
 
 
 def _gh_graphql(token: str, query: str, variables: dict) -> dict:
@@ -194,8 +237,14 @@ def _gh_graphql(token: str, query: str, variables: dict) -> dict:
         },
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            _record_api_call("/graphql", resp.status, resp.headers)
+            return data
+    except urllib.error.HTTPError as exc:
+        _record_api_call("/graphql", exc.code, exc.headers)
+        raise
 
 
 def _parse_review_from_claude(text: str) -> dict:
@@ -746,6 +795,11 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
     inp = tu.input
     result_text = ""
     is_error = False
+    # Set up a fresh per-call collector for GitHub API response metadata.
+    # _api_calls_ctx is a ContextVar so each concurrent task gets its own list;
+    # asyncio.to_thread copies the context so thread-pool calls can also append.
+    _api_call_log: list = []
+    _api_calls_ctx.set(_api_call_log)
     try:
         db = await get_db()
         try:
@@ -1845,7 +1899,16 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
         result_text = f"Tool {tu.name} failed: {exc}"
         is_error = True
 
+    # Surface GitHub request IDs in error responses so failures are easy to
+    # correlate with provider-side logs without digging through the database.
+    if is_error and _api_call_log:
+        req_ids = [c["x_github_request_id"] for c in _api_call_log if c.get("x_github_request_id")]
+        if req_ids:
+            result_text = f"{result_text}\n[x-github-request-id: {', '.join(req_ids)}]"
+
     block: dict = {"type": "tool_result", "tool_use_id": tu.id, "content": result_text}
     if is_error:
         block["is_error"] = True
+    if _api_call_log:
+        block["api_calls"] = _api_call_log
     return block

--- a/backend/models.py
+++ b/backend/models.py
@@ -282,6 +282,10 @@ class ForemanTurn(SQLModel, table=True):
     # Token usage from the API response (assistant turns only; NULL for user/system turns)
     input_tokens: int | None = None
     output_tokens: int | None = None
+    # JSON array of per-HTTP-call metadata captured during tool execution.
+    # Each entry: {tool_use_id, path, status, x_request_id?, x_github_request_id?, ts}
+    # Set on is_tool_response=1 turns; NULL otherwise.
+    api_calls_json: str | None = None
 
 
 class GithubEvent(SQLModel, table=True):

--- a/backend/models.py
+++ b/backend/models.py
@@ -282,9 +282,9 @@ class ForemanTurn(SQLModel, table=True):
     # Token usage from the API response (assistant turns only; NULL for user/system turns)
     input_tokens: int | None = None
     output_tokens: int | None = None
-    # JSON array of per-HTTP-call metadata captured during tool execution.
-    # Each entry: {tool_use_id, path, status, x_request_id?, x_github_request_id?, ts}
-    # Set on is_tool_response=1 turns; NULL otherwise.
+    # JSON array of Anthropic API call metadata captured for each messages.create() call.
+    # Each entry: {request_id?, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, ts}
+    # Set on assistant turns; NULL otherwise.
     api_calls_json: str | None = None
 
 

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -249,6 +249,7 @@ async def get_foreman_history_for_user(
             col(ForemanTurn.is_tool_response),
             col(ForemanTurn.parent_id),
             col(ForemanTurn.created_at),
+            col(ForemanTurn.api_calls_json),
         )
         .where(col(ForemanTurn.guild_id) == guild_pk, col(ForemanTurn.user_id) == user_id)
         .order_by(col(ForemanTurn.id))
@@ -266,6 +267,7 @@ async def get_foreman_history_for_user(
             "is_tool_response": bool(t.is_tool_response),
             "parent_id": t.parent_id,
             "created_at": t.created_at,
+            "api_calls_json": t.api_calls_json,
         }
         for t in turns
     ]
@@ -314,6 +316,7 @@ class ForemanTurnCreate(BaseModel):
     content_json: str  # JSON-serialised content blocks (string, list, …)
     is_tool_response: bool = False
     parent_id: int | None = None
+    api_calls: list | None = None  # per-HTTP-call metadata from tool execution
 
 
 @router.post("/guilds/{guild_id}/foreman/history")
@@ -330,6 +333,8 @@ async def create_foreman_turn(
 
     Response: ``{ "id": int, "created_at": str }``
     """
+    import json as _json
+
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
@@ -342,6 +347,7 @@ async def create_foreman_turn(
         is_tool_response=1 if body.is_tool_response else 0,
         parent_id=body.parent_id,
         created_at=created_at,
+        api_calls_json=_json.dumps(body.api_calls) if body.api_calls else None,
     )
     db.add(turn)
     await db.commit()

--- a/foreman/pioneer_foreman/http_client.py
+++ b/foreman/pioneer_foreman/http_client.py
@@ -139,6 +139,7 @@ class ForemanHTTPClient:
         *,
         is_tool_response: bool = False,
         parent_id: int | None = None,
+        api_calls: list | None = None,
     ) -> dict:
         """Persist one foreman conversation turn. Returns {id, created_at}."""
         body: dict = {
@@ -149,6 +150,8 @@ class ForemanHTTPClient:
         }
         if parent_id is not None:
             body["parent_id"] = parent_id
+        if api_calls:
+            body["api_calls"] = api_calls
         return await self._post(self._guild_url("/foreman/history"), body)
 
     async def update_turn_tokens(self, turn_id: int, input_tokens: int, output_tokens: int) -> None:

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -201,30 +201,47 @@ async def run_foreman_ai(
                 round_num,
                 len(messages),
             )
-            resp = await client.messages.create(
+            _raw = await client.messages.with_raw_response.create(
                 model=config.effective_model,
                 max_tokens=1024,
                 system=system_blocks,
                 messages=messages,
                 tools=FOREMAN_TOOLS,
             )
+            resp = _raw.parse()
             usage = resp.usage
             _input_tokens = getattr(usage, "input_tokens", 0) or 0
             _output_tokens = getattr(usage, "output_tokens", 0) or 0
+            _cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
+            _cache_write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+            _anthropic_request_id = _raw.headers.get("request-id")
             logger.info(
                 "guild=%s round %d: stop_reason=%s content_blocks=%d "
-                "input=%d cache_read=%d cache_write=%d output=%d",
+                "input=%d cache_read=%d cache_write=%d output=%d request_id=%s",
                 guild_id,
                 round_num,
                 resp.stop_reason,
                 len(resp.content),
                 _input_tokens,
-                getattr(usage, "cache_read_input_tokens", 0) or 0,
-                getattr(usage, "cache_creation_input_tokens", 0) or 0,
+                _cache_read,
+                _cache_write,
                 _output_tokens,
+                _anthropic_request_id,
             )
 
-            asst_turn_id = await _save_turn(guild_id, user_id, "assistant", resp.content, http=http)
+            _api_call_meta = {
+                "request_id": _anthropic_request_id,
+                "model": config.effective_model,
+                "input_tokens": _input_tokens,
+                "output_tokens": _output_tokens,
+                "cache_read_tokens": _cache_read,
+                "cache_write_tokens": _cache_write,
+                "ts": datetime.now(UTC).isoformat(),
+            }
+
+            asst_turn_id = await _save_turn(
+                guild_id, user_id, "assistant", resp.content, http=http, api_calls=[_api_call_meta]
+            )
             await http.update_turn_tokens(asst_turn_id, _input_tokens, _output_tokens)
             messages.append({"role": "assistant", "content": _serialize_content(resp.content)})
             # Re-parse so messages stays as plain dicts (not SDK objects)
@@ -267,15 +284,10 @@ async def run_foreman_ai(
 
             tool_results = await exec_tools(guild_id, tool_uses, http=http, user_id=user_id)
             current_tool_use_ids = {tu.id for tu in tool_uses}
-            # Extract api_calls metadata before building trimmed — the Anthropic API
-            # only accepts {type, tool_use_id, content, is_error} in tool_result blocks.
-            all_api_calls: list[dict] = []
             trimmed: list[dict] = []
             for r in tool_results:
                 if r.get("tool_use_id") not in current_tool_use_ids:
                     continue
-                for call in r.get("api_calls") or []:
-                    all_api_calls.append({"tool_use_id": r["tool_use_id"], **call})
                 entry = {k: v for k, v in r.items() if k != "api_calls"}
                 if entry.get("content"):
                     entry = {**entry, "content": truncate_tool_result(entry["content"])}
@@ -305,14 +317,16 @@ async def run_foreman_ai(
                 http=http,
                 is_tool_response=True,
                 parent_id=asst_turn_id,
-                api_calls=all_api_calls if all_api_calls else None,
             )
             logger.info(
                 "guild=%s round %d: %d tool call(s): %s",
                 guild_id,
                 round_num,
                 len(trimmed),
-                [r.get("tool_use_id") for r in trimmed],
+                [
+                    {"tool_use_id": r.get("tool_use_id"), "is_error": r.get("is_error", False)}
+                    for r in trimmed
+                ],
             )
             messages.append({"role": "user", "content": trimmed})
         else:
@@ -321,7 +335,7 @@ async def run_foreman_ai(
             messages = prune_history(messages)
             messages = strip_orphaned_tool_results(messages)
             _stamp_message_cache_breakpoint(messages)
-            wrap_resp = await client.messages.create(
+            _wrap_raw = await client.messages.with_raw_response.create(
                 model=config.effective_model,
                 max_tokens=1024,
                 system=system_blocks,
@@ -329,20 +343,39 @@ async def run_foreman_ai(
                 tools=FOREMAN_TOOLS,
                 tool_choice={"type": "none"},
             )
+            wrap_resp = _wrap_raw.parse()
             wrap_usage = wrap_resp.usage
             _wrap_input = getattr(wrap_usage, "input_tokens", 0) or 0
             _wrap_output = getattr(wrap_usage, "output_tokens", 0) or 0
+            _wrap_cache_read = getattr(wrap_usage, "cache_read_input_tokens", 0) or 0
+            _wrap_cache_write = getattr(wrap_usage, "cache_creation_input_tokens", 0) or 0
+            _wrap_request_id = _wrap_raw.headers.get("request-id")
             logger.info(
-                "guild=%s wrap-up: stop_reason=%s input=%d cache_read=%d cache_write=%d output=%d",
+                "guild=%s wrap-up: stop_reason=%s input=%d cache_read=%d cache_write=%d output=%d request_id=%s",
                 guild_id,
                 wrap_resp.stop_reason,
                 _wrap_input,
-                getattr(wrap_usage, "cache_read_input_tokens", 0) or 0,
-                getattr(wrap_usage, "cache_creation_input_tokens", 0) or 0,
+                _wrap_cache_read,
+                _wrap_cache_write,
                 _wrap_output,
+                _wrap_request_id,
             )
+            _wrap_api_meta = {
+                "request_id": _wrap_request_id,
+                "model": config.effective_model,
+                "input_tokens": _wrap_input,
+                "output_tokens": _wrap_output,
+                "cache_read_tokens": _wrap_cache_read,
+                "cache_write_tokens": _wrap_cache_write,
+                "ts": datetime.now(UTC).isoformat(),
+            }
             wrap_turn_id = await _save_turn(
-                guild_id, user_id, "assistant", wrap_resp.content, http=http
+                guild_id,
+                user_id,
+                "assistant",
+                wrap_resp.content,
+                http=http,
+                api_calls=[_wrap_api_meta],
             )
             await http.update_turn_tokens(wrap_turn_id, _wrap_input, _wrap_output)
             _now = datetime.now(UTC).isoformat()

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -90,6 +90,7 @@ async def _save_turn(
     http: ForemanHTTPClient,
     is_tool_response: bool = False,
     parent_id: int | None = None,
+    api_calls: list | None = None,
 ) -> int:
     """Persist one turn via REST. Returns the new row's id."""
     result = await http.save_turn(
@@ -98,6 +99,7 @@ async def _save_turn(
         _serialize_content(content),
         is_tool_response=is_tool_response,
         parent_id=parent_id,
+        api_calls=api_calls,
     )
     return result["id"]
 
@@ -265,11 +267,19 @@ async def run_foreman_ai(
 
             tool_results = await exec_tools(guild_id, tool_uses, http=http, user_id=user_id)
             current_tool_use_ids = {tu.id for tu in tool_uses}
-            trimmed = [
-                {**r, "content": truncate_tool_result(r["content"])} if r.get("content") else r
-                for r in tool_results
-                if r.get("tool_use_id") in current_tool_use_ids
-            ]
+            # Extract api_calls metadata before building trimmed — the Anthropic API
+            # only accepts {type, tool_use_id, content, is_error} in tool_result blocks.
+            all_api_calls: list[dict] = []
+            trimmed: list[dict] = []
+            for r in tool_results:
+                if r.get("tool_use_id") not in current_tool_use_ids:
+                    continue
+                for call in r.get("api_calls") or []:
+                    all_api_calls.append({"tool_use_id": r["tool_use_id"], **call})
+                entry = {k: v for k, v in r.items() if k != "api_calls"}
+                if entry.get("content"):
+                    entry = {**entry, "content": truncate_tool_result(entry["content"])}
+                trimmed.append(entry)
 
             _now = datetime.now(UTC).isoformat()
             for result in trimmed:
@@ -295,6 +305,7 @@ async def run_foreman_ai(
                 http=http,
                 is_tool_response=True,
                 parent_id=asst_turn_id,
+                api_calls=all_api_calls if all_api_calls else None,
             )
             logger.info(
                 "guild=%s round %d: %d tool call(s): %s",


### PR DESCRIPTION
## Summary

- Adds an `api_calls_json` TEXT column to `foreman_turns` (via Alembic migration `20260605_000001`) to store per-HTTP-call metadata alongside each tool-result turn.
- Instruments all four GitHub HTTP helpers (`_gh_api`, `_gh_api_post`, `_gh_api_diff`, `_gh_graphql`) to record `x-request-id`, `x-github-request-id`, HTTP status code, path, and wall-clock timestamp on every call — including error responses.
- Uses a `ContextVar` (`_api_calls_ctx`) so concurrent tool executions each collect their own metadata without cross-contamination; `asyncio.to_thread` copies the context automatically so thread-pool calls participate too.
- Strips `api_calls` from tool-result blocks before they are sent to the Anthropic API (the API only accepts `type/tool_use_id/content/is_error`), then persists the metadata on the DB turn row.
- Surfaces GitHub request IDs in error result text so failures are immediately visible in logs without needing to query the database.
- Propagates the full pipeline to the standalone foreman process (`foreman/pioneer_foreman/`) via `ForemanHTTPClient.save_turn` and `runner._save_turn`.
- Exposes `api_calls_json` in the foreman history REST endpoints so callers can retrieve the metadata.

Closes #575