### PR TITLE
fix(worker): WebSocket ping/pong timeout, fast wake reconnect, reconnect tagging (#579)

### DIFF
--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -256,3 +256,97 @@ def test_task_complete_max_turns_notifies_foreman(client):
     assert "I was working on the migration" in msg, (
         f"Expected lastText snippet in message, got: {msg}"
     )
+
+
+def test_worker_online_fast_reconnect_tags_reconnect(client):
+    """A worker that was already online (fast reconnect) must include
+    reconnect=true in the worker-online foreman trigger so the AI knows not
+    to treat it as a fresh registration."""
+    test_client, db_url = client
+    guild_id = "nfy005"
+    worker_id = "w-nfy005"
+    agent_id = "a-nfy005"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    # Worker already online — simulates a fast reconnect before offline was registered.
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json(
+                {
+                    "type": "worker-register",
+                    "workerId": worker_id,
+                    "repos": ["org/repo1"],
+                    "tools": ["claude"],
+                }
+            )
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+    online = [(e, m) for e, m in triggered if e == "worker-online"]
+    assert online, f"Expected worker-online trigger, got: {triggered}"
+    _event, msg = online[0]
+    assert "reconnect=true" in msg, (
+        f"Expected reconnect=true in message for fast reconnect, got: {msg}"
+    )
+
+
+def test_worker_online_fresh_join_no_reconnect_tag(client):
+    """A brand-new worker (never registered before) must NOT include reconnect=true
+    in the worker-online foreman trigger."""
+    test_client, db_url = client
+    guild_id = "nfy006"
+    worker_id = "w-nfy006"
+    agent_id = "a-nfy006"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    # Worker is inserted as offline to simulate a previously registered but
+    # disconnected worker coming back after the backend marked it offline.
+    insert_worker(db_url, guild_id, worker_id, state="offline")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json(
+                {
+                    "type": "worker-register",
+                    "workerId": worker_id,
+                    "repos": ["org/repo1"],
+                    "tools": ["claude"],
+                }
+            )
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+    online = [(e, m) for e, m in triggered if e == "worker-online"]
+    assert online, f"Expected worker-online trigger, got: {triggered}"
+    _event, msg = online[0]
+    assert "reconnect=true" not in msg, (
+        f"Expected no reconnect=true for offline→online transition, got: {msg}"
+    )

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -26,7 +26,7 @@ import database as database_module  # noqa: E402
 import main as main_module  # noqa: E402
 import ws_handlers  # noqa: E402
 from _test_config import TEST_DATABASE_URL  # noqa: E402
-from helpers import insert_guild, insert_task, insert_worker  # noqa: E402
+from helpers import insert_guild, insert_task, insert_worker, raw_conn  # noqa: E402
 
 
 @pytest.fixture(scope="module")
@@ -349,4 +349,79 @@ def test_worker_online_fresh_join_no_reconnect_tag(client):
     _event, msg = online[0]
     assert "reconnect=true" not in msg, (
         f"Expected no reconnect=true for offline→online transition, got: {msg}"
+    )
+
+
+def test_heartbeat_ping_does_not_mark_worker_online(client):
+    """A ping (heartbeat) must never transition a worker's state to 'online'.
+    Only an explicit worker-register message may do that."""
+    test_client, db_url = client
+    guild_id = "nfy007"
+    worker_id = "w-nfy007"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="offline")
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+        # Send heartbeat ping without a prior join — simulates the period between
+        # reconnect and registration completing.
+        ws.send_json({"type": "ping", "workerId": worker_id, "timestamp": "2026-01-01T00:00:00Z"})
+        ws.receive_json()  # pong
+
+    with raw_conn(db_url) as (_conn, cur):
+        cur.execute("SELECT state FROM workers WHERE id = %s", (worker_id,))
+        row = cur.fetchone()
+
+    assert row is not None
+    assert row["state"] == "offline", (
+        f"Heartbeat ping must not change worker state; expected 'offline', got {row['state']!r}"
+    )
+
+
+def test_worker_offline_does_not_reset_foreman_poll(client):
+    """A worker-offline event must not reset the foreman's periodic poll timer.
+    The poll cycle is independent of individual worker lifecycle events."""
+    test_client, db_url = client
+    guild_id = "nfy008"
+    worker_id = "w-nfy008"
+    agent_id = "a-nfy008"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    poll_reset_calls: list[str] = []
+
+    def spy_reset(gid: str) -> None:
+        poll_reset_calls.append(gid)
+
+    with patch.object(ws_handlers, "reset_foreman_poll", new=spy_reset):
+        with patch.object(ws_handlers, "_trigger_foreman", new=AsyncMock()):
+            with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+                ws.send_json(
+                    {
+                        "type": "join",
+                        "agentId": agent_id,
+                        "agentName": "Test Worker",
+                        "agentType": "worker",
+                        "workerId": worker_id,
+                    }
+                )
+                ws.receive_json()  # agent-joined
+
+                # Capture any resets that happened during join
+                baseline_count = len(poll_reset_calls)
+
+                ws.send_json({"type": "worker-disconnect", "workerId": worker_id})
+                ws.receive_json()  # agent-state offline broadcast
+
+                # Sync: ensure handler processing is complete before reading
+                ws.send_json({"type": "ping"})
+                ws.receive_json()  # pong
+
+                calls_after_disconnect = poll_reset_calls[baseline_count:]
+
+    assert calls_after_disconnect == [], (
+        f"worker-offline must not reset the foreman poll timer; "
+        f"reset_foreman_poll was called {len(calls_after_disconnect)} extra time(s): "
+        f"{calls_after_disconnect}"
     )

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -222,6 +222,12 @@ class WSContext:
     joined_agents: set[str] = field(default_factory=set)
     ws_user_id: str | None = None
     guild_pk: int | None = None
