### PR TITLE
Fix foreman startup with alternate provider (Bedrock)

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1725,9 +1725,11 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             head_ref = (pr_data.get("head") or {}).get("ref", "")
 
                             try:
-                                import anthropic as _anthropic
+                                # Use the shared factory so alternate providers (e.g. Bedrock)
+                                # are handled correctly — avoids hardcoding AsyncAnthropic().
+                                from foreman_core.llm import make_anthropic_client as _make_client
 
-                                _ai = _anthropic.AsyncAnthropic()
+                                _ai = _make_client()
                                 review_prompt = (
                                     "You are a thorough code reviewer. Review the following "
                                     "GitHub pull request and provide structured feedback.\n\n"

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from database import get_db
 from events import broadcast, broadcast_msg, emit_terminal_line
-from foreman_core.llm import get_foreman_model
+from foreman_core.llm import get_foreman_model, make_anthropic_client
 from foreman_core.message_utils import _json_default
 from foreman_core.tools_schema import (
     FOREMAN_TOOLS,  # noqa: F401 — re-exported for test compatibility
@@ -1725,11 +1725,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             head_ref = (pr_data.get("head") or {}).get("ref", "")
 
                             try:
-                                # Use the shared factory so alternate providers (e.g. Bedrock)
-                                # are handled correctly — avoids hardcoding AsyncAnthropic().
-                                from foreman_core.llm import make_anthropic_client as _make_client
-
-                                _ai = _make_client()
+                                _ai = make_anthropic_client()
                                 review_prompt = (
                                     "You are a thorough code reviewer. Review the following "
                                     "GitHub pull request and provide structured feedback.\n\n"

--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -63,7 +63,9 @@ def make_anthropic_client(
     if not HAS_ANTHROPIC or _anthropic_mod is None:
         raise ImportError("anthropic package is not installed")
 
-    resolved_provider = (provider or FOREMAN_PROVIDER).lower()
+    # Read env dynamically (same as get_foreman_model) so patching os.environ in
+    # tests works and a late-set FOREMAN_PROVIDER env var is picked up correctly.
+    resolved_provider = (provider or os.environ.get("FOREMAN_PROVIDER", "anthropic")).lower()
     resolved_region = region or _BEDROCK_REGION
 
     if resolved_provider == "bedrock":

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -1,0 +1,251 @@
+"""Tests for foreman_core/llm.py — provider selection and client factory.
+
+Verifies that make_anthropic_client() and get_foreman_model() correctly handle
+both the default Anthropic provider and alternate providers (e.g. AWS Bedrock).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_anthropic(anthropic_cls=None, bedrock_cls=None):
+    """Build a minimal mock of the anthropic module."""
+    mock_mod = MagicMock()
+    mock_mod.AsyncAnthropic = anthropic_cls or MagicMock(return_value=MagicMock())
+    mock_mod.AsyncAnthropicBedrock = bedrock_cls or MagicMock(return_value=MagicMock())
+    return mock_mod
+
+
+# ---------------------------------------------------------------------------
+# get_foreman_model
+# ---------------------------------------------------------------------------
+
+
+class TestGetForemanModel:
+    def test_default_returns_anthropic_model(self, monkeypatch):
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        monkeypatch.delenv("FOREMAN_MODEL", raising=False)
+        from foreman_core.llm import get_foreman_model
+
+        assert get_foreman_model() == "claude-sonnet-4-6"
+
+    def test_bedrock_provider_env_returns_bedrock_model(self, monkeypatch):
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        monkeypatch.delenv("FOREMAN_BEDROCK_MODEL", raising=False)
+        from foreman_core.llm import _DEFAULT_BEDROCK_MODEL, get_foreman_model
+
+        assert get_foreman_model() == _DEFAULT_BEDROCK_MODEL
+
+    def test_explicit_provider_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("FOREMAN_PROVIDER", "anthropic")
+        from foreman_core.llm import _DEFAULT_BEDROCK_MODEL, get_foreman_model
+
+        assert get_foreman_model(provider="bedrock") == _DEFAULT_BEDROCK_MODEL
+
+    def test_custom_bedrock_model_env(self, monkeypatch):
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        monkeypatch.setenv("FOREMAN_BEDROCK_MODEL", "arn:aws:bedrock:us-west-2::my-profile")
+        from foreman_core.llm import get_foreman_model
+
+        assert get_foreman_model() == "arn:aws:bedrock:us-west-2::my-profile"
+
+    def test_custom_anthropic_model_env(self, monkeypatch):
+        monkeypatch.setenv("FOREMAN_PROVIDER", "anthropic")
+        monkeypatch.setenv("FOREMAN_MODEL", "claude-opus-4-8")
+        from foreman_core.llm import get_foreman_model
+
+        assert get_foreman_model() == "claude-opus-4-8"
+
+
+# ---------------------------------------------------------------------------
+# make_anthropic_client — provider dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMakeAnthropicClient:
+    def test_default_creates_anthropic_client(self, monkeypatch):
+        """When no provider is specified and FOREMAN_PROVIDER is unset, use AsyncAnthropic."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        mock_mod = _make_mock_anthropic()
+        with patch.dict("sys.modules", {"anthropic": mock_mod}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            llm_mod.make_anthropic_client()
+            mock_mod.AsyncAnthropic.assert_called_once()
+            mock_mod.AsyncAnthropicBedrock.assert_not_called()
+
+    def test_bedrock_env_creates_bedrock_client(self, monkeypatch):
+        """FOREMAN_PROVIDER=bedrock must produce an AsyncAnthropicBedrock client."""
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        mock_mod = _make_mock_anthropic()
+        with patch.dict("sys.modules", {"anthropic": mock_mod}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            llm_mod.make_anthropic_client()
+            mock_mod.AsyncAnthropicBedrock.assert_called_once()
+            mock_mod.AsyncAnthropic.assert_not_called()
+
+    def test_explicit_bedrock_provider_arg_overrides_env(self, monkeypatch):
+        """Passing provider='bedrock' explicitly must use Bedrock even if env says anthropic."""
+        monkeypatch.setenv("FOREMAN_PROVIDER", "anthropic")
+        mock_mod = _make_mock_anthropic()
+        with patch.dict("sys.modules", {"anthropic": mock_mod}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            llm_mod.make_anthropic_client(provider="bedrock")
+            mock_mod.AsyncAnthropicBedrock.assert_called_once()
+            mock_mod.AsyncAnthropic.assert_not_called()
+
+    def test_explicit_anthropic_provider_arg_overrides_bedrock_env(self, monkeypatch):
+        """Passing provider='anthropic' must use AsyncAnthropic even if env says bedrock."""
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        mock_mod = _make_mock_anthropic()
+        with patch.dict("sys.modules", {"anthropic": mock_mod}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            llm_mod.make_anthropic_client(provider="anthropic", api_key="test-key")
+            mock_mod.AsyncAnthropic.assert_called_once()
+            mock_mod.AsyncAnthropicBedrock.assert_not_called()
+
+    def test_bedrock_passes_region(self, monkeypatch):
+        """The aws_region argument must be forwarded to AsyncAnthropicBedrock."""
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+        mock_mod = _make_mock_anthropic()
+        with patch.dict("sys.modules", {"anthropic": mock_mod}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            llm_mod.make_anthropic_client()
+            mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="eu-west-1")
+
+    def test_bedrock_region_explicit_arg_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+        mock_mod = _make_mock_anthropic()
+        with patch.dict("sys.modules", {"anthropic": mock_mod}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            llm_mod.make_anthropic_client(provider="bedrock", region="ap-southeast-1")
+            mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="ap-southeast-1")
+
+    def test_api_key_forwarded_to_anthropic_client(self, monkeypatch):
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        mock_mod = _make_mock_anthropic()
+        with patch.dict("sys.modules", {"anthropic": mock_mod}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            llm_mod.make_anthropic_client(api_key="sk-test-123")
+            mock_mod.AsyncAnthropic.assert_called_once_with(api_key="sk-test-123")
+
+    def test_no_api_key_omitted_from_kwargs(self, monkeypatch):
+        """When api_key is None, it must not be passed to AsyncAnthropic (lets SDK read env)."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        mock_mod = _make_mock_anthropic()
+        with patch.dict("sys.modules", {"anthropic": mock_mod}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            llm_mod.make_anthropic_client()
+            mock_mod.AsyncAnthropic.assert_called_once_with()
+
+    def test_missing_anthropic_package_raises(self, monkeypatch):
+        """If anthropic is not installed, make_anthropic_client must raise ImportError."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        with patch.dict("sys.modules", {"anthropic": None}):
+            import importlib
+
+            import foreman_core.llm as llm_mod
+
+            importlib.reload(llm_mod)
+            # HAS_ANTHROPIC will be False after reload with anthropic=None in sys.modules
+            if not llm_mod.HAS_ANTHROPIC:
+                with pytest.raises(ImportError):
+                    llm_mod.make_anthropic_client()
+
+
+# ---------------------------------------------------------------------------
+# Regression: make_anthropic_client reads FOREMAN_PROVIDER dynamically
+# ---------------------------------------------------------------------------
+
+
+class TestMakeAnthropicClientDynamicEnv:
+    """Regression for issue #608: make_anthropic_client() must read FOREMAN_PROVIDER from
+    os.environ on every call, not from a module-level constant captured at import time.
+
+    This ensures that tests and environments that set the env var after module import
+    get the correct provider, and matches the behaviour of get_foreman_model().
+    """
+
+    def test_bedrock_env_set_after_import_is_respected(self, monkeypatch):
+        """Patching FOREMAN_PROVIDER after module import must still produce a Bedrock client."""
+        # Start with anthropic, import module, then switch to bedrock — the call must still
+        # create AsyncAnthropicBedrock because we read os.environ dynamically.
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import importlib
+
+        import foreman_core.llm as llm_mod
+
+        importlib.reload(llm_mod)  # captures "anthropic" in any cached constant
+
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        mock_mod = _make_mock_anthropic()
+        with patch.object(llm_mod, "_anthropic_mod", mock_mod):
+            llm_mod.HAS_ANTHROPIC = True
+            llm_mod.make_anthropic_client()
+            mock_mod.AsyncAnthropicBedrock.assert_called_once()
+            mock_mod.AsyncAnthropic.assert_not_called()
+
+    def test_anthropic_env_set_after_bedrock_reload(self, monkeypatch):
+        """Switching from bedrock back to anthropic must produce an AsyncAnthropic client."""
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        import importlib
+
+        import foreman_core.llm as llm_mod
+
+        importlib.reload(llm_mod)
+
+        monkeypatch.setenv("FOREMAN_PROVIDER", "anthropic")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        mock_mod = _make_mock_anthropic()
+        with patch.object(llm_mod, "_anthropic_mod", mock_mod):
+            llm_mod.HAS_ANTHROPIC = True
+            llm_mod.make_anthropic_client()
+            mock_mod.AsyncAnthropic.assert_called_once()
+            mock_mod.AsyncAnthropicBedrock.assert_not_called()

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -79,125 +79,108 @@ class TestMakeAnthropicClient:
     def test_default_creates_anthropic_client(self, monkeypatch):
         """When no provider is specified and FOREMAN_PROVIDER is unset, use AsyncAnthropic."""
         monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman_core.llm as llm_mod
+
         mock_mod = _make_mock_anthropic()
-        with patch.dict("sys.modules", {"anthropic": mock_mod}):
-            import importlib
-
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            llm_mod.make_anthropic_client()
-            mock_mod.AsyncAnthropic.assert_called_once()
-            mock_mod.AsyncAnthropicBedrock.assert_not_called()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client()
+        mock_mod.AsyncAnthropic.assert_called_once()
+        mock_mod.AsyncAnthropicBedrock.assert_not_called()
 
     def test_bedrock_env_creates_bedrock_client(self, monkeypatch):
         """FOREMAN_PROVIDER=bedrock must produce an AsyncAnthropicBedrock client."""
         monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        import foreman_core.llm as llm_mod
+
         mock_mod = _make_mock_anthropic()
-        with patch.dict("sys.modules", {"anthropic": mock_mod}):
-            import importlib
-
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            llm_mod.make_anthropic_client()
-            mock_mod.AsyncAnthropicBedrock.assert_called_once()
-            mock_mod.AsyncAnthropic.assert_not_called()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client()
+        mock_mod.AsyncAnthropicBedrock.assert_called_once()
+        mock_mod.AsyncAnthropic.assert_not_called()
 
     def test_explicit_bedrock_provider_arg_overrides_env(self, monkeypatch):
         """Passing provider='bedrock' explicitly must use Bedrock even if env says anthropic."""
         monkeypatch.setenv("FOREMAN_PROVIDER", "anthropic")
+        import foreman_core.llm as llm_mod
+
         mock_mod = _make_mock_anthropic()
-        with patch.dict("sys.modules", {"anthropic": mock_mod}):
-            import importlib
-
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            llm_mod.make_anthropic_client(provider="bedrock")
-            mock_mod.AsyncAnthropicBedrock.assert_called_once()
-            mock_mod.AsyncAnthropic.assert_not_called()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(provider="bedrock")
+        mock_mod.AsyncAnthropicBedrock.assert_called_once()
+        mock_mod.AsyncAnthropic.assert_not_called()
 
     def test_explicit_anthropic_provider_arg_overrides_bedrock_env(self, monkeypatch):
         """Passing provider='anthropic' must use AsyncAnthropic even if env says bedrock."""
         monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        import foreman_core.llm as llm_mod
+
         mock_mod = _make_mock_anthropic()
-        with patch.dict("sys.modules", {"anthropic": mock_mod}):
-            import importlib
-
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            llm_mod.make_anthropic_client(provider="anthropic", api_key="test-key")
-            mock_mod.AsyncAnthropic.assert_called_once()
-            mock_mod.AsyncAnthropicBedrock.assert_not_called()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(provider="anthropic", api_key="test-key")
+        mock_mod.AsyncAnthropic.assert_called_once()
+        mock_mod.AsyncAnthropicBedrock.assert_not_called()
 
     def test_bedrock_passes_region(self, monkeypatch):
         """The aws_region argument must be forwarded to AsyncAnthropicBedrock."""
         monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
-        monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+        import foreman_core.llm as llm_mod
+
         mock_mod = _make_mock_anthropic()
-        with patch.dict("sys.modules", {"anthropic": mock_mod}):
-            import importlib
-
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            llm_mod.make_anthropic_client()
-            mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="eu-west-1")
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        # Patch the module-level constant directly rather than relying on env + reload.
+        monkeypatch.setattr(llm_mod, "_BEDROCK_REGION", "eu-west-1")
+        llm_mod.make_anthropic_client()
+        mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="eu-west-1")
 
     def test_bedrock_region_explicit_arg_overrides_env(self, monkeypatch):
         monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
-        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+        import foreman_core.llm as llm_mod
+
         mock_mod = _make_mock_anthropic()
-        with patch.dict("sys.modules", {"anthropic": mock_mod}):
-            import importlib
-
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            llm_mod.make_anthropic_client(provider="bedrock", region="ap-southeast-1")
-            mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="ap-southeast-1")
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        monkeypatch.setattr(llm_mod, "_BEDROCK_REGION", "us-east-1")
+        llm_mod.make_anthropic_client(provider="bedrock", region="ap-southeast-1")
+        mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="ap-southeast-1")
 
     def test_api_key_forwarded_to_anthropic_client(self, monkeypatch):
         monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman_core.llm as llm_mod
+
         mock_mod = _make_mock_anthropic()
-        with patch.dict("sys.modules", {"anthropic": mock_mod}):
-            import importlib
-
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            llm_mod.make_anthropic_client(api_key="sk-test-123")
-            mock_mod.AsyncAnthropic.assert_called_once_with(api_key="sk-test-123")
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(api_key="sk-test-123")
+        mock_mod.AsyncAnthropic.assert_called_once_with(api_key="sk-test-123")
 
     def test_no_api_key_omitted_from_kwargs(self, monkeypatch):
         """When api_key is None, it must not be passed to AsyncAnthropic (lets SDK read env)."""
         monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman_core.llm as llm_mod
+
         mock_mod = _make_mock_anthropic()
-        with patch.dict("sys.modules", {"anthropic": mock_mod}):
-            import importlib
-
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            llm_mod.make_anthropic_client()
-            mock_mod.AsyncAnthropic.assert_called_once_with()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client()
+        mock_mod.AsyncAnthropic.assert_called_once_with()
 
     def test_missing_anthropic_package_raises(self, monkeypatch):
         """If anthropic is not installed, make_anthropic_client must raise ImportError."""
         monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
-        with patch.dict("sys.modules", {"anthropic": None}):
-            import importlib
+        import foreman_core.llm as llm_mod
 
-            import foreman_core.llm as llm_mod
-
-            importlib.reload(llm_mod)
-            # HAS_ANTHROPIC will be False after reload with anthropic=None in sys.modules
-            if not llm_mod.HAS_ANTHROPIC:
-                with pytest.raises(ImportError):
-                    llm_mod.make_anthropic_client()
+        # Explicitly force the "no anthropic" path regardless of CI environment so the
+        # test exercises the ImportError branch even when the package is installed.
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", False)
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", None)
+        with pytest.raises(ImportError):
+            llm_mod.make_anthropic_client()
 
 
 # ---------------------------------------------------------------------------
@@ -218,11 +201,7 @@ class TestMakeAnthropicClientDynamicEnv:
         # Start with anthropic, import module, then switch to bedrock — the call must still
         # create AsyncAnthropicBedrock because we read os.environ dynamically.
         monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
-        import importlib
-
         import foreman_core.llm as llm_mod
-
-        importlib.reload(llm_mod)  # captures "anthropic" in any cached constant
 
         monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
         mock_mod = _make_mock_anthropic()
@@ -235,11 +214,7 @@ class TestMakeAnthropicClientDynamicEnv:
     def test_anthropic_env_set_after_bedrock_reload(self, monkeypatch):
         """Switching from bedrock back to anthropic must produce an AsyncAnthropic client."""
         monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
-        import importlib
-
         import foreman_core.llm as llm_mod
-
-        importlib.reload(llm_mod)
 
         monkeypatch.setenv("FOREMAN_PROVIDER", "anthropic")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")


### PR DESCRIPTION
## Summary

Fixes two bugs that prevented the embedded foreman from working when configured with an alternate provider (e.g. `FOREMAN_PROVIDER=bedrock`):

- **`backend/foreman/tools.py`** – `review_pr_internal` hardcoded `_anthropic.AsyncAnthropic()` instead of the shared `make_anthropic_client()` factory. On Bedrock deployments only AWS credentials are available (no `ANTHROPIC_API_KEY`), so the direct constructor raised `AuthenticationError` and the foreman failed.

- **`backend/foreman_core/llm.py`** – `make_anthropic_client()` resolved the provider from a module-level `FOREMAN_PROVIDER` constant captured at import time, not from `os.environ` dynamically. This was inconsistent with `get_foreman_model()` and meant tests (or environments) that set the env var after module import got the wrong client type.

## Changes

| File | Change |
|------|--------|
| `backend/foreman/tools.py` | Replace `_anthropic.AsyncAnthropic()` with `make_anthropic_client()` in `review_pr_internal` |
| `backend/foreman_core/llm.py` | Read `FOREMAN_PROVIDER` via `os.environ.get(...)` on every call instead of the cached module-level constant |
| `backend/tests/test_foreman_llm.py` | 16 new tests: provider dispatch, Bedrock region forwarding, API key passthrough, dynamic env-var read |

## Test plan

- `python -m pytest backend/tests/test_foreman_llm.py -v` → 16 passed
- `python -m pytest backend/tests/test_foreman.py::TestBuildSystemPrompt backend/tests/test_foreman.py::TestSerializeContent backend/tests/test_foreman_runner.py backend/tests/test_tool_use_parser.py backend/tests/test_tools_dedup.py -v` → 53 passed (non-DB tests)

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)