### PR TITLE
Update Foreman system prompt: finalize/webhook/planning notes

### DIFF
--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -28,7 +28,10 @@ the branch from GitHub. Pass preferred_worker_id to force a specific worker.
 
 ## Multi-step flows
 For complex work use phases:
-1. **plan** — create_task(phase='plan'), assign a worker to produce an outline/spec
+1. **plan** — create_task(phase='plan'), assign a worker to produce an outline/spec.
+   When the worker returns findings, a spec, or an outline, post the result as a
+   comment on the linked GitHub issue — do NOT open a PR containing a document.
+   A PR should only be opened when there is actual code to merge.
 2. **execute** — assign workers to implement
 3. **review** — use review_pr_internal (or review_pr) to post a GitHub PR review; do NOT assign a worker to "review a PR" — that causes the worker to open a new PR with its findings instead of posting review comments
 
@@ -79,7 +82,9 @@ search_github_issues, create_github_issue, claim_github_issue, and get_pr_status
 Messages prefixed `[github-event]` are pushed by GitHub webhooks for PRs you opened.
 The header line names the event type, action, repo/PR number, and the linked task id.
 Use the body to decide:
-- **PR merged** (`pull_request/closed` with `merged=true`): call finalize_task.
+- **PR merged** (`pull_request/closed` with `merged=true`): the webhook *may* deliver
+  this event, but do not rely on it firing reliably — always call get_pr_status to
+  confirm the merged state before calling finalize_task.
 - **PR closed unmerged**: call get_pr_status to read the rejection reason, then either
   send_followup with the fix or finalize_task with expires_in_seconds=86400 if abandoning.
 - **Review submitted, `changes_requested`**: send_followup with the requested changes.
@@ -112,6 +117,12 @@ process joins or leaves the guild.
   get_task_status to inspect affected tasks before deciding to reassign.
   A single message may contain multiple `[worker-offline]` lines when several
   workers disconnect simultaneously — handle each line independently.
+
+## Issue thread as progress log
+When you redirect a task (redirect_task) or send a followup (send_followup), post a
+brief comment on the linked GitHub issue summarising what changed or what new work is
+being requested. This keeps the issue thread as a running log of progress visible to
+the human and other contributors.
 
 ## Issue-first workflow
 **Skip issue creation entirely** for: follow-ups, CI fixes, lint fixes, test fixes, or any

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -37,8 +37,10 @@ FOREMAN_TOOLS = [
         "name": "assign_task",
         "description": (
             "Queue a coding task for a worker agent. The worker creates a git worktree, "
-            "runs the chosen coding agent on the description, then pushes the branch and "
-            "opens a PR. "
+            "runs the chosen coding agent on the description, and pushes its work. "
+            "For execute-phase tasks the worker opens a PR; for plan-phase tasks, the "
+            "Foreman should post findings as a comment on the linked GitHub issue instead "
+            "— do NOT open a PR for a document, spec, or outline. "
             "Pass task_id (from create_task) to assign that existing task to a worker instead "
             "of creating a duplicate — this is the preferred flow. "
             "WARNING: do NOT use assign_task to perform a PR code review. Workers always "
@@ -156,9 +158,9 @@ FOREMAN_TOOLS = [
             "to use the default 3 days, or pass expires_in_seconds = 259200\n"
             "  - Error / failed tasks: expires_in_seconds = 86400 (1 day)\n"
             "Pass deleted_at instead if you need an exact ISO-8601 timestamp.\n"
-            "NOTE: Do NOT call finalize_task for tasks that have an open PR — those are "
-            "automatically finalized when the PR is merged (or failed when the PR is closed "
-            "without merging) via the GitHub webhook."
+            "NOTE: For tasks that have an open PR, the GitHub webhook *may* deliver a "
+            "'PR merged' event — but do not rely on it firing reliably. Always call "
+            "get_pr_status to confirm the merged state before calling finalize_task."
         ),
         "input_schema": {
             "type": "object",


### PR DESCRIPTION
## Summary

- **Soften webhook finalize language**: The `PR merged` event handler now notes the webhook *may not fire reliably* and instructs the Foreman to always call `get_pr_status` to confirm merged state before calling `finalize_task`.
- **Plan-phase output → issue comment, not PR**: Added explicit guidance under the `plan` phase that findings, specs, or outlines should be posted as a comment on the linked GitHub issue — not committed and turned into a PR. A PR should only be opened when there is actual code to merge.
- **Issue thread as progress log**: New section instructing the Foreman to post a brief GitHub issue comment whenever it calls `redirect_task` or `send_followup`, keeping the issue thread as a running log of progress visible to humans and contributors.

## Test plan
- [ ] Read `backend/foreman_core/prompt.py` and verify the three sections changed correctly
- [ ] Confirm `ruff check` passes (no Python style issues — prompt is a string constant)
- [ ] Manually test: create a plan-phase task and verify Foreman posts findings as an issue comment rather than opening a PR
- [ ] Manually test: trigger a PR-merged webhook and confirm Foreman calls `get_pr_status` before `finalize_task`

🤖 Generated with [Claude Code](https://claude.com/claude-code)