### PR TITLE
Fix PR #606 review feedback: lifecycle race/drain/version

### DIFF
--- a/backend/alembic/versions/20260607_000000_add_worker_lifecycle_columns.py
+++ b/backend/alembic/versions/20260607_000000_add_worker_lifecycle_columns.py
@@ -1,0 +1,42 @@
+"""Add worker lifecycle tracking columns to workers table.
+
+Revision ID: 20260607_000000_add_worker_lifecycle_columns
+Revises: 20260606_000000_index_tasks_parent_task_id
+Create Date: 2026-06-07
+
+Adds four nullable columns to ``workers`` that enable stale-worker detection
+and graceful restart when the backend version changes:
+
+  container_id       — full Docker container id; used to force-kill stale containers
+  spawned_version    — backend version at spawn time (PIONEER_VERSION or git SHA)
+  started_at         — UTC instant the container was confirmed running
+  drain_requested_at — UTC instant a graceful-shutdown signal was sent
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260607_000000_add_worker_lifecycle_columns"
+down_revision: str | Sequence[str] | None = "20260606_000000_index_tasks_parent_task_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("workers", sa.Column("container_id", sa.Text(), nullable=True))
+    op.add_column("workers", sa.Column("spawned_version", sa.Text(), nullable=True))
+    op.add_column("workers", sa.Column("started_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "workers", sa.Column("drain_requested_at", sa.DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "drain_requested_at")
+    op.drop_column("workers", "started_at")
+    op.drop_column("workers", "spawned_version")
+    op.drop_column("workers", "container_id")

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -747,18 +747,9 @@ async def spawn_worker(
         container = await asyncio.to_thread(docker_client.containers.run, **run_kwargs)
         # Persist container id and version so the lifecycle module can force-kill
         # this container if the backend is redeployed with a different version.
-        from worker_lifecycle import get_current_version as _get_current_version  # noqa: PLC0415
+        from worker_lifecycle import record_worker_spawn as _record_worker_spawn  # noqa: PLC0415
 
-        await db.exec(
-            update(Worker)
-            .where(col(Worker.id) == worker_id)
-            .values(
-                container_id=container.id,
-                spawned_version=_get_current_version(),
-                started_at=datetime.now(UTC),
-            )
-        )
-        await db.commit()
+        await _record_worker_spawn(db, worker_id, container.id)
         result_text = json.dumps(
             {
                 "worker_id": worker_id,

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -745,6 +745,20 @@ async def spawn_worker(
             run_kwargs["network"] = network
 
         container = await asyncio.to_thread(docker_client.containers.run, **run_kwargs)
+        # Persist container id and version so the lifecycle module can force-kill
+        # this container if the backend is redeployed with a different version.
+        from worker_lifecycle import get_current_version as _get_current_version  # noqa: PLC0415
+
+        await db.exec(
+            update(Worker)
+            .where(col(Worker.id) == worker_id)
+            .values(
+                container_id=container.id,
+                spawned_version=_get_current_version(),
+                started_at=datetime.now(UTC),
+            )
+        )
+        await db.commit()
         result_text = json.dumps(
             {
                 "worker_id": worker_id,

--- a/backend/main.py
+++ b/backend/main.py
@@ -337,15 +337,21 @@ async def lifespan(app: FastAPI):
     _log_format = os.environ.get("LOG_FORMAT", "colored")
     logging.config.dictConfig(_get_logging_config(_log_level, _log_format))
 
-    # Detect and drain stale workers BEFORE reset_connection_state() wipes the
-    # DB state needed to distinguish stale from fresh rows. The drain sleeps up
-    # to PIONEER_WORKER_DRAIN_TIMEOUT seconds before force-killing, so it runs
-    # in the background and does not block the rest of startup.
-    from worker_lifecycle import drain_stale_workers_on_startup  # noqa: PLC0415
+    # Phase 1: detect stale workers and send graceful-shutdown signals.
+    # Must be awaited directly before reset_connection_state() so the DB still
+    # holds the non-offline state that identifies which workers were stale.
+    from worker_lifecycle import (  # noqa: PLC0415
+        drain_stale_workers_on_startup,
+        force_kill_stale_workers,
+    )
 
-    drain_bg = spawn(drain_stale_workers_on_startup(), name="stale-worker-drain")
+    stale_ids = await drain_stale_workers_on_startup()
 
     await reset_connection_state()
+
+    # Phase 2: after the drain window, force-kill any surviving stale containers.
+    # Runs in background so it does not block startup or the first request.
+    drain_bg = spawn(force_kill_stale_workers(stale_ids), name="stale-worker-drain") if stale_ids else None
     # Pre-warm the models.dev cache so the first /api/models request is fast.
     from util.models_dev import fetch_providers as _fetch_providers  # noqa: PLC0415
 
@@ -355,15 +361,17 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         sweeper.cancel()
-        drain_bg.cancel()
+        if drain_bg is not None:
+            drain_bg.cancel()
         try:
             await sweeper
         except (asyncio.CancelledError, Exception):
             pass
-        try:
-            await drain_bg
-        except (asyncio.CancelledError, Exception):
-            pass
+        if drain_bg is not None:
+            try:
+                await drain_bg
+            except (asyncio.CancelledError, Exception):
+                pass
         await _shutdown_webhook_debouncer()
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -348,7 +348,9 @@ async def lifespan(app: FastAPI):
     # Phase 2: after the drain window, force-kill any surviving stale containers.
     # Runs in background so it does not block startup or the first request.
     drain_bg = (
-        spawn(spawn_replacement_workers(stale_ids), name="stale-worker-drain") if stale_ids else None
+        spawn(spawn_replacement_workers(stale_ids), name="stale-worker-drain")
+        if stale_ids
+        else None
     )
     # Pre-warm the models.dev cache so the first /api/models request is fast.
     from util.models_dev import fetch_providers as _fetch_providers  # noqa: PLC0415

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,6 +35,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from util.tasks import spawn
+from worker_lifecycle import drain_stale_workers_on_startup, force_kill_stale_workers
 from ws_types import WorkerPingMsg
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
@@ -340,11 +341,6 @@ async def lifespan(app: FastAPI):
     # Phase 1: detect stale workers and send graceful-shutdown signals.
     # Must be awaited directly before reset_connection_state() so the DB still
     # holds the non-offline state that identifies which workers were stale.
-    from worker_lifecycle import (  # noqa: PLC0415
-        drain_stale_workers_on_startup,
-        force_kill_stale_workers,
-    )
-
     stale_ids = await drain_stale_workers_on_startup()
 
     await reset_connection_state()

--- a/backend/main.py
+++ b/backend/main.py
@@ -336,6 +336,15 @@ async def lifespan(app: FastAPI):
     _log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
     _log_format = os.environ.get("LOG_FORMAT", "colored")
     logging.config.dictConfig(_get_logging_config(_log_level, _log_format))
+
+    # Detect and drain stale workers BEFORE reset_connection_state() wipes the
+    # DB state needed to distinguish stale from fresh rows. The drain sleeps up
+    # to PIONEER_WORKER_DRAIN_TIMEOUT seconds before force-killing, so it runs
+    # in the background and does not block the rest of startup.
+    from worker_lifecycle import drain_stale_workers_on_startup  # noqa: PLC0415
+
+    drain_bg = spawn(drain_stale_workers_on_startup(), name="stale-worker-drain")
+
     await reset_connection_state()
     # Pre-warm the models.dev cache so the first /api/models request is fast.
     from util.models_dev import fetch_providers as _fetch_providers  # noqa: PLC0415
@@ -346,8 +355,13 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         sweeper.cancel()
+        drain_bg.cancel()
         try:
             await sweeper
+        except (asyncio.CancelledError, Exception):
+            pass
+        try:
+            await drain_bg
         except (asyncio.CancelledError, Exception):
             pass
         await _shutdown_webhook_debouncer()

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from util.tasks import spawn
-from worker_lifecycle import drain_stale_workers_on_startup, force_kill_stale_workers
+from worker_lifecycle import drain_stale_workers_on_startup, spawn_replacement_workers
 from ws_types import WorkerPingMsg
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
@@ -348,7 +348,7 @@ async def lifespan(app: FastAPI):
     # Phase 2: after the drain window, force-kill any surviving stale containers.
     # Runs in background so it does not block startup or the first request.
     drain_bg = (
-        spawn(force_kill_stale_workers(stale_ids), name="stale-worker-drain") if stale_ids else None
+        spawn(spawn_replacement_workers(stale_ids), name="stale-worker-drain") if stale_ids else None
     )
     # Pre-warm the models.dev cache so the first /api/models request is fast.
     from util.models_dev import fetch_providers as _fetch_providers  # noqa: PLC0415

--- a/backend/main.py
+++ b/backend/main.py
@@ -351,7 +351,9 @@ async def lifespan(app: FastAPI):
 
     # Phase 2: after the drain window, force-kill any surviving stale containers.
     # Runs in background so it does not block startup or the first request.
-    drain_bg = spawn(force_kill_stale_workers(stale_ids), name="stale-worker-drain") if stale_ids else None
+    drain_bg = (
+        spawn(force_kill_stale_workers(stale_ids), name="stale-worker-drain") if stale_ids else None
+    )
     # Pre-warm the models.dev cache so the first /api/models request is fast.
     from util.models_dev import fetch_providers as _fetch_providers  # noqa: PLC0415
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -128,6 +128,23 @@ class Worker(SQLModel, table=True):
     # NULL on rows created before this column was added; the API falls back to
     # worker_id for those legacy rows.
     name: str | None = None
+    # Docker container id for this worker process (full 64-char hex or short 12-char).
+    # NULL for workers started outside of Docker (compose, manual CLI).
+    # Used by the lifecycle module to force-kill stale containers on version change.
+    container_id: str | None = None
+    # Backend version string recorded at spawn time (PIONEER_VERSION env var or git SHA).
+    # On startup, workers whose spawned_version differs from the current version are
+    # considered stale and drained/killed before fresh workers are started.
+    spawned_version: str | None = None
+    # UTC instant the container was successfully started (set after containers.run()).
+    started_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    # UTC instant a graceful-shutdown signal was sent to this worker (set during drain).
+    # NULL until the lifecycle module initiates a drain for this worker.
+    drain_requested_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
 
 
 class Task(SQLModel, table=True):

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -31,6 +31,7 @@ from utils import (
     row_to_dict,
     worker_display_name,
 )
+from worker_lifecycle import get_current_version
 from ws_handlers import _resolve_user_identifier
 from ws_types import TaskAssignedMsg, WorkerMessageMsg
 
@@ -268,6 +269,19 @@ async def spawn_worker_container(
         )
         await db.commit()
         raise HTTPException(status_code=500, detail=f"Failed to start container: {e}")
+
+    # Persist container id and spawned version so the lifecycle module can
+    # force-kill this container if the backend is redeployed at a different version.
+    await db.exec(
+        update(Worker)
+        .where(col(Worker.id) == worker_id)
+        .values(
+            container_id=container.id,
+            spawned_version=get_current_version(),
+            started_at=datetime.now(UTC),
+        )
+    )
+    await db.commit()
 
     return {"worker_id": worker_id, "container_id": container.id[:12], "image": image}
 

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -31,7 +31,7 @@ from utils import (
     row_to_dict,
     worker_display_name,
 )
-from worker_lifecycle import get_current_version
+from worker_lifecycle import record_worker_spawn
 from ws_handlers import _resolve_user_identifier
 from ws_types import TaskAssignedMsg, WorkerMessageMsg
 
@@ -272,16 +272,7 @@ async def spawn_worker_container(
 
     # Persist container id and spawned version so the lifecycle module can
     # force-kill this container if the backend is redeployed at a different version.
-    await db.exec(
-        update(Worker)
-        .where(col(Worker.id) == worker_id)
-        .values(
-            container_id=container.id,
-            spawned_version=get_current_version(),
-            started_at=datetime.now(UTC),
-        )
-    )
-    await db.commit()
+    await record_worker_spawn(db, worker_id, container.id)
 
     return {"worker_id": worker_id, "container_id": container.id[:12], "image": image}
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import sys
+from unittest import mock
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -69,8 +70,12 @@ def client(monkeypatch, _setup_schema):
     monkeypatch.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
     monkeypatch.setenv("DATABASE_URL", db_url)
 
-    with TestClient(main_module.app) as c:
-        yield c, db_url
+    # Stub drain_stale_workers_on_startup: it uses its own AsyncSessionLocal import
+    # (not patched above) and would fail with "Future attached to a different loop".
+    # Lifecycle drain logic is tested separately in test_worker_lifecycle.py.
+    with mock.patch("main.drain_stale_workers_on_startup", return_value=[]):
+        with TestClient(main_module.app) as c:
+            yield c, db_url
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_agent_state_ws_persistence.py
+++ b/backend/tests/test_agent_state_ws_persistence.py
@@ -65,6 +65,13 @@ def client(_setup_schema):
         pass
 
     mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
+
+    async def _stubbed_drain_stale_workers_on_startup():
+        return []
+
+    mp.setattr(
+        main_module, "drain_stale_workers_on_startup", _stubbed_drain_stale_workers_on_startup
+    )
     mp.setenv("DATABASE_URL", db_url)
 
     with TestClient(main_module.app) as c:

--- a/backend/tests/test_disconnect.py
+++ b/backend/tests/test_disconnect.py
@@ -49,6 +49,13 @@ def client(_setup_schema):
         pass
 
     mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
+
+    async def _stubbed_drain_stale_workers_on_startup():
+        return []
+
+    mp.setattr(
+        main_module, "drain_stale_workers_on_startup", _stubbed_drain_stale_workers_on_startup
+    )
     mp.setenv("DATABASE_URL", db_url)
 
     with TestClient(main_module.app) as c:

--- a/backend/tests/test_liveness.py
+++ b/backend/tests/test_liveness.py
@@ -53,6 +53,13 @@ def client():
         pass
 
     mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
+
+    async def _stubbed_drain_stale_workers_on_startup():
+        return []
+
+    mp.setattr(
+        main_module, "drain_stale_workers_on_startup", _stubbed_drain_stale_workers_on_startup
+    )
     mp.setenv("DATABASE_URL", db_url)
 
     with TestClient(main_module.app) as c:

--- a/backend/tests/test_pr_url_ws_persistence.py
+++ b/backend/tests/test_pr_url_ws_persistence.py
@@ -53,6 +53,13 @@ def client(_setup_schema):
         pass
 
     mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
+
+    async def _stubbed_drain_stale_workers_on_startup():
+        return []
+
+    mp.setattr(
+        main_module, "drain_stale_workers_on_startup", _stubbed_drain_stale_workers_on_startup
+    )
     mp.setenv("DATABASE_URL", db_url)
 
     with TestClient(main_module.app) as c:

--- a/backend/tests/test_terminal_output_ws_routing.py
+++ b/backend/tests/test_terminal_output_ws_routing.py
@@ -44,6 +44,13 @@ def client(_setup_schema):
         pass
 
     mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
+
+    async def _stubbed_drain_stale_workers_on_startup():
+        return []
+
+    mp.setattr(
+        main_module, "drain_stale_workers_on_startup", _stubbed_drain_stale_workers_on_startup
+    )
     mp.setenv("DATABASE_URL", db_url)
 
     with TestClient(main_module.app) as c:

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -43,6 +43,13 @@ def client(_setup_schema):
         pass
 
     mp.setattr(main_module, "reset_connection_state", _stubbed_reset_connection_state)
+
+    async def _stubbed_drain_stale_workers_on_startup():
+        return []
+
+    mp.setattr(
+        main_module, "drain_stale_workers_on_startup", _stubbed_drain_stale_workers_on_startup
+    )
     mp.setenv("DATABASE_URL", db_url)
 
     with TestClient(main_module.app) as c:

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -185,7 +185,8 @@ async def test_drain_force_kills_surviving_container(monkeypatch):
         async def __aexit__(self, *a):
             return False
 
-    # force_kill_stale_workers opens one DB session to fetch the workers.
+    # Patch drain timeout to 0 so the polling loop is skipped; only the final
+    # container-fetch session is needed.
     sessions = [FakeDB([fake_worker])]
     session_iter = iter(sessions)
 
@@ -198,12 +199,51 @@ async def test_drain_force_kills_surviving_container(monkeypatch):
     with (
         patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
         patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
+        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.0),
         patch.dict("sys.modules", {"docker": fake_docker_module}),
     ):
         await force_kill_stale_workers(["w-stale2"])
 
     fake_docker_client.containers.get.assert_called_once_with("abc123deadbeef")
     fake_container.kill.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_force_kill_exits_early_when_workers_self_terminate():
+    """Polling loop exits before the full drain timeout once all workers go offline."""
+
+    class FakeDB:
+        def __init__(self, rows):
+            self._rows = rows
+            self.exec = AsyncMock(
+                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
+            )
+            self.commit = AsyncMock()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    # First poll: worker still alive. Second poll: worker gone → early exit.
+    sessions = [FakeDB(["w-early"]), FakeDB([])]
+    session_iter = iter(sessions)
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(s):
+        sleep_calls.append(s)
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.asyncio.sleep", fake_sleep),
+        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 60.0),
+    ):
+        await force_kill_stale_workers(["w-early"])
+
+    # Returned after the second DB poll — only one sleep occurred (after first poll).
+    assert len(sleep_calls) == 1
+    # Docker kill was never reached because function returned early.
 
 
 @pytest.mark.asyncio
@@ -227,6 +267,7 @@ async def test_drain_skips_kill_when_no_container_id(monkeypatch):
         async def __aexit__(self, *a):
             return False
 
+    # Patch drain timeout to 0 so the polling loop is skipped.
     sessions = [FakeDB([fake_worker])]
     session_iter = iter(sessions)
 
@@ -235,6 +276,7 @@ async def test_drain_skips_kill_when_no_container_id(monkeypatch):
     with (
         patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
         patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
+        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.0),
         patch.dict("sys.modules", {"docker": fake_docker_module}),
     ):
         await force_kill_stale_workers(["w-nocontainer"])

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -110,6 +110,53 @@ async def test_drain_treats_all_workers_as_stale_when_no_version(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_drain_treats_null_version_workers_as_stale():
+    """Workers with NULL spawned_version are drained even when current version is known.
+
+    Pre-migration rows have no spawned_version stamp and cannot be confirmed to match
+    the current backend version, so they are conservatively treated as stale.
+    """
+    fake_worker = MagicMock()
+    fake_worker.id = "w-null-ver"
+    fake_worker.container_id = None
+
+    class FakeDB:
+        def __init__(self, rows):
+            self._rows = rows
+            self.exec = AsyncMock(
+                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
+            )
+            self.commit = AsyncMock()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    # Session 1: returns the NULL-version worker as stale.
+    # Session 2: write drain_requested_at.
+    sessions = [FakeDB([(fake_worker, "g-guild")]), FakeDB(None)]
+    session_iter = iter(sessions)
+    broadcast_calls = []
+
+    async def fake_broadcast(guild_slug, msg, *a, **kw):
+        broadcast_calls.append((guild_slug, msg))
+
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="v-current"),
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.broadcast_msg", fake_broadcast),
+    ):
+        result = await drain_stale_workers_on_startup()
+
+    # NULL-version worker is treated as stale and receives a shutdown signal.
+    assert result == ["w-null-ver"]
+    assert len(broadcast_calls) == 1
+    assert broadcast_calls[0][0] == "g-guild"
+
+
+@pytest.mark.asyncio
 async def test_drain_skipped_when_no_stale_workers(monkeypatch):
     """When all workers match the current version, drain is a no-op."""
     mock_exec = AsyncMock(return_value=MagicMock(all=MagicMock(return_value=[])))

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -15,9 +15,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from worker_lifecycle import (  # noqa: E402
     WORKER_DRAIN_TIMEOUT,
+    _spawn_replacement_workers,
     drain_stale_workers_on_startup,
     force_kill_stale_workers,
     get_current_version,
+    record_worker_spawn,
 )
 
 # ---------------------------------------------------------------------------
@@ -201,6 +203,7 @@ async def test_drain_force_kills_surviving_container(monkeypatch):
         patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
         patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.0),
         patch.dict("sys.modules", {"docker": fake_docker_module}),
+        patch("worker_lifecycle._spawn_replacement_workers", AsyncMock()),
     ):
         await force_kill_stale_workers(["w-stale2"])
 
@@ -238,6 +241,7 @@ async def test_force_kill_exits_early_when_workers_self_terminate():
         patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
         patch("worker_lifecycle.asyncio.sleep", fake_sleep),
         patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 60.0),
+        patch("worker_lifecycle._spawn_replacement_workers", AsyncMock()),
     ):
         await force_kill_stale_workers(["w-early"])
 
@@ -278,6 +282,7 @@ async def test_drain_skips_kill_when_no_container_id(monkeypatch):
         patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
         patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.0),
         patch.dict("sys.modules", {"docker": fake_docker_module}),
+        patch("worker_lifecycle._spawn_replacement_workers", AsyncMock()),
     ):
         await force_kill_stale_workers(["w-nocontainer"])
 
@@ -308,3 +313,116 @@ def test_drain_timeout_env_override(monkeypatch):
     # Restore.
     monkeypatch.delenv("PIONEER_WORKER_DRAIN_TIMEOUT", raising=False)
     importlib.reload(wl)
+
+
+# ---------------------------------------------------------------------------
+# record_worker_spawn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_worker_spawn_writes_fields():
+    """record_worker_spawn updates container_id, spawned_version, and started_at."""
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock()
+    mock_db.commit = AsyncMock()
+
+    with patch("worker_lifecycle.get_current_version", return_value="v-test"):
+        await record_worker_spawn(mock_db, "w-abc123", "container-deadbeef")
+
+    mock_db.exec.assert_called_once()
+    mock_db.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _spawn_replacement_workers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spawn_replacement_workers_no_op_on_empty():
+    """Empty stale_ids list → no DB or spawn calls."""
+    with patch("worker_lifecycle.AsyncSessionLocal") as mock_session:
+        await _spawn_replacement_workers([])
+    mock_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_spawn_replacement_workers_calls_spawn_for_each():
+    """One replacement worker is spawned per stale worker."""
+    fake_worker = MagicMock()
+    fake_worker.id = "w-old1"
+    fake_worker.guild_id = 42
+    fake_worker.repos = '["owner/repo"]'
+    fake_worker.name = "old-worker"
+
+    class FakeDB:
+        def __init__(self, rows):
+            self._rows = rows
+            self.exec = AsyncMock(
+                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
+            )
+            self.commit = AsyncMock()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    # Session 1: query workers + guild slugs.
+    # Session 2: passed to spawn_worker call.
+    sessions = [FakeDB([(fake_worker, "g-myguild")]), FakeDB([])]
+    session_iter = iter(sessions)
+    spawn_calls: list[dict] = []
+
+    async def fake_spawn(inp, guild_id, guild_pk, db):
+        spawn_calls.append({"inp": inp, "guild_id": guild_id, "guild_pk": guild_pk})
+        return ("ok", False)
+
+    fake_tools = MagicMock()
+    fake_tools.spawn_worker = fake_spawn
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch.dict("sys.modules", {"foreman": MagicMock(), "foreman.tools": fake_tools}),
+    ):
+        await _spawn_replacement_workers(["w-old1"])
+
+    assert len(spawn_calls) == 1
+    assert spawn_calls[0]["guild_id"] == "g-myguild"
+    assert spawn_calls[0]["guild_pk"] == 42
+    assert spawn_calls[0]["inp"]["repos"] == ["owner/repo"]
+
+
+@pytest.mark.asyncio
+async def test_force_kill_spawns_replacements_after_drain():
+    """force_kill_stale_workers calls _spawn_replacement_workers with the stale ids."""
+    spawn_mock = AsyncMock()
+
+    class FakeDB:
+        def __init__(self, rows):
+            self._rows = rows
+            self.exec = AsyncMock(
+                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
+            )
+            self.commit = AsyncMock()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    # Drain timeout = 0 → polling loop skipped → single DB session for kill fetch.
+    sessions = [FakeDB([])]
+    session_iter = iter(sessions)
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
+        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.0),
+        patch("worker_lifecycle._spawn_replacement_workers", spawn_mock),
+    ):
+        await force_kill_stale_workers(["w-s1", "w-s2"])
+
+    spawn_mock.assert_awaited_once_with(["w-s1", "w-s2"])

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -15,9 +15,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from worker_lifecycle import (  # noqa: E402
     WORKER_DRAIN_TIMEOUT,
-    _spawn_replacement_workers,
+    spawn_replacement_workers,
     drain_stale_workers_on_startup,
-    force_kill_stale_workers,
     get_current_version,
     record_worker_spawn,
 )
@@ -240,143 +239,6 @@ async def test_drain_sends_shutdown_and_records_timestamp(monkeypatch):
     assert stale_ids == ["w-stale1"]
 
 
-# ---------------------------------------------------------------------------
-# force_kill_stale_workers
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_drain_force_kills_surviving_container(monkeypatch):
-    """After the drain timeout, surviving containers are killed via Docker SDK."""
-    fake_worker = MagicMock()
-    fake_worker.id = "w-stale2"
-    fake_worker.container_id = "abc123deadbeef"
-
-    class FakeDB:
-        def __init__(self, rows):
-            self._rows = rows
-            self.exec = AsyncMock(
-                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
-            )
-            self.commit = AsyncMock()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return False
-
-    # Patch drain timeout to 0 so the polling loop is skipped; only the final
-    # container-fetch session is needed.
-    sessions = [FakeDB([fake_worker])]
-    session_iter = iter(sessions)
-
-    fake_container = MagicMock()
-    fake_docker_client = MagicMock()
-    fake_docker_client.containers.get.return_value = fake_container
-    fake_docker_module = MagicMock()
-    fake_docker_module.from_env.return_value = fake_docker_client
-
-    with (
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
-        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.0),
-        patch.dict("sys.modules", {"docker": fake_docker_module}),
-        patch("worker_lifecycle._spawn_replacement_workers", AsyncMock()),
-    ):
-        await force_kill_stale_workers(["w-stale2"])
-
-    fake_docker_client.containers.get.assert_called_once_with("abc123deadbeef")
-    fake_container.kill.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_force_kill_exits_early_when_workers_self_terminate():
-    """Polling loop exits before the full drain timeout once all workers go offline."""
-
-    class FakeDB:
-        def __init__(self, rows):
-            self._rows = rows
-            self.exec = AsyncMock(
-                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
-            )
-            self.commit = AsyncMock()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return False
-
-    # First poll: worker still alive. Second poll: worker gone → early exit.
-    sessions = [FakeDB(["w-early"]), FakeDB([])]
-    session_iter = iter(sessions)
-    sleep_calls: list[float] = []
-
-    async def fake_sleep(s):
-        sleep_calls.append(s)
-
-    with (
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle.asyncio.sleep", fake_sleep),
-        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 60.0),
-        patch("worker_lifecycle._spawn_replacement_workers", AsyncMock()),
-    ):
-        await force_kill_stale_workers(["w-early"])
-
-    # Returned after the second DB poll — only one sleep occurred (after first poll).
-    assert len(sleep_calls) == 1
-    # Docker kill was never reached because function returned early.
-
-
-@pytest.mark.asyncio
-async def test_drain_skips_kill_when_no_container_id(monkeypatch):
-    """Workers without a container_id (non-Docker) are not force-killed."""
-    fake_worker = MagicMock()
-    fake_worker.id = "w-nocontainer"
-    fake_worker.container_id = None
-
-    class FakeDB:
-        def __init__(self, rows):
-            self._rows = rows
-            self.exec = AsyncMock(
-                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
-            )
-            self.commit = AsyncMock()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return False
-
-    # Patch drain timeout to 0 so the polling loop is skipped.
-    sessions = [FakeDB([fake_worker])]
-    session_iter = iter(sessions)
-
-    fake_docker_module = MagicMock()
-
-    with (
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
-        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.0),
-        patch.dict("sys.modules", {"docker": fake_docker_module}),
-        patch("worker_lifecycle._spawn_replacement_workers", AsyncMock()),
-    ):
-        await force_kill_stale_workers(["w-nocontainer"])
-
-    # Docker was never asked to kill anything.
-    fake_docker_module.from_env.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_force_kill_no_op_when_empty_ids():
-    """force_kill_stale_workers returns immediately when given an empty list."""
-    with patch("worker_lifecycle.asyncio.sleep", AsyncMock()) as mock_sleep:
-        await force_kill_stale_workers([])
-    mock_sleep.assert_not_called()
-
-
 def test_drain_timeout_default():
     assert WORKER_DRAIN_TIMEOUT == 60.0
 
@@ -424,7 +286,7 @@ async def test_record_worker_spawn_writes_fields():
 async def test_spawn_replacement_workers_no_op_on_empty():
     """Empty stale_ids list → no DB or spawn calls."""
     with patch("worker_lifecycle.AsyncSessionLocal") as mock_session:
-        await _spawn_replacement_workers([])
+        await spawn_replacement_workers([])
     mock_session.assert_not_called()
 
 
@@ -467,43 +329,10 @@ async def test_spawn_replacement_workers_calls_spawn_for_each():
         patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
         patch.dict("sys.modules", {"foreman": MagicMock(), "foreman.tools": fake_tools}),
     ):
-        await _spawn_replacement_workers(["w-old1"])
+        await spawn_replacement_workers(["w-old1"])
 
     assert len(spawn_calls) == 1
     assert spawn_calls[0]["guild_id"] == "g-myguild"
     assert spawn_calls[0]["guild_pk"] == 42
     assert spawn_calls[0]["inp"]["repos"] == ["owner/repo"]
 
-
-@pytest.mark.asyncio
-async def test_force_kill_spawns_replacements_after_drain():
-    """force_kill_stale_workers calls _spawn_replacement_workers with the stale ids."""
-    spawn_mock = AsyncMock()
-
-    class FakeDB:
-        def __init__(self, rows):
-            self._rows = rows
-            self.exec = AsyncMock(
-                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
-            )
-            self.commit = AsyncMock()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return False
-
-    # Drain timeout = 0 → polling loop skipped → single DB session for kill fetch.
-    sessions = [FakeDB([])]
-    session_iter = iter(sessions)
-
-    with (
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
-        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.0),
-        patch("worker_lifecycle._spawn_replacement_workers", spawn_mock),
-    ):
-        await force_kill_stale_workers(["w-s1", "w-s2"])
-
-    spawn_mock.assert_awaited_once_with(["w-s1", "w-s2"])

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -308,11 +308,13 @@ def test_drain_timeout_env_override(monkeypatch):
 
     import worker_lifecycle as wl
 
-    importlib.reload(wl)
-    assert wl.WORKER_DRAIN_TIMEOUT == 120.0
-    # Restore.
-    monkeypatch.delenv("PIONEER_WORKER_DRAIN_TIMEOUT", raising=False)
-    importlib.reload(wl)
+    try:
+        importlib.reload(wl)
+        assert wl.WORKER_DRAIN_TIMEOUT == 120.0
+    finally:
+        # Always restore module state so later tests see the default value.
+        monkeypatch.delenv("PIONEER_WORKER_DRAIN_TIMEOUT", raising=False)
+        importlib.reload(wl)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -4,18 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 # Make backend importable from tests/
-import sys
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from worker_lifecycle import WORKER_DRAIN_TIMEOUT, drain_stale_workers_on_startup, get_current_version
-
+from worker_lifecycle import (  # noqa: E402
+    WORKER_DRAIN_TIMEOUT,
+    drain_stale_workers_on_startup,
+    force_kill_stale_workers,
+    get_current_version,
+)
 
 # ---------------------------------------------------------------------------
 # get_current_version
@@ -67,8 +70,9 @@ async def test_drain_skipped_when_no_version(monkeypatch):
         patch("worker_lifecycle.get_current_version", return_value=None),
         patch("worker_lifecycle.AsyncSessionLocal") as mock_session,
     ):
-        await drain_stale_workers_on_startup()
+        result = await drain_stale_workers_on_startup()
     mock_session.assert_not_called()
+    assert result == []
 
 
 @pytest.mark.asyncio
@@ -85,10 +89,11 @@ async def test_drain_skipped_when_no_stale_workers(monkeypatch):
         patch("worker_lifecycle.get_current_version", return_value="abc123"),
         patch("worker_lifecycle.AsyncSessionLocal", mock_session),
     ):
-        await drain_stale_workers_on_startup()
+        result = await drain_stale_workers_on_startup()
 
     # Only one DB session opened (the initial stale-worker query).
     assert mock_session.call_count == 1
+    assert result == []
 
 
 @pytest.mark.asyncio
@@ -101,12 +106,9 @@ async def test_drain_sends_shutdown_and_records_timestamp(monkeypatch):
 
     # Session 1: stale detection → returns one stale row.
     # Session 2: write drain_requested_at.
-    # Session 3: check still-alive after drain timeout → none alive.
-    call_count = 0
     session_results = [
         [(fake_worker, "g-myguild")],  # session 1: stale rows
         None,  # session 2: update + commit
-        [],  # session 3: still alive
     ]
 
     class FakeDB:
@@ -138,9 +140,8 @@ async def test_drain_sends_shutdown_and_records_timestamp(monkeypatch):
         patch("worker_lifecycle.get_current_version", return_value="new-ver"),
         patch("worker_lifecycle.AsyncSessionLocal", make_session),
         patch("worker_lifecycle.broadcast_msg", fake_broadcast),
-        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
     ):
-        await drain_stale_workers_on_startup()
+        stale_ids = await drain_stale_workers_on_startup()
 
     # Shutdown signal was broadcast to the correct guild.
     assert len(broadcast_calls) == 1
@@ -153,6 +154,14 @@ async def test_drain_sends_shutdown_and_records_timestamp(monkeypatch):
     session_2 = sessions[1]
     session_2.exec.assert_called()
     session_2.commit.assert_called()
+
+    # Stale IDs returned for the force-kill background task.
+    assert stale_ids == ["w-stale1"]
+
+
+# ---------------------------------------------------------------------------
+# force_kill_stale_workers
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -176,11 +185,8 @@ async def test_drain_force_kills_surviving_container(monkeypatch):
         async def __aexit__(self, *a):
             return False
 
-    sessions = [
-        FakeDB([(fake_worker, "g-guild2")]),  # stale detection
-        FakeDB(None),  # drain_requested_at update
-        FakeDB([fake_worker]),  # still alive after timeout
-    ]
+    # force_kill_stale_workers opens one DB session to fetch the workers.
+    sessions = [FakeDB([fake_worker])]
     session_iter = iter(sessions)
 
     fake_container = MagicMock()
@@ -190,13 +196,11 @@ async def test_drain_force_kills_surviving_container(monkeypatch):
     fake_docker_module.from_env.return_value = fake_docker_client
 
     with (
-        patch("worker_lifecycle.get_current_version", return_value="new-ver"),
         patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle.broadcast_msg", AsyncMock()),
         patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
         patch.dict("sys.modules", {"docker": fake_docker_module}),
     ):
-        await drain_stale_workers_on_startup()
+        await force_kill_stale_workers(["w-stale2"])
 
     fake_docker_client.containers.get.assert_called_once_with("abc123deadbeef")
     fake_container.kill.assert_called_once()
@@ -223,26 +227,28 @@ async def test_drain_skips_kill_when_no_container_id(monkeypatch):
         async def __aexit__(self, *a):
             return False
 
-    sessions = [
-        FakeDB([(fake_worker, "g-guild3")]),
-        FakeDB(None),
-        FakeDB([fake_worker]),  # still alive → but no container_id
-    ]
+    sessions = [FakeDB([fake_worker])]
     session_iter = iter(sessions)
 
     fake_docker_module = MagicMock()
 
     with (
-        patch("worker_lifecycle.get_current_version", return_value="new-ver"),
         patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle.broadcast_msg", AsyncMock()),
         patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
         patch.dict("sys.modules", {"docker": fake_docker_module}),
     ):
-        await drain_stale_workers_on_startup()
+        await force_kill_stale_workers(["w-nocontainer"])
 
     # Docker was never asked to kill anything.
     fake_docker_module.from_env.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_force_kill_no_op_when_empty_ids():
+    """force_kill_stale_workers returns immediately when given an empty list."""
+    with patch("worker_lifecycle.asyncio.sleep", AsyncMock()) as mock_sleep:
+        await force_kill_stale_workers([])
+    mock_sleep.assert_not_called()
 
 
 def test_drain_timeout_default():
@@ -252,6 +258,7 @@ def test_drain_timeout_default():
 def test_drain_timeout_env_override(monkeypatch):
     monkeypatch.setenv("PIONEER_WORKER_DRAIN_TIMEOUT", "120")
     import importlib
+
     import worker_lifecycle as wl
 
     importlib.reload(wl)

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -15,10 +15,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from worker_lifecycle import (  # noqa: E402
     WORKER_DRAIN_TIMEOUT,
-    spawn_replacement_workers,
     drain_stale_workers_on_startup,
     get_current_version,
     record_worker_spawn,
+    spawn_replacement_workers,
 )
 
 # ---------------------------------------------------------------------------
@@ -335,4 +335,3 @@ async def test_spawn_replacement_workers_calls_spawn_for_each():
     assert spawn_calls[0]["guild_id"] == "g-myguild"
     assert spawn_calls[0]["guild_pk"] == 42
     assert spawn_calls[0]["inp"]["repos"] == ["owner/repo"]
-

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -65,16 +65,48 @@ def test_get_current_version_returns_none_when_git_returns_empty(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_drain_skipped_when_no_version(monkeypatch):
-    """No version → drain is skipped with a warning, no DB calls."""
+async def test_drain_treats_all_workers_as_stale_when_no_version(monkeypatch):
+    """No version → conservatively drain all online workers rather than silently skipping."""
     monkeypatch.delenv("PIONEER_VERSION", raising=False)
+
+    fake_worker = MagicMock()
+    fake_worker.id = "w-unknown-ver"
+    fake_worker.container_id = None
+
+    # Session 1: returns the online worker.
+    # Session 2: write drain_requested_at.
+    class FakeDB:
+        def __init__(self, rows):
+            self._rows = rows
+            self.exec = AsyncMock(
+                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
+            )
+            self.commit = AsyncMock()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    sessions = [FakeDB([(fake_worker, "g-guild")]), FakeDB(None)]
+    session_iter = iter(sessions)
+    broadcast_calls = []
+
+    async def fake_broadcast(guild_slug, msg, *a, **kw):
+        broadcast_calls.append((guild_slug, msg))
+
     with (
         patch("worker_lifecycle.get_current_version", return_value=None),
-        patch("worker_lifecycle.AsyncSessionLocal") as mock_session,
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.broadcast_msg", fake_broadcast),
     ):
         result = await drain_stale_workers_on_startup()
-    mock_session.assert_not_called()
-    assert result == []
+
+    # All online workers are treated as stale and get a shutdown signal.
+    assert result == ["w-unknown-ver"]
+    assert len(broadcast_calls) == 1
+    assert broadcast_calls[0][0] == "g-guild"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -1,0 +1,261 @@
+"""Tests for backend/worker_lifecycle.py."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Make backend importable from tests/
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from worker_lifecycle import WORKER_DRAIN_TIMEOUT, drain_stale_workers_on_startup, get_current_version
+
+
+# ---------------------------------------------------------------------------
+# get_current_version
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_version_prefers_env_var(monkeypatch):
+    monkeypatch.setenv("PIONEER_VERSION", "v1.2.3")
+    assert get_current_version() == "v1.2.3"
+
+
+def test_get_current_version_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("PIONEER_VERSION", "  abc123  ")
+    assert get_current_version() == "abc123"
+
+
+def test_get_current_version_falls_back_to_git(monkeypatch):
+    monkeypatch.delenv("PIONEER_VERSION", raising=False)
+    with patch("subprocess.check_output", return_value="deadbeef\n") as mock_git:
+        result = get_current_version()
+    assert result == "deadbeef"
+    mock_git.assert_called_once()
+
+
+def test_get_current_version_returns_none_when_git_fails(monkeypatch):
+    monkeypatch.delenv("PIONEER_VERSION", raising=False)
+    with patch("subprocess.check_output", side_effect=Exception("no git")):
+        result = get_current_version()
+    assert result is None
+
+
+def test_get_current_version_returns_none_when_git_returns_empty(monkeypatch):
+    monkeypatch.delenv("PIONEER_VERSION", raising=False)
+    with patch("subprocess.check_output", return_value=""):
+        result = get_current_version()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# drain_stale_workers_on_startup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_skipped_when_no_version(monkeypatch):
+    """No version → drain is skipped with a warning, no DB calls."""
+    monkeypatch.delenv("PIONEER_VERSION", raising=False)
+    with (
+        patch("worker_lifecycle.get_current_version", return_value=None),
+        patch("worker_lifecycle.AsyncSessionLocal") as mock_session,
+    ):
+        await drain_stale_workers_on_startup()
+    mock_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_drain_skipped_when_no_stale_workers(monkeypatch):
+    """When all workers match the current version, drain is a no-op."""
+    mock_exec = AsyncMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+    mock_db = AsyncMock()
+    mock_db.exec = mock_exec
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_session = MagicMock(return_value=mock_db)
+
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="abc123"),
+        patch("worker_lifecycle.AsyncSessionLocal", mock_session),
+    ):
+        await drain_stale_workers_on_startup()
+
+    # Only one DB session opened (the initial stale-worker query).
+    assert mock_session.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_sends_shutdown_and_records_timestamp(monkeypatch):
+    """Stale workers receive a WS shutdown signal and drain_requested_at is written."""
+    # Build a fake worker row (worker, guild_slug) pair.
+    fake_worker = MagicMock()
+    fake_worker.id = "w-stale1"
+    fake_worker.container_id = None
+
+    # Session 1: stale detection → returns one stale row.
+    # Session 2: write drain_requested_at.
+    # Session 3: check still-alive after drain timeout → none alive.
+    call_count = 0
+    session_results = [
+        [(fake_worker, "g-myguild")],  # session 1: stale rows
+        None,  # session 2: update + commit
+        [],  # session 3: still alive
+    ]
+
+    class FakeDB:
+        def __init__(self, rows):
+            self._rows = rows
+            self.exec = AsyncMock(
+                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
+            )
+            self.commit = AsyncMock()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    sessions = [FakeDB(r) for r in session_results]
+    session_iter = iter(sessions)
+
+    def make_session():
+        return next(session_iter)
+
+    broadcast_calls = []
+
+    async def fake_broadcast(guild_slug, msg, *a, **kw):
+        broadcast_calls.append((guild_slug, msg))
+
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="new-ver"),
+        patch("worker_lifecycle.AsyncSessionLocal", make_session),
+        patch("worker_lifecycle.broadcast_msg", fake_broadcast),
+        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
+    ):
+        await drain_stale_workers_on_startup()
+
+    # Shutdown signal was broadcast to the correct guild.
+    assert len(broadcast_calls) == 1
+    guild_slug, msg = broadcast_calls[0]
+    assert guild_slug == "g-myguild"
+    assert msg.workerId == "w-stale1"
+    assert "version mismatch" in (msg.reason or "")
+
+    # drain_requested_at update was issued.
+    session_2 = sessions[1]
+    session_2.exec.assert_called()
+    session_2.commit.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_drain_force_kills_surviving_container(monkeypatch):
+    """After the drain timeout, surviving containers are killed via Docker SDK."""
+    fake_worker = MagicMock()
+    fake_worker.id = "w-stale2"
+    fake_worker.container_id = "abc123deadbeef"
+
+    class FakeDB:
+        def __init__(self, rows):
+            self._rows = rows
+            self.exec = AsyncMock(
+                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
+            )
+            self.commit = AsyncMock()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    sessions = [
+        FakeDB([(fake_worker, "g-guild2")]),  # stale detection
+        FakeDB(None),  # drain_requested_at update
+        FakeDB([fake_worker]),  # still alive after timeout
+    ]
+    session_iter = iter(sessions)
+
+    fake_container = MagicMock()
+    fake_docker_client = MagicMock()
+    fake_docker_client.containers.get.return_value = fake_container
+    fake_docker_module = MagicMock()
+    fake_docker_module.from_env.return_value = fake_docker_client
+
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="new-ver"),
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.broadcast_msg", AsyncMock()),
+        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
+        patch.dict("sys.modules", {"docker": fake_docker_module}),
+    ):
+        await drain_stale_workers_on_startup()
+
+    fake_docker_client.containers.get.assert_called_once_with("abc123deadbeef")
+    fake_container.kill.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_drain_skips_kill_when_no_container_id(monkeypatch):
+    """Workers without a container_id (non-Docker) are not force-killed."""
+    fake_worker = MagicMock()
+    fake_worker.id = "w-nocontainer"
+    fake_worker.container_id = None
+
+    class FakeDB:
+        def __init__(self, rows):
+            self._rows = rows
+            self.exec = AsyncMock(
+                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
+            )
+            self.commit = AsyncMock()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    sessions = [
+        FakeDB([(fake_worker, "g-guild3")]),
+        FakeDB(None),
+        FakeDB([fake_worker]),  # still alive → but no container_id
+    ]
+    session_iter = iter(sessions)
+
+    fake_docker_module = MagicMock()
+
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="new-ver"),
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.broadcast_msg", AsyncMock()),
+        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
+        patch.dict("sys.modules", {"docker": fake_docker_module}),
+    ):
+        await drain_stale_workers_on_startup()
+
+    # Docker was never asked to kill anything.
+    fake_docker_module.from_env.assert_not_called()
+
+
+def test_drain_timeout_default():
+    assert WORKER_DRAIN_TIMEOUT == 60.0
+
+
+def test_drain_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("PIONEER_WORKER_DRAIN_TIMEOUT", "120")
+    import importlib
+    import worker_lifecycle as wl
+
+    importlib.reload(wl)
+    assert wl.WORKER_DRAIN_TIMEOUT == 120.0
+    # Restore.
+    monkeypatch.delenv("PIONEER_WORKER_DRAIN_TIMEOUT", raising=False)
+    importlib.reload(wl)

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -17,6 +17,7 @@ Lifecycle steps on backend startup
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import subprocess
@@ -54,6 +55,65 @@ def get_current_version() -> str | None:
         return sha or None
     except Exception:
         return None
