### PR TITLE
fix(backend): build dnsid sdk from release tarball

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ CLAUDE_CODE_OAUTH_TOKEN=
 # Optional — if empty, worker fetches the OAuth token from the backend DB.
 GITHUB_TOKEN=
 
+# Build-only: GitHub token used by backend/Dockerfile to clone private dnsid-go.
+BUILD_GITHUB_TOKEN=
+
 # --- A2A / code-review-agent integration ---
 # REVIEWER_AGENT_URL: base URL of the A2A code-review agent.
 #   Default: https://agent.meyers.life

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,14 +3,25 @@
 # ---- dnsid-sdk build stage ----
 FROM golang:latest AS dnsid-build
 
+ARG DNSID_GO_VERSION=v0.5.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN --mount=type=secret,id=build_github_token \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    git config --global \
-        url."https://$(cat /run/secrets/build_github_token)@github.com/".insteadOf \
-        "https://github.com/" && \
-    git clone https://github.com/Identity-Digital/dnsid-go.git /src/dnsid-go && \
-    cd /src/dnsid-go && \
+    set -eu; \
+    token="$(cat /run/secrets/build_github_token)"; \
+    mkdir -p /src/dnsid-go; \
+    curl -fsSL \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/Identity-Digital/dnsid-go/tarball/${DNSID_GO_VERSION}" \
+        -o /tmp/dnsid-go.tgz; \
+    tar -xzf /tmp/dnsid-go.tgz -C /src/dnsid-go --strip-components=1; \
+    cd /src/dnsid-go; \
     go build -o /usr/local/bin/dnsid-sdk ./cmd/dnsid
 
 # ---- frontend build stage ----


### PR DESCRIPTION
## Summary\n- Pin dnsid-go build to v0.5.1\n- Fetch the private GitHub release tarball with the existing BuildKit secret instead of cloning the repo\n- Document BUILD_GITHUB_TOKEN in the example env file\n\n## Testing\n- docker compose build backend