### PR TITLE
Fix default tool selection in assign_task / send_followup

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1167,14 +1167,15 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 ).model_dump(by_alias=True, exclude_none=True),
                             )
                             followup_worker_result = await db.exec(
-                                select(col(Worker.tools)).where(
-                                    col(Worker.id) == target_worker_id
-                                )
+                                select(col(Worker.tools)).where(col(Worker.id) == target_worker_id)
                             )
                             followup_worker_tools_json = followup_worker_result.one_or_none()
-                            followup_worker_tools: list[str] = json.loads(
-                                followup_worker_tools_json or "[]"
-                            )
+                            if isinstance(followup_worker_tools_json, str):
+                                followup_worker_tools: list[str] = json.loads(
+                                    followup_worker_tools_json or "[]"
+                                )
+                            else:
+                                followup_worker_tools = followup_worker_tools_json or []
                             await broadcast(
                                 guild_id,
                                 TaskFollowupMsg(
@@ -1182,7 +1183,12 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     taskId=task_id,
                                     name=task_name or "",
                                     description=task_desc or "",
-                                    tool=task_tool or (followup_worker_tools[0] if followup_worker_tools else "claude"),
+                                    tool=task_tool
+                                    or (
+                                        followup_worker_tools[0]
+                                        if followup_worker_tools
+                                        else "claude"
+                                    ),
                                     model=task_model,
                                     provider=task_provider,
                                     branch=branch,

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1166,6 +1166,15 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     finishedAt=None,
                                 ).model_dump(by_alias=True, exclude_none=True),
                             )
+                            followup_worker_result = await db.exec(
+                                select(col(Worker.tools)).where(
+                                    col(Worker.id) == target_worker_id
+                                )
+                            )
+                            followup_worker_tools_json = followup_worker_result.one_or_none()
+                            followup_worker_tools: list[str] = json.loads(
+                                followup_worker_tools_json or "[]"
+                            )
                             await broadcast(
                                 guild_id,
                                 TaskFollowupMsg(
@@ -1173,7 +1182,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     taskId=task_id,
                                     name=task_name or "",
                                     description=task_desc or "",
-                                    tool=task_tool or "claude",
+                                    tool=task_tool or (followup_worker_tools[0] if followup_worker_tools else "claude"),
                                     model=task_model,
                                     provider=task_provider,
                                     branch=branch,

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -505,9 +505,9 @@ class TestExecToolsDispatching:
                 ],
             )
         assert "t-flwup-tool" in results[0]["content"]
-        followup_msgs = [m for m in broadcast_calls if getattr(m, "type", None) == "task-followup"]
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
         assert len(followup_msgs) == 1
-        assert followup_msgs[0].tool == "pi"
+        assert followup_msgs[0]["tool"] == "pi"
 
     async def test_send_followup_task_not_found(self, db_session):
         insert_guild(db_session, "g-followup-missing")

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -474,6 +474,41 @@ class TestExecToolsDispatching:
             )
         assert task_tool == "pi"
 
+    async def test_send_followup_defaults_to_first_worker_tool(self, db_session):
+        insert_guild(db_session, "g-followup-tooldefault")
+        insert_worker(
+            db_session, "g-followup-tooldefault", "w-flwup-tool", tools='["pi", "claude"]'
+        )
+        _insert_agent(db_session, "g-followup-tooldefault", "w-flwup-tool", "a-flwup-tool")
+        # Insert task with empty tool so the falsy fallback triggers
+        insert_task(
+            db_session,
+            "g-followup-tooldefault",
+            "t-flwup-tool",
+            worker_id="w-flwup-tool",
+            tool="",
+            branch="claude/test-tool-branch",
+        )
+        broadcast_calls = []
+
+        async def capture(gid, msg):
+            broadcast_calls.append(msg)
+
+        with patch("foreman.tools.broadcast", side_effect=capture):
+            results = await exec_tools(
+                "g-followup-tooldefault",
+                [
+                    _fake_tool_use(
+                        "send_followup",
+                        {"task_id": "t-flwup-tool", "instructions": "Continue work"},
+                    )
+                ],
+            )
+        assert "t-flwup-tool" in results[0]["content"]
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        assert len(followup_msgs) == 1
+        assert followup_msgs[0]["tool"] == "pi"
+
     async def test_send_followup_task_not_found(self, db_session):
         insert_guild(db_session, "g-followup-missing")
         with patch("foreman.tools.broadcast", new_callable=AsyncMock):

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -505,9 +505,9 @@ class TestExecToolsDispatching:
                 ],
             )
         assert "t-flwup-tool" in results[0]["content"]
-        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        followup_msgs = [m for m in broadcast_calls if getattr(m, "type", None) == "task-followup"]
         assert len(followup_msgs) == 1
-        assert followup_msgs[0]["tool"] == "pi"
+        assert followup_msgs[0].tool == "pi"
 
     async def test_send_followup_task_not_found(self, db_session):
         insert_guild(db_session, "g-followup-missing")


### PR DESCRIPTION
## Summary

- **`assign_task`** (line 873): Already had the fix at lines 893–894 (`worker_tools[0] if worker_tools else "claude"`); no change needed.
- **`create_task`** (line 837): Uses `tool="claude"` as an unassigned-task placeholder; `assign_task` overwrites it with the worker's first tool when the task is later assigned — acceptable, no change.
- **`send_followup`** (line 1176): Added a Worker tools lookup for `target_worker_id` and changed the fallback from hardcoded `"claude"` to `worker_tools[0] if worker_tools else "claude"`, matching `assign_task` behaviour.

## Test plan

- [ ] `test_assign_task_defaults_to_first_tool` (existing) — confirms assign_task picks `worker_tools[0]`
- [ ] `test_send_followup_defaults_to_first_worker_tool` (new) — inserts a task with `tool=""` (falsy), worker with `tools=["pi","claude"]`, verifies `TaskFollowupMsg.tool == "pi"`

Closes #593