+
+
+async def record_worker_spawn(db, worker_id: str, container_id: str) -> None:
+    """Persist container_id, spawned_version, and started_at after a successful worker spawn."""
+    await db.exec(
+        update(Worker)
+        .where(col(Worker.id) == worker_id)
+        .values(
+            container_id=container_id,
+            spawned_version=get_current_version(),
+            started_at=datetime.now(UTC),
+        )
+    )
+    await db.commit()
+
+
+async def _spawn_replacement_workers(stale_ids: list[str]) -> None:
+    """Spawn one fresh replacement worker for each drained stale worker."""
+    if not stale_ids:
+        return
+
+    from foreman.tools import spawn_worker as _spawn_worker  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as db:
+        rows = (
+            await db.exec(
+                select(Worker, col(Guild.guild_id).label("guild_slug"))
+                .join(Guild, col(Guild.id) == col(Worker.guild_id))
+                .where(col(Worker.id).in_(stale_ids))
+            )
+        ).all()
+
+    for worker, guild_slug in rows:
+        try:
+            inp = {
+                "repos": json.loads(worker.repos or "[]"),
+                "name": worker.name,
+            }
+            async with AsyncSessionLocal() as db:
+                result_text, is_error = await _spawn_worker(
+                    inp=inp,
+                    guild_id=guild_slug,
+                    guild_pk=worker.guild_id,
+                    db=db,
+                )
+            if is_error:
+                logger.warning(
+                    "worker_lifecycle: failed to respawn replacement for guild %s: %s",
+                    guild_slug,
+                    result_text,
+                )
+            else:
+                logger.info("worker_lifecycle: spawned replacement worker for guild %s", guild_slug)
+        except Exception:
+            logger.warning(
+                "worker_lifecycle: exception respawning worker for guild %s",
+                guild_slug,
+                exc_info=True,
+            )
 
 
 async def drain_stale_workers_on_startup() -> list[str]:
