### PR TITLE
feat: enforce tool_choice for create_task/send_followup foreman calls

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -426,6 +426,7 @@ async def run_foreman_ai(
     human_message: str,
     extra_context: str = "",
     user_id: str | None = None,
+    required_tool: str | None = None,
 ) -> None:
     """Serialise per-(guild, user) and delegate to ``_run_foreman_ai``.
 
@@ -453,7 +454,7 @@ async def run_foreman_ai(
         return
     await lock.acquire()
     try:
-        await _run_foreman_ai(guild_id, human_message, extra_context, user_id)
+        await _run_foreman_ai(guild_id, human_message, extra_context, user_id, required_tool)
     finally:
         lock.release()
         _guild_locks.pop(lock_key, None)
@@ -464,6 +465,7 @@ async def _run_foreman_ai(
     human_message: str,
     extra_context: str = "",
     user_id: str | None = None,
+    required_tool: str | None = None,
 ):
     """Process a human message (or system escalation) through the Claude foreman AI."""
     if not HAS_ANTHROPIC:
@@ -612,11 +614,14 @@ async def _run_foreman_ai(
                 round_num,
                 len(messages),
             )
+            _tool_choice_kw: dict = {}
+            if required_tool and round_num == 0:
+                _tool_choice_kw = {"tool_choice": {"type": "tool", "name": required_tool}}
             api_log_id = await _create_api_request_log(
                 model=foreman_model,
                 system_blocks=system_blocks,
                 messages=messages,
-                extra={"max_tokens": 1024, "tools": FOREMAN_TOOLS},
+                extra={"max_tokens": 1024, "tools": FOREMAN_TOOLS, **_tool_choice_kw},
                 task_id=_task_id,
             )
             _raw = await client.messages.with_raw_response.create(
@@ -625,6 +630,7 @@ async def _run_foreman_ai(
                 system=system_blocks,  # type: ignore[arg-type]
                 messages=messages,  # type: ignore[arg-type]
                 tools=FOREMAN_TOOLS,  # type: ignore[arg-type]
+                **_tool_choice_kw,  # type: ignore[arg-type]
             )
             resp = _raw.parse()
             usage = resp.usage
@@ -699,6 +705,10 @@ async def _run_foreman_ai(
 
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
             if not tool_uses:
+                if required_tool and round_num == 0:
+                    raise RuntimeError(
+                        f"Foreman returned no tool call on round 0 despite required_tool={required_tool!r}"
+                    )
                 break  # end_turn — foreman is done
 
             _record_guild_action(guild_id)
@@ -932,6 +942,8 @@ async def _run_foreman_ai(
             guild_id,
             ChatMsg(from_="foreman", to="user", content=f"Foreman error: {exc}", createdAt=now),
         )
+        if isinstance(exc, RuntimeError) and "required_tool" in str(exc):
+            raise
     finally:
         await db.close()
 

--- a/backend/tests/test_foreman_guild_lock.py
+++ b/backend/tests/test_foreman_guild_lock.py
@@ -18,7 +18,7 @@ async def _run_foreman_ai_patched(guild_id: str, impl_event: asyncio.Event | Non
     """
     import foreman.runner as runner
 
-    async def _slow_impl(gid, msg, extra="", uid=None):
+    async def _slow_impl(gid, msg, extra="", uid=None, required_tool=None):
         if impl_event is not None:
             await impl_event.wait()
 
@@ -47,7 +47,7 @@ def test_concurrent_same_guild_drops_second():
         call_count = 0
         hold = asyncio.Event()
 
-        async def _impl(gid, msg, extra="", uid=None):
+        async def _impl(gid, msg, extra="", uid=None, required_tool=None):
             nonlocal call_count
             call_count += 1
             await hold.wait()
@@ -81,7 +81,7 @@ def test_concurrent_different_guilds_both_run():
         call_log: list[str] = []
         hold = asyncio.Event()
 
-        async def _impl(gid, msg, extra="", uid=None):
+        async def _impl(gid, msg, extra="", uid=None, required_tool=None):
             call_log.append(gid)
             await hold.wait()
 
@@ -107,7 +107,7 @@ def test_lock_released_after_completion():
 
         call_count = 0
 
-        async def _impl(gid, msg, extra="", uid=None):
+        async def _impl(gid, msg, extra="", uid=None, required_tool=None):
             nonlocal call_count
             call_count += 1
 
@@ -130,7 +130,7 @@ def test_lock_released_after_impl_exception():
 
         call_count = 0
 