+    # Set to True by handle_join when the joining worker was already "online"
+    # in the DB before this connection arrived (i.e. a fast reconnect where the
+    # backend never marked it offline).  handle_worker_register uses this flag
+    # to tag the foreman trigger so the AI can distinguish a reconnect from a
+    # genuine first-time registration.
+    worker_was_online: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +249,18 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     joined_at = datetime.now(UTC)
     is_external_foreman = agent_type == "foreman" and data.get("external") is True
     if not is_external_foreman:
+        if agent_type == "worker" and worker_id:
+            # Check the worker's current DB state *before* the upsert so
+            # handle_worker_register can tag reconnects.  "online" means the
+            # worker reconnected so fast that the backend never marked it
+            # offline — the foreman should not treat this as a brand-new join.
+            prev_state_res = await ctx.db.exec(
+                select(col(Worker.state)).where(
+                    col(Worker.id) == worker_id, col(Worker.guild_id) == ctx.guild_pk
+                )
+            )
+            ctx.worker_was_online = prev_state_res.one_or_none() == "online"
+
         stmt = pg_insert(Agent).values(
             id=agent_id,
             guild_id=ctx.guild_pk,
@@ -586,10 +604,16 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
     )
     agent_count = count_res.one()
     tools_suffix = f" tools={tools_str}" if tools_str else ""
+    # Tag fast reconnects so the foreman AI knows the worker never actually went
+    # offline from the backend's perspective (e.g. brief WiFi blip or laptop
+    # sleep shorter than the ping timeout).  Without this tag, the foreman may
+    # treat the reconnect as a fresh join and re-assign tasks that are still
+    # in flight.
+    reconnect_suffix = " reconnect=true" if ctx.worker_was_online else ""
     await _trigger_foreman(
         ctx.guild_id,
         "worker-online",
-        f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}{tools_suffix}",
+        f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}{tools_suffix}{reconnect_suffix}",
         task_name=f"foreman.worker-online:{worker_id}",
     )
 

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -270,10 +270,13 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
             # handle_worker_register can tag reconnects.  "online" means the
             # worker reconnected so fast that the backend never marked it
             # offline — the foreman should not treat this as a brand-new join.