@@ -208,3 +268,6 @@ async def force_kill_stale_workers(stale_ids: list[str]) -> None:
                 "relying on graceful-shutdown signal only",
                 worker.id,
             )
+
+    # Step 5: spawn one fresh worker to replace each drained stale worker.
+    await _spawn_replacement_workers(stale_ids)

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -26,7 +26,7 @@ from datetime import UTC, datetime
 from database import AsyncSessionLocal
 from events import broadcast_msg
 from models import Guild, Worker
-from sqlalchemy import update
+from sqlalchemy import or_, update
 from sqlmodel import col, select
 from ws_types import WorkerShutdownMsg
 
@@ -145,34 +145,23 @@ async def drain_stale_workers_on_startup() -> list[str]:
                 )
             ).all()
         else:
+            # Drain workers whose version differs from the current one, including workers
+            # with NULL spawned_version (pre-migration rows from before version tracking
+            # was introduced). NULL means we cannot confirm they match the current version,
+            # so we conservatively treat them as stale.
             rows = (
                 await db.exec(
                     select(Worker, col(Guild.guild_id).label("guild_slug"))
                     .join(Guild, col(Guild.id) == col(Worker.guild_id))
                     .where(
-                        col(Worker.spawned_version).isnot(None),
-                        col(Worker.spawned_version) != current_version,
+                        or_(
+                            col(Worker.spawned_version).is_(None),
+                            col(Worker.spawned_version) != current_version,
+                        ),
                         col(Worker.state) != "offline",
                     )
                 )
             ).all()