-        async def _impl(gid, msg, extra="", uid=None):
+        async def _impl(gid, msg, extra="", uid=None, required_tool=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:

--- a/backend/tests/test_foreman_tool_choice.py
+++ b/backend/tests/test_foreman_tool_choice.py
@@ -1,0 +1,251 @@
+"""Tests for required_tool / tool_choice enforcement in the foreman runner (issue #602).
+
+Verifies that:
+- When required_tool is set, the API call includes tool_choice on round 0.
+- When the model returns no tool call despite required_tool being set, a RuntimeError is raised.
+- When the model returns a valid tool call, execution proceeds normally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _mock_db_session() -> MagicMock:
+    """Return a mock that quacks like an AsyncSession for runner tests."""
+    result = MagicMock()
+    result.one_or_none = MagicMock(return_value=None)
+    result.all = MagicMock(return_value=[])
+
+    session = MagicMock()
+    session.exec = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.close = AsyncMock()
+    return session
+
+
+def _make_text_response(text: str = "I'll think about this.") -> MagicMock:
+    """Mock Anthropic response containing only a text block (no tool call)."""
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+
+    usage = MagicMock()
+    usage.input_tokens = 10
+    usage.output_tokens = 5
+    usage.cache_read_input_tokens = 0
+    usage.cache_creation_input_tokens = 0
+
+    resp = MagicMock()
+    resp.content = [block]
+    resp.stop_reason = "end_turn"
+    resp.usage = usage
+    resp.model_dump = MagicMock(return_value={"stop_reason": "end_turn"})
+
+    raw = MagicMock()
+    raw.parse = MagicMock(return_value=resp)
+    raw.headers = {"request-id": "req-test-123"}
+    return raw
+
+
+def _make_tool_use_response(tool_name: str = "send_followup") -> MagicMock:
+    """Mock Anthropic response containing a tool_use block."""
+    tool_block = MagicMock()
+    tool_block.type = "tool_use"
+    tool_block.name = tool_name
+    tool_block.id = "toolu_test_abc"
+    tool_block.input = {"task_id": "t-test", "instructions": "continue"}
+
+    usage = MagicMock()
+    usage.input_tokens = 20
+    usage.output_tokens = 10
+    usage.cache_read_input_tokens = 0
+    usage.cache_creation_input_tokens = 0
+
+    resp = MagicMock()
+    resp.content = [tool_block]
+    resp.stop_reason = "tool_use"
+    resp.usage = usage
+    resp.model_dump = MagicMock(return_value={"stop_reason": "tool_use"})
+
+    raw = MagicMock()
+    raw.parse = MagicMock(return_value=resp)
+    raw.headers = {"request-id": "req-test-456"}
+    return raw
+
+
+def _apply_runner_patches(stack: ExitStack, client_mock=None, exec_tools_mock=None) -> MagicMock:
+    """Enter all standard patches needed for _run_foreman_ai tests into an ExitStack."""
+    if client_mock is None:
+        client_mock = MagicMock()
+
+    db = _mock_db_session()
+
+    stack.enter_context(patch("foreman.runner._get_anthropic_client", return_value=client_mock))
+    stack.enter_context(patch("foreman.runner.get_foreman_model", return_value="claude-test"))
+    stack.enter_context(patch("foreman.runner._load_foreman_config", new=AsyncMock(return_value={})))
+    stack.enter_context(patch("foreman.runner._get_guild_user_id", new=AsyncMock(return_value="user-1")))
+    stack.enter_context(patch("foreman.runner.get_db", new=AsyncMock(return_value=db)))
+    stack.enter_context(patch("foreman.runner.get_guild_pk", new=AsyncMock(return_value=1)))
+    stack.enter_context(patch("foreman.runner._fetch_online_workers", new=AsyncMock(return_value=[])))
+    stack.enter_context(patch("foreman.runner._load_history", new=AsyncMock(return_value=[
+        {"role": "user", "content": "test message"}
+    ])))
+    stack.enter_context(patch("foreman.runner._save_turn", new=AsyncMock(return_value=1)))
+    stack.enter_context(patch("foreman.runner._create_api_request_log", new=AsyncMock(return_value=42)))
+    stack.enter_context(patch("foreman.runner._complete_api_request_log", new=AsyncMock()))
+    stack.enter_context(patch("foreman.runner.broadcast_msg", new=AsyncMock()))
+    stack.enter_context(patch("foreman.runner.prune_history", side_effect=lambda m: m))
+    stack.enter_context(patch("foreman.runner.strip_orphaned_tool_results", side_effect=lambda m: m))
+    stack.enter_context(patch("foreman.runner._stamp_message_cache_breakpoint"))
+    stack.enter_context(patch("foreman.runner.build_system_blocks", return_value=[{"type": "text", "text": "sys"}]))
+    stack.enter_context(patch("foreman.runner.build_state_preamble", return_value="preamble"))
+    stack.enter_context(patch("foreman.runner.build_system_prompt", return_value="audit"))
+    stack.enter_context(patch("foreman.runner._inject_state_preamble"))
+    stack.enter_context(patch("foreman.runner._serialize_content", side_effect=lambda c: json.dumps(str(c))))
+    stack.enter_context(patch("foreman.runner._summarize_task", return_value=None))
+    stack.enter_context(patch("foreman.runner.HAS_ANTHROPIC", True))
+    stack.enter_context(patch("foreman.runner.Message"))
+    stack.enter_context(patch("foreman.runner.live_tasks_filter", return_value=True))
+    if exec_tools_mock is not None:
+        stack.enter_context(patch("foreman.runner.exec_tools", exec_tools_mock))
+        stack.enter_context(patch("foreman.runner.truncate_tool_result", side_effect=lambda x: x))
+    return client_mock
+
+
+# ---------------------------------------------------------------------------
+# Tool-choice enforcement: API call must include tool_choice when required_tool set
+# ---------------------------------------------------------------------------
+
+
+def test_required_tool_passes_tool_choice_to_api():
+    """When required_tool is set, the first API call must include tool_choice."""
+    api_calls = []
+    tool_result = {"type": "tool_result", "tool_use_id": "toolu_test_abc", "content": "ok"}
+    exec_tools_mock = AsyncMock(return_value=[tool_result])
+
+    # Round 0 returns a tool_use; round 1 returns text to exit the loop.
+    responses = [_make_tool_use_response("send_followup"), _make_text_response()]
+    call_idx = [0]
+
+    async def _side_effect(**kwargs):
+        api_calls.append(kwargs)
+        idx = call_idx[0]
+        call_idx[0] += 1
+        return responses[min(idx, len(responses) - 1)]
+
+    client_mock = MagicMock()
+    client_mock.messages.with_raw_response.create = AsyncMock(side_effect=_side_effect)
+
+    with ExitStack() as stack:
+        _apply_runner_patches(stack, client_mock=client_mock, exec_tools_mock=exec_tools_mock)
+        from foreman import runner as fr
+        _run(fr._run_foreman_ai("guild1", "continue please", required_tool="send_followup"))
+
+    assert api_calls, "API was never called"
+    first_call = api_calls[0]
+    assert "tool_choice" in first_call, "tool_choice must be present in round-0 API call"
+    assert first_call["tool_choice"] == {"type": "tool", "name": "send_followup"}
+
+
+def test_no_required_tool_omits_tool_choice():
+    """When required_tool is None, the API call must NOT include tool_choice."""
+    api_calls = []
+
+    async def _capture_create(**kwargs):
+        api_calls.append(kwargs)
+        return _make_text_response()
+
+    client_mock = MagicMock()
+    client_mock.messages.with_raw_response.create = AsyncMock(side_effect=_capture_create)
+
+    with ExitStack() as stack:
+        _apply_runner_patches(stack, client_mock=client_mock)
+        from foreman import runner as fr
+        _run(fr._run_foreman_ai("guild1", "just chatting", required_tool=None))
+
+    assert api_calls, "API was never called"
+    assert "tool_choice" not in api_calls[0], (
+        "tool_choice must NOT be set when required_tool is None"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error enforcement: RuntimeError when model ignores required_tool
+# ---------------------------------------------------------------------------
+
+
+def test_required_tool_raises_when_model_returns_text_only():
+    """When required_tool is set and the model returns no tool call, raise RuntimeError."""
+    client_mock = MagicMock()
+    client_mock.messages.with_raw_response.create = AsyncMock(
+        return_value=_make_text_response("I'll think about it.")
+    )
+
+    with ExitStack() as stack:
+        _apply_runner_patches(stack, client_mock=client_mock)
+        from foreman import runner as fr
+
+        with pytest.raises(RuntimeError, match="required_tool='send_followup'"):
+            _run(fr._run_foreman_ai("guild1", "continue please", required_tool="send_followup"))
+
+
+def test_no_required_tool_text_only_response_does_not_raise():
+    """Without required_tool, a text-only response should exit the loop cleanly."""
+    client_mock = MagicMock()
+    client_mock.messages.with_raw_response.create = AsyncMock(
+        return_value=_make_text_response("Sure, I'll just reply.")
+    )
+
+    with ExitStack() as stack:
+        _apply_runner_patches(stack, client_mock=client_mock)
+        from foreman import runner as fr
+        # Should not raise — text-only is acceptable when no tool is required
+        _run(fr._run_foreman_ai("guild1", "hi there", required_tool=None))
+
+
+# ---------------------------------------------------------------------------
+# Valid tool-use response: accepted and dispatched
+# ---------------------------------------------------------------------------
+
+
+def test_required_tool_valid_response_dispatches_tool():
+    """When required_tool is set and the model returns the matching tool, exec_tools is called."""
+    tool_result = {"type": "tool_result", "tool_use_id": "toolu_test_abc", "content": "ok"}
+    exec_tools_mock = AsyncMock(return_value=[tool_result])
+
+    responses = [_make_tool_use_response("send_followup"), _make_text_response("Done.")]
+    call_idx = [0]
+
+    async def _side_effect(**kwargs):
+        idx = call_idx[0]
+        call_idx[0] += 1
+        return responses[min(idx, len(responses) - 1)]
+
+    client_mock = MagicMock()
+    client_mock.messages.with_raw_response.create = AsyncMock(side_effect=_side_effect)
+
+    with ExitStack() as stack:
+        _apply_runner_patches(stack, client_mock=client_mock, exec_tools_mock=exec_tools_mock)
+        from foreman import runner as fr
+        _run(fr._run_foreman_ai("guild1", "continue the task", required_tool="send_followup"))
+
+    exec_tools_mock.assert_called_once()
+    tool_uses_passed = exec_tools_mock.call_args[0][1]
+    assert len(tool_uses_passed) == 1
+    assert tool_uses_passed[0].name == "send_followup"

--- a/backend/tests/test_foreman_tool_choice.py
+++ b/backend/tests/test_foreman_tool_choice.py
@@ -98,26 +98,43 @@ def _apply_runner_patches(stack: ExitStack, client_mock=None, exec_tools_mock=No
 
     stack.enter_context(patch("foreman.runner._get_anthropic_client", return_value=client_mock))
     stack.enter_context(patch("foreman.runner.get_foreman_model", return_value="claude-test"))
-    stack.enter_context(patch("foreman.runner._load_foreman_config", new=AsyncMock(return_value={})))
-    stack.enter_context(patch("foreman.runner._get_guild_user_id", new=AsyncMock(return_value="user-1")))
+    stack.enter_context(
+        patch("foreman.runner._load_foreman_config", new=AsyncMock(return_value={}))
+    )
+    stack.enter_context(
+        patch("foreman.runner._get_guild_user_id", new=AsyncMock(return_value="user-1"))
+    )
     stack.enter_context(patch("foreman.runner.get_db", new=AsyncMock(return_value=db)))
     stack.enter_context(patch("foreman.runner.get_guild_pk", new=AsyncMock(return_value=1)))
-    stack.enter_context(patch("foreman.runner._fetch_online_workers", new=AsyncMock(return_value=[])))
-    stack.enter_context(patch("foreman.runner._load_history", new=AsyncMock(return_value=[
-        {"role": "user", "content": "test message"}
-    ])))
+    stack.enter_context(
+        patch("foreman.runner._fetch_online_workers", new=AsyncMock(return_value=[]))
+    )
+    stack.enter_context(
+        patch(
+            "foreman.runner._load_history",
+            new=AsyncMock(return_value=[{"role": "user", "content": "test message"}]),
+        )
+    )
     stack.enter_context(patch("foreman.runner._save_turn", new=AsyncMock(return_value=1)))
-    stack.enter_context(patch("foreman.runner._create_api_request_log", new=AsyncMock(return_value=42)))
+    stack.enter_context(
+        patch("foreman.runner._create_api_request_log", new=AsyncMock(return_value=42))
+    )
     stack.enter_context(patch("foreman.runner._complete_api_request_log", new=AsyncMock()))
     stack.enter_context(patch("foreman.runner.broadcast_msg", new=AsyncMock()))
     stack.enter_context(patch("foreman.runner.prune_history", side_effect=lambda m: m))
-    stack.enter_context(patch("foreman.runner.strip_orphaned_tool_results", side_effect=lambda m: m))
+    stack.enter_context(
+        patch("foreman.runner.strip_orphaned_tool_results", side_effect=lambda m: m)
+    )
     stack.enter_context(patch("foreman.runner._stamp_message_cache_breakpoint"))
-    stack.enter_context(patch("foreman.runner.build_system_blocks", return_value=[{"type": "text", "text": "sys"}]))
+    stack.enter_context(
+        patch("foreman.runner.build_system_blocks", return_value=[{"type": "text", "text": "sys"}])
+    )
     stack.enter_context(patch("foreman.runner.build_state_preamble", return_value="preamble"))
     stack.enter_context(patch("foreman.runner.build_system_prompt", return_value="audit"))
     stack.enter_context(patch("foreman.runner._inject_state_preamble"))
-    stack.enter_context(patch("foreman.runner._serialize_content", side_effect=lambda c: json.dumps(str(c))))
+    stack.enter_context(
+        patch("foreman.runner._serialize_content", side_effect=lambda c: json.dumps(str(c)))
+    )
     stack.enter_context(patch("foreman.runner._summarize_task", return_value=None))
     stack.enter_context(patch("foreman.runner.HAS_ANTHROPIC", True))
     stack.enter_context(patch("foreman.runner.Message"))
@@ -155,6 +172,7 @@ def test_required_tool_passes_tool_choice_to_api():
     with ExitStack() as stack:
         _apply_runner_patches(stack, client_mock=client_mock, exec_tools_mock=exec_tools_mock)
         from foreman import runner as fr
+
         _run(fr._run_foreman_ai("guild1", "continue please", required_tool="send_followup"))
 
     assert api_calls, "API was never called"
@@ -177,6 +195,7 @@ def test_no_required_tool_omits_tool_choice():
     with ExitStack() as stack:
         _apply_runner_patches(stack, client_mock=client_mock)
         from foreman import runner as fr
+
         _run(fr._run_foreman_ai("guild1", "just chatting", required_tool=None))
 
     assert api_calls, "API was never called"
@@ -215,6 +234,7 @@ def test_no_required_tool_text_only_response_does_not_raise():
     with ExitStack() as stack:
         _apply_runner_patches(stack, client_mock=client_mock)
         from foreman import runner as fr
+
         # Should not raise — text-only is acceptable when no tool is required
         _run(fr._run_foreman_ai("guild1", "hi there", required_tool=None))
 
@@ -243,6 +263,7 @@ def test_required_tool_valid_response_dispatches_tool():
     with ExitStack() as stack:
         _apply_runner_patches(stack, client_mock=client_mock, exec_tools_mock=exec_tools_mock)
         from foreman import runner as fr
+
         _run(fr._run_foreman_ai("guild1", "continue the task", required_tool="send_followup"))
 
     exec_tools_mock.assert_called_once()

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -63,6 +63,7 @@ def _make_trigger_spy():
         user_id: str | None = None,
         task_id: str | None = None,
         task_name: str = "",
+        required_tool: str | None = None,
     ) -> None:
         triggered.append((event, msg))
 

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -146,6 +146,7 @@ async def _trigger_foreman(
     user_id: str | None = None,
     task_id: str | None = None,
     task_name: str = "foreman.unknown",
+    required_tool: str | None = None,
 ) -> None:
     """Send a ``foreman-trigger`` WS message to an external foreman if one is
     connected for this guild; otherwise fall back to the embedded foreman.
@@ -180,6 +181,7 @@ async def _trigger_foreman(
             humanMessage=human_message,
             userId=user_id or None,  # coerce empty string to None
             taskId=task_id or None,  # coerce empty string to None
+            requiredTool=required_tool or None,
         )
         try:
             await send_ws_message(ws, msg)
@@ -198,7 +200,7 @@ async def _trigger_foreman(
             foreman_connections.pop(guild_id, None)
     # Embedded fallback — identical to the pre-Phase-2 behaviour.
     spawn(
-        run_foreman_ai(guild_id, human_message, user_id=user_id),
+        run_foreman_ai(guild_id, human_message, user_id=user_id, required_tool=required_tool),
         name=task_name,
     )
 
@@ -801,6 +803,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
         user_id=task_uid,
         task_id=task_id,
         task_name=f"foreman.task-complete:{task_id}",
+        required_tool="send_followup" if stop_reason == "max_turns" else None,
     )
     reset_foreman_poll(ctx.guild_id)
 
@@ -886,6 +889,7 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
         user_id=task_uid,
         task_id=task_id,
         task_name=f"foreman.followup-done:{task_id}",
+        required_tool="send_followup" if stop_reason == "max_turns" else None,
     )
     reset_foreman_poll(ctx.guild_id)
 

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -261,6 +261,7 @@ class ForemanTriggerMsg(_WS):
     humanMessage: str
     userId: str | None = None
     taskId: str | None = None
