### PR TITLE
Fix task_id in api_request_logs and foreman turns

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -537,8 +537,8 @@ async def _run_foreman_ai(
 
         # Persist the rendered prompt + human turn for auditing; the API receives
         # `system_blocks` (cacheable) and the state preamble injected at send time.
-        await _save_turn(guild_id, user_id, "system", audit_system)
-        await _save_turn(guild_id, user_id, "user", human_message)
+        await _save_turn(guild_id, user_id, "system", audit_system, task_id=_task_id)
+        await _save_turn(guild_id, user_id, "user", human_message, task_id=_task_id)
         messages = await _load_history(guild_id, user_id)
 
         logger.info(
@@ -633,6 +633,7 @@ async def _run_foreman_ai(
                 resp.content,
                 api_calls=[_api_call_meta],
                 api_log_id=api_log_id,
+                task_id=_task_id,
             )
             messages.append({"role": "assistant", "content": _serialize_content(resp.content)})
             # Re-parse so messages stays as plain dicts (not SDK objects)
@@ -759,6 +760,7 @@ async def _run_foreman_ai(
                 trimmed,
                 is_tool_response=True,
                 parent_id=asst_turn_id,
+                task_id=_task_id,
             )
             logger.info(
                 "guild=%s round %d: %d tool call(s) dispatched: %s",
@@ -848,6 +850,7 @@ async def _run_foreman_ai(
                 wrap_resp.content,
                 api_calls=[_wrap_api_meta],
                 api_log_id=_wrap_api_log_id,
+                task_id=_task_id,
             )
             _now = datetime.now(UTC).isoformat()
             for b in wrap_resp.content:

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -59,6 +59,22 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+async def _require_task_in_guild(db: AsyncSession, task_id: str, guild_pk: int) -> None:
+    """Raise HTTP 404 if task_id does not exist or belongs to a different guild.
+
+    Task.id is the string PK (e.g. "t-abc123"), not an integer. guild_pk is the
+    integer FK from guilds.id. This check enforces guild ownership, which a bare
+    FK constraint cannot express.
+    """
+    result = await db.exec(
+        select(col(Task.id)).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+    )
+    if result.one_or_none() is None:
+        raise HTTPException(
+            status_code=404, detail="Task not found or does not belong to this guild"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Existing debug endpoints (unchanged)
 # ---------------------------------------------------------------------------
@@ -362,15 +378,7 @@ async def create_foreman_turn(
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
     if body.task_id is not None:
-        task_check = await db.exec(
-            select(col(Task.id)).where(
-                col(Task.id) == body.task_id, col(Task.guild_id) == guild_pk
-            )
-        )
-        if task_check.one_or_none() is None:
-            raise HTTPException(
-                status_code=404, detail="Task not found or does not belong to this guild"
-            )
+        await _require_task_in_guild(db, body.task_id, guild_pk)
     created_at = datetime.now(UTC)
     turn = ForemanTurn(
         guild_id=guild_pk,

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -339,6 +339,7 @@ class ForemanTurnCreate(BaseModel):
     is_tool_response: bool = False
     parent_id: int | None = None
     api_calls: list | None = None  # per-HTTP-call metadata from tool execution
+    task_id: str | None = None
 
 
 @router.post("/guilds/{guild_id}/foreman/history")
@@ -370,6 +371,7 @@ async def create_foreman_turn(
         parent_id=body.parent_id,
         created_at=created_at,
         api_calls_json=_json.dumps(body.api_calls) if body.api_calls else None,
+        task_id=body.task_id,
     )
     db.add(turn)
     await db.commit()

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -361,6 +361,16 @@ async def create_foreman_turn(
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
+    if body.task_id is not None:
+        task_check = await db.exec(
+            select(col(Task.id)).where(
+                col(Task.id) == body.task_id, col(Task.guild_id) == guild_pk
+            )
+        )
+        if task_check.one_or_none() is None:
+            raise HTTPException(
+                status_code=404, detail="Task not found or does not belong to this guild"
+            )
     created_at = datetime.now(UTC)
     turn = ForemanTurn(
         guild_id=guild_pk,

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -41,7 +41,7 @@ from foreman_core.message_utils import (
     truncate_tool_result,
 )
 from helpers import _sync_session, create_db, insert_agent, insert_guild, insert_task, insert_worker
-from models import Guild, Lock, Task, TaskEvent, TaskLog  # noqa: E402
+from models import ForemanTurn, Guild, Lock, Task, TaskEvent, TaskLog  # noqa: E402
 from sqlalchemy import func, select  # noqa: E402
 from sqlmodel import col  # noqa: E402
 
@@ -1590,6 +1590,25 @@ class TestForemanHistory:
         assert len(tool_results) == 1
         assert tool_results[0]["tool_use_id"] == "tu-42"
         assert tool_results[0]["content"] == "Created t-xyz"
+
+    async def test_save_turn_persists_task_id(self, db_session):
+        """task_id passed to _save_turn must be stored on the ForemanTurn row."""
+        insert_guild(db_session, "g-hist-taskid")
+        insert_task(db_session, "g-hist-taskid", "t-taskid1")
+        await _save_turn("g-hist-taskid", "u-1", "user", "Hello", task_id="t-taskid1")
+        with _sync_session(db_session) as session:
+            turn = session.scalar(select(ForemanTurn).order_by(col(ForemanTurn.id).desc()).limit(1))
+        assert turn is not None
+        assert turn.task_id == "t-taskid1"
+
+    async def test_save_turn_task_id_none_by_default(self, db_session):
+        """When task_id is not provided, ForemanTurn.task_id must be NULL."""
+        insert_guild(db_session, "g-hist-taskid-null")
+        await _save_turn("g-hist-taskid-null", "u-1", "user", "Hello")
+        with _sync_session(db_session) as session:
+            turn = session.scalar(select(ForemanTurn).order_by(col(ForemanTurn.id).desc()).limit(1))
+        assert turn is not None
+        assert turn.task_id is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_foreman_context_api.py
+++ b/backend/tests/test_foreman_context_api.py
@@ -234,3 +234,25 @@ def test_create_foreman_turn_null_task_id_by_default(client):
         turn = session.scalar(select(ForemanTurn).where(col(ForemanTurn.id) == turn_id))
     assert turn is not None
     assert turn.task_id is None
+
+
+def test_create_foreman_turn_cross_guild_task_returns_404(client):
+    """task_id that belongs to a different guild must return 404."""
+    test_client, db_url = client
+    insert_guild(db_url, "g-xguild-a")
+    insert_guild(db_url, "g-xguild-b")
+    token = make_auth_token(db_url)
+    insert_task(db_url, "g-xguild-a", "t-xguild1")
+
+    # Reference guild-A's task from guild-B's endpoint — must be rejected.
+    resp = test_client.post(
+        "/guilds/g-xguild-b/foreman/history",
+        json={
+            "user_id": "gh-user-test",
+            "role": "user",
+            "content_json": '"Hello"',
+            "task_id": "t-xguild1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_foreman_context_api.py
+++ b/backend/tests/test_foreman_context_api.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
-from helpers import _sync_session, insert_guild, insert_member, make_auth_token
+from helpers import _sync_session, insert_guild, insert_member, insert_task, make_auth_token
 from models import ForemanTurn, Guild
 from sqlalchemy import select
 from sqlmodel import col  # noqa: E402
@@ -179,3 +179,58 @@ def test_get_foreman_context_isolates_across_guilds(client):
     )
     assert resp.status_code == 200
     assert resp.json()["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# task_id propagation
+# ---------------------------------------------------------------------------
+
+
+def test_create_foreman_turn_persists_task_id(client):
+    """POST /guilds/{guild_id}/foreman/history with task_id stores it on the row."""
+    test_client, db_url = client
+    insert_guild(db_url, "g-ftask")
+    token = make_auth_token(db_url)
+    insert_task(db_url, "g-ftask", "t-ftask1")
+
+    resp = test_client.post(
+        "/guilds/g-ftask/foreman/history",
+        json={
+            "user_id": "gh-user-test",
+            "role": "user",
+            "content_json": '"Hello"',
+            "task_id": "t-ftask1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    turn_id = resp.json()["id"]
+
+    with _sync_session(db_url) as session:
+        turn = session.scalar(select(ForemanTurn).where(col(ForemanTurn.id) == turn_id))
+    assert turn is not None
+    assert turn.task_id == "t-ftask1"
+
+
+def test_create_foreman_turn_null_task_id_by_default(client):
+    """POST /guilds/{guild_id}/foreman/history without task_id stores NULL."""
+    test_client, db_url = client
+    insert_guild(db_url, "g-ftask-null")
+    token = make_auth_token(db_url)
+
+    resp = test_client.post(
+        "/guilds/g-ftask-null/foreman/history",
+        json={
+            "user_id": "gh-user-test",
+            "role": "user",
+            "content_json": '"Hello"',
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    turn_id = resp.json()["id"]
+
+    with _sync_session(db_url) as session:
+        turn = session.scalar(select(ForemanTurn).where(col(ForemanTurn.id) == turn_id))
+    assert turn is not None
+    assert turn.task_id is None

--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -85,6 +85,7 @@ class Foreman:
                 human_message = data.get("humanMessage", "")
                 user_id = data.get("userId")
                 extra_context = data.get("extraContext", "")
+                trigger_task_id = data.get("taskId")
                 if not guild_id or not human_message:
                     logger.warning("Ignoring malformed foreman-trigger: %s", data)
                     return
@@ -94,6 +95,7 @@ class Foreman:
                         human_message,
                         extra_context=extra_context,
                         user_id=user_id,
+                        task_id=trigger_task_id,
                         http=self._http,
                         ws_send=_ws_send,
                         config=self._config,

--- a/foreman/pioneer_foreman/http_client.py
+++ b/foreman/pioneer_foreman/http_client.py
@@ -140,6 +140,7 @@ class ForemanHTTPClient:
         is_tool_response: bool = False,
         parent_id: int | None = None,
         api_calls: list | None = None,
+        task_id: str | None = None,
     ) -> dict:
         """Persist one foreman conversation turn. Returns {id, created_at}."""
         body: dict = {
@@ -152,6 +153,8 @@ class ForemanHTTPClient:
             body["parent_id"] = parent_id
         if api_calls:
             body["api_calls"] = api_calls
+        if task_id is not None:
+            body["task_id"] = task_id
         return await self._post(self._guild_url("/foreman/history"), body)
 
     async def update_turn_tokens(self, turn_id: int, input_tokens: int, output_tokens: int) -> None:

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -141,7 +141,14 @@ async def run_foreman_ai(
     primary_repo = guild_data.get("primary_repo")
     worker_rows = state.get("workers") or []
     task_rows = state.get("tasks") or []
-    _task_id: str | None = task_rows[0]["id"] if len(task_rows) == 1 else None
+    if len(task_rows) == 1:
+        _task_id: str | None = task_rows[0]["id"]
+    else:
+        if len(task_rows) > 1:
+            logger.warning(
+                "Ambiguous task lookup: %d tasks found, task_id will be NULL", len(task_rows)
+            )
+        _task_id = None
 
     # Resolve user_id from guild owner if not provided
     if not user_id:

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -111,6 +111,7 @@ async def run_foreman_ai(
     human_message: str,
     extra_context: str = "",
     user_id: str | None = None,
+    task_id: str | None = None,
     *,
     http: ForemanHTTPClient,
     ws_send: Callable[[dict], Awaitable[None]],
@@ -119,6 +120,8 @@ async def run_foreman_ai(
     """Process a human message (or system escalation) through the Claude foreman AI.
 
     Standalone version — uses REST for state/history, WS for broadcasts.
+    ``task_id`` must be passed explicitly by the caller; it is not inferred from
+    guild state so there is no ambiguity when multiple tasks are active.
     """
     from .tools import FOREMAN_TOOLS, exec_tools
 
@@ -141,14 +144,6 @@ async def run_foreman_ai(
     primary_repo = guild_data.get("primary_repo")
     worker_rows = state.get("workers") or []
     task_rows = state.get("tasks") or []
-    if len(task_rows) == 1:
-        _task_id: str | None = task_rows[0]["id"]
-    else:
-        if len(task_rows) > 1:
-            logger.warning(
-                "Ambiguous task lookup: %d tasks found, task_id will be NULL", len(task_rows)
-            )
-        _task_id = None
 
     # Resolve user_id from guild owner if not provided
     if not user_id:
@@ -192,8 +187,8 @@ async def run_foreman_ai(
             len(extra_context),
         )
 
-        await _save_turn(guild_id, user_id, "system", audit_system, http=http, task_id=_task_id)
-        await _save_turn(guild_id, user_id, "user", human_message, http=http, task_id=_task_id)
+        await _save_turn(guild_id, user_id, "system", audit_system, http=http, task_id=task_id)
+        await _save_turn(guild_id, user_id, "user", human_message, http=http, task_id=task_id)
         messages = await _load_history(guild_id, user_id, http=http)
 
         _inject_state_preamble(messages, state_preamble)
@@ -256,7 +251,7 @@ async def run_foreman_ai(
                 resp.content,
                 http=http,
                 api_calls=[_api_call_meta],
-                task_id=_task_id,
+                task_id=task_id,
             )
             await http.update_turn_tokens(asst_turn_id, _input_tokens, _output_tokens)
             messages.append({"role": "assistant", "content": _serialize_content(resp.content)})
@@ -333,7 +328,7 @@ async def run_foreman_ai(
                 http=http,
                 is_tool_response=True,
                 parent_id=asst_turn_id,
-                task_id=_task_id,
+                task_id=task_id,
             )
             logger.info(
                 "guild=%s round %d: %d tool call(s): %s",
@@ -393,7 +388,7 @@ async def run_foreman_ai(
                 wrap_resp.content,
                 http=http,
                 api_calls=[_wrap_api_meta],
-                task_id=_task_id,
+                task_id=task_id,
             )
             await http.update_turn_tokens(wrap_turn_id, _wrap_input, _wrap_output)
             _now = datetime.now(UTC).isoformat()

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -91,6 +91,7 @@ async def _save_turn(
     is_tool_response: bool = False,
     parent_id: int | None = None,
     api_calls: list | None = None,
+    task_id: str | None = None,
 ) -> int:
     """Persist one turn via REST. Returns the new row's id."""
     result = await http.save_turn(
@@ -100,6 +101,7 @@ async def _save_turn(
         is_tool_response=is_tool_response,
         parent_id=parent_id,
         api_calls=api_calls,
+        task_id=task_id,
     )
     return result["id"]
 
@@ -139,6 +141,7 @@ async def run_foreman_ai(
     primary_repo = guild_data.get("primary_repo")
     worker_rows = state.get("workers") or []
     task_rows = state.get("tasks") or []
+    _task_id: str | None = task_rows[0]["id"] if len(task_rows) == 1 else None
 
     # Resolve user_id from guild owner if not provided
     if not user_id:
@@ -182,8 +185,8 @@ async def run_foreman_ai(
             len(extra_context),
         )
 
-        await _save_turn(guild_id, user_id, "system", audit_system, http=http)
-        await _save_turn(guild_id, user_id, "user", human_message, http=http)
+        await _save_turn(guild_id, user_id, "system", audit_system, http=http, task_id=_task_id)
+        await _save_turn(guild_id, user_id, "user", human_message, http=http, task_id=_task_id)
         messages = await _load_history(guild_id, user_id, http=http)
 
         _inject_state_preamble(messages, state_preamble)
@@ -240,7 +243,13 @@ async def run_foreman_ai(
             }
 
             asst_turn_id = await _save_turn(
-                guild_id, user_id, "assistant", resp.content, http=http, api_calls=[_api_call_meta]
+                guild_id,
+                user_id,
+                "assistant",
+                resp.content,
+                http=http,
+                api_calls=[_api_call_meta],
+                task_id=_task_id,
             )
             await http.update_turn_tokens(asst_turn_id, _input_tokens, _output_tokens)
             messages.append({"role": "assistant", "content": _serialize_content(resp.content)})
@@ -317,6 +326,7 @@ async def run_foreman_ai(
                 http=http,
                 is_tool_response=True,
                 parent_id=asst_turn_id,
+                task_id=_task_id,
             )
             logger.info(
                 "guild=%s round %d: %d tool call(s): %s",
@@ -376,6 +386,7 @@ async def run_foreman_ai(
                 wrap_resp.content,
                 http=http,
                 api_calls=[_wrap_api_meta],
+                task_id=_task_id,
             )
             await http.update_turn_tokens(wrap_turn_id, _wrap_input, _wrap_output)
             _now = datetime.now(UTC).isoformat()


### PR DESCRIPTION
Fixes #590 — propagates task_id correctly into api_request_logs and foreman turn records.