### PR TITLE
fix(alembic): resolve multiple heads by chaining rename_guild_slug

### DIFF
--- a/backend/alembic/versions/20260608_000000_rename_guild_slug.py
+++ b/backend/alembic/versions/20260608_000000_rename_guild_slug.py
@@ -1,7 +1,7 @@
 """Rename guilds.guild_id to guilds.slug.
 
 Revision ID: 20260608_000000_rename_guild_slug
-Revises: 20260606_000000_index_tasks_parent_task_id
+Revises: 20260607_000000_add_worker_lifecycle_columns
 Create Date: 2026-06-08
 
 The human-readable 6-char guild identifier was stored as ``guild_id`` on the
@@ -21,7 +21,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260608_000000_rename_guild_slug"
-down_revision: str | Sequence[str] | None = "20260606_000000_index_tasks_parent_task_id"
+down_revision: str | Sequence[str] | None = "20260607_000000_add_worker_lifecycle_columns"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Problem

`alembic heads` reported two divergent heads:

- `20260607_000000_add_worker_lifecycle_columns`
- `20260608_000000_rename_guild_slug`

Both declared `20260606_000000_index_tasks_parent_task_id` as their `down_revision`, so Alembic saw two branches forking from one revision. `alembic upgrade head` would fail with a multiple-heads error.

## Fix

Re-point `rename_guild_slug` (06-08) at `add_worker_lifecycle_columns` (06-07) to linearize into a single head:

```
...index_tasks_parent_task_id
  → add_worker_lifecycle_columns
    → rename_guild_slug (head)
```

A linear re-chain is preferred over a merge revision because the two migrations touch disjoint schema — one adds columns to `workers`, the other renames `guilds.guild_id` → `guilds.slug` — so neither depends on the other's effects and apply order is functionally irrelevant.

## Verification

`alembic heads` now reports a single head and `alembic history` shows a clean linear chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)