+    requiredTool: str | None = None
 
 
 class ForemanRegisteredMsg(_WS):

--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -98,6 +98,7 @@ class Foreman:
                 extra_context: str = "",
                 user_id: str | None = None,
                 task_id: str | None = None,
+                required_tool: str | None = None,
                 task_name: str = "foreman.run",
             ) -> None:
                 """Wrapper that enforces the in-flight flag and updates last_action_at."""
@@ -116,6 +117,7 @@ class Foreman:
                         extra_context=extra_context,
                         user_id=user_id,
                         task_id=task_id,
+                        required_tool=required_tool,
                         http=self._http,
                         ws_send=_ws_send,
                         config=self._config,
@@ -134,6 +136,7 @@ class Foreman:
                 user_id = data.get("userId")
                 extra_context = data.get("extraContext", "")
                 trigger_task_id = data.get("taskId")
+                required_tool = data.get("requiredTool")
                 if not guild_id or not human_message:
                     logger.warning("Ignoring malformed foreman-trigger: %s", data)
                     return
@@ -144,6 +147,7 @@ class Foreman:
                         extra_context=extra_context,
                         user_id=user_id,
                         task_id=trigger_task_id,
+                        required_tool=required_tool,
                         task_name=f"foreman.trigger:{guild_id}:{data.get('event', '?')}",
                     ),
                     name=f"foreman.trigger:{guild_id}:{data.get('event', '?')}",

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -112,6 +112,7 @@ async def run_foreman_ai(
     extra_context: str = "",
     user_id: str | None = None,
     task_id: str | None = None,
+    required_tool: str | None = None,
     *,
     http: ForemanHTTPClient,
     ws_send: Callable[[dict], Awaitable[None]],
@@ -210,12 +211,16 @@ async def run_foreman_ai(
                 round_num,
                 len(messages),
             )
+            _tool_choice_kw: dict = {}
+            if required_tool and round_num == 0:
+                _tool_choice_kw = {"tool_choice": {"type": "tool", "name": required_tool}}
             _raw = await client.messages.with_raw_response.create(
                 model=config.effective_model,
                 max_tokens=1024,
                 system=system_blocks,
                 messages=messages,
                 tools=FOREMAN_TOOLS,
+                **_tool_choice_kw,
             )
             resp = _raw.parse()
             usage = resp.usage
@@ -278,6 +283,10 @@ async def run_foreman_ai(
 
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
             if not tool_uses:
+                if required_tool and round_num == 0:
+                    raise RuntimeError(
+                        f"Foreman returned no tool call on round 0 despite required_tool={required_tool!r}"
+                    )
                 break
 
             made_tool_calls = True
@@ -443,6 +452,8 @@ async def run_foreman_ai(
                 "createdAt": now,
             }
         )
+        if isinstance(exc, RuntimeError) and "required_tool" in str(exc):
+            raise
         return False
 
     return made_tool_calls


### PR DESCRIPTION
## Summary

- Adds a `required_tool` parameter throughout the foreman call stack (`ws_handlers.py` → `ws_types.py` → `foreman.py` → `runner.py`) so callers can mandate a specific tool on round 0.
- When `required_tool` is set, the Anthropic API call includes `tool_choice: {type: "tool", name: <tool>}`, preventing the model from returning a plain-text response instead of calling the tool.
- If the model still returns no tool call on round 0 when `required_tool` is set, a `RuntimeError` is raised (and re-raised past the error-handler) so the failure is visible rather than silently dropped.
- `handle_task_complete` and `handle_task_followup_done` in `ws_handlers.py` now pass `required_tool="send_followup"` when `stop_reason == "max_turns"`, covering the primary cases where a forced follow-up is needed.
- Adds `backend/tests/test_foreman_tool_choice.py` with unit tests verifying: tool_choice kwarg is injected on round 0, text-only responses raise when a tool is required, text-only responses are fine without `required_tool`, and a valid tool-use response is accepted and dispatched.

Closes #602

## Test plan

- [ ] Run `pytest backend/tests/test_foreman_tool_choice.py` — all tests pass.
- [ ] Trigger a task that hits `max_turns` and confirm the foreman issues a `send_followup` tool call rather than a plain-text reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)