### PR TITLE
fix(worker): probe stale workers from backend

### DIFF
--- a/backend/events.py
+++ b/backend/events.py
@@ -57,6 +57,10 @@ _agent_owner_locks: dict[str, asyncio.Lock] = {}
 # WS message or fall back to the embedded run_foreman_ai().
 foreman_connections: dict[str, WebSocket] = {}
 
+# Worker liveness probes currently awaiting a response. Keys are
+# (guild_pk, worker_id); values are the UTC instant the backend sent worker-ping.
+pending_worker_probes: dict[tuple[int, str], datetime] = {}
+
 # Optional broadcast override for the standalone foreman process.
 # When set (to an async callable with the same signature as broadcast), all
 # broadcast() calls are routed through this function instead of the in-process

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from database import AsyncSessionLocal
-from events import agent_owners, broadcast
+from events import agent_owners, broadcast, pending_worker_probes, send_ws_message
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -35,6 +35,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from util.tasks import spawn
+from ws_types import WorkerPingMsg
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
 # code reads os.environ, so ANTHROPIC_API_KEY etc. are available.
@@ -63,10 +64,14 @@ logger = logging.getLogger(__name__)
 # Liveness / sweeper config
 # ---------------------------------------------------------------------------
 
-# How long an agent/worker can go without sending any WebSocket message before
-# the sweeper marks it offline. Workers send an application-level `ping` every
-# ~25s, so 90s = three missed heartbeats.
+# How long a worker can go without sending any WebSocket message before the
+# sweeper probes it. If the worker does not answer the probe, the next sweep
+# marks it and its agents offline.
 WORKER_OFFLINE_AFTER_SECONDS = float(os.environ.get("WORKER_OFFLINE_AFTER_SECONDS", "90"))
+# How long an unanswered worker-ping is allowed to sit before the worker is
+# considered offline. The sweeper checks this on its normal interval, so the
+# practical delay is this timeout plus up to WORKER_SWEEP_INTERVAL_SECONDS.
+WORKER_PROBE_TIMEOUT_SECONDS = float(os.environ.get("WORKER_PROBE_TIMEOUT_SECONDS", "10"))
 # How often the sweeper task wakes up to look for stale agents.
 WORKER_SWEEP_INTERVAL_SECONDS = float(os.environ.get("WORKER_SWEEP_INTERVAL_SECONDS", "30"))
 
@@ -88,77 +93,136 @@ async def reset_connection_state() -> None:
 
 
 async def _sweep_stale_workers_once() -> int:
-    """One pass of the stale-worker sweep. Returns the total number of agents
-    and zombie workers marked offline. Extracted for direct testing."""
-    cutoff = datetime.now(UTC) - timedelta(seconds=WORKER_OFFLINE_AFTER_SECONDS)
-    stale_agents: list[Any] = []
-    zombie_workers: list[Any] = []
-    agent_cascade_wids: set[str] = set()
+    """One stale-worker sweep pass. Returns workers/agent-only presences marked offline."""
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(seconds=WORKER_OFFLINE_AFTER_SECONDS)
+    probe_cutoff = now - timedelta(seconds=WORKER_PROBE_TIMEOUT_SECONDS)
+    workers_marked_offline: list[Any] = []
+    agents_marked_offline: list[Any] = []
     async with AsyncSessionLocal() as db:
-        # Zombie-worker pass runs first so the agent-state guard sees pre-update
-        # states.  A zombie is a worker stuck "online" with a stale last_seen
-        # whose agents are ALL already offline (the WS close handler marked them
-        # offline but failed to flip the Worker row due to the agent_id/worker_id
-        # bug).  Workers that still have any non-offline agent are skipped here
-        # and handled via the agent cascade below.
-        zombie_workers = (
+        stale_workers = (
             await db.exec(
                 select(
                     col(Worker.id),
                     col(Worker.guild_id),
                     col(Guild.guild_id).label("guild_slug"),
+                    col(Worker.last_seen),
                 )
                 .join(Guild, col(Guild.id) == col(Worker.guild_id))
                 .where(col(Worker.state) != "offline")
                 .where(col(Worker.last_seen).isnot(None))
                 .where(col(Worker.last_seen) < cutoff)
-                .where(
-                    ~select(col(Agent.id))
-                    .where(col(Agent.worker_id) == col(Worker.id))
-                    .where(col(Agent.state) != "offline")
-                    .exists()
-                )
             )
         ).all()
 
-        stale_agents = (
+        # Agent rows that do not belong to a worker still use their own timestamp
+        # as the liveness source. Worker-owned agents are taken offline only when
+        # their parent worker fails the active probe below.
+        stale_agent_only_rows = (
             await db.exec(
                 select(
                     col(Agent.id),
                     col(Agent.guild_id),
-                    col(Agent.worker_id),
                     col(Guild.guild_id).label("guild_slug"),
                 )
                 .join(Guild, col(Guild.id) == col(Agent.guild_id))
                 .where(col(Agent.state) != "offline")
+                .where(col(Agent.worker_id).is_(None))
                 .where(col(Agent.last_seen).isnot(None))
                 .where(col(Agent.last_seen) < cutoff)
             )
         ).all()
-        # stale_worker_keys stores (worker_id, guild_id) where guild_id is the
-        # integer FK to guilds.id (not the text slug guild_slug selected above).
-        stale_worker_keys: set[tuple[str, int]] = set()
-        for row in stale_agents:
+
+        for row in stale_agent_only_rows:
             await db.exec(
                 update(Agent)
                 .where(col(Agent.id) == row.id, col(Agent.guild_id) == row.guild_id)
                 .values(state="offline", activity=None, current_task_id=None)
             )
-            if row.worker_id:
-                stale_worker_keys.add((row.worker_id, row.guild_id))
-                agent_cascade_wids.add(row.worker_id)
             agent_owners.pop(row.id, None)
+            agents_marked_offline.append(row)
 
-        for row in zombie_workers:
-            stale_worker_keys.add((row.id, row.guild_id))
+        for row in stale_workers:
+            key = (row.guild_id, row.id)
+            agent_ids = (
+                await db.exec(
+                    select(col(Agent.id)).where(
+                        col(Agent.worker_id) == row.id,
+                        col(Agent.guild_id) == row.guild_id,
+                        col(Agent.state) != "offline",
+                    )
+                )
+            ).all()
+            owner_ws = next(
+                (ws for agent_id in agent_ids if (ws := agent_owners.get(agent_id)) is not None),
+                None,
+            )
+            pending_since = pending_worker_probes.get(key)
+            should_mark_offline = False
 
-        for worker_id, gpk in stale_worker_keys:
+            if owner_ws is None:
+                should_mark_offline = True
+            elif pending_since is not None and pending_since < probe_cutoff:
+                should_mark_offline = True
+            elif pending_since is None:
+                try:
+                    await send_ws_message(
+                        owner_ws,
+                        WorkerPingMsg(workerId=row.id, timestamp=now.isoformat()),
+                    )
+                    pending_worker_probes[key] = now
+                    logger.info(
+                        "Sent liveness probe to worker %s after %.0fs without inbound WS frame"
+                        " (guild=%s)",
+                        row.id,
+                        WORKER_OFFLINE_AFTER_SECONDS,
+                        row.guild_slug,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Worker liveness probe failed for %s (guild=%s); marking offline",
+                        row.id,
+                        row.guild_slug,
+                        exc_info=True,
+                    )
+                    should_mark_offline = True
+
+            if not should_mark_offline:
+                continue
+
+            workers_marked_offline.append(row)
+            pending_worker_probes.pop(key, None)
+            worker_agent_rows = (
+                await db.exec(
+                    select(
+                        col(Agent.id),
+                        col(Agent.guild_id),
+                        col(Guild.guild_id).label("guild_slug"),
+                    )
+                    .join(Guild, col(Guild.id) == col(Agent.guild_id))
+                    .where(
+                        col(Agent.worker_id) == row.id,
+                        col(Agent.guild_id) == row.guild_id,
+                        col(Agent.state) != "offline",
+                    )
+                )
+            ).all()
+            for agent_row in worker_agent_rows:
+                await db.exec(
+                    update(Agent)
+                    .where(col(Agent.id) == agent_row.id, col(Agent.guild_id) == row.guild_id)
+                    .values(state="offline", activity=None, current_task_id=None)
+                )
+                agent_owners.pop(agent_row.id, None)
+                agents_marked_offline.append(agent_row)
+
             await db.exec(
                 update(Worker)
-                .where(col(Worker.id) == worker_id, col(Worker.guild_id) == gpk)
+                .where(col(Worker.id) == row.id, col(Worker.guild_id) == row.guild_id)
                 .values(state="offline")
             )
-        if stale_agents or zombie_workers:
+
+        if agents_marked_offline or workers_marked_offline:
             await db.commit()
 
     async with AsyncSessionLocal() as db:
@@ -222,9 +286,9 @@ async def _sweep_stale_workers_once() -> int:
             WORKER_OFFLINE_AFTER_SECONDS,
         )
 
-    for row in stale_agents:
+    for row in agents_marked_offline:
         logger.warning(
-            "Marking %s offline: no ping in over %.0fs (guild=%s)",
+            "Marking %s offline: no live parent worker or agent frame in over %.0fs (guild=%s)",
             row.id,
             WORKER_OFFLINE_AFTER_SECONDS,
             row.guild_slug,
@@ -233,27 +297,18 @@ async def _sweep_stale_workers_once() -> int:
             row.guild_slug,
             {"type": "agent-state", "agentId": row.id, "state": "offline"},
         )
-    # Log zombie workers not already covered by the per-agent log above.
-    for row in zombie_workers:
-        if row.id not in agent_cascade_wids:
-            logger.warning(
-                "Marking zombie worker %s offline: no ping in over %.0fs,"
-                " no active agents (guild=%s)",
-                row.id,
-                WORKER_OFFLINE_AFTER_SECONDS,
-                row.guild_slug,
-            )
-    return len(stale_agents) + len(zombie_workers)
+    for row in workers_marked_offline:
+        logger.warning(
+            "Marking worker %s offline: no liveness probe response after %.0fs stale (guild=%s)",
+            row.id,
+            WORKER_OFFLINE_AFTER_SECONDS,
+            row.guild_slug,
+        )
+    return len(workers_marked_offline) + len(stale_agent_only_rows)
 
 
 async def _stale_worker_sweeper() -> None:
-    """Background task: mark workers/agents offline if they haven't pinged recently.
-
-    Runs forever (cancelled at app shutdown). The websocket library's own
-    ping/pong catches dead TCP connections, but a worker process could be
-    stuck in a way that still answers protocol pings; the application-level
-    `ping` heartbeat is what this sweeper actually relies on.
-    """
+    """Background task: probe stale workers and mark unresponsive workers offline."""
     logger.info(
         "Stale-worker sweeper started: threshold=%.1fs interval=%.1fs",
         WORKER_OFFLINE_AFTER_SECONDS,

--- a/backend/models.py
+++ b/backend/models.py
@@ -68,9 +68,8 @@ class Agent(SQLModel, table=True):
     # share a worker_id.
     current_task_id: str | None = None
     joined_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
-    # UTC instant of the last message received from this agent over the
-    # WebSocket. Refreshed by every inbound frame (incl. application-level
-    # `ping`); the sweeper marks the agent offline when this gets stale.
+    # UTC instant of the last agent-scoped message received over the WebSocket.
+    # Worker-scoped liveness frames update Worker.last_seen instead.
     last_seen: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
@@ -111,6 +110,9 @@ class Worker(SQLModel, table=True):
     org: str | None = None
     state: str = Field(default="idle", sa_column_kwargs={"server_default": "'idle'"})
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    # UTC instant of the last worker-scoped or agent-scoped frame received from
+    # this worker process. The backend probes stale workers before marking them
+    # and their agents offline.
     last_seen: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -20,6 +20,7 @@ from events import (
     broadcast_msg,
     connections,
     foreman_connections,
+    pending_worker_probes,
 )
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from models import Agent, Guild, UserSession, Worker
@@ -35,40 +36,37 @@ logger = logging.getLogger(__name__)
 async def _touch_agent(
     db, guild_pk: int | None, agent_id: str | None, worker_id: str | None = None
 ) -> None:
-    """Refresh ``last_seen`` for the agent (and its worker) so the sweeper
-    knows the connection is still alive. Called for every inbound WS frame.
+    """Refresh ``last_seen`` for the sender named by an inbound WS frame.
 
-    If *worker_id* isn't passed we look it up from the agent row so messages
-    that only carry an ``agentId`` (most of them) still keep the worker fresh.
-    Once we know the worker, we also refresh every other agent owned by it —
-    a single worker process owns all its slots over one socket, so any
-    inbound frame proves the whole worker is alive.
+    Agent-scoped frames refresh that agent and its parent worker. Worker-scoped
+    frames refresh only the worker row; they do not imply that sibling agent
+    slots emitted anything.
     """
     if not guild_pk:
         return
     if not agent_id and not worker_id:
         return
     now = datetime.now(UTC)
-    if agent_id and worker_id is None:
-        res = await db.exec(select(col(Agent.worker_id)).where(col(Agent.id) == agent_id))
-        worker_id = res.one_or_none()
+    if agent_id:
+        if worker_id is None:
+            res = await db.exec(
+                select(col(Agent.worker_id)).where(
+                    col(Agent.id) == agent_id, col(Agent.guild_id) == guild_pk
+                )
+            )
+            worker_id = res.one_or_none()
+        await db.exec(
+            update(Agent)
+            .where(col(Agent.id) == agent_id, col(Agent.guild_id) == guild_pk)
+            .values(last_seen=now)
+        )
     if worker_id:
         await db.exec(
             update(Worker)
             .where(col(Worker.id) == worker_id, col(Worker.guild_id) == guild_pk)
             .values(last_seen=now)
         )
-        await db.exec(
-            update(Agent)
-            .where(col(Agent.worker_id) == worker_id, col(Agent.guild_id) == guild_pk)
-            .values(last_seen=now)
-        )
-    elif agent_id:
-        await db.exec(
-            update(Agent)
-            .where(col(Agent.id) == agent_id, col(Agent.guild_id) == guild_pk)
-            .values(last_seen=now)
-        )
+        pending_worker_probes.pop((guild_pk, worker_id), None)
     await db.commit()
 
 
@@ -130,9 +128,9 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
         while True:
             data = await websocket.receive_json()
 
-            # Refresh last_seen for any inbound frame so the sweeper knows
-            # this worker is still alive. Cheap no-op for browser users
-            # (they don't carry an agentId/workerId).
+            # Refresh last_seen for the inbound frame's sender. Worker-scoped
+            # messages only touch Worker.last_seen; agent-scoped messages touch
+            # that agent and the parent worker.
             await _touch_agent(db, ctx.guild_pk, data.get("agentId"), data.get("workerId"))
 
             await ws_handlers.dispatch(ctx, data)

--- a/backend/tests/test_liveness.py
+++ b/backend/tests/test_liveness.py
@@ -1,10 +1,9 @@
 """Tests for WebSocket liveness tracking.
 
 Covers:
-  - inbound frames refresh ``last_seen`` on the agent and worker rows
+  - inbound frames refresh ``last_seen`` only for the sender and parent worker
   - the ``ping`` message is answered with ``pong``
-  - the stale-worker sweeper marks workers offline once ``last_seen`` is
-    older than the configured threshold and broadcasts the state change
+  - the stale-worker sweeper probes workers before marking them offline
 """
 
 from __future__ import annotations
@@ -24,6 +23,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
 import database as database_module  # noqa: E402
+import events as events_module  # noqa: E402
 import main as main_module  # noqa: E402
 from _test_config import TEST_DATABASE_URL  # noqa: E402
 from helpers import _sync_session, insert_guild, insert_worker, truncate_all  # noqa: E402
@@ -59,6 +59,13 @@ def client():
         yield c, db_url
 
     mp.undo()
+
+
+@pytest.fixture(autouse=True)
+def _clear_liveness_state():
+    events_module.pending_worker_probes.clear()
+    yield
+    events_module.pending_worker_probes.clear()
 
 
 def _setup_guild_and_worker(db_url: str, guild_id: str, worker_id: str) -> None:
@@ -107,8 +114,8 @@ def test_join_initialises_last_seen(client):
     assert worker_seen >= before - timedelta(seconds=5)
 
 
-def test_ping_message_replies_pong_and_refreshes_last_seen(client):
-    """Application-level ping is acknowledged with pong and bumps last_seen."""
+def test_ping_message_replies_pong_and_refreshes_worker_last_seen_only(client):
+    """Worker-scoped ping is acknowledged and bumps only Worker.last_seen."""
     test_client, db_url = client
     guild_id = "lvg002"
     worker_id = "w-lvb002"
@@ -138,21 +145,18 @@ def test_ping_message_replies_pong_and_refreshes_last_seen(client):
             )
             session.commit()
 
-        # Heartbeat ping carries only workerId — backend looks up agents from
-        # the worker_id and refreshes them all together.
         ws.send_json({"type": "ping", "workerId": worker_id})
         reply = ws.receive_json()
         assert reply["type"] == "pong"
         assert "timestamp" in reply
 
     agent_seen, worker_seen = _read_last_seen(db_url, agent_id, worker_id)
-    assert agent_seen is not None and str(agent_seen) != old_ts
-    assert worker_seen is not None and str(worker_seen) != old_ts
+    assert str(agent_seen) == str(old_ts)
+    assert worker_seen is not None and str(worker_seen) != str(old_ts)
 
 
-def test_any_inbound_frame_touches_sibling_agents(client):
-    """A ping carrying agent slot 0's id must also refresh sibling slot rows
-    so that idle slots aren't swept offline while their parent worker is alive."""
+def test_agent_scoped_frame_touches_agent_and_parent_but_not_siblings(client):
+    """An agent-scoped frame refreshes that slot and its worker, not siblings."""
     test_client, db_url = client
     guild_id = "lvg003"
     worker_id = "w-lvc003"
@@ -180,20 +184,129 @@ def test_any_inbound_frame_touches_sibling_agents(client):
             session.execute(
                 update(Agent).where(col(Agent.worker_id) == worker_id).values(last_seen=old_ts)
             )
+            session.execute(
+                update(Worker).where(col(Worker.id) == worker_id).values(last_seen=old_ts)
+            )
             session.commit()
 
-        ws.send_json({"type": "ping", "workerId": worker_id})
-        ws.receive_json()  # pong
+        ws.send_json(
+            {
+                "type": "agent-state",
+                "agentId": slot0,
+                "workerId": worker_id,
+                "state": "idle",
+            }
+        )
+        ws.receive_json()  # agent-state broadcast
 
-    seen0, _ = _read_last_seen(db_url, slot0, worker_id)
+    seen0, worker_seen = _read_last_seen(db_url, slot0, worker_id)
     seen1, _ = _read_last_seen(db_url, slot1, worker_id)
-    assert str(seen0) != old_ts, "slot 0 should be refreshed via the worker_id ping"
-    assert str(seen1) != old_ts, "slot 1 should be refreshed via the worker_id ping"
+    assert str(seen0) != str(old_ts), "slot 0 should be refreshed by its own frame"
+    assert str(seen1) == str(old_ts), "sibling slots should not be refreshed"
+    assert worker_seen is not None and str(worker_seen) != str(old_ts)
+
+
+def test_sweeper_probes_stale_connected_worker_before_marking_offline(client, monkeypatch):
+    """A stale worker with an owned socket gets worker-ping before offline cleanup."""
+    test_client, db_url = client
+    guild_id = "lvg0p1"
+    worker_id = "w-lvp001"
+    agent_id = "a-lvp001"
+
+    _setup_guild_and_worker(db_url, guild_id, worker_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+        ws.send_json(
+            {
+                "type": "join",
+                "agentId": agent_id,
+                "agentName": "Test",
+                "agentType": "worker",
+                "workerId": worker_id,
+            }
+        )
+        ws.receive_json()  # agent-joined
+
+        old_ts = datetime.now(UTC) - timedelta(minutes=5)
+        with _sync_session(db_url) as session:
+            session.execute(update(Agent).where(col(Agent.id) == agent_id).values(last_seen=old_ts))
+            session.execute(
+                update(Worker).where(col(Worker.id) == worker_id).values(last_seen=old_ts)
+            )
+            session.commit()
+
+        monkeypatch.setattr(main_module, "WORKER_OFFLINE_AFTER_SECONDS", 1.0)
+        monkeypatch.setattr(main_module, "WORKER_PROBE_TIMEOUT_SECONDS", 10.0)
+
+        marked = asyncio.run(main_module._sweep_stale_workers_once())
+        assert marked == 0
+
+        probe = ws.receive_json()
+        assert probe["type"] == "worker-ping"
+        assert probe["workerId"] == worker_id
+        assert probe["from"] == "foreman"
+
+        ws.send_json({"type": "worker-pong", "workerId": worker_id})
+        ws.send_json({"type": "ping"})
+        assert ws.receive_json()["type"] == "pong"
+
+        agent_seen, worker_seen = _read_last_seen(db_url, agent_id, worker_id)
+        assert str(agent_seen) == str(old_ts)
+        assert worker_seen is not None and str(worker_seen) != str(old_ts)
+
+
+def test_sweeper_marks_stale_connected_worker_after_probe_timeout(client, monkeypatch):
+    """If a stale connected worker does not answer worker-ping, it is marked offline."""
+    test_client, db_url = client
+    guild_id = "lvg0p2"
+    worker_id = "w-lvp002"
+    agent_id = "a-lvp002"
+
+    _setup_guild_and_worker(db_url, guild_id, worker_id)
+
+    with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+        ws.send_json(
+            {
+                "type": "join",
+                "agentId": agent_id,
+                "agentName": "Test",
+                "agentType": "worker",
+                "workerId": worker_id,
+            }
+        )
+        ws.receive_json()  # agent-joined
+
+        old_ts = datetime.now(UTC) - timedelta(minutes=5)
+        with _sync_session(db_url) as session:
+            session.execute(update(Agent).where(col(Agent.id) == agent_id).values(last_seen=old_ts))
+            session.execute(
+                update(Worker).where(col(Worker.id) == worker_id).values(last_seen=old_ts)
+            )
+            session.commit()
+
+        monkeypatch.setattr(main_module, "WORKER_OFFLINE_AFTER_SECONDS", 1.0)
+        monkeypatch.setattr(main_module, "WORKER_PROBE_TIMEOUT_SECONDS", 0.0)
+
+        marked = asyncio.run(main_module._sweep_stale_workers_once())
+        assert marked == 0
+        assert ws.receive_json()["type"] == "worker-ping"
+
+        marked = asyncio.run(main_module._sweep_stale_workers_once())
+        assert marked == 1
+        offline = ws.receive_json()
+        assert offline["type"] == "agent-state"
+        assert offline["agentId"] == agent_id
+        assert offline["state"] == "offline"
+
+        with _sync_session(db_url) as session:
+            a_state = session.scalar(select(col(Agent.state)).where(col(Agent.id) == agent_id))
+            w_state = session.scalar(select(col(Worker.state)).where(col(Worker.id) == worker_id))
+        assert a_state == "offline"
+        assert w_state == "offline"
 
 
 def test_stale_sweeper_marks_silent_workers_offline(client, monkeypatch):
-    """The sweeper marks any agent whose last_seen is past the cutoff offline,
-    cascades to the worker row, and emits an agent-state offline broadcast."""
+    """A stale worker with no owned socket is marked offline immediately."""
     test_client, db_url = client
     guild_id = "lvg004"
     worker_id = "w-lvd004"

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -230,9 +230,17 @@ class WSContext:
 
 
 async def handle_ping(ctx: WSContext, data: dict) -> None:
-    """Application-level heartbeat. Reply with pong so the worker can detect a
-    half-open socket too."""
+    """Generic application-level ping used by tests and legacy clients."""
     await send_ws_message(ctx.websocket, PongMsg(timestamp=datetime.now(UTC).isoformat()))
+
+
+async def handle_worker_pong(ctx: WSContext, data: dict) -> None:
+    """Worker liveness probe reply.
+
+    ``routes.websocket._touch_agent`` already refreshed Worker.last_seen before
+    dispatch. The explicit handler keeps this protocol message from falling
+    through to legacy broadcast behaviour.
+    """
 
 
 async def handle_join(ctx: WSContext, data: dict) -> None:
@@ -1007,6 +1015,7 @@ HANDLERS: dict[str, Any] = {
     "terminal-output": handle_terminal_output,
     "worker-register": handle_worker_register,
     "worker-disconnect": handle_worker_disconnect,
+    "worker-pong": handle_worker_pong,
     "task-update": handle_task_update,
     "task-complete": handle_task_complete,
     "task-followup-done": handle_task_followup_done,

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -247,6 +247,13 @@ class WorkerShutdownMsg(_WS):
     reason: str | None = None
 
 
+class WorkerPingMsg(_WS):
+    type: Literal["worker-ping"] = "worker-ping"
+    workerId: str
+    timestamp: str
+    from_: str = Field("foreman", alias="from")
+
+
 class ForemanTriggerMsg(_WS):
     type: Literal["foreman-trigger"] = "foreman-trigger"
     event: str
@@ -360,6 +367,12 @@ class WorkerDisconnectMsg(_WS):
     workerId: str | None = None
 
 
+class WorkerPongMsg(_WS):
+    type: Literal["worker-pong"] = "worker-pong"
+    workerId: str
+    timestamp: str | None = None
+
+
 class ForemanBroadcastMsg(_WS):
     type: Literal["foreman-broadcast"] = "foreman-broadcast"
     payload: dict[str, Any]
@@ -389,6 +402,7 @@ OutboundWSMessage = Annotated[
     | WorkerAuthResponseMsg
     | WorkerMessageMsg
     | WorkerShutdownMsg
+    | WorkerPingMsg
     | ForemanTriggerMsg
     | ForemanRegisteredMsg
     | ForemanEvictedMsg
@@ -411,6 +425,7 @@ InboundWSMessage = Annotated[
     | TerminalOutputMsg
     | WorkerRegisterMsg
     | WorkerDisconnectMsg
+    | WorkerPongMsg
     | TaskUpdateMsg
     | TaskCompleteMsg
     | TaskFollowupDoneMsg
@@ -437,6 +452,7 @@ KNOWN_INBOUND_TYPES: frozenset[str] = frozenset(
         "terminal-output",
         "worker-register",
         "worker-disconnect",
+        "worker-pong",
         "task-update",
         "task-complete",
         "task-followup-done",

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1134,38 +1134,6 @@ class Worker:
         )
         loop.create_task(self._initiate_shutdown(f"signal {sig.name}"))
 
-    # Interval between application-level pings sent to the backend. Three
-    # missed heartbeats (~75s) is enough to trip the backend's 90s sweeper.
-    HEARTBEAT_INTERVAL_SECONDS: float = 25.0
-
-    async def _heartbeat(self) -> None:
-        """Send an application-level ping to the backend on a steady cadence.
-
-        The websockets library handles transport-level ping/pong on its own,
-        but the backend can't see those frames — its liveness tracking runs
-        on application messages. Without this loop a worker that finishes
-        all its tasks would go silent and the sweeper would mark it offline
-        even though the connection is healthy.
-        """
-        while not self._shutdown_event.is_set():
-            try:
-                await self._send(
-                    {
-                        "type": "ping",
-                        "workerId": self.cfg.worker_id,
-                        "timestamp": _now_iso(),
-                    }
-                )
-            except Exception as exc:
-                logger.debug("Heartbeat send failed (ignored): %s", exc)
-            try:
-                await asyncio.wait_for(
-                    self._shutdown_event.wait(), timeout=self.HEARTBEAT_INTERVAL_SECONDS
-                )
-                return  # shutdown event fired
-            except TimeoutError:
-                continue
-
     async def _notify_offline(self) -> None:
         """Send an explicit worker-disconnect message before the WebSocket closes.
 
@@ -1271,13 +1239,12 @@ class Worker:
 
         runners = [asyncio.create_task(self._agent_loop(slot)) for slot in self.agents]
         puller = asyncio.create_task(self._idle_puller())
-        heartbeat = asyncio.create_task(self._heartbeat())
         sweeper = asyncio.create_task(self._worktree_sweeper())
         try:
             # Wait for either: all runners exit (graceful shutdown), or one of
             # the auxiliary tasks crashes (unexpected).
             done, _pending = await asyncio.wait(
-                [listener, puller, heartbeat, sweeper, *runners],
+                [listener, puller, sweeper, *runners],
                 return_when=asyncio.FIRST_COMPLETED,
             )
             # Surface any non-cancellation exception that fired first.
@@ -1298,12 +1265,9 @@ class Worker:
             # Stop the auxiliary tasks; the agent loops drain themselves.
             listener.cancel()
             puller.cancel()
-            heartbeat.cancel()
             sweeper.cancel()
 
-            await asyncio.gather(
-                listener, puller, heartbeat, sweeper, *runners, return_exceptions=True
-            )
+            await asyncio.gather(listener, puller, sweeper, *runners, return_exceptions=True)
 
             if first_exc is not None:
                 raise first_exc
@@ -1319,9 +1283,9 @@ class Worker:
         logger.info("Listener started")
         # Message types safe to process before _join() completes — auth-related
         # messages flow during the pre-join window (claude setup-token), and
-        # heartbeats are protocol-level. Everything else (task assignments,
-        # follow-ups, redirects, etc.) must wait until we've actually joined,
-        # otherwise we'd start work before the backend sees us online.
+        # Everything else (task assignments, follow-ups, redirects, etc.) must
+        # wait until we've actually joined, otherwise we'd start work before
+        # the backend sees us online.
         _PRE_JOIN_ALLOWED = {"pong", "worker-message", "worker-auth-response"}
         async for msg in self.ws.messages():
             mtype = msg.get("type")
@@ -1332,7 +1296,20 @@ class Worker:
                 continue
 
             if mtype == "pong":
-                # Heartbeat reply from the backend; nothing to do.
+                # Generic ping reply from the backend; nothing to do.
+                continue
+
+            if mtype == "worker-ping":
+                target = msg.get("workerId")
+                if target and target != self.cfg.worker_id:
+                    continue
+                await self._send(
+                    {
+                        "type": "worker-pong",
+                        "workerId": self.cfg.worker_id,
+                        "timestamp": _now_iso(),
+                    }
+                )
                 continue
 
             if mtype == "task-assigned":

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -29,7 +29,6 @@ def _is_open(ws) -> bool:
 def _backoff_delay(attempt: int, base: float, cap: float) -> float:
     """Exponential backoff with full jitter."""
     return min(cap, base * (2**attempt)) + random.uniform(0, base)
-    
 
 
 class WSClient:

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -181,57 +181,26 @@ async def test_set_state_tracks_state_on_slot():
     assert slot.state == "awaiting-review"
 
 
-async def test_heartbeat_sends_ping_messages(monkeypatch):
-    """The heartbeat task must send periodic ping frames carrying worker_id +
-    slot 0's agent_id so the backend can refresh last_seen."""
-    monkeypatch.setattr(Worker, "HEARTBEAT_INTERVAL_SECONDS", 0.05)
+async def test_worker_ping_replies_with_worker_pong():
+    """The worker replies to backend liveness probes with worker-pong."""
     worker = Worker(_make_cfg())
+    worker._joined = True
     sent: list[dict] = []
     worker._send = AsyncMock(side_effect=lambda p: sent.append(p))
 
-    task = asyncio.create_task(worker._heartbeat())
-    await asyncio.sleep(0.2)
-    worker._shutdown_event.set()
-    await asyncio.wait_for(task, timeout=1.0)
+    async def messages():
+        yield {"type": "worker-ping", "workerId": "w-test01", "timestamp": "now"}
+        await asyncio.sleep(3600)
 
-    pings = [m for m in sent if m.get("type") == "ping"]
-    assert pings, f"Expected at least one ping, got: {sent}"
-    first = pings[0]
-    assert first["workerId"] == "w-test01"
-    assert "timestamp" in first
-    # Heartbeat is a worker-level signal; it must not be tied to any agent slot.
-    assert "agentId" not in first
+    worker.ws.messages = messages
 
+    task = asyncio.create_task(worker._listen())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
-async def test_heartbeat_stops_when_shutdown_signalled():
-    """_heartbeat must exit promptly once the shutdown event fires."""
-    worker = Worker(_make_cfg())
-    worker._send = AsyncMock()
-
-    worker._shutdown_event.set()
-    # Should return without hanging since shutdown is already signalled.
-    await asyncio.wait_for(worker._heartbeat(), timeout=2.0)
-
-
-async def test_heartbeat_swallows_send_failures(monkeypatch):
-    """A transient send failure must not kill the heartbeat loop."""
-    monkeypatch.setattr(Worker, "HEARTBEAT_INTERVAL_SECONDS", 0.02)
-    worker = Worker(_make_cfg())
-    calls = 0
-
-    async def flaky(_payload: dict) -> None:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            raise OSError("transient")
-
-    worker._send = flaky
-
-    async def stop_soon() -> None:
-        await asyncio.sleep(0.1)
-        worker._shutdown_event.set()
-
-    asyncio.create_task(stop_soon())
-    # Should not raise even though the first send failed.
-    await asyncio.wait_for(worker._heartbeat(), timeout=2.0)
-    assert calls >= 2, f"Loop should keep going after send failure, got {calls} calls"
+    pongs = [m for m in sent if m.get("type") == "worker-pong"]
+    assert len(pongs) == 1, f"Expected one worker-pong, got: {sent}"
+    assert pongs[0]["workerId"] == "w-test01"
+    assert "timestamp" in pongs[0]


### PR DESCRIPTION
## Summary
- remove the worker daemon's periodic application heartbeat loop
- keep Worker.last_seen worker-scoped and Agent.last_seen agent-scoped, without refreshing sibling agents
- add backend worker-ping / worker-pong liveness probes before stale worker cleanup

## Tests
- ruff check .
- ruff format . --check
- cd backend && .venv/bin/python -m pytest
- cd worker && python -m pytest