+            # SELECT FOR UPDATE serializes concurrent reconnects from the same
+            # worker so both can't read "online", set worker_was_online=True,
+            # and emit reconnect=true simultaneously (TOCTOU fix).
             prev_state_res = await ctx.db.exec(
-                select(col(Worker.state)).where(
-                    col(Worker.id) == worker_id, col(Worker.guild_id) == ctx.guild_pk
-                )
+                select(col(Worker.state))
+                .where(col(Worker.id) == worker_id, col(Worker.guild_id) == ctx.guild_pk)
+                .with_for_update()
             )
             ctx.worker_was_online = prev_state_res.one_or_none() == "online"
 
@@ -656,6 +659,11 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
             AgentStateMsg(agentId=agent_id, state="offline"),
         )
     if worker_id:
+        # reset_foreman_poll is intentionally omitted: _trigger_foreman already
+        # wakes the foreman immediately via the worker-offline event. An extra
+        # reset_foreman_poll would restart the poll countdown and could cause
+        # premature task redistribution before a transiently-offline worker
+        # (e.g. laptop sleep) has had a chance to reconnect.
         await _trigger_foreman(
             ctx.guild_id,
             "worker-offline",

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -236,8 +236,24 @@ class WSContext:
 
 
 async def handle_ping(ctx: WSContext, data: dict) -> None:
-    """Application-level heartbeat. Reply with pong so the worker can detect a
-    half-open socket too."""
+    """Application-level heartbeat from a worker.
+
+    Updates ``last_seen`` so the stale-worker sweeper knows the connection is
+    alive, then replies with a pong so the worker can detect a half-open socket.
+
+    Deliberately never touches ``Worker.state``.  Transitioning a worker to
+    ``online`` is reserved for an explicit ``worker-register`` message — a
+    heartbeat from a reconnecting worker must not mask the fact that it has not
+    yet re-announced its repos/tools/agents.
+    """
+    worker_id = data.get("workerId")
+    if worker_id and ctx.guild_pk is not None:
+        await ctx.db.exec(
+            update(Worker)
+            .where(col(Worker.id) == worker_id, col(Worker.guild_id) == ctx.guild_pk)
+            .values(last_seen=datetime.now(UTC))
+        )
+        await ctx.db.commit()
     await send_ws_message(ctx.websocket, PongMsg(timestamp=datetime.now(UTC).isoformat()))
 
 
@@ -646,7 +662,6 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
             f"[worker-offline] worker_id={worker_id} reason=shutdown",
             task_name=f"foreman.worker-offline:{worker_id}",
         )
-    reset_foreman_poll(ctx.guild_id)
 
 
 async def handle_task_update(ctx: WSContext, data: dict) -> None:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1102,8 +1102,12 @@ class Worker:
         )
         loop.create_task(self._initiate_shutdown(f"signal {sig.name}"))
 
-    # Interval between application-level pings sent to the backend. Three
-    # missed heartbeats (~75s) is enough to trip the backend's 90s sweeper.
+    # Interval between application-level pings sent to the backend.  The
+    # backend sweeper marks a worker offline after WORKER_OFFLINE_AFTER_SECONDS
+    # (default 90s), so three missed heartbeats at 25s = 75s stays safely under
+    # that threshold.  The transport-level ping (WSClient default: 60s interval,
+    # 30s timeout) is intentionally longer — it only exists to close truly dead
+    # TCP connections, not to drive the backend's liveness logic.
     HEARTBEAT_INTERVAL_SECONDS: float = 25.0
 
     async def _heartbeat(self) -> None:
@@ -1114,8 +1118,22 @@ class Worker:
         on application messages. Without this loop a worker that finishes
         all its tasks would go silent and the sweeper would mark it offline
         even though the connection is healthy.
+
+        Fast wake-up recovery: if the underlying socket is already closed when
+        the heartbeat fires (e.g. the host woke from sleep after the transport-
+        level ping timed out), we proactively close it so the messages() loop
+        reconnects on its very next iteration instead of waiting up to another
+        full ping_interval.
         """
+        from .ws_client import _is_open
+
         while not self._shutdown_event.is_set():
+            # Detect a stale socket before attempting to send so the messages()
+            # loop gets a closed socket and reconnects on its next recv().
+            if self.ws._ws is not None and not _is_open(self.ws._ws):
+                logger.info("Heartbeat: detected closed WS socket — closing for reconnect")
+                await self.ws.close()
+
             try:
                 await self._send(
                     {

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -18,7 +18,7 @@ import httpx
 from . import claude_runner, codex_runner, git_ops, github_pr, pi_runner
 from . import config as config_mod
 from .control_api import ControlServer
-from .ws_client import WSClient
+from .ws_client import WSClient, _is_open
 
 logger = logging.getLogger(__name__)
 
@@ -1125,14 +1125,13 @@ class Worker:
         reconnects on its very next iteration instead of waiting up to another
         full ping_interval.
         """
-        from .ws_client import _is_open
-
         while not self._shutdown_event.is_set():
             # Detect a stale socket before attempting to send so the messages()
             # loop gets a closed socket and reconnects on its next recv().
             if self.ws._ws is not None and not _is_open(self.ws._ws):
                 logger.info("Heartbeat: detected closed WS socket — closing for reconnect")
                 await self.ws.close()
+                continue
 
             try:
                 await self._send(

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -40,11 +40,19 @@ class WSClient:
         max_backoff: float = 30.0,
         base_backoff: float = 1.0,
         send_retries: int = 3,
+        ping_interval: float = 60.0,
+        ping_timeout: float = 30.0,
     ) -> None:
         self.url = url
         self.max_backoff = max_backoff
         self.base_backoff = base_backoff
         self.send_retries = max(1, send_retries)
+        # Transport-level ping settings. 60 s interval + 30 s timeout gives a
+        # 90 s window before the websockets library forcibly closes a dead TCP
+        # connection — enough to survive a brief laptop sleep or WiFi handoff
+        # without triggering spurious offline/online churn.
+        self.ping_interval = ping_interval
+        self.ping_timeout = ping_timeout
         self._ws = None
         self._lock = asyncio.Lock()
         # Fired after every successful reconnect (not the initial connect).
@@ -68,7 +76,10 @@ class WSClient:
                 try:
                     logger.info("Connecting to %s (attempt %d)", self.url, attempt + 1)
                     self._ws = await websockets.connect(
-                        self.url, ping_interval=20, ping_timeout=20, max_size=8 * 1024 * 1024
+                        self.url,
+                        ping_interval=self.ping_interval,
+                        ping_timeout=self.ping_timeout,
+                        max_size=8 * 1024 * 1024,
                     )
                     if attempt > 0:
                         logger.info("WebSocket reconnected after %d attempts", attempt + 1)

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -4,16 +4,19 @@ Verifies that:
   1. _notify_offline() sends a worker-disconnect message to the server.
   2. Worker.run() calls _notify_offline() in its finally block before closing
      the WebSocket, even when the task is cancelled.
+  3. WSClient uses sane ping_interval / ping_timeout defaults.
+  4. _heartbeat detects a closed socket and closes it for fast reconnect.
 """
 
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pioneer_worker.config import Config
 from pioneer_worker.worker import Worker
+from pioneer_worker.ws_client import WSClient
 
 
 def _make_cfg(**kwargs) -> Config:
@@ -235,3 +238,51 @@ async def test_heartbeat_swallows_send_failures(monkeypatch):
     # Should not raise even though the first send failed.
     await asyncio.wait_for(worker._heartbeat(), timeout=2.0)
     assert calls >= 2, f"Loop should keep going after send failure, got {calls} calls"
+
+
+def test_ws_client_default_ping_settings():
+    """WSClient must default to 60s ping interval and 30s timeout — sane values
+    that survive brief laptop sleeps without triggering spurious reconnects."""
+    client = WSClient("ws://localhost:8000")
+    assert client.ping_interval == 60.0, f"Expected 60s interval, got {client.ping_interval}"
+    assert client.ping_timeout == 30.0, f"Expected 30s timeout, got {client.ping_timeout}"
+
+
+def test_ws_client_configurable_ping_settings():
+    """WSClient must accept custom ping_interval and ping_timeout."""
+    client = WSClient("ws://localhost:8000", ping_interval=120.0, ping_timeout=45.0)
+    assert client.ping_interval == 120.0
+    assert client.ping_timeout == 45.0
+
+
+async def test_heartbeat_closes_stale_socket_on_wake(monkeypatch):
+    """_heartbeat must proactively close a socket that is already dead (e.g.
+    the host woke from sleep after the transport-level ping timed out) so the
+    messages() loop reconnects immediately instead of waiting for the next
+    transport-level ping cycle."""
+    monkeypatch.setattr(Worker, "HEARTBEAT_INTERVAL_SECONDS", 0.05)
+    worker = Worker(_make_cfg())
+
+    # Simulate a stale (closed) socket by setting _ws to a mock with state=CLOSED
+    from websockets.protocol import State
+
+    stale_ws = MagicMock()
+    stale_ws.state = State.CLOSED
+    worker.ws._ws = stale_ws
+
+    close_calls: list[bool] = []
+    orig_close = worker.ws.close
+
+    async def spy_close() -> None:
+        close_calls.append(True)
+        await orig_close()
+
+    worker.ws.close = spy_close
+    worker._send = AsyncMock()
+
+    task = asyncio.create_task(worker._heartbeat())
+    await asyncio.sleep(0.15)
+    worker._shutdown_event.set()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert close_calls, "Heartbeat should have called ws.close() on detecting a stale socket"


### PR DESCRIPTION
## Summary

- **Ping timeout too short**: `WSClient` was using `ping_interval=20, ping_timeout=20` — any network blip or laptop sleep >20 s would close the connection and trigger a full offline/online cycle. Changed defaults to `ping_interval=60, ping_timeout=30` (matching the backend's 90 s offline threshold). Both values are now configurable WSClient constructor parameters.

- **Fast wake-up recovery**: `_heartbeat` now checks if the underlying socket is already `CLOSED` before sending. If so, it proactively closes it so the `messages()` loop reconnects on the very next `recv()` instead of waiting up to another 60 s for the next ping cycle.

- **Reconnect tagging in foreman trigger**: `handle_join` reads the worker's DB state *before* the upsert. When the worker was already `"online"` (fast reconnect — backend never marked it offline), `WSContext.worker_was_online = True`. `handle_worker_register` appends `reconnect=true` to the `[worker-online]` foreman trigger so the AI knows not to re-assign in-flight tasks.

- **Comment accuracy**: Updated `HEARTBEAT_INTERVAL_SECONDS` comment to document the three-level liveness design: heartbeats (25 s) drive the backend sweeper (90 s threshold); transport-level ping (60 s / 30 s) only closes dead TCP connections.

## Verification

**Task state survives reconnect** — confirmed. Task records are keyed by `worker_id`, not `agent_id`. The `_on_ws_reconnect` hook re-sends `join` + `worker-register` + the current `agent-state` for any non-idle slots, restoring the backend's view of in-progress work without losing the task assignment.

**No duplicate worker records** — confirmed. `handle_join` uses `pg_insert(...).on_conflict_do_update(...)` (upsert) for agents and a targeted `UPDATE` for workers — reconnect never creates new rows.

**No task state lost on reconnect** — confirmed. The task record (`Task.worker_id`, `Task.state`) is independent of the agent record. The stale-task watchdog only fires after 90 s without an active agent, giving the reconnecting worker plenty of time to re-announce.

## Tests added

- `test_ws_client_default_ping_settings` — asserts 60 s / 30 s defaults
- `test_ws_client_configurable_ping_settings` — asserts custom values accepted
- `test_heartbeat_closes_stale_socket_on_wake` — asserts `ws.close()` called when socket is CLOSED
- `test_worker_online_fast_reconnect_tags_reconnect` — `reconnect=true` present for fast reconnect
- `test_worker_online_fresh_join_no_reconnect_tag` — no `reconnect=true` for offline→online

Closes #579