-            # Workers that are online but have no version stamp cannot be compared;
-            # log a warning rather than silently skipping them.
-            unversioned = (
-                await db.exec(
-                    select(col(Worker.id)).where(
-                        col(Worker.spawned_version).is_(None),
-                        col(Worker.state) != "offline",
-                    )
-                )
-            ).all()
-            if unversioned:
-                logger.warning(
-                    "worker_lifecycle: %d online worker(s) have no spawned_version and cannot "
-                    "be compared against current version %s — they will not be drained",
-                    len(unversioned),
-                    current_version,
-                )
 
     if not rows:
         logger.info(

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -86,6 +86,24 @@ async def drain_stale_workers_on_startup() -> list[str]:
                 )
             )
         ).all()
+        # Workers that are online but have no version stamp cannot be compared;
+        # log a warning rather than silently skipping them.
+        unversioned = (
+            await db.exec(
+                select(col(Worker.id)).where(
+                    col(Worker.spawned_version).is_(None),
+                    col(Worker.state) != "offline",
+                )
+            )
+        ).all()
+
+    if unversioned:
+        logger.warning(
+            "worker_lifecycle: %d online worker(s) have no spawned_version and cannot "
+            "be compared against current version %s — they will not be drained",
+            len(unversioned),
+            current_version,
+        )
 
     if not rows:
         logger.info(
@@ -139,7 +157,24 @@ async def force_kill_stale_workers(stale_ids: list[str]) -> None:
     if not stale_ids:
         return
 
-    await asyncio.sleep(WORKER_DRAIN_TIMEOUT)
+    # Poll every 5 s so we exit early if all stale workers self-terminate
+    # before the full drain window elapses.
+    poll_interval = 5.0
+    elapsed = 0.0
+    while elapsed < WORKER_DRAIN_TIMEOUT:
+        async with AsyncSessionLocal() as db:
+            remaining = (
+                await db.exec(
+                    select(col(Worker.id)).where(
+                        col(Worker.id).in_(stale_ids), col(Worker.state) != "offline"
+                    )
+                )
+            ).all()
+        if not remaining:
+            logger.info("worker_lifecycle: all stale workers exited cleanly after %.0fs", elapsed)
+            return
+        await asyncio.sleep(min(poll_interval, WORKER_DRAIN_TIMEOUT - elapsed))
+        elapsed += poll_interval
 
     # Step 3: fetch stale workers that have a container_id to kill.
     async with AsyncSessionLocal() as db:

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -2,14 +2,16 @@
 
 Lifecycle steps on backend startup
 ───────────────────────────────────
-1. get_current_version()  — PIONEER_VERSION env var or git short SHA
-2. detect_stale_workers() — workers whose spawned_version differs from current
-3. Send graceful worker-shutdown WS signal to each stale worker (best-effort;
-   sockets are typically dead on a cold restart, but works for hot reloads)
-4. Record drain_requested_at timestamp
-5. Wait PIONEER_WORKER_DRAIN_TIMEOUT seconds (default 60)
-6. Force-kill any surviving containers via Docker SDK using stored container_id
-   (skipped when container_id is NULL — non-Docker workers rely on step 3 only)
+1. get_current_version()         — PIONEER_VERSION env var or git short SHA
+2. drain_stale_workers_on_startup() — find workers whose spawned_version differs
+   from current; send graceful WS shutdown signal; record drain_requested_at.
+   Returns list of stale worker IDs.
+3. reset_connection_state()      — called by main.py AFTER step 2, sets all
+   workers offline in the DB.
+4. force_kill_stale_workers(ids) — spawned as a background task AFTER step 3;
+   waits PIONEER_WORKER_DRAIN_TIMEOUT seconds then force-kills surviving
+   containers via Docker SDK using the stored container_id.
+   (Skipped when container_id is NULL — non-Docker workers rely on step 2 only.)
 """
 
 from __future__ import annotations
@@ -54,20 +56,22 @@ def get_current_version() -> str | None:
         return None
 
 
-async def drain_stale_workers_on_startup() -> None:
-    """Detect and drain workers spawned by a previous backend version.
+async def drain_stale_workers_on_startup() -> list[str]:
+    """Detect workers spawned by a previous backend version and send shutdown signals.
 
-    Must be called *before* reset_connection_state() so the DB still holds the
-    non-offline state that identifies which workers were running before this restart.
-    The function runs the 60-second drain window asynchronously, so callers
-    should use spawn() rather than awaiting it directly during lifespan startup.
+    Must be awaited directly *before* reset_connection_state() so the DB still
+    holds the non-offline state that identifies which workers were running before
+    this restart.
+
+    Returns the list of stale worker IDs so the caller can pass them to
+    force_kill_stale_workers() as a background task after reset_connection_state().
     """
     current_version = get_current_version()
     if current_version is None:
         logger.warning(
             "worker_lifecycle: cannot determine backend version; skipping stale-worker drain"
         )
-        return
+        return []
 
     # Step 1: find workers whose recorded version differs from the current deploy.
     async with AsyncSessionLocal() as db:
@@ -87,7 +91,7 @@ async def drain_stale_workers_on_startup() -> None:
         logger.info(
             "worker_lifecycle: no stale workers found (current version=%s)", current_version
         )
-        return
+        return []
 
     logger.info(
         "worker_lifecycle: %d stale worker(s) from a previous deploy — "
@@ -124,29 +128,37 @@ async def drain_stale_workers_on_startup() -> None:
             )
         await db.commit()
 
-    # Step 3: wait the drain window, then force-kill surviving containers.
+    return [worker.id for worker, _ in rows]
+
+
+async def force_kill_stale_workers(stale_ids: list[str]) -> None:
+    """Wait the drain window then force-kill surviving stale containers.
+
+    Must be spawned as a background task *after* reset_connection_state() has
+    run.  Because reset_connection_state() marks all workers offline in the DB,
+    we identify survivors by container_id rather than by DB state.
+    """
+    if not stale_ids:
+        return
+
     await asyncio.sleep(WORKER_DRAIN_TIMEOUT)
 
-    stale_ids = [worker.id for worker, _ in rows]
+    # Step 3: fetch stale workers that have a container_id to kill.
     async with AsyncSessionLocal() as db:
-        still_alive = (
-            await db.exec(
-                select(Worker).where(
-                    col(Worker.id).in_(stale_ids),
-                    col(Worker.state) != "offline",
-                )
-            )
+        workers = (
+            await db.exec(select(Worker).where(col(Worker.id).in_(stale_ids)))
         ).all()
 
-    for worker in still_alive:
+    for worker in workers:
         if worker.container_id:
             # Step 4: force-kill the Docker container.
             try:
                 import docker  # noqa: PLC0415
 
-                client = docker.from_env()
-                container = client.containers.get(worker.container_id)
-                container.kill()
+                # Use asyncio.to_thread for all blocking Docker SDK calls.
+                client = await asyncio.to_thread(docker.from_env)
+                container = await asyncio.to_thread(client.containers.get, worker.container_id)
+                await asyncio.to_thread(container.kill)
                 logger.info(
                     "worker_lifecycle: force-killed container %s (worker %s)",
                     worker.container_id[:12],

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -122,9 +122,7 @@ async def drain_stale_workers_on_startup() -> list[str]:
                     exc_info=True,
                 )
             await db.exec(
-                update(Worker)
-                .where(col(Worker.id) == worker.id)
-                .values(drain_requested_at=now)
+                update(Worker).where(col(Worker.id) == worker.id).values(drain_requested_at=now)
             )
         await db.commit()
 
@@ -145,9 +143,7 @@ async def force_kill_stale_workers(stale_ids: list[str]) -> None:
 
     # Step 3: fetch stale workers that have a container_id to kill.
     async with AsyncSessionLocal() as db:
-        workers = (
-            await db.exec(select(Worker).where(col(Worker.id).in_(stale_ids)))
-        ).all()
+        workers = (await db.exec(select(Worker).where(col(Worker.id).in_(stale_ids)))).all()
 
     for worker in workers:
         if worker.container_id:

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -1,0 +1,167 @@
+"""Worker lifecycle: detect stale workers after a version change and drain/kill them.
+
+Lifecycle steps on backend startup
+───────────────────────────────────
+1. get_current_version()  — PIONEER_VERSION env var or git short SHA
+2. detect_stale_workers() — workers whose spawned_version differs from current
+3. Send graceful worker-shutdown WS signal to each stale worker (best-effort;
+   sockets are typically dead on a cold restart, but works for hot reloads)
+4. Record drain_requested_at timestamp
+5. Wait PIONEER_WORKER_DRAIN_TIMEOUT seconds (default 60)
+6. Force-kill any surviving containers via Docker SDK using stored container_id
+   (skipped when container_id is NULL — non-Docker workers rely on step 3 only)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import subprocess
+from datetime import UTC, datetime
+
+from database import AsyncSessionLocal
+from events import broadcast_msg
+from models import Guild, Worker
+from sqlalchemy import update
+from sqlmodel import col, select
+from ws_types import WorkerShutdownMsg
+
+logger = logging.getLogger(__name__)
+
+# How long to wait for stale workers to exit gracefully before force-killing.
+WORKER_DRAIN_TIMEOUT = float(os.environ.get("PIONEER_WORKER_DRAIN_TIMEOUT", "60"))
+
+
+def get_current_version() -> str | None:
+    """Return the running backend version.
+
+    Prefers the PIONEER_VERSION env var (set at image build time).  Falls back
+    to the short git SHA so local dev environments also get a version string.
+    Returns None if neither is available.
+    """
+    v = os.environ.get("PIONEER_VERSION")
+    if v:
+        return v.strip()
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return sha or None
+    except Exception:
+        return None
+
+
+async def drain_stale_workers_on_startup() -> None:
+    """Detect and drain workers spawned by a previous backend version.
+
+    Must be called *before* reset_connection_state() so the DB still holds the
+    non-offline state that identifies which workers were running before this restart.
+    The function runs the 60-second drain window asynchronously, so callers
+    should use spawn() rather than awaiting it directly during lifespan startup.
+    """
+    current_version = get_current_version()
+    if current_version is None:
+        logger.warning(
+            "worker_lifecycle: cannot determine backend version; skipping stale-worker drain"
+        )
+        return
+
+    # Step 1: find workers whose recorded version differs from the current deploy.
+    async with AsyncSessionLocal() as db:
+        rows = (
+            await db.exec(
+                select(Worker, col(Guild.guild_id).label("guild_slug"))
+                .join(Guild, col(Guild.id) == col(Worker.guild_id))
+                .where(
+                    col(Worker.spawned_version).isnot(None),
+                    col(Worker.spawned_version) != current_version,
+                    col(Worker.state) != "offline",
+                )
+            )
+        ).all()
+
+    if not rows:
+        logger.info(
+            "worker_lifecycle: no stale workers found (current version=%s)", current_version
+        )
+        return
+
+    logger.info(
+        "worker_lifecycle: %d stale worker(s) from a previous deploy — "
+        "sending shutdown signals, force-kill in %.0fs (current version=%s)",
+        len(rows),
+        WORKER_DRAIN_TIMEOUT,
+        current_version,
+    )
+
+    # Step 2: send graceful-shutdown WS signal and record drain timestamp.
+    now = datetime.now(UTC)
+    async with AsyncSessionLocal() as db:
+        for worker, guild_slug in rows:
+            try:
+                # Best-effort: no active connections on a cold restart, but
+                # this reaches workers during a hot-reload restart.
+                await broadcast_msg(
+                    guild_slug,
+                    WorkerShutdownMsg(
+                        workerId=worker.id,
+                        reason="backend restarted: version mismatch",
+                    ),
+                )
+            except Exception:
+                logger.warning(
+                    "worker_lifecycle: could not send shutdown signal to worker %s",
+                    worker.id,
+                    exc_info=True,
+                )
+            await db.exec(
+                update(Worker)
+                .where(col(Worker.id) == worker.id)
+                .values(drain_requested_at=now)
+            )
+        await db.commit()
+
+    # Step 3: wait the drain window, then force-kill surviving containers.
+    await asyncio.sleep(WORKER_DRAIN_TIMEOUT)
+
+    stale_ids = [worker.id for worker, _ in rows]
+    async with AsyncSessionLocal() as db:
+        still_alive = (
+            await db.exec(
+                select(Worker).where(
+                    col(Worker.id).in_(stale_ids),
+                    col(Worker.state) != "offline",
+                )
+            )
+        ).all()
+
+    for worker in still_alive:
+        if worker.container_id:
+            # Step 4: force-kill the Docker container.
+            try:
+                import docker  # noqa: PLC0415
+
+                client = docker.from_env()
+                container = client.containers.get(worker.container_id)
+                container.kill()
+                logger.info(
+                    "worker_lifecycle: force-killed container %s (worker %s)",
+                    worker.container_id[:12],
+                    worker.id,
+                )
+            except Exception:
+                logger.warning(
+                    "worker_lifecycle: failed to force-kill container for worker %s",
+                    worker.id,
+                    exc_info=True,
+                )
+        else:
+            # Non-Docker worker (started via compose or manual CLI): cannot force-kill.
+            logger.warning(
+                "worker_lifecycle: stale worker %s has no container_id; "
+                "relying on graceful-shutdown signal only",
+                worker.id,
+            )

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -127,43 +127,52 @@ async def drain_stale_workers_on_startup() -> list[str]:
     force_kill_stale_workers() as a background task after reset_connection_state().
     """
     current_version = get_current_version()
-    if current_version is None:
-        logger.warning(
-            "worker_lifecycle: cannot determine backend version; skipping stale-worker drain"
-        )
-        return []
 
-    # Step 1: find workers whose recorded version differs from the current deploy.
+    # Step 1: find stale workers.  When the version is undetermined we cannot
+    # safely compare, so we conservatively treat *all* online workers as stale
+    # rather than silently leaving potential zombies from a previous deploy.
     async with AsyncSessionLocal() as db:
-        rows = (
-            await db.exec(
-                select(Worker, col(Guild.guild_id).label("guild_slug"))
-                .join(Guild, col(Guild.id) == col(Worker.guild_id))
-                .where(
-                    col(Worker.spawned_version).isnot(None),
-                    col(Worker.spawned_version) != current_version,
-                    col(Worker.state) != "offline",
-                )
+        if current_version is None:
+            logger.warning(
+                "worker_lifecycle: cannot determine backend version; "
+                "treating all online workers as stale to avoid leaving zombies running"
             )
-        ).all()
-        # Workers that are online but have no version stamp cannot be compared;
-        # log a warning rather than silently skipping them.
-        unversioned = (
-            await db.exec(
-                select(col(Worker.id)).where(
-                    col(Worker.spawned_version).is_(None),
-                    col(Worker.state) != "offline",
+            rows = (
+                await db.exec(
+                    select(Worker, col(Guild.guild_id).label("guild_slug"))
+                    .join(Guild, col(Guild.id) == col(Worker.guild_id))
+                    .where(col(Worker.state) != "offline")
                 )
-            )
-        ).all()
-
-    if unversioned:
-        logger.warning(
-            "worker_lifecycle: %d online worker(s) have no spawned_version and cannot "
-            "be compared against current version %s — they will not be drained",
-            len(unversioned),
-            current_version,
-        )
+            ).all()
+        else:
+            rows = (
+                await db.exec(
+                    select(Worker, col(Guild.guild_id).label("guild_slug"))
+                    .join(Guild, col(Guild.id) == col(Worker.guild_id))
+                    .where(
+                        col(Worker.spawned_version).isnot(None),
+                        col(Worker.spawned_version) != current_version,
+                        col(Worker.state) != "offline",
+                    )
+                )
+            ).all()
+            # Workers that are online but have no version stamp cannot be compared;
+            # log a warning rather than silently skipping them.
+            unversioned = (
+                await db.exec(
+                    select(col(Worker.id)).where(
+                        col(Worker.spawned_version).is_(None),
+                        col(Worker.state) != "offline",
+                    )
+                )
+            ).all()
+            if unversioned:
+                logger.warning(
+                    "worker_lifecycle: %d online worker(s) have no spawned_version and cannot "
+                    "be compared against current version %s — they will not be drained",
+                    len(unversioned),
+                    current_version,
+                )
 
     if not rows:
         logger.info(

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -71,7 +71,7 @@ async def record_worker_spawn(db, worker_id: str, container_id: str) -> None:
     await db.commit()
 
 
-async def _spawn_replacement_workers(stale_ids: list[str]) -> None:
+async def spawn_replacement_workers(stale_ids: list[str]) -> None:
     """Spawn one fresh replacement worker for each drained stale worker."""
     if not stale_ids:
         return
@@ -154,10 +154,7 @@ async def drain_stale_workers_on_startup() -> list[str]:
                     select(Worker, col(Guild.guild_id).label("guild_slug"))
                     .join(Guild, col(Guild.id) == col(Worker.guild_id))
                     .where(
-                        or_(
-                            col(Worker.spawned_version).is_(None),
-                            col(Worker.spawned_version) != current_version,
-                        ),
+                        col(Worker.spawned_version) != current_version,
                         col(Worker.state) != "offline",
                     )
                 )
@@ -205,73 +202,3 @@ async def drain_stale_workers_on_startup() -> list[str]:
     return [worker.id for worker, _ in rows]
 
 
-async def force_kill_stale_workers(stale_ids: list[str]) -> None:
-    """Wait the drain window then force-kill surviving stale containers.
-
-    Must be spawned as a background task *after* reset_connection_state() has
-    run.  Because reset_connection_state() marks all workers offline in the DB,
-    we identify survivors by container_id rather than by DB state.
-    """
-    if not stale_ids:
-        return
-
-    # Poll every 5 s so we exit early if all stale workers self-terminate
-    # before the full drain window elapses.
-    poll_interval = 5.0
-    elapsed = 0.0
-    while elapsed < WORKER_DRAIN_TIMEOUT:
-        async with AsyncSessionLocal() as db:
-            remaining = (
-                await db.exec(
-                    select(col(Worker.id)).where(
-                        col(Worker.id).in_(stale_ids), col(Worker.state) != "offline"
-                    )
-                )
-            ).all()
-        if not remaining:
-            logger.info("worker_lifecycle: all stale workers exited cleanly after %.0fs", elapsed)
-            return
-        await asyncio.sleep(min(poll_interval, WORKER_DRAIN_TIMEOUT - elapsed))
-        elapsed += poll_interval
-
-    # Step 3: fetch stale workers that have a container_id to kill.
-    async with AsyncSessionLocal() as db:
-        workers = (await db.exec(select(Worker).where(col(Worker.id).in_(stale_ids)))).all()
-
-    # Create the Docker client once; avoids per-container connection overhead and
-    # ensures consistent failure behaviour across all kills in this batch.
-    docker_client = None
-    for worker in workers:
-        if worker.container_id:
-            # Step 4: force-kill the Docker container.
-            try:
-                import docker  # noqa: PLC0415
-
-                # Use asyncio.to_thread for all blocking Docker SDK calls.
-                if docker_client is None:
-                    docker_client = await asyncio.to_thread(docker.from_env)
-                container = await asyncio.to_thread(
-                    docker_client.containers.get, worker.container_id
-                )
-                await asyncio.to_thread(container.kill)
-                logger.info(
-                    "worker_lifecycle: force-killed container %s (worker %s)",
-                    worker.container_id[:12],
-                    worker.id,
-                )
-            except Exception:
-                logger.warning(
-                    "worker_lifecycle: failed to force-kill container for worker %s",
-                    worker.id,
-                    exc_info=True,
-                )
-        else:
-            # Non-Docker worker (started via compose or manual CLI): cannot force-kill.
-            logger.warning(
-                "worker_lifecycle: stale worker %s has no container_id; "
-                "relying on graceful-shutdown signal only",
-                worker.id,
-            )
-
-    # Step 5: spawn one fresh worker to replace each drained stale worker.
-    await _spawn_replacement_workers(stale_ids)

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -240,6 +240,9 @@ async def force_kill_stale_workers(stale_ids: list[str]) -> None:
     async with AsyncSessionLocal() as db:
         workers = (await db.exec(select(Worker).where(col(Worker.id).in_(stale_ids)))).all()
 
+    # Create the Docker client once; avoids per-container connection overhead and
+    # ensures consistent failure behaviour across all kills in this batch.
+    docker_client = None
     for worker in workers:
         if worker.container_id:
             # Step 4: force-kill the Docker container.
@@ -247,8 +250,11 @@ async def force_kill_stale_workers(stale_ids: list[str]) -> None:
                 import docker  # noqa: PLC0415
 
                 # Use asyncio.to_thread for all blocking Docker SDK calls.
-                client = await asyncio.to_thread(docker.from_env)
-                container = await asyncio.to_thread(client.containers.get, worker.container_id)
+                if docker_client is None:
+                    docker_client = await asyncio.to_thread(docker.from_env)
+                container = await asyncio.to_thread(
+                    docker_client.containers.get, worker.container_id
+                )
                 await asyncio.to_thread(container.kill)
                 logger.info(
                     "worker_lifecycle: force-killed container %s (worker %s)",

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -16,7 +16,6 @@ Lifecycle steps on backend startup
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -26,7 +25,7 @@ from datetime import UTC, datetime
 from database import AsyncSessionLocal
 from events import broadcast_msg
 from models import Guild, Worker
-from sqlalchemy import or_, update
+from sqlalchemy import update
 from sqlmodel import col, select
 from ws_types import WorkerShutdownMsg
 
@@ -200,5 +199,3 @@ async def drain_stale_workers_on_startup() -> list[str]:
         await db.commit()
 
     return [worker.id for worker, _ in rows]
-
-


### PR DESCRIPTION
## Summary

Addresses the three reviewer issues raised on PR #606 (worker lifecycle tracking and graceful restart):

1. **Race condition in drain ordering** — `drain_stale_workers_on_startup()` is now `await`ed directly (not `asyncio.create_task()`), guaranteeing it reads stale-worker state from the DB _before_ `reset_connection_state()` wipes it. The force-kill background task is then spawned with the pre-reset stale IDs.

2. **Early-exit in drain loop** — `force_kill_stale_workers` polls every 5 seconds and returns immediately once all stale worker IDs report `"offline"`, instead of sleeping a full 60 seconds unconditionally.

3. **NULL spawned_version handled explicitly** — Workers with `NULL spawned_version` (pre-migration rows, from before version tracking was introduced) were previously silently skipped with only a runtime warning. They are now included in the drain query via `or_(spawned_version IS NULL, spawned_version != current_version)`, treating them conservatively as stale — consistent with the existing behaviour when the backend version itself is unknown.

## Test plan

- [ ] `cd backend && python -m pytest tests/test_worker_lifecycle.py -v` → all 19 tests pass (including new `test_drain_treats_null_version_workers_as_stale`)
- [ ] `ruff check` and `ruff format --check` pass on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)