### PR TITLE
Increase foreman max sleep from 1h to 4h

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -37,7 +37,7 @@ from ws_types import ChatMsg, ForemanPollStatusMsg
 logger = logging.getLogger(__name__)
 
 POLL_MIN_SECS = 60  # initial poll interval: 1 minute
-POLL_MAX_SECS = 3600  # maximum poll interval: 60 minutes
+POLL_MAX_SECS = 14400  # maximum poll interval: 4 hours
 
 # Per-guild background poll task registry
 _poll_tasks: dict[str, "asyncio.Task[None]"] = {}

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -43,7 +43,7 @@ class Config:
     history_limit: int = 40
     # Poll settings
     poll_min_interval: int = 60
-    poll_max_interval: int = 3600
+    poll_max_interval: int = 14400
     # Logging
     log_level: str = "INFO"
 
@@ -200,7 +200,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             overrides.get("poll_min_interval", poll_block.get("min_interval", 60))
         ),
         poll_max_interval=int(
-            overrides.get("poll_max_interval", poll_block.get("max_interval", 3600))
+            overrides.get("poll_max_interval", poll_block.get("max_interval", 14400))
         ),
         log_level=log_level.upper(),
         config_path=cfg_path,


### PR DESCRIPTION
## Summary

- `backend/foreman/runner.py`: raise `POLL_MAX_SECS` from 3600 → 14400 seconds
- `foreman/pioneer_foreman/config.py`: raise the `poll_max_interval` dataclass default and the TOML parsing fallback from 3600 → 14400 seconds

Allows the foreman to back off to a 4-hour poll interval during long idle periods instead of capping at 1 hour.

## Test plan

- [ ] Confirm `POLL_MAX_SECS` and `poll_max_interval` read 14400 in both modules
- [ ] Run existing foreman tests (`pytest backend/tests/test_foreman.py`) — no behavioural changes expected other than the higher cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)