### PR TITLE
Fix models.dev provider catalog

### DIFF
--- a/backend/tests/test_models_dev.py
+++ b/backend/tests/test_models_dev.py
@@ -49,9 +49,9 @@ SAMPLE_RESPONSE = {
             "gemini-2.5-flash": {"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash"},
         },
     },
-    "bedrock": {
-        "id": "bedrock",
-        "name": "AWS Bedrock",
+    "amazon-bedrock": {
+        "id": "amazon-bedrock",
+        "name": "Amazon Bedrock",
         "models": {
             "claude-sonnet-4-6": {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6 (Bedrock)"},
         },
@@ -68,8 +68,8 @@ def test_parse_response_basic():
     result = _parse_response(SAMPLE_RESPONSE)
     ids = {p["id"] for p in result}
     assert "anthropic" in ids
-    assert "openai" in ids
     assert "bedrock" in ids
+    assert "openai" not in ids
     # providers with no models are excluded
     assert "empty-provider" not in ids
 
@@ -79,8 +79,14 @@ def test_parse_response_filters_non_allowed_providers():
     ids = {p["id"] for p in result}
     # google is not in the allowed provider list
     assert "google" not in ids
-    # only anthropic, openai, bedrock are allowed
-    assert ids == {"anthropic", "openai", "bedrock"}
+    # only foreman-supported providers are allowed
+    assert ids == {"anthropic", "bedrock"}
+
+
+def test_parse_response_normalizes_amazon_bedrock_provider_id():
+    result = _parse_response(SAMPLE_RESPONSE)
+    bedrock = next(p for p in result if p["id"] == "bedrock")
+    assert bedrock["name"] == "Amazon Bedrock"
 
 
 def test_parse_response_model_fields():
@@ -110,8 +116,8 @@ async def test_fetch_providers_success():
     with patch("util.models_dev.httpx.AsyncClient", return_value=mock_client):
         result = await fetch_providers()
 
-    assert len(result) >= 2
-    assert any(p["id"] == "anthropic" for p in result)
+    ids = {p["id"] for p in result}
+    assert ids == {"anthropic", "bedrock"}
 
 
 async def test_fetch_providers_uses_cache():
@@ -140,6 +146,8 @@ async def test_fetch_providers_fallback_on_error():
     assert result is _FALLBACK_PROVIDERS
     assert len(result) > 0
     assert any(p["id"] == "anthropic" for p in result)
+    assert any(p["id"] == "bedrock" for p in result)
+    assert not any(p["id"] == "openai" for p in result)
 
 
 async def test_fetch_providers_force_refresh():

--- a/backend/util/models_dev.py
+++ b/backend/util/models_dev.py
@@ -17,8 +17,13 @@ logger = logging.getLogger(__name__)
 MODELS_DEV_URL = "https://models.dev/api.json"
 _CACHE_TTL = 3600  # 1 hour
 
-# Only surface these providers in the UI for now.
-_ALLOWED_PROVIDERS = {"anthropic", "openai", "bedrock"}
+# Only surface Foreman-supported providers in the UI for now. models.dev uses
+# "amazon-bedrock"; the rest of this app expects "bedrock" in config.
+_PROVIDER_ALIASES = {
+    "anthropic": "anthropic",
+    "amazon-bedrock": "bedrock",
+    "bedrock": "bedrock",
+}
 
 # Minimal fallback so the UI always has something to show.
 _FALLBACK_PROVIDERS: list[dict[str, Any]] = [
@@ -32,17 +37,8 @@ _FALLBACK_PROVIDERS: list[dict[str, Any]] = [
         ],
     },
     {
-        "id": "openai",
-        "name": "OpenAI",
-        "models": [
-            {"id": "gpt-4o", "name": "GPT-4o"},
-            {"id": "o4-mini", "name": "o4-mini"},
-            {"id": "gpt-4.1", "name": "GPT-4.1"},
-        ],
-    },
-    {
         "id": "bedrock",
-        "name": "AWS Bedrock",
+        "name": "Amazon Bedrock",
         "models": [
             {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6 (Bedrock)"},
         ],
@@ -57,7 +53,8 @@ def _parse_response(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Convert the models.dev API response into a flat list of provider dicts."""
     providers: list[dict[str, Any]] = []
     for provider_id, entry in data.items():
-        if provider_id not in _ALLOWED_PROVIDERS:
+        normalized_provider_id = _PROVIDER_ALIASES.get(provider_id)
+        if normalized_provider_id is None:
             continue
         if not isinstance(entry, dict):
             continue
@@ -73,7 +70,7 @@ def _parse_response(data: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         providers.append(
             {
-                "id": provider_id,
+                "id": normalized_provider_id,
                 "name": entry.get("name", provider_id),
                 "models": models,
             }

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -144,33 +144,28 @@
             <label class="foreman-field-label">Provider</label>
             <select v-model="foremanProvider" class="settings-input" @change="foremanModel = ''">
               <option value="">default (anthropic)</option>
-              <option
-                v-for="p in modelsStore.providers"
-                :key="p.id"
-                :value="p.id"
-              >{{ p.name }}</option>
+              <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
+                {{ p.name }}
+              </option>
             </select>
           </div>
           <div class="foreman-field">
             <label class="foreman-field-label">Model</label>
-            <select
-              v-if="foremanProviderModels.length"
+            <input
               v-model="foremanModel"
               class="settings-input"
-            >
-              <option value="">default</option>
+              list="foreman-model-hints"
+              placeholder="default"
+              autocomplete="off"
+            />
+            <datalist id="foreman-model-hints">
               <option
                 v-for="m in foremanProviderModels"
                 :key="m.id"
                 :value="m.id"
-              >{{ m.name }}</option>
-            </select>
-            <input
-              v-else
-              v-model="foremanModel"
-              class="settings-input"
-              placeholder="claude-sonnet-4-6"
-            />
+                :label="m.name"
+              />
+            </datalist>
           </div>
           <div class="foreman-field">
             <label class="foreman-field-label">System Prompt Suffix</label>
@@ -238,7 +233,9 @@
                     class="env-var-change-btn pixel-btn"
                     @click="unlockEnvVar(i)"
                     title="Change value"
-                  >✎</button>
+                  >
+                    ✎
+                  </button>
                 </template>
                 <template v-else>
                   <input
@@ -249,19 +246,12 @@
                     autocomplete="new-password"
                   />
                 </template>
-                <button
-                  class="env-var-delete-btn"
-                  @click="removeEnvVar(i)"
-                  title="Remove variable"
-                >✕</button>
+                <button class="env-var-delete-btn" @click="removeEnvVar(i)" title="Remove variable">
+                  ✕
+                </button>
               </div>
               <datalist id="foreman-env-key-hints">
-                <option value="ANTHROPIC_API_KEY" />
-                <option value="OPENAI_API_KEY" />
-                <option value="GITHUB_TOKEN" />
-                <option value="GEMINI_API_KEY" />
-                <option value="AWS_ACCESS_KEY_ID" />
-                <option value="AWS_SECRET_ACCESS_KEY" />
+                <option v-for="key in foremanEnvKeyHints" :key="key" :value="key" />
               </datalist>
               <button class="pixel-btn env-var-add-btn" @click="addEnvVar">+ Add Variable</button>
             </div>
@@ -275,11 +265,7 @@
             >
               {{ foremanSaving ? 'Saving…' : 'Save' }}
             </button>
-            <span
-              v-if="foremanStatus"
-              class="save-status"
-              :class="'save-status-' + foremanStatus"
-            >
+            <span v-if="foremanStatus" class="save-status" :class="'save-status-' + foremanStatus">
               {{ foremanStatus === 'saved' ? 'Saved' : 'Error' }}
             </span>
           </div>
@@ -321,6 +307,17 @@ const modelsStore = reactive(useModels())
 const foremanProviderModels = computed(() =>
   foremanProvider.value ? modelsStore.modelsForProvider(foremanProvider.value) : [],
 )
+const FOREMAN_ENV_KEY_HINTS: Record<string, string[]> = {
+  anthropic: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_API_URL'],
+  bedrock: [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_DEFAULT_REGION',
+    'AWS_REGION',
+    'AWS_PROFILE',
+  ],
+}
 
 const showGitHubModal = ref(false)
 const showSettings = ref(false)
@@ -350,6 +347,10 @@ const foremanPollMax = ref<number | ''>('')
 const foremanSaving = ref(false)
 const foremanStatus = ref<'' | 'saved' | 'error'>('')
 let foremanStatusTimer: ReturnType<typeof setTimeout> | null = null
+const foremanEnvKeyHints = computed(() => {
+  const provider = foremanProvider.value || 'anthropic'
+  return FOREMAN_ENV_KEY_HINTS[provider] ?? []
+})
 
 interface EnvVarRow {
   key: string


### PR DESCRIPTION
## Summary
- normalize models.dev amazon-bedrock entries to the internal bedrock provider id and stop surfacing OpenAI for Foreman config
- make the Foreman model control a typed input with provider-scoped model suggestions
- show provider-specific env var hints for Anthropic/default and Amazon Bedrock

## Tests
- npm run lint
- npm run type-check
- ruff check backend/util/models_dev.py backend/tests/test_models_dev.py
- backend/.venv/bin/python -m pytest backend/tests/test_models_dev.py