### PR TITLE
fix(worker_lifecycle): use Guild.slug instead of renamed Guild.guild_id

### DIFF
--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -80,7 +80,7 @@ async def spawn_replacement_workers(stale_ids: list[str]) -> None:
     async with AsyncSessionLocal() as db:
         rows = (
             await db.exec(
-                select(Worker, col(Guild.guild_id).label("guild_slug"))
+                select(Worker, col(Guild.slug).label("guild_slug"))
                 .join(Guild, col(Guild.id) == col(Worker.guild_id))
                 .where(col(Worker.id).in_(stale_ids))
             )
@@ -138,7 +138,7 @@ async def drain_stale_workers_on_startup() -> list[str]:
             )
             rows = (
                 await db.exec(
-                    select(Worker, col(Guild.guild_id).label("guild_slug"))
+                    select(Worker, col(Guild.slug).label("guild_slug"))
                     .join(Guild, col(Guild.id) == col(Worker.guild_id))
                     .where(col(Worker.state) != "offline")
                 )
@@ -150,7 +150,7 @@ async def drain_stale_workers_on_startup() -> list[str]:
             # so we conservatively treat them as stale.
             rows = (
                 await db.exec(
-                    select(Worker, col(Guild.guild_id).label("guild_slug"))
+                    select(Worker, col(Guild.slug).label("guild_slug"))
                     .join(Guild, col(Guild.id) == col(Worker.guild_id))
                     .where(
                         col(Worker.spawned_version) != current_version,


### PR DESCRIPTION
## Summary
Three `select()` calls in `worker_lifecycle.py` still referenced `Guild.guild_id`, which was renamed to `Guild.slug`. This raised `AttributeError` during `drain_stale_workers_on_startup` (and the other two startup drain queries) on backend boot.

## Fix
Replace `col(Guild.guild_id).label("guild_slug")` with `col(Guild.slug).label("guild_slug")` in all three queries. The `.label("guild_slug")` alias and the `Worker.guild_id` / `Guild.id` FK joins were already correct and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)