### PR TITLE
Fix poll loop backoff reset on foreman trigger (#556)

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from datetime import UTC, datetime
 
 from auth_deps import get_guild_pk
@@ -58,6 +59,22 @@ _poll_tasks: dict[str, "asyncio.Task[None]"] = {}
 # memory bounded and avoids stale snapshots piling up under load.
 # Entries are popped in the finally block after each run so the dict stays small.
 _guild_locks: dict[tuple[str, str | None], asyncio.Lock] = {}
+
+# Monotonic timestamp (time.monotonic()) of the last foreman run that made at
+# least one tool call, keyed by guild_id.  Used by reset_foreman_poll to decide
+# whether to reset the backoff: only reset when the foreman was recently active.
+_guild_last_action_at: dict[str, float] = {}
+
+
+def _record_guild_action(guild_id: str) -> None:
+    """Record that the foreman made tool calls for *guild_id* right now."""
+    _guild_last_action_at[guild_id] = time.monotonic()
+
+
+def _guild_active_recently(guild_id: str) -> bool:
+    """Return True if the foreman made tool calls within the last POLL_MIN_SECS."""
+    return (time.monotonic() - _guild_last_action_at.get(guild_id, 0.0)) <= POLL_MIN_SECS
+
 
 # Module-level client — reused across calls so the underlying httpx connection
 # pool isn't thrown away every invocation. Lazily initialised so import works
@@ -340,16 +357,41 @@ async def _poll_loop(guild_id: str) -> None:
 
 
 def reset_foreman_poll(guild_id: str) -> None:
-    """Cancel any running poll loop for this guild and start a fresh one at POLL_MIN_SECS.
+    """Ensure a poll loop is running for this guild, resetting the backoff only when appropriate.
 
-    Call whenever a significant event occurs (human message, worker state change,
-    task transition) to reset the backoff so the next check happens in 1 minute.
+    The backoff is only reset to POLL_MIN_SECS when the foreman was recently
+    active (made at least one tool call within the last POLL_MIN_SECS seconds).
+    If the foreman is idle, the existing loop is left undisturbed so the interval
+    continues to grow — spurious events from worker completions/state changes will
+    not spam the Claude API by repeatedly resetting the timer to 60 s.
+
+    If a foreman run is already in-flight for this guild, the call is a no-op:
+    the in-flight run was already triggered by _trigger_foreman and the poll loop
+    will re-fire on its next tick anyway.
     """
-    old = _poll_tasks.pop(guild_id, None)
-    if old and not old.done():
-        old.cancel()
-    task = spawn(_poll_loop(guild_id), name=f"foreman.poll-loop:{guild_id}")
-    _poll_tasks[guild_id] = task
+    # Debounce: any in-flight run for this guild (regardless of user_id) means we
+    # skip the reset entirely.  The run was already dispatched; another timer reset
+    # would be wasteful and could mask the first run's backoff contribution.
+    in_flight = any(k[0] == guild_id and lock.locked() for k, lock in _guild_locks.items())
+    if in_flight:
+        logger.debug("guild=%s reset_foreman_poll: run in-flight, skipping timer reset", guild_id)
+        return
+
+    if _guild_active_recently(guild_id):
+        # Foreman was active recently — cancel and restart at the minimum interval
+        # so the next check happens in POLL_MIN_SECS.
+        old = _poll_tasks.pop(guild_id, None)
+        if old and not old.done():
+            old.cancel()
+        task = spawn(_poll_loop(guild_id), name=f"foreman.poll-loop:{guild_id}")
+        _poll_tasks[guild_id] = task
+    else:
+        # Foreman is idle — only start a loop if none exists; do not interrupt
+        # the current loop's sleep so the backoff continues to grow naturally.
+        existing = _poll_tasks.get(guild_id)
+        if existing is None or existing.done():
+            task = spawn(_poll_loop(guild_id), name=f"foreman.poll-loop:{guild_id}")
+            _poll_tasks[guild_id] = task
 
 
 async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
@@ -658,6 +700,8 @@ async def _run_foreman_ai(
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
             if not tool_uses:
                 break  # end_turn — foreman is done
+
+            _record_guild_action(guild_id)
 
             # Broadcast tool-use events so the frontend chat shows them live
             for tu in tool_uses:

--- a/backend/tests/test_foreman_poll_backoff.py
+++ b/backend/tests/test_foreman_poll_backoff.py
@@ -1,0 +1,301 @@
+"""Tests for the poll-loop backoff behaviour (issue #556).
+
+Verifies that:
+- reset_foreman_poll only resets the interval to POLL_MIN_SECS when the foreman
+  was recently active (made tool calls within POLL_MIN_SECS seconds).
+- reset_foreman_poll does not restart an existing loop if the foreman is idle.
+- reset_foreman_poll is a no-op when a foreman run is already in-flight.
+- _record_guild_action and _guild_active_recently behave correctly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock, patch
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# _record_guild_action / _guild_active_recently helpers
+# ---------------------------------------------------------------------------
+
+
+def test_record_guild_action_sets_timestamp():
+    import foreman.runner as runner
+
+    runner._guild_last_action_at.pop("g-ts", None)
+    before = time.monotonic()
+    runner._record_guild_action("g-ts")
+    after = time.monotonic()
+
+    ts = runner._guild_last_action_at["g-ts"]
+    assert before <= ts <= after
+
+
+def test_guild_active_recently_true_for_fresh_action():
+    import foreman.runner as runner
+
+    runner._guild_last_action_at["g-fresh"] = time.monotonic()
+    assert runner._guild_active_recently("g-fresh") is True
+
+
+def test_guild_active_recently_false_for_old_action():
+    import foreman.runner as runner
+
+    # Simulate an action that happened long before POLL_MIN_SECS
+    runner._guild_last_action_at["g-old"] = time.monotonic() - (runner.POLL_MIN_SECS * 2)
+    assert runner._guild_active_recently("g-old") is False
+
+
+def test_guild_active_recently_false_for_unknown_guild():
+    import foreman.runner as runner
+
+    runner._guild_last_action_at.pop("g-never", None)
+    assert runner._guild_active_recently("g-never") is False
+
+
+# ---------------------------------------------------------------------------
+# reset_foreman_poll — in-flight debounce
+# ---------------------------------------------------------------------------
+
+
+def test_reset_poll_skips_when_run_in_flight():
+    """reset_foreman_poll must not restart the loop when a run holds the lock."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        guild = "g-inflight"
+        runner._guild_locks.clear()
+        runner._poll_tasks.pop(guild, None)
+        runner._guild_last_action_at[guild] = time.monotonic()  # recently active
+
+        # Acquire the lock as if a run is in progress.
+        lock = asyncio.Lock()
+        await lock.acquire()
+        runner._guild_locks[(guild, None)] = lock
+
+        spawned = []
+        with patch.object(runner, "spawn", side_effect=lambda c, **kw: spawned.append(c)):
+            runner.reset_foreman_poll(guild)
+
+        lock.release()
+        assert spawned == [], "spawn must not be called while a run is in-flight"
+
+    _run(_test())
+
+
+# ---------------------------------------------------------------------------
+# reset_foreman_poll — idle guard (no recent tool calls)
+# ---------------------------------------------------------------------------
+
+
+def test_reset_poll_does_not_restart_existing_loop_when_idle():
+    """When foreman is idle, an existing running poll loop must not be restarted."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        guild = "g-idle-existing"
+        runner._guild_locks.clear()
+        runner._guild_last_action_at.pop(guild, None)  # never active
+
+        # Install a fake task that is *not* done.
+        fake_task = MagicMock()
+        fake_task.done.return_value = False
+        runner._poll_tasks[guild] = fake_task
+
+        spawned = []
+        with patch.object(runner, "spawn", side_effect=lambda c, **kw: spawned.append(c)):
+            runner.reset_foreman_poll(guild)
+
+        assert spawned == [], "existing loop must not be cancelled/restarted when idle"
+        # The fake task must not have been cancelled.
+        fake_task.cancel.assert_not_called()
+
+    _run(_test())
+
+
+def test_reset_poll_starts_loop_when_none_exists_and_idle():
+    """When foreman is idle but no loop exists, reset_foreman_poll must start one."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        guild = "g-idle-no-loop"
+        runner._guild_locks.clear()
+        runner._guild_last_action_at.pop(guild, None)  # never active
+        runner._poll_tasks.pop(guild, None)  # no existing loop
+
+        fake_task = MagicMock()
+        spawned = []
+
+        def _fake_spawn(coro, **kw):
+            spawned.append(coro)
+            return fake_task
+
+        with patch.object(runner, "spawn", side_effect=_fake_spawn):
+            runner.reset_foreman_poll(guild)
+
+        assert len(spawned) == 1, "should start a new loop when none exists"
+        assert runner._poll_tasks[guild] is fake_task
+
+    _run(_test())
+
+
+# ---------------------------------------------------------------------------
+# reset_foreman_poll — active reset
+# ---------------------------------------------------------------------------
+
+
+def test_reset_poll_cancels_and_restarts_when_recently_active():
+    """When foreman was recently active, the poll loop is restarted at POLL_MIN_SECS."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        guild = "g-active-reset"
+        runner._guild_locks.clear()
+        runner._guild_last_action_at[guild] = time.monotonic()  # just made tool calls
+
+        # Install a fake running task.
+        old_task = MagicMock()
+        old_task.done.return_value = False
+        runner._poll_tasks[guild] = old_task
+
+        new_task = MagicMock()
+        spawned = []
+
+        def _fake_spawn(coro, **kw):
+            spawned.append(coro)
+            return new_task
+
+        with patch.object(runner, "spawn", side_effect=_fake_spawn):
+            runner.reset_foreman_poll(guild)
+
+        old_task.cancel.assert_called_once()
+        assert len(spawned) == 1, "should spawn a new poll loop"
+        assert runner._poll_tasks[guild] is new_task
+
+    _run(_test())
+
+
+# ---------------------------------------------------------------------------
+# _run_foreman_ai records action when tool calls are made
+# ---------------------------------------------------------------------------
+
+
+def test_run_foreman_ai_records_action_on_tool_calls():
+    """_run_foreman_ai must call _record_guild_action when tool_uses are present."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        guild = "g-action-record"
+        runner._guild_last_action_at.pop(guild, None)
+
+        # Build a minimal fake response with one tool_use block
+        tool_use_block = MagicMock()
+        tool_use_block.type = "tool_use"
+        tool_use_block.name = "get_task_status"
+        tool_use_block.id = "tu-1"
+        tool_use_block.input = {"task_id": "t-1"}
+        # _serialize_content calls b.model_dump(); return a proper dict so json.dumps works.
+        tool_use_block.model_dump.return_value = {
+            "type": "tool_use",
+            "id": "tu-1",
+            "name": "get_task_status",
+            "input": {"task_id": "t-1"},
+        }
+
+        end_turn_block = MagicMock()
+        end_turn_block.type = "text"
+        end_turn_block.text = "done"
+        end_turn_block.model_dump.return_value = {"type": "text", "text": "done"}
+
+        first_resp = MagicMock()
+        first_resp.stop_reason = "tool_use"
+        first_resp.content = [tool_use_block]
+        first_resp.usage = MagicMock(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        )
+
+        second_resp = MagicMock()
+        second_resp.stop_reason = "end_turn"
+        second_resp.content = [end_turn_block]
+        second_resp.usage = MagicMock(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        )
+
+        call_count = 0
+
+        async def _fake_create(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = first_resp if call_count == 1 else second_resp
+            raw = MagicMock()
+            raw.parse.return_value = resp
+            raw.headers = {"request-id": "req-1"}
+            return raw
+
+        fake_client = MagicMock()
+        fake_client.messages.with_raw_response.create = _fake_create
+
+        from unittest.mock import AsyncMock
+
+        with (
+            patch.object(runner, "_get_anthropic_client", return_value=fake_client),
+            patch.object(runner, "HAS_ANTHROPIC", True),
+            patch.object(runner, "_get_guild_user_id", AsyncMock(return_value="u-1")),
+            patch.object(runner, "_load_foreman_config", AsyncMock(return_value={})),
+            patch.object(runner, "_save_turn", AsyncMock(return_value=1)),
+            patch.object(runner, "_load_history", AsyncMock(return_value=[])),
+            patch.object(runner, "_create_api_request_log", AsyncMock(return_value=1)),
+            patch.object(runner, "_complete_api_request_log", AsyncMock()),
+            patch.object(runner, "broadcast_msg", AsyncMock()),
+            patch.object(
+                runner,
+                "exec_tools",
+                AsyncMock(
+                    return_value=[
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu-1",
+                            "content": "ok",
+                        }
+                    ]
+                ),
+            ),
+            patch.object(runner, "_fetch_online_workers", AsyncMock(return_value=[])),
+            patch("foreman.runner.get_db") as mock_get_db,
+            patch("foreman.runner.get_guild_pk", AsyncMock(return_value=1)),
+        ):
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_db.commit = AsyncMock()
+            mock_db.add = MagicMock()
+            mock_db.rollback = AsyncMock()
+            mock_db.exec = AsyncMock(
+                return_value=MagicMock(
+                    one_or_none=MagicMock(return_value=None),
+                    all=MagicMock(return_value=[]),
+                )
+            )
+            mock_get_db.return_value = mock_db
+
+            await runner._run_foreman_ai(guild, "check tasks")
+
+        assert guild in runner._guild_last_action_at, "_record_guild_action should have been called"
+        assert runner._guild_active_recently(guild) is True
+
+    _run(_test())

--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from typing import TYPE_CHECKING
 
 import websockets
@@ -24,6 +25,16 @@ class Foreman:
     def __init__(self, config: Config):
         self._config = config
         self._http: ForemanHTTPClient | None = None
+        # In-flight flag: True while a foreman run coroutine is executing.
+        # Checked before spawning a new trigger run or poll run so we never
+        # have two concurrent runs for the same guild.
+        self._in_flight: bool = False
+        # Monotonic timestamp of the last run that made at least one tool call.
+        # Used to decide whether to reset the poll backoff.
+        self._last_action_at: float = 0.0
+        # Current poll interval in seconds.  Reset to poll_min_interval when
+        # the foreman makes tool calls; otherwise advanced exponentially each tick.
+        self._poll_interval: int = config.poll_min_interval
 
     async def run(self) -> None:
         """Connect to the backend and handle triggers until stopped."""
@@ -80,6 +91,43 @@ class Foreman:
                 except Exception as exc:
                     logger.warning("_ws_send failed: %s", exc)
 
+            async def _run_foreman(
+                guild_id: str,
+                human_message: str,
+                *,
+                extra_context: str = "",
+                user_id: str | None = None,
+                task_id: str | None = None,
+                task_name: str = "foreman.run",
+            ) -> None:
+                """Wrapper that enforces the in-flight flag and updates last_action_at."""
+                if self._in_flight:
+                    logger.info(
+                        "guild=%s %s: dropped — run already in-flight",
+                        guild_id,
+                        task_name,
+                    )
+                    return
+                self._in_flight = True
+                try:
+                    made_calls = await run_foreman_ai(
+                        guild_id,
+                        human_message,
+                        extra_context=extra_context,
+                        user_id=user_id,
+                        task_id=task_id,
+                        http=self._http,
+                        ws_send=_ws_send,
+                        config=self._config,
+                    )
+                    if made_calls:
+                        self._last_action_at = time.monotonic()
+                        self._poll_interval = self._config.poll_min_interval
+                except Exception:
+                    logger.exception("guild=%s %s: unhandled error", guild_id, task_name)
+                finally:
+                    self._in_flight = False
+
             async def _handle_trigger(data: dict) -> None:
                 guild_id = data.get("guildId", "")
                 human_message = data.get("humanMessage", "")
@@ -90,25 +138,25 @@ class Foreman:
                     logger.warning("Ignoring malformed foreman-trigger: %s", data)
                     return
                 asyncio.create_task(
-                    run_foreman_ai(
+                    _run_foreman(
                         guild_id,
                         human_message,
                         extra_context=extra_context,
                         user_id=user_id,
                         task_id=trigger_task_id,
-                        http=self._http,
-                        ws_send=_ws_send,
-                        config=self._config,
+                        task_name=f"foreman.trigger:{guild_id}:{data.get('event', '?')}",
                     ),
                     name=f"foreman.trigger:{guild_id}:{data.get('event', '?')}",
                 )
 
             async def _poll_loop() -> None:
                 """Background poll — check active tasks periodically."""
-                interval = self._config.poll_min_interval
                 while True:
+                    # Capture the sleep duration so we can detect if a run reset
+                    # self._poll_interval during the sleep.
+                    sleep_duration = self._poll_interval
                     try:
-                        await asyncio.sleep(interval)
+                        await asyncio.sleep(sleep_duration)
                     except asyncio.CancelledError:
                         return
 
@@ -120,30 +168,33 @@ class Foreman:
                             if t.get("state") not in ("done", "failed", "cancelled")
                         ]
                         n = len(active)
-                        next_interval = min(interval * 2, self._config.poll_max_interval)
 
-                        if active:
+                        # Advance the interval for the next tick.  If a triggered run
+                        # reset self._poll_interval to poll_min_interval during our
+                        # sleep, that value will be smaller than sleep_duration, so
+                        # we advance from the reset value (not from sleep_duration).
+                        base = min(self._poll_interval, sleep_duration)
+                        self._poll_interval = min(base * 2, self._config.poll_max_interval)
+
+                        if active and not self._in_flight:
                             task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active)
                             msg = (
                                 f"[periodic-check] Automated status poll — {n} non-terminal "
                                 f"task(s): {task_summary}. Check whether any are stalled."
                             )
                             asyncio.create_task(
-                                run_foreman_ai(
+                                _run_foreman(
                                     self._config.guild_id,
                                     msg,
-                                    http=self._http,
-                                    ws_send=_ws_send,
-                                    config=self._config,
+                                    task_name=f"foreman.poll:{self._config.guild_id}",
                                 ),
                                 name=f"foreman.poll:{self._config.guild_id}",
                             )
 
-                        interval = next_interval
                         await _ws_send(
                             {
                                 "type": "foreman-poll-status",
-                                "nextCheckIn": interval,
+                                "nextCheckIn": self._poll_interval,
                             }
                         )
                     except asyncio.CancelledError:

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -116,12 +116,15 @@ async def run_foreman_ai(
     http: ForemanHTTPClient,
     ws_send: Callable[[dict], Awaitable[None]],
     config: Config,
-) -> None:
+) -> bool:
     """Process a human message (or system escalation) through the Claude foreman AI.
 
     Standalone version — uses REST for state/history, WS for broadcasts.
     ``task_id`` must be passed explicitly by the caller; it is not inferred from
     guild state so there is no ambiguity when multiple tasks are active.
+
+    Returns True if the foreman made at least one tool call, False otherwise.
+    Callers use this to decide whether to reset the poll backoff.
     """
     from .tools import FOREMAN_TOOLS, exec_tools
 
@@ -136,7 +139,7 @@ async def run_foreman_ai(
                 "createdAt": now,
             }
         )
-        return
+        return False
 
     # Fetch guild state
     state = await http.get_state()
@@ -149,6 +152,7 @@ async def run_foreman_ai(
     if not user_id:
         user_id = guild_data.get("owner_user_id") or guild_id
 
+    made_tool_calls = False
     try:
         workers_block = json.dumps(
             [
@@ -275,6 +279,8 @@ async def run_foreman_ai(
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
             if not tool_uses:
                 break
+
+            made_tool_calls = True
 
             for tu in tool_uses:
                 await ws_send(
@@ -437,3 +443,6 @@ async def run_foreman_ai(
                 "createdAt": now,
             }
         )
+        return False
+
+    return made_tool_calls


### PR DESCRIPTION
## Summary

- **Decouple backoff reset from trigger events**: `reset_foreman_poll` only cancels/restarts the embedded poll loop at `POLL_MIN_SECS` when the foreman made at least one tool call within the last `POLL_MIN_SECS` seconds. When the foreman is idle (no tool calls), the existing loop is left undisturbed so the interval continues to grow normally (60 s → 120 s → … → 14400 s). Previously every `task-complete` / `agent-state` / `needs-input` event reset the timer to 60 s even when the foreman had nothing useful to do.
- **In-flight debounce**: `reset_foreman_poll` checks `_guild_locks` and returns immediately if any run is already executing for the guild. The spawned run was already triggered by `_trigger_foreman`; a second timer reset would be wasteful.
- **Last-action tracking**: new `_record_guild_action` / `_guild_active_recently` helpers track a per-guild monotonic timestamp that `_run_foreman_ai` updates whenever it processes at least one tool call.
- **Standalone foreman**: added `_in_flight` flag to `Foreman` to prevent concurrent trigger runs; `run_foreman_ai` returns `bool` (made tool calls); poll interval resets to `poll_min_interval` only when the foreman was active.

## Test plan

- [ ] `cd backend && python -m pytest tests/test_foreman_poll_backoff.py -v` — 9 new tests (all pass)
- [ ] `cd backend && python -m pytest tests/test_foreman_guild_lock.py tests/test_foreman_runner.py -v` — existing tests still pass

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)