### PR TITLE
Validate tool availability in assign_task (#586)

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -869,7 +869,8 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         "review comments on the original PR.",
                         wid,
                     )
-                tool = inp.get("tool", "claude")
+                requested_tool: str | None = inp.get("tool")
+                tool = requested_tool or "claude"  # overwritten during worker tool validation
                 model = inp.get("model") or None
                 provider = inp.get("provider") or None
                 existing_task_id = inp.get("task_id")
@@ -879,32 +880,45 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 primary_repo: str | None = guild_result.one_or_none()
                 repos: list[str] = inp.get("repos") or ([primary_repo] if primary_repo else [])
                 worker_result = await db.exec(
-                    select(col(Worker.id), col(Worker.repos), col(Worker.org)).where(
-                        col(Worker.id) == wid, col(Worker.guild_id) == guild_pk
-                    )
+                    select(
+                        col(Worker.id), col(Worker.repos), col(Worker.org), col(Worker.tools)
+                    ).where(col(Worker.id) == wid, col(Worker.guild_id) == guild_pk)
                 )
                 worker_row = worker_result.one_or_none()
                 if not worker_row:
                     result_text = f"Worker {wid} not found — task NOT queued."
                     is_error = True
-                elif repos:
-                    worker_repos: list[str] = json.loads(worker_row.repos or "[]")
-                    worker_org: str | None = worker_row.org
-                    unreachable = [
-                        r
-                        for r in repos
-                        if r not in worker_repos
-                        and not (worker_org and r.startswith(f"{worker_org}/"))
-                    ]
-                    if unreachable:
+                else:
+                    worker_tools: list[str] = json.loads(worker_row.tools or "[]")
+                    if requested_tool is None:
+                        tool = worker_tools[0] if worker_tools else "claude"
+                    elif worker_tools and requested_tool not in worker_tools:
+                        available = ", ".join(worker_tools)
                         result_text = (
-                            f"Worker {wid} cannot access repo(s) {unreachable} — "
-                            f"task NOT queued. Worker has {len(worker_repos)} registered "
-                            f"repo(s) and org={worker_org!r}. Choose a worker that has "
-                            f"access to these repos, or omit repos to use the worker's "
-                            f"full configured list."
+                            f"Worker {wid} does not support tool {requested_tool!r}. "
+                            f"Available tools: {available}"
                         )
                         is_error = True
+                    else:
+                        tool = requested_tool
+                    if not is_error and repos:
+                        worker_repos: list[str] = json.loads(worker_row.repos or "[]")
+                        worker_org: str | None = worker_row.org
+                        unreachable = [
+                            r
+                            for r in repos
+                            if r not in worker_repos
+                            and not (worker_org and r.startswith(f"{worker_org}/"))
+                        ]
+                        if unreachable:
+                            result_text = (
+                                f"Worker {wid} cannot access repo(s) {unreachable} — "
+                                f"task NOT queued. Worker has {len(worker_repos)} registered "
+                                f"repo(s) and org={worker_org!r}. Choose a worker that has "
+                                f"access to these repos, or omit repos to use the worker's "
+                                f"full configured list."
+                            )
+                            is_error = True
                 if not is_error:
                     # Prevent two concurrent foreman runs from double-assigning
                     # the same idle worker.  Lock covers the window from worker

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -870,7 +870,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         wid,
                     )
                 requested_tool: str | None = inp.get("tool")
-                tool = requested_tool or "claude"  # overwritten during worker tool validation
+                tool = requested_tool or "claude"  # may be replaced below during tool validation
                 model = inp.get("model") or None
                 provider = inp.get("provider") or None
                 existing_task_id = inp.get("task_id")
@@ -899,6 +899,9 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             f"Available tools: {available}"
                         )
                         is_error = True
+                    elif not worker_tools:
+                        # legacy worker: no tools registered, accept any requested tool
+                        tool = requested_tool
                     else:
                         tool = requested_tool
                     if not is_error and repos:

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -212,6 +212,7 @@ def insert_worker(
     state: str = "online",
     repos: str = "[]",
     org: str | None = None,
+    tools: str = "[]",
 ) -> None:
     """Insert a worker row for a guild."""
     now = datetime.now(UTC)
@@ -225,7 +226,13 @@ def insert_worker(
         session.execute(
             pg_insert(Worker)
             .values(
-                id=worker_id, guild_id=guild_pk, repos=repos, state=state, org=org, created_at=now
+                id=worker_id,
+                guild_id=guild_pk,
+                repos=repos,
+                tools=tools,
+                state=state,
+                org=org,
+                created_at=now,
             )
             .on_conflict_do_nothing(index_elements=["id"])
         )

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -432,6 +432,46 @@ class TestExecToolsDispatching:
         assert "assigned" in results[0]["content"].lower()
         assert "t-exist1" in results[0]["content"]
 
+    async def test_assign_task_unsupported_tool(self, db_session):
+        insert_guild(db_session, "g-assign-toolcheck")
+        insert_worker(db_session, "g-assign-toolcheck", "w-toolcheck", tools='["claude", "pi"]')
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-assign-toolcheck",
+                [
+                    _fake_tool_use(
+                        "assign_task",
+                        {"worker_id": "w-toolcheck", "description": "Run it", "tool": "codex"},
+                    )
+                ],
+            )
+        content = results[0]["content"]
+        assert "does not support tool" in content
+        assert "codex" in content
+        assert "claude" in content
+        assert "pi" in content
+
+    async def test_assign_task_defaults_to_first_tool(self, db_session):
+        insert_guild(db_session, "g-assign-tooldefault")
+        insert_worker(db_session, "g-assign-tooldefault", "w-tooldefault", tools='["pi", "claude"]')
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-assign-tooldefault",
+                [
+                    _fake_tool_use(
+                        "assign_task",
+                        {"worker_id": "w-tooldefault", "description": "Do something"},
+                    )
+                ],
+            )
+        assert "queued" in results[0]["content"].lower()
+
+        with _sync_session(db_session) as session:
+            task_tool = session.scalar(
+                select(col(Task.tool)).where(col(Task.worker_id) == "w-tooldefault")
+            )
+        assert task_tool == "pi"
+
     async def test_send_followup_task_not_found(self, db_session):
         insert_guild(db_session, "g-followup-missing")
         with patch("foreman.tools.broadcast", new_callable=AsyncMock):

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -408,8 +408,10 @@ class TestExecToolsDispatching:
                     )
                 ],
             )
-        assert "queued" in results[0]["content"].lower()
-        assert "w-worker1" in results[0]["content"]
+        content = results[0]["content"]
+        assert "queued" in content.lower()
+        assert "does not support" not in content
+        assert "w-worker1" in content
 
     async def test_assign_task_with_existing_task_id(self, db_session):
         insert_guild(db_session, "g-assign-existing")

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -29,7 +29,6 @@ def _is_open(ws) -> bool:
 def _backoff_delay(attempt: int, base: float, cap: float) -> float:
     """Exponential backoff with full jitter."""
     return min(cap, base * (2**attempt)) + random.uniform(0, base)
-    
 
 
 class WSClient:


### PR DESCRIPTION
## Summary

- In `assign_task`, fetch `Worker.tools` alongside `repos`/`org` and validate the requested tool against it.
- If the requested `tool` is not in the worker's registered tools list (and the list is non-empty), the call is rejected with a clear error: `"Worker w-xxx does not support tool 'codex'. Available tools: claude, pi"`.
- If `tool` is omitted, default to `worker.tools[0]` instead of hardcoding `"claude"`. Falls back to `"claude"` only for legacy workers with an empty tools list (backward-compatible).
- Extended `insert_worker` in `helpers.py` to accept a `tools` parameter so tests can set up workers with specific tool lists.
- Added two new tests in `test_foreman.py`: unsupported tool → error, omitted tool → defaults to first available.

## Test plan
- [ ] `cd backend && python -m pytest tests/test_foreman.py -k "assign_task" -v` (requires `docker compose up -d postgres-test`)
- [ ] Existing assign_task tests unaffected: workers with empty `tools=[]` continue to accept any tool (backward-compatible).

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)