### PR TITLE
feat(foreman): API keys / env vars panel (#578)

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -639,6 +639,19 @@ async def spawn_worker(
     )
     stored_blob = creds_result.one_or_none()
 
+    # Fetch guild-level env vars from foreman config and pass them to the worker.
+    foreman_env_vars: dict[str, str] = {}
+    if guild_pk is not None:
+        guild_res = await db.exec(
+            select(col(Guild.foreman_config)).where(col(Guild.id) == guild_pk)
+        )
+        guild_cfg = guild_res.one_or_none() or {}
+        foreman_env_vars = {
+            e["key"]: e["value"]
+            for e in (guild_cfg.get("env_vars") or [])
+            if e.get("key") and e.get("value") is not None
+        }
+
     env = build_spawn_worker_env(
         guild_id=guild_id,
         repos=repos,
@@ -649,6 +662,7 @@ async def spawn_worker(
         auth_token=auth_token,
         agent_count=agent_count,
         tools=tools_list or None,
+        extra_env=foreman_env_vars or None,
     )
 
     try:

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -271,6 +271,28 @@ async def get_foreman_history_for_user(
     ]
 
 
+@router.get("/guilds/{guild_id}/foreman/env-vars")
+async def get_foreman_env_vars(
+    guild_id: str,
+    _caller: str = Depends(require_worker_or_member_path),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Return the guild's foreman env vars with real (unmasked) values.
+
+    Used by standalone workers at startup to apply guild-configured API keys
+    (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) into their process environment.
+    Requires a valid worker auth_token or member login_token.
+
+    Response: ``{ "env_vars": [{"key": str, "value": str}, ...] }``
+    """
+    res = await db.exec(select(Guild).where(col(Guild.guild_id) == guild_id))
+    guild = res.one_or_none()
+    if not guild:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    config = guild.foreman_config or {}
+    return {"env_vars": config.get("env_vars", [])}
+
+
 @router.get("/guilds/{guild_id}/guild-key")
 async def get_guild_key(
     guild_id: str,

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import secrets
 from datetime import UTC, datetime
 
@@ -16,7 +17,7 @@ from database import get_db_dep
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException
 from models import Agent, Guild, GuildMember, Message, User, Worker
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import delete, func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
@@ -57,6 +58,27 @@ class GuildUpdate(BaseModel):
     version: str | None = None
 
 
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_MAX_FOREMAN_ENV_VARS = 20
+_MAX_ENV_VALUE_LEN = 4096
+_MASK_PLACEHOLDER = "••••••"
+
+
+class EnvVarItem(BaseModel):
+    key: str
+    # None → keep the currently stored value (used when the UI has a masked placeholder)
+    value: str | None = None
+
+
+def _mask_foreman_config(config: dict) -> dict:
+    """Return a shallow copy of foreman_config with env var values replaced by the mask."""
+    if "env_vars" not in config:
+        return config
+    masked = dict(config)
+    masked["env_vars"] = [{"key": e["key"], "value": _MASK_PLACEHOLDER} for e in config["env_vars"]]
+    return masked
+
+
 class ForemanConfigUpdate(BaseModel):
     model: str | None = None
     provider: str | None = None
@@ -64,6 +86,27 @@ class ForemanConfigUpdate(BaseModel):
     max_rounds: int | None = Field(default=None, gt=0)
     poll_min_interval: int | None = Field(default=None, gt=0)
     poll_max_interval: int | None = Field(default=None, gt=0)
+    # None (field absent) → leave existing env_vars unchanged.
+    # Empty list → clear all env_vars.
+    env_vars: list[EnvVarItem] | None = None
+
+    @field_validator("env_vars")
+    @classmethod
+    def validate_env_vars(cls, v: list[EnvVarItem] | None) -> list[EnvVarItem] | None:
+        if v is None:
+            return v
+        if len(v) > _MAX_FOREMAN_ENV_VARS:
+            raise ValueError(f"Too many env vars (max {_MAX_FOREMAN_ENV_VARS})")
+        for item in v:
+            if not _ENV_KEY_RE.match(item.key):
+                raise ValueError(
+                    f"Invalid env var key {item.key!r}; must match ^[A-Za-z_][A-Za-z0-9_]*$"
+                )
+            if item.value is not None and len(item.value) > _MAX_ENV_VALUE_LEN:
+                raise ValueError(
+                    f"Value for {item.key!r} exceeds max length ({_MAX_ENV_VALUE_LEN} chars)"
+                )
+        return v
 
 
 class MemberCreate(BaseModel):
@@ -383,12 +426,12 @@ async def get_foreman_config(
     github_user_id: str = Depends(require_member("owner")),
     db: AsyncSession = Depends(get_db_dep),
 ):
-    """Return the guild's foreman configuration (owner only)."""
+    """Return the guild's foreman configuration (owner only). Env var values are masked."""
     res = await db.exec(select(Guild).where(col(Guild.guild_id) == guild_id))
     guild = res.one_or_none()
     if not guild:
         raise HTTPException(status_code=404, detail="Guild not found")
-    return guild.foreman_config or {}
+    return _mask_foreman_config(guild.foreman_config or {})
 
 
 @router.patch("/api/guilds/{guild_id}/foreman-config")
@@ -398,7 +441,13 @@ async def update_foreman_config(
     github_user_id: str = Depends(require_member("owner")),
     db: AsyncSession = Depends(get_db_dep),
 ):
-    """Update (merge) the guild's foreman configuration (owner only)."""
+    """Update (merge) the guild's foreman configuration (owner only).
+
+    Env var values sent as null preserve the existing stored secret — the UI uses
+    this for masked (unchanged) rows so secrets don't round-trip through the browser.
+    Env var values sent as empty string or a new string replace the stored value.
+    Keys absent from the submitted list are deleted.
+    """
     res = await db.exec(select(Guild).where(col(Guild.guild_id) == guild_id))
     guild = res.one_or_none()
     if not guild:
@@ -406,13 +455,30 @@ async def update_foreman_config(
     config: dict = dict(guild.foreman_config or {})
     for field in data.model_fields_set:
         value = getattr(data, field)
-        if value is None:
+        if field == "env_vars":
+            if value is None:
+                # Explicit null → clear all env vars
+                config.pop("env_vars", None)
+            else:
+                existing_map: dict[str, str] = {
+                    e["key"]: e["value"] for e in config.get("env_vars", [])
+                }
+                new_env_vars: list[dict] = []
+                for item in value:
+                    if item.value is None:
+                        # Masked / unchanged: keep the existing stored value if present
+                        if item.key in existing_map:
+                            new_env_vars.append({"key": item.key, "value": existing_map[item.key]})
+                    else:
+                        new_env_vars.append({"key": item.key, "value": item.value})
+                config["env_vars"] = new_env_vars
+        elif value is None:
             config.pop(field, None)
         else:
             config[field] = value
     guild.foreman_config = config
     await db.commit()
-    return config
+    return _mask_foreman_config(config)
 
 
 @router.delete("/api/guilds/{guild_id}/members/{user_id}")

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -20,7 +20,7 @@ from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg, emit_terminal_line, pending_claude_auth
 from fastapi import APIRouter, Depends, HTTPException
-from models import ClaudeCredentials, Task, UserSpawnSettings, Worker, live_tasks_filter
+from models import ClaudeCredentials, Guild, Task, UserSpawnSettings, Worker, live_tasks_filter
 from pydantic import BaseModel, field_validator
 from sqlalchemy import update
 from sqlmodel import col, select
@@ -175,6 +175,19 @@ async def spawn_worker_container(
     )
     stored_blob = result.one_or_none()
 
+    # Merge guild-level foreman env vars (base) with user-supplied env vars (override).
+    guild_cfg_res = await db.exec(
+        select(col(Guild.foreman_config)).where(col(Guild.id) == guild_pk)
+    )
+    guild_cfg = guild_cfg_res.one_or_none() or {}
+    foreman_env_vars: dict[str, str] = {
+        e["key"]: e["value"]
+        for e in (guild_cfg.get("env_vars") or [])
+        if e.get("key") and e.get("value") is not None
+    }
+    # User-supplied vars at spawn time override guild defaults.
+    extra_env: dict[str, str] = {**foreman_env_vars, **(data.env_vars or {})}
+
     # Pre-register the worker so the container inherits a known worker_id and
     # can skip self-registration on startup.
     worker_id = "w-" + secrets.token_hex(3)
@@ -207,7 +220,7 @@ async def spawn_worker_container(
         auth_token=auth_token,
         agent_count=data.agent_count,
         tools=data.tools or None,
-        extra_env=data.env_vars or None,
+        extra_env=extra_env or None,
     )
 
     # Join the same Docker network as the backend so the worker can reach it.

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -214,6 +214,59 @@
               />
             </div>
           </div>
+
+          <div class="foreman-field">
+            <label class="foreman-field-label">Environment Variables / API Keys</label>
+            <div class="env-var-list">
+              <div v-for="(row, i) in envVarRows" :key="i" class="env-var-row">
+                <input
+                  v-model="row.key"
+                  class="settings-input env-var-key"
+                  placeholder="KEY_NAME"
+                  list="foreman-env-key-hints"
+                  :readonly="row.masked"
+                  @input="onEnvKeyInput(i)"
+                />
+                <template v-if="row.masked">
+                  <input
+                    class="settings-input env-var-value env-var-value--masked"
+                    value="••••••"
+                    readonly
+                    title="Click Change to update value"
+                  />
+                  <button
+                    class="env-var-change-btn pixel-btn"
+                    @click="unlockEnvVar(i)"
+                    title="Change value"
+                  >✎</button>
+                </template>
+                <template v-else>
+                  <input
+                    v-model="row.value"
+                    type="password"
+                    class="settings-input env-var-value"
+                    placeholder="value"
+                    autocomplete="new-password"
+                  />
+                </template>
+                <button
+                  class="env-var-delete-btn"
+                  @click="removeEnvVar(i)"
+                  title="Remove variable"
+                >✕</button>
+              </div>
+              <datalist id="foreman-env-key-hints">
+                <option value="ANTHROPIC_API_KEY" />
+                <option value="OPENAI_API_KEY" />
+                <option value="GITHUB_TOKEN" />
+                <option value="GEMINI_API_KEY" />
+                <option value="AWS_ACCESS_KEY_ID" />
+                <option value="AWS_SECRET_ACCESS_KEY" />
+              </datalist>
+              <button class="pixel-btn env-var-add-btn" @click="addEnvVar">+ Add Variable</button>
+            </div>
+          </div>
+
           <div class="foreman-actions">
             <button
               class="pixel-btn settings-save-btn"
@@ -298,6 +351,13 @@ const foremanSaving = ref(false)
 const foremanStatus = ref<'' | 'saved' | 'error'>('')
 let foremanStatusTimer: ReturnType<typeof setTimeout> | null = null
 
+interface EnvVarRow {
+  key: string
+  value: string
+  masked: boolean
+}
+const envVarRows = ref<EnvVarRow[]>([])
+
 async function loadForemanConfig() {
   if (!currentGuild.value) return
   try {
@@ -313,9 +373,37 @@ async function loadForemanConfig() {
       foremanMaxRounds.value = cfg.max_rounds ?? ''
       foremanPollMin.value = cfg.poll_min_interval ?? ''
       foremanPollMax.value = cfg.poll_max_interval ?? ''
+      // Env vars come back with masked values (••••••); track them as masked rows
+      envVarRows.value = (cfg.env_vars ?? []).map((e: { key: string }) => ({
+        key: e.key,
+        value: '',
+        masked: true,
+      }))
     }
   } catch {
     // non-fatal: fields stay blank (will use server defaults)
+  }
+}
+
+function addEnvVar() {
+  envVarRows.value.push({ key: '', value: '', masked: false })
+}
+
+function removeEnvVar(i: number) {
+  envVarRows.value.splice(i, 1)
+}
+
+function unlockEnvVar(i: number) {
+  envVarRows.value[i].masked = false
+  envVarRows.value[i].value = ''
+}
+
+function onEnvKeyInput(i: number) {
+  // If user edits the key of a masked row, the backend can no longer match the
+  // existing stored value, so unlock it so they must enter the value explicitly.
+  if (envVarRows.value[i].masked) {
+    envVarRows.value[i].masked = false
+    envVarRows.value[i].value = ''
   }
 }
 
@@ -337,6 +425,11 @@ async function saveForemanConfig() {
     else body.poll_min_interval = null
     if (foremanPollMax.value !== '') body.poll_max_interval = foremanPollMax.value
     else body.poll_max_interval = null
+    // Build env_vars: masked rows send null value (keep existing), unlocked rows send actual value.
+    // Skip rows with empty keys.
+    body.env_vars = envVarRows.value
+      .filter((r) => r.key.trim())
+      .map((r) => ({ key: r.key.trim(), value: r.masked ? null : r.value }))
     const res = await fetch(
       `${API_BASE}/api/guilds/${encodeURIComponent(currentGuild.value.id)}/foreman-config`,
       {
@@ -347,6 +440,13 @@ async function saveForemanConfig() {
     )
     if (res.ok) {
       foremanStatus.value = 'saved'
+      // Re-load to sync masked state with what the server now has
+      const saved = await res.json()
+      envVarRows.value = (saved.env_vars ?? []).map((e: { key: string }) => ({
+        key: e.key,
+        value: '',
+        masked: true,
+      }))
     } else {
       foremanStatus.value = 'error'
     }
@@ -429,6 +529,7 @@ watch(
     foremanPollMin.value = ''
     foremanPollMax.value = ''
     foremanStatus.value = ''
+    envVarRows.value = []
   },
   { immediate: true },
 )
@@ -928,6 +1029,78 @@ function goHome() {
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-top: 2px;
+}
+
+.env-var-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.env-var-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.env-var-key {
+  flex: 0 0 130px;
+  min-width: 0;
+  font-size: 10px;
+}
+
+.env-var-value {
+  flex: 1;
+  min-width: 0;
+  font-size: 10px;
+}
+
+.env-var-value--masked {
+  color: var(--color-text-dim);
+  letter-spacing: 2px;
+  cursor: default;
+}
+
+.env-var-change-btn {
+  font-size: 10px;
+  padding: 3px 6px;
+  flex-shrink: 0;
+  border-color: var(--color-teal);
+  color: var(--color-teal);
+}
+
+.env-var-change-btn:hover {
+  background: rgba(0, 187, 170, 0.12);
+}
+
+.env-var-delete-btn {
+  background: none;
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text-dim);
+  cursor: pointer;
+  width: 22px;
+  height: 22px;
+  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  flex-shrink: 0;
+  transition:
+    border-color 0.12s,
+    color 0.12s;
+}
+
+.env-var-delete-btn:hover {
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #c0392b);
+}
+
+.env-var-add-btn {
+  font-size: 7px;
+  padding: 4px 8px;
+  align-self: flex-start;
   margin-top: 2px;
 }
 

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -275,6 +275,38 @@ class Worker:
             os.environ["GITHUB_TOKEN"] = self.cfg.github_token
             logger.info("GITHUB_TOKEN set in environment for gh CLI and subprocesses")
 
+    async def _fetch_guild_env_vars(self) -> None:
+        """Fetch guild-level env vars from foreman config and apply to the process environment.
+
+        Only sets vars not already present — docker-provided env vars take precedence
+        so production deployments aren't overridden unexpectedly.
+        """
+        try:
+            async with await self._http(authed=True) as client:
+                resp = await client.get(f"/guilds/{self.cfg.guild_id}/foreman/env-vars")
+            if resp.status_code != 200:
+                logger.debug(
+                    "Foreman env vars: status %d (no vars or not auth'd)", resp.status_code
+                )
+                return
+            env_vars = resp.json().get("env_vars", [])
+            applied = 0
+            for item in env_vars:
+                key = item.get("key", "")
+                value = item.get("value")
+                if not key or value is None:
+                    continue
+                if key not in os.environ:
+                    os.environ[key] = value
+                    applied += 1
+                    logger.info("Applied foreman env var: %s (len=%d)", key, len(str(value)))
+                else:
+                    logger.debug("Skipping foreman env var %s (already set in environment)", key)
+            if applied:
+                logger.info("Applied %d foreman env var(s) to process environment", applied)
+        except Exception as exc:
+            logger.warning("Could not fetch foreman env vars: %s", exc)
+
     async def _check_gh_auth(self) -> None:
         """Run `gh auth status` and log the result as a startup health check."""
         try:
@@ -1181,6 +1213,7 @@ class Worker:
         assert self.cfg.worker_id, "worker_id must be set after registration"
 
         await self._fetch_github_token_if_needed()
+        await self._fetch_guild_env_vars()
         await self._refresh_github_repos()
         await self._check_gh_auth()
         await self._check_codex_doctor()


### PR DESCRIPTION
## Summary

- **UI**: Adds an "Environment Variables / API Keys" section to the foreman edit panel in `TopBar.vue`. Supports key/value rows with autocomplete hints for common keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GITHUB_TOKEN`, etc.). Values are shown as `••••••` after save; clicking the edit button unlocks the field to update.
- **Storage**: Env vars are persisted in `Guild.foreman_config` as a JSONB array `[{"key": str, "value": str}, ...]`. Validation enforces valid identifier keys, max 20 vars, and max 4096-char values.
- **Masking**: `GET /api/guilds/{guild_id}/foreman-config` and `PATCH` responses always return masked placeholder values. The bare values are never echoed back to the browser. When saving, masked (unchanged) rows send `null` for value so the server keeps the stored secret without it round-tripping through the client.
- **Injection into spawned workers**: `spawn_worker` in `backend/foreman/tools.py` and `backend/routes/workers.py` read the stored env vars and pass them as `extra_env` when launching subprocess workers, with user-supplied vars taking precedence over guild defaults.
- **Standalone worker startup**: `worker/pioneer_worker/worker.py` fetches guild env vars via the new `GET /guilds/{guild_id}/foreman/env-vars` endpoint at startup and applies any vars not already present in the process environment (so container-provided vars are never overridden).

Closes #578

## Test plan
- [ ] Open foreman edit panel → "Environment Variables / API Keys" section is visible
- [ ] Add `ANTHROPIC_API_KEY` with a test value, save → value shows as `••••••`, key is visible
- [ ] Reload page → row is still present (masked)
- [ ] Click ✎ (Change) → field unlocks, enter new value, save → still masked after save
- [ ] Spawn a worker → worker logs show `Applied foreman env var: ANTHROPIC_API_KEY`
- [ ] Delete a row and save → var is removed from storage and not injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)