### PR TITLE
Add api_request_log + refactor foreman_turns (#583)

### DIFF
--- a/backend/alembic/versions/20260605_000002_add_api_request_log.py
+++ b/backend/alembic/versions/20260605_000002_add_api_request_log.py
@@ -1,0 +1,57 @@
+"""Add api_request_log table.
+
+Revision ID: 20260605_000002_add_api_request_log
+Revises: 20260605_000001_add_api_calls_to_foreman_turns
+Create Date: 2026-06-05
+
+Records every Anthropic messages.create() call made by the foreman: the full
+request (model, system prompt, messages, extra params) and the full response
+(request_id header, response body, token usage, stop_reason). Created before
+the API call; updated after. foreman_turns.request_id FK points here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260605_000002_add_api_request_log"
+down_revision: str | Sequence[str] | None = "20260605_000001_add_api_calls_to_foreman_turns"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_request_log",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        # Anthropic x-request-id response header; nullable until the call completes.
+        sa.Column("request_id", sa.Text(), nullable=True, unique=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("model", sa.Text(), nullable=False),
+        # Full JSON of the system blocks sent (serialized list of content block dicts).
+        sa.Column("system", sa.Text(), nullable=True),
+        # Full outbound messages array as JSONB.
+        sa.Column("messages", sa.JSON(), nullable=True),
+        # Full response body from Anthropic as JSONB.
+        sa.Column("response", sa.JSON(), nullable=True),
+        sa.Column("input_tokens", sa.Integer(), nullable=True),
+        sa.Column("output_tokens", sa.Integer(), nullable=True),
+        sa.Column("cache_read_tokens", sa.Integer(), nullable=True),
+        sa.Column("cache_write_tokens", sa.Integer(), nullable=True),
+        sa.Column("stop_reason", sa.Text(), nullable=True),
+        sa.Column("task_id", sa.Text(), sa.ForeignKey("tasks.id"), nullable=True),
+        # Extra API parameters: max_tokens, tools, tool_choice, etc.
+        sa.Column("extra", sa.JSON(), nullable=True),
+    )
+    op.create_index("ix_api_request_log_task_id", "api_request_log", ["task_id"])
+    op.create_index("ix_api_request_log_created_at", "api_request_log", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_api_request_log_created_at", table_name="api_request_log")
+    op.drop_index("ix_api_request_log_task_id", table_name="api_request_log")
+    op.drop_table("api_request_log")

--- a/backend/alembic/versions/20260605_000002_add_api_request_log.py
+++ b/backend/alembic/versions/20260605_000002_add_api_request_log.py
@@ -32,8 +32,8 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("model", sa.Text(), nullable=False),
-        # Full JSON of the system blocks sent (serialized list of content block dicts).
-        sa.Column("system", sa.Text(), nullable=True),
+        # Full list of system content blocks sent (matches the list passed to the API).
+        sa.Column("system", sa.JSON(), nullable=True),
         # Full outbound messages array as JSONB.
         sa.Column("messages", sa.JSON(), nullable=True),
         # Full response body from Anthropic as JSONB.

--- a/backend/alembic/versions/20260605_000003_refactor_foreman_turns.py
+++ b/backend/alembic/versions/20260605_000003_refactor_foreman_turns.py
@@ -1,0 +1,56 @@
+"""Refactor foreman_turns: add request_id FK and task_id columns.
+
+Revision ID: 20260605_000003_refactor_foreman_turns
+Revises: 20260605_000002_add_api_request_log
+Create Date: 2026-06-05
+
+Adds:
+  - foreman_turns.request_id  INT  FK → api_request_log.id  (nullable)
+  - foreman_turns.task_id     TEXT FK → tasks.id            (nullable)
+
+Usage columns (input_tokens, output_tokens) are left as-is — nullable and
+kept for historical rows. New rows should get usage from api_request_log
+instead; foreman runner no longer writes those columns.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260605_000003_refactor_foreman_turns"
+down_revision: str | Sequence[str] | None = "20260605_000002_add_api_request_log"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "foreman_turns",
+        sa.Column(
+            "request_id",
+            sa.Integer(),
+            sa.ForeignKey("api_request_log.id"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "foreman_turns",
+        sa.Column(
+            "task_id",
+            sa.Text(),
+            sa.ForeignKey("tasks.id"),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_foreman_turns_request_id", "foreman_turns", ["request_id"])
+    op.create_index("ix_foreman_turns_task_id", "foreman_turns", ["task_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_foreman_turns_task_id", table_name="foreman_turns")
+    op.drop_index("ix_foreman_turns_request_id", table_name="foreman_turns")
+    op.drop_column("foreman_turns", "task_id")
+    op.drop_column("foreman_turns", "request_id")

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -210,7 +210,7 @@ async def _create_api_request_log(
         log = ApiRequestLog(
             created_at=datetime.now(UTC),
             model=model,
-            system=json.dumps(system_blocks),
+            system=system_blocks,
             messages=messages,
             extra=extra or None,
             task_id=task_id,
@@ -218,7 +218,9 @@ async def _create_api_request_log(
         db.add(log)
         await db.commit()
         await db.refresh(log)
-        return log.id or 0
+        if log.id is None:
+            raise RuntimeError("api_request_log row has no id after commit")
+        return log.id
     finally:
         await db.close()
 
@@ -482,6 +484,7 @@ async def _run_foreman_ai(
             {**dict(r._mapping), "description": dict(r._mapping).get("description") or ""}
             for r in task_result.all()
         ]
+        _task_id: str | None = task_rows[0]["id"] if len(task_rows) == 1 else None
     except Exception:
         await db.close()
         raise
@@ -571,7 +574,8 @@ async def _run_foreman_ai(
                 model=foreman_model,
                 system_blocks=system_blocks,
                 messages=messages,
-                extra={"max_tokens": 1024, "tools": [t["name"] for t in FOREMAN_TOOLS]},
+                extra={"max_tokens": 1024, "tools": FOREMAN_TOOLS},
+                task_id=_task_id,
             )
             _raw = await client.messages.with_raw_response.create(
                 model=foreman_model,
@@ -603,7 +607,7 @@ async def _run_foreman_ai(
             await _complete_api_request_log(
                 api_log_id,
                 request_id=_anthropic_request_id,
-                response_dict=json.loads(_serialize_content(resp.content)),
+                response_dict=resp.model_dump(),
                 input_tokens=_input_tokens,
                 output_tokens=_output_tokens,
                 cache_read_tokens=_cache_read,
@@ -787,9 +791,10 @@ async def _run_foreman_ai(
                 messages=messages,
                 extra={
                     "max_tokens": 1024,
-                    "tools": [t["name"] for t in FOREMAN_TOOLS],
+                    "tools": FOREMAN_TOOLS,
                     "tool_choice": {"type": "none"},
                 },
+                task_id=_task_id,
             )
             _wrap_raw = await client.messages.with_raw_response.create(
                 model=foreman_model,
@@ -820,7 +825,7 @@ async def _run_foreman_ai(
             await _complete_api_request_log(
                 _wrap_api_log_id,
                 request_id=_wrap_request_id,
-                response_dict=json.loads(_serialize_content(wrap_resp.content)),
+                response_dict=wrap_resp.model_dump(),
                 input_tokens=_wrap_input,
                 output_tokens=_wrap_output,
                 cache_read_tokens=_wrap_cache_read,

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -28,7 +28,17 @@ from foreman_core.message_utils import (
     truncate_tool_result,
 )
 from foreman_core.tools_schema import FOREMAN_TOOLS
-from models import Agent, ForemanTurn, Guild, GuildMember, Message, Task, Worker, live_tasks_filter
+from models import (
+    Agent,
+    ApiRequestLog,
+    ForemanTurn,
+    Guild,
+    GuildMember,
+    Message,
+    Task,
+    Worker,
+    live_tasks_filter,
+)
 from sqlalchemy import delete, func
 from sqlmodel import col, select
 from util.tasks import spawn
@@ -157,6 +167,8 @@ async def _save_turn(
     is_tool_response: bool = False,
     parent_id: int | None = None,
     api_calls: list | None = None,
+    api_log_id: int | None = None,
+    task_id: str | None = None,
 ) -> int:
     """Persist one turn to the DB. Returns the new row's id."""
     db = await get_db()
@@ -171,6 +183,8 @@ async def _save_turn(
             parent_id=parent_id,
             created_at=datetime.now(UTC),
             api_calls_json=json.dumps(api_calls) if api_calls else None,
+            request_id=api_log_id,
+            task_id=task_id,
         )
         db.add(turn)
         await db.commit()
@@ -180,16 +194,64 @@ async def _save_turn(
         await db.close()
 
 
-async def _update_turn_tokens(turn_id: int, input_tokens: int, output_tokens: int) -> None:
-    """Write token counts back to an existing ForemanTurn row."""
+async def _create_api_request_log(
+    model: str,
+    system_blocks: list,
+    messages: list,
+    extra: dict,
+    task_id: str | None = None,
+) -> int:
+    """Insert an api_request_log row before making the Anthropic API call.
+
+    Returns the new row's id so it can be updated after the call completes.
+    """
+    db = await get_db()
+    try:
+        log = ApiRequestLog(
+            created_at=datetime.now(UTC),
+            model=model,
+            system=json.dumps(system_blocks),
+            messages=messages,
+            extra=extra or None,
+            task_id=task_id,
+        )
+        db.add(log)
+        await db.commit()
+        await db.refresh(log)
+        return log.id or 0
+    finally:
+        await db.close()
+
+
+async def _complete_api_request_log(
+    log_id: int,
+    *,
+    request_id: str | None,
+    response_dict: dict,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+    stop_reason: str | None,
+) -> None:
+    """Update an api_request_log row after the Anthropic API call completes."""
     from sqlalchemy import update as sa_update
 
     db = await get_db()
     try:
         await db.exec(
-            sa_update(ForemanTurn)
-            .where(col(ForemanTurn.id) == turn_id)
-            .values(input_tokens=input_tokens, output_tokens=output_tokens)
+            sa_update(ApiRequestLog)
+            .where(col(ApiRequestLog.id) == log_id)
+            .values(
+                request_id=request_id,
+                response=response_dict,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+                stop_reason=stop_reason,
+                completed_at=datetime.now(UTC),
+            )
         )
         await db.commit()
     finally:
@@ -505,6 +567,12 @@ async def _run_foreman_ai(
                 round_num,
                 len(messages),
             )
+            api_log_id = await _create_api_request_log(
+                model=foreman_model,
+                system_blocks=system_blocks,
+                messages=messages,
+                extra={"max_tokens": 1024, "tools": [t["name"] for t in FOREMAN_TOOLS]},
+            )
             _raw = await client.messages.with_raw_response.create(
                 model=foreman_model,
                 max_tokens=1024,
@@ -532,6 +600,16 @@ async def _run_foreman_ai(
                 _output_tokens,
                 _anthropic_request_id,
             )
+            await _complete_api_request_log(
+                api_log_id,
+                request_id=_anthropic_request_id,
+                response_dict=json.loads(_serialize_content(resp.content)),
+                input_tokens=_input_tokens,
+                output_tokens=_output_tokens,
+                cache_read_tokens=_cache_read,
+                cache_write_tokens=_cache_write,
+                stop_reason=resp.stop_reason,
+            )
 
             _api_call_meta = {
                 "request_id": _anthropic_request_id,
@@ -545,9 +623,13 @@ async def _run_foreman_ai(
 
             # Persist assistant turn and append to local messages
             asst_turn_id = await _save_turn(
-                guild_id, user_id, "assistant", resp.content, api_calls=[_api_call_meta]
+                guild_id,
+                user_id,
+                "assistant",
+                resp.content,
+                api_calls=[_api_call_meta],
+                api_log_id=api_log_id,
             )
-            await _update_turn_tokens(asst_turn_id, _input_tokens, _output_tokens)
             messages.append({"role": "assistant", "content": _serialize_content(resp.content)})
             # Re-parse so messages stays as plain dicts (not SDK objects)
             messages[-1]["content"] = json.loads(messages[-1]["content"])
@@ -699,6 +781,16 @@ async def _run_foreman_ai(
             messages = prune_history(messages)
             messages = strip_orphaned_tool_results(messages)
             _stamp_message_cache_breakpoint(messages)
+            _wrap_api_log_id = await _create_api_request_log(
+                model=foreman_model,
+                system_blocks=system_blocks,
+                messages=messages,
+                extra={
+                    "max_tokens": 1024,
+                    "tools": [t["name"] for t in FOREMAN_TOOLS],
+                    "tool_choice": {"type": "none"},
+                },
+            )
             _wrap_raw = await client.messages.with_raw_response.create(
                 model=foreman_model,
                 max_tokens=1024,
@@ -725,6 +817,16 @@ async def _run_foreman_ai(
                 _wrap_output,
                 _wrap_request_id,
             )
+            await _complete_api_request_log(
+                _wrap_api_log_id,
+                request_id=_wrap_request_id,
+                response_dict=json.loads(_serialize_content(wrap_resp.content)),
+                input_tokens=_wrap_input,
+                output_tokens=_wrap_output,
+                cache_read_tokens=_wrap_cache_read,
+                cache_write_tokens=_wrap_cache_write,
+                stop_reason=wrap_resp.stop_reason,
+            )
             _wrap_api_meta = {
                 "request_id": _wrap_request_id,
                 "model": foreman_model,
@@ -734,10 +836,14 @@ async def _run_foreman_ai(
                 "cache_write_tokens": _wrap_cache_write,
                 "ts": datetime.now(UTC).isoformat(),
             }
-            wrap_turn_id = await _save_turn(
-                guild_id, user_id, "assistant", wrap_resp.content, api_calls=[_wrap_api_meta]
+            await _save_turn(
+                guild_id,
+                user_id,
+                "assistant",
+                wrap_resp.content,
+                api_calls=[_wrap_api_meta],
+                api_log_id=_wrap_api_log_id,
             )
-            await _update_turn_tokens(wrap_turn_id, _wrap_input, _wrap_output)
             _now = datetime.now(UTC).isoformat()
             for b in wrap_resp.content:
                 if b.type == "text" and b.text.strip():

--- a/backend/models.py
+++ b/backend/models.py
@@ -283,8 +283,8 @@ class ApiRequestLog(SQLModel, table=True):
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
     model: str
-    # Full JSON of the system blocks sent (serialized list of content blocks).
-    system: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    # Full list of system content blocks sent (matches the list passed to the API).
+    system: list | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     # Full outbound messages array.
     messages: list | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     # Full response body from Anthropic (model_dump() of the SDK Message object).

--- a/backend/models.py
+++ b/backend/models.py
@@ -265,6 +265,41 @@ class GuildKey(SQLModel, table=True):
     private_key_jwk: str | None = None
 
 
+class ApiRequestLog(SQLModel, table=True):
+    """Full record of one Anthropic messages.create() call made by the foreman.
+
+    Created before the call (with model/system/messages/extra) and updated
+    after with request_id, response body, token usage, stop_reason, and
+    completed_at. Linked from foreman_turns.request_id (FK to this table's id).
+    """
+
+    __tablename__ = "api_request_log"  # type: ignore[assignment]
+
+    id: int | None = Field(default=None, primary_key=True)
+    # Anthropic x-request-id response header; set after the call completes.
+    request_id: str | None = Field(default=None, unique=True)
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    completed_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    model: str
+    # Full JSON of the system blocks sent (serialized list of content blocks).
+    system: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    # Full outbound messages array.
+    messages: list | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    # Full response body from Anthropic (model_dump() of the SDK Message object).
+    response: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cache_write_tokens: int | None = None
+    stop_reason: str | None = None
+    # Task this API call was made on behalf of (nullable; foreman may handle multiple tasks).
+    task_id: str | None = Field(default=None, foreign_key="tasks.id")
+    # Extra API parameters: max_tokens, tools list, tool_choice, etc.
+    extra: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+
+
 class ForemanTurn(SQLModel, table=True):
     __tablename__ = "foreman_turns"  # type: ignore[assignment]
 
@@ -279,13 +314,19 @@ class ForemanTurn(SQLModel, table=True):
     # For tool_result turns: id of the assistant turn whose tool_use blocks this answers
     parent_id: int | None = Field(default=None, foreign_key="foreman_turns.id")
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
-    # Token usage from the API response (assistant turns only; NULL for user/system turns)
+    # Token usage — deprecated; use api_request_log for usage going forward.
+    # Kept nullable so existing rows are not affected.
     input_tokens: int | None = None
     output_tokens: int | None = None
     # JSON array of Anthropic API call metadata captured for each messages.create() call.
     # Each entry: {request_id?, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, ts}
     # Set on assistant turns; NULL otherwise.
     api_calls_json: str | None = None
+    # FK to api_request_log.id for the API call that produced this assistant turn.
+    # NULL on user/system turns and on turns predating this column.
+    request_id: int | None = Field(default=None, foreign_key="api_request_log.id")
+    # Task this turn was produced for (mirrors api_request_log.task_id for convenience).
+    task_id: str | None = Field(default=None, foreign_key="tasks.id")
 
 
 class GithubEvent(SQLModel, table=True):

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -29,7 +29,6 @@ def _is_open(ws) -> bool:
 def _backoff_delay(attempt: int, base: float, cap: float) -> float:
     """Exponential backoff with full jitter."""
     return min(cap, base * (2**attempt)) + random.uniform(0, base)
-    
 
 
 class WSClient:


### PR DESCRIPTION
## Summary

- **New `api_request_log` table** (`ApiRequestLog` SQLAlchemy model): records every `anthropic.messages.create()` call the embedded foreman makes — full request (`model`, `system` prompt blocks, `messages` array, `extra` params) and full response (`request_id` header, response body as JSONB, token usage, `stop_reason`, `completed_at`). Two indexes: `task_id` and `created_at`.
- **Migration `20260605_000002_add_api_request_log`**: creates the table with proper FK to `tasks.id` and a unique constraint on `request_id` (Anthropic header value).
- **Migration `20260605_000003_refactor_foreman_turns`**: adds `foreman_turns.request_id` (FK → `api_request_log.id`) and `foreman_turns.task_id` (FK → `tasks.id`). Usage columns (`input_tokens`, `output_tokens`) are left nullable on existing rows — no data loss.
- **Foreman runner wiring** (`backend/foreman/runner.py`): `_create_api_request_log()` inserts a log row before each `messages.create()` call; `_complete_api_request_log()` updates it after with the response. `_save_turn()` now accepts `api_log_id` and `task_id` to populate the new FK columns. `_update_turn_tokens()` calls removed — usage lives in `api_request_log` going forward.
- Both the normal rounds and the safety-cap wrap-up call are fully instrumented.

## Test plan

- [ ] `docker compose up -d postgres-test && cd backend && python -m pytest` — all 119 tests pass
- [ ] Apply migrations against a live DB: `alembic upgrade head` — table created, columns added
- [ ] Downgrade roundtrip: `alembic downgrade -1` twice — columns/table dropped cleanly
- [ ] Start backend with `ANTHROPIC_API_KEY` set and send a foreman message; confirm `api_request_log` row appears with `request_id`, usage, and `completed_at` populated, and the `foreman_turns` assistant row has `request_id` FK set

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)