### PR TITLE
fix(foreman): resolve Bedrock/Anthropic credentials from guild settings

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -487,6 +487,16 @@ async def _run_foreman_ai(
     cfg_model: str | None = guild_cfg.get("model")
     cfg_system_prompt_suffix: str | None = guild_cfg.get("system_prompt_suffix")
     cfg_max_rounds: int = int(guild_cfg.get("max_rounds", MAX_FOREMAN_ROUNDS))
+    # Guild-configured env vars (settings dialogue) — these are otherwise only
+    # injected into spawned workers, never the foreman process. They carry the
+    # AI provider credentials configured via the dialogue (AWS_* for Bedrock,
+    # ANTHROPIC_* for the direct API), so pass them to the client factory or the
+    # foreman's own client can't authenticate.
+    cfg_env_vars: dict[str, str] = {
+        e["key"]: e["value"]
+        for e in (guild_cfg.get("env_vars") or [])
+        if e.get("key") and e.get("value") is not None
+    }
 
     # Build live context for the system prompt.  The session is kept open until
     # the end of the function so the tool_use / tool_result Message rows and the
@@ -594,12 +604,18 @@ async def _run_foreman_ai(
         # with this call only — the DB still holds just the human's literal text.
         _inject_state_preamble(messages, state_preamble)
 
-        # Use a per-guild client/model if the config overrides provider or model.
-        if cfg_provider and cfg_provider != os.environ.get("FOREMAN_PROVIDER", "anthropic").lower():
-            client = make_anthropic_client(provider=cfg_provider)
+        # Use a per-guild client when the config overrides the provider or
+        # supplies its own env vars (e.g. Bedrock AWS credentials/region from
+        # the settings dialogue, which otherwise never reach this process).
+        effective_provider = cfg_provider or os.environ.get("FOREMAN_PROVIDER", "anthropic").lower()
+        if cfg_provider or cfg_env_vars:
+            client = make_anthropic_client(
+                provider=effective_provider,
+                extra_env=cfg_env_vars or None,
+            )
         else:
             client = _get_anthropic_client()
-        foreman_model = cfg_model or get_foreman_model(provider=cfg_provider)
+        foreman_model = cfg_model or get_foreman_model(provider=effective_provider)
 
         text_parts = []
         for round_num in range(cfg_max_rounds):

--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 
 try:
     import anthropic as _anthropic_mod
@@ -49,16 +50,139 @@ def get_foreman_model(provider: str | None = None) -> str:
     return os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 
 
+def _log_bedrock_credentials(
+    region: str | None,
+    profile: str | None,
+    *,
+    access_key: str | None = None,
+    secret_key: str | None = None,
+    session_token: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """Probe boto3's credential chain and log what it resolves (or why it can't).
+
+    The anthropic SDK builds a ``boto3.Session`` and raises the opaque
+    ``"could not resolve credentials from session"`` when
+    ``session.get_credentials()`` returns ``None``. We replicate that session
+    here at client-creation time so the *reason* (no creds, wrong profile,
+    expired SSO token, missing region) shows up in the logs instead.
+
+    ``env`` is the effective credential source (guild env_vars overlaid on
+    os.environ); explicit access/secret keys, when given, mirror what we pass
+    to the SDK so the probe reflects the real resolution.
+    """
+    env = env if env is not None else os.environ
+    # Surface the relevant env vars regardless of whether boto3 imports.
+    env_summary = {
+        "AWS_PROFILE": env.get("AWS_PROFILE"),
+        "AWS_BEARER_TOKEN_BEDROCK": "set" if env.get("AWS_BEARER_TOKEN_BEDROCK") else None,
+        "AWS_DEFAULT_REGION": env.get("AWS_DEFAULT_REGION"),
+        "AWS_REGION": env.get("AWS_REGION"),
+        "AWS_ACCESS_KEY_ID": "set" if (access_key or env.get("AWS_ACCESS_KEY_ID")) else None,
+        "AWS_SECRET_ACCESS_KEY": "set"
+        if (secret_key or env.get("AWS_SECRET_ACCESS_KEY"))
+        else None,
+        "AWS_SESSION_TOKEN": "set" if (session_token or env.get("AWS_SESSION_TOKEN")) else None,
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": env.get(
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+        ),
+        "AWS_WEB_IDENTITY_TOKEN_FILE": env.get("AWS_WEB_IDENTITY_TOKEN_FILE"),
+    }
+    logger.info(
+        "Bedrock credential probe: requested region=%s profile=%s explicit_keys=%s; env=%s",
+        region,
+        profile,
+        bool(access_key and secret_key),
+        {k: v for k, v in env_summary.items() if v is not None},
+    )
+
+    try:
+        import boto3  # noqa: PLC0415  (lazy: only needed for the bedrock path)
+    except ImportError:
+        logger.warning(
+            "Bedrock credential probe: boto3 not importable; install "
+            'anthropic[bedrock]. Falling back to SDK credential resolution.'
+        )
+        return
+
+    try:
+        session = boto3.Session(
+            profile_name=profile,
+            region_name=region,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            aws_session_token=session_token,
+        )
+    except Exception as exc:  # e.g. ProfileNotFound
+        logger.error(
+            "Bedrock credential probe: failed to build boto3 session "
+            "(profile=%s region=%s): %s: %s",
+            profile,
+            region,
+            type(exc).__name__,
+            exc,
+        )
+        return
+
+    if not session.region_name:
+        logger.warning(
+            "Bedrock credential probe: no region resolved (pass region or set "
+            "AWS_DEFAULT_REGION); SigV4 signing will fail without one."
+        )
+
+    try:
+        creds = session.get_credentials()
+    except Exception as exc:  # e.g. SSO token expired, unable to load credentials
+        logger.error(
+            "Bedrock credential probe: get_credentials() raised %s: %s "
+            "(this is the cause of 'could not resolve credentials from session')",
+            type(exc).__name__,
+            exc,
+        )
+        return
+
+    if creds is None:
+        logger.error(
+            "Bedrock credential probe: boto3 resolved NO credentials. This is "
+            "exactly what makes the anthropic SDK raise 'could not resolve "
+            "credentials from session'. Checked profile=%s. Provide credentials "
+            "via AWS_PROFILE, ~/.aws/credentials, env keys, or an IAM role. "
+            "(When configuring via the guild settings dialogue, AWS_* env vars "
+            "must reach the foreman process, not just spawned workers.)",
+            profile or env.get("AWS_PROFILE") or "default",
+        )
+        return
+
+    method = getattr(creds, "method", "unknown")
+    frozen = creds.get_frozen_credentials()
+    logger.info(
+        "Bedrock credential probe: resolved credentials via method=%s "
+        "(access_key=…%s, session_token=%s, region=%s)",
+        method,
+        (frozen.access_key or "")[-4:],
+        "present" if frozen.token else "none",
+        session.region_name,
+    )
+
+
 def make_anthropic_client(
     provider: str | None = None,
     api_key: str | None = None,
     region: str | None = None,
+    aws_profile: str | None = None,
+    extra_env: Mapping[str, str] | None = None,
 ):
     """Create and return an Anthropic async client.
 
-    provider: 'anthropic' (default, reads FOREMAN_PROVIDER env) or 'bedrock'.
-    api_key:  API key for direct Anthropic API (ignored for Bedrock).
-    region:   AWS region for Bedrock (defaults to AWS_DEFAULT_REGION or 'us-east-1').
+    provider:    'anthropic' (default, reads FOREMAN_PROVIDER env) or 'bedrock'.
+    api_key:     API key for direct Anthropic API (ignored for Bedrock).
+    region:      AWS region for Bedrock (defaults to AWS_DEFAULT_REGION or 'us-east-1').
+    aws_profile: Named AWS profile for Bedrock (defaults to AWS_PROFILE env).
+    extra_env:   Guild-configured env vars (settings dialogue) overlaid on
+                 os.environ for credential resolution — AWS_* for Bedrock,
+                 ANTHROPIC_* for the direct API. These do NOT reach the foreman
+                 process otherwise: the dialogue's env_vars are only injected
+                 into spawned workers, never this process.
     """
     if not HAS_ANTHROPIC or _anthropic_mod is None:
         raise ImportError("anthropic package is not installed")
@@ -66,18 +190,81 @@ def make_anthropic_client(
     # Read env dynamically (same as get_foreman_model) so patching os.environ in
     # tests works and a late-set FOREMAN_PROVIDER env var is picked up correctly.
     resolved_provider = (provider or os.environ.get("FOREMAN_PROVIDER", "anthropic")).lower()
-    resolved_region = region or _BEDROCK_REGION
+    # Effective credential source: guild-supplied env vars take precedence over
+    # the foreman process env (guild settings are the more specific config).
+    # Explicit args still win over both.
+    env: Mapping[str, str] = {**os.environ, **(extra_env or {})}
 
     if resolved_provider == "bedrock":
-        client = _anthropic_mod.AsyncAnthropicBedrock(aws_region=resolved_region)
+        resolved_region = (
+            region or env.get("AWS_DEFAULT_REGION") or env.get("AWS_REGION") or _BEDROCK_REGION
+        )
+        resolved_profile = aws_profile or env.get("AWS_PROFILE") or None
+        access_key = env.get("AWS_ACCESS_KEY_ID")
+        secret_key = env.get("AWS_SECRET_ACCESS_KEY")
+        session_token = env.get("AWS_SESSION_TOKEN")
+        # Bearer-token auth (AWS_BEARER_TOKEN_BEDROCK) bypasses SigV4/boto3
+        # entirely. The SDK reads it into `api_key` and *raises* if you also
+        # pass any AWS credential (aws_profile/keys), so when a token is present
+        # we must not pass any AWS credential and we skip the boto3 probe.
+        bearer_token = env.get("AWS_BEARER_TOKEN_BEDROCK")
         logger.info(
-            "Foreman using Amazon Bedrock (region=%s, model=%s)",
+            "Foreman using Amazon Bedrock (region=%s, profile=%s, auth=%s, model=%s)",
             resolved_region,
+            resolved_profile,
+            "bearer-token"
+            if bearer_token
+            else ("explicit-keys" if (access_key and secret_key) else "sigv4"),
             get_foreman_model("bedrock"),
         )
-        return client
+        bedrock_kwargs: dict = {"aws_region": resolved_region}
+        if bearer_token:
+            logger.info(
+                "Bedrock credential probe: AWS_BEARER_TOKEN_BEDROCK is set "
+                "(len=%d); using bearer-token auth, skipping boto3 SigV4 "
+                "resolution.",
+                len(bearer_token),
+            )
+            bedrock_kwargs["api_key"] = bearer_token
+        else:
+            # Probe up front so a missing/expired credential shows up in the
+            # logs with a clear reason rather than the SDK's opaque
+            # RuntimeError later.
+            _log_bedrock_credentials(
+                resolved_region,
+                resolved_profile,
+                access_key=access_key,
+                secret_key=secret_key,
+                session_token=session_token,
+                env=env,
+            )
+            # Pass credentials explicitly so resolution is deterministic and
+            # matches what the probe validated. Only safe when there's no
+            # bearer token. Explicit keys (from guild env_vars) take priority
+            # over a profile, mirroring boto3's own precedence.
+            if access_key and secret_key:
+                bedrock_kwargs["aws_access_key"] = access_key
+                bedrock_kwargs["aws_secret_key"] = secret_key
+                if session_token:
+                    bedrock_kwargs["aws_session_token"] = session_token
+            elif resolved_profile:
+                bedrock_kwargs["aws_profile"] = resolved_profile
+        return _anthropic_mod.AsyncAnthropicBedrock(**bedrock_kwargs)
 
+    # Direct Anthropic API. The SDK reads ANTHROPIC_* from os.environ on its own,
+    # but guild-configured env_vars never reach this process, so resolve them
+    # from the merged `env` and pass explicitly. Explicit api_key arg wins.
     kwargs: dict = {}
-    if api_key:
-        kwargs["api_key"] = api_key
+    resolved_api_key = api_key or env.get("ANTHROPIC_API_KEY")
+    if resolved_api_key:
+        kwargs["api_key"] = resolved_api_key
+    if env.get("ANTHROPIC_AUTH_TOKEN"):
+        kwargs["auth_token"] = env["ANTHROPIC_AUTH_TOKEN"]
+    if env.get("ANTHROPIC_BASE_URL"):
+        kwargs["base_url"] = env["ANTHROPIC_BASE_URL"]
+    logger.info(
+        "Foreman using Anthropic API (auth=%s, base_url=%s)",
+        "auth-token" if kwargs.get("auth_token") else ("api-key" if resolved_api_key else "default"),
+        kwargs.get("base_url", "default"),
+    )
     return _anthropic_mod.AsyncAnthropic(**kwargs)

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -61,22 +61,13 @@ class GuildUpdate(BaseModel):
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _MAX_FOREMAN_ENV_VARS = 20
 _MAX_ENV_VALUE_LEN = 4096
-_MASK_PLACEHOLDER = "••••••"
 
 
 class EnvVarItem(BaseModel):
     key: str
-    # None → keep the currently stored value (used when the UI has a masked placeholder)
+    # None → keep the currently stored value. Kept for API compatibility; the UI
+    # now sends actual values since env vars are returned in clear text.
     value: str | None = None
-
-
-def _mask_foreman_config(config: dict) -> dict:
-    """Return a shallow copy of foreman_config with env var values replaced by the mask."""
-    if "env_vars" not in config:
-        return config
-    masked = dict(config)
-    masked["env_vars"] = [{"key": e["key"], "value": _MASK_PLACEHOLDER} for e in config["env_vars"]]
-    return masked
 
 
 class ForemanConfigUpdate(BaseModel):
@@ -426,12 +417,16 @@ async def get_foreman_config(
     github_user_id: str = Depends(require_member("owner")),
     db: AsyncSession = Depends(get_db_dep),
 ):
-    """Return the guild's foreman configuration (owner only). Env var values are masked."""
+    """Return the guild's foreman configuration (owner only).
+
+    Env var values are returned in clear text (owner-only) so the settings
+    dialogue can display and copy/paste them for verification.
+    """
     res = await db.exec(select(Guild).where(col(Guild.slug) == guild_id))
     guild = res.one_or_none()
     if not guild:
         raise HTTPException(status_code=404, detail="Guild not found")
-    return _mask_foreman_config(guild.foreman_config or {})
+    return guild.foreman_config or {}
 
 
 @router.patch("/api/guilds/{guild_id}/foreman-config")
@@ -443,9 +438,8 @@ async def update_foreman_config(
 ):
     """Update (merge) the guild's foreman configuration (owner only).
 
-    Env var values sent as null preserve the existing stored secret — the UI uses
-    this for masked (unchanged) rows so secrets don't round-trip through the browser.
-    Env var values sent as empty string or a new string replace the stored value.
+    Env var values sent as null preserve the existing stored value (kept for API
+    compatibility); an empty string or a new string replaces the stored value.
     Keys absent from the submitted list are deleted.
     """
     res = await db.exec(select(Guild).where(col(Guild.slug) == guild_id))
@@ -466,7 +460,7 @@ async def update_foreman_config(
                 new_env_vars: list[dict] = []
                 for item in value:
                     if item.value is None:
-                        # Masked / unchanged: keep the existing stored value if present
+                        # Unchanged: keep the existing stored value if present
                         if item.key in existing_map:
                             new_env_vars.append({"key": item.key, "value": existing_map[item.key]})
                     else:
@@ -478,7 +472,7 @@ async def update_foreman_config(
             config[field] = value
     guild.foreman_config = config
     await db.commit()
-    return _mask_foreman_config(config)
+    return config
 
 
 @router.delete("/api/guilds/{guild_id}/members/{user_id}")

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -75,6 +75,32 @@ class TestGetForemanModel:
 # ---------------------------------------------------------------------------
 
 
+_PROVIDER_ENV_VARS = (
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_REGION",
+    "AWS_REGION",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_ambient_provider_env(monkeypatch):
+    """Strip ambient provider credentials so tests assert on a clean slate.
+
+    Without this, a host/CI env that exports e.g. AWS_BEARER_TOKEN_BEDROCK or
+    ANTHROPIC_API_KEY would make make_anthropic_client() forward extra kwargs
+    (api_key / auth_token / aws_*) and break the exact-kwargs assertions below.
+    """
+    for var in _PROVIDER_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
 class TestMakeAnthropicClient:
     def test_default_creates_anthropic_client(self, monkeypatch):
         """When no provider is specified and FOREMAN_PROVIDER is unset, use AsyncAnthropic."""
@@ -149,6 +175,67 @@ class TestMakeAnthropicClient:
         llm_mod.make_anthropic_client(provider="bedrock", region="ap-southeast-1")
         mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="ap-southeast-1")
 
+    def test_bedrock_aws_env_explicit_keys_forwarded(self, monkeypatch):
+        """Guild env_vars (settings dialogue) carrying AWS keys must reach the SDK.
+
+        Regression: the settings dialogue stores AWS creds in foreman_config
+        env_vars, which only ever reached spawned workers — not the foreman's
+        own Bedrock client — so boto3 raised 'could not resolve credentials'.
+        """
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(
+            provider="bedrock",
+            extra_env={
+                "AWS_ACCESS_KEY_ID": "AKIATEST",
+                "AWS_SECRET_ACCESS_KEY": "secret",
+                "AWS_SESSION_TOKEN": "token",
+                "AWS_DEFAULT_REGION": "eu-west-1",
+            },
+        )
+        mock_mod.AsyncAnthropicBedrock.assert_called_once_with(
+            aws_region="eu-west-1",
+            aws_access_key="AKIATEST",
+            aws_secret_key="secret",
+            aws_session_token="token",
+        )
+
+    def test_bedrock_aws_env_bearer_token_forwarded(self, monkeypatch):
+        """A bearer token in guild env_vars must be passed as api_key, not SigV4."""
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        monkeypatch.setattr(llm_mod, "_BEDROCK_REGION", "us-east-1")
+        llm_mod.make_anthropic_client(
+            provider="bedrock",
+            extra_env={"AWS_BEARER_TOKEN_BEDROCK": "bedrock-token-xyz"},
+        )
+        mock_mod.AsyncAnthropicBedrock.assert_called_once_with(
+            aws_region="us-east-1", api_key="bedrock-token-xyz"
+        )
+
+    def test_bedrock_aws_env_profile_forwarded(self, monkeypatch):
+        """An AWS_PROFILE in guild env_vars must be passed as aws_profile."""
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        monkeypatch.setattr(llm_mod, "_BEDROCK_REGION", "us-east-1")
+        # Patch boto3 session probe so a missing real profile doesn't error the test.
+        with patch.object(llm_mod, "_log_bedrock_credentials"):
+            llm_mod.make_anthropic_client(
+                provider="bedrock", extra_env={"AWS_PROFILE": "my-sso-profile"}
+            )
+        mock_mod.AsyncAnthropicBedrock.assert_called_once_with(
+            aws_region="us-east-1", aws_profile="my-sso-profile"
+        )
+
     def test_api_key_forwarded_to_anthropic_client(self, monkeypatch):
         monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
         import foreman_core.llm as llm_mod
@@ -169,6 +256,55 @@ class TestMakeAnthropicClient:
         monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
         llm_mod.make_anthropic_client()
         mock_mod.AsyncAnthropic.assert_called_once_with()
+
+    def test_anthropic_extra_env_api_key_and_base_url_forwarded(self, monkeypatch):
+        """Guild env_vars carrying ANTHROPIC_* must reach the direct API client.
+
+        Like the Bedrock case, the settings dialogue's env_vars never reach the
+        foreman process, so they must be forwarded explicitly.
+        """
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(
+            provider="anthropic",
+            extra_env={
+                "ANTHROPIC_API_KEY": "sk-ant-guild",
+                "ANTHROPIC_BASE_URL": "https://proxy.example.com",
+            },
+        )
+        mock_mod.AsyncAnthropic.assert_called_once_with(
+            api_key="sk-ant-guild", base_url="https://proxy.example.com"
+        )
+
+    def test_anthropic_extra_env_auth_token_forwarded(self, monkeypatch):
+        """ANTHROPIC_AUTH_TOKEN in guild env_vars must be passed as auth_token."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(
+            provider="anthropic", extra_env={"ANTHROPIC_AUTH_TOKEN": "tok-abc"}
+        )
+        mock_mod.AsyncAnthropic.assert_called_once_with(auth_token="tok-abc")
+
+    def test_explicit_api_key_wins_over_extra_env(self, monkeypatch):
+        """An explicit api_key arg takes precedence over extra_env ANTHROPIC_API_KEY."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(
+            api_key="sk-explicit", extra_env={"ANTHROPIC_API_KEY": "sk-from-env"}
+        )
+        mock_mod.AsyncAnthropic.assert_called_once_with(api_key="sk-explicit")
 
     def test_missing_anthropic_package_raises(self, monkeypatch):
         """If anthropic is not installed, make_anthropic_client must raise ImportError."""

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -293,3 +293,42 @@ def test_get_guild_rejects_legacy_owner(client):
     _insert_guild_legacy_only(db_url, "g-leg2", "gh-user-test")
     resp = test_client.get("/guilds/g-leg2", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# foreman-config env vars — stored and returned in clear text (no masking)
+# ---------------------------------------------------------------------------
+
+
+def test_foreman_config_env_vars_round_trip_in_clear(client):
+    """PATCHed env var values (including secrets) come back verbatim on GET.
+
+    Masking was intentionally removed so owners can verify and copy/paste values.
+    """
+    test_client, db_url = client
+    token = make_auth_token(db_url)  # owner of g-fconf
+    insert_guild(db_url, "g-fconf")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    patch = test_client.patch(
+        "/api/guilds/g-fconf/foreman-config",
+        headers=headers,
+        json={
+            "provider": "bedrock",
+            "env_vars": [
+                {"key": "AWS_DEFAULT_REGION", "value": "eu-west-1"},
+                {"key": "AWS_ACCESS_KEY_ID", "value": "AKIASECRET"},
+                {"key": "AWS_SECRET_ACCESS_KEY", "value": "topsecret"},
+            ],
+        },
+    )
+    assert patch.status_code == 200
+
+    got = test_client.get("/api/guilds/g-fconf/foreman-config", headers=headers)
+    assert got.status_code == 200
+    env = {e["key"]: e["value"] for e in got.json()["env_vars"]}
+    assert env == {
+        "AWS_DEFAULT_REGION": "eu-west-1",
+        "AWS_ACCESS_KEY_ID": "AKIASECRET",
+        "AWS_SECRET_ACCESS_KEY": "topsecret",  # secret returned in clear, not masked
+    }

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -39,6 +39,9 @@ class Config:
     provider: str = "anthropic"
     # AWS region for Bedrock; ignored when provider != "bedrock"
     aws_region: str = "us-east-1"
+    # Named AWS profile for Bedrock (defaults to AWS_PROFILE env); ignored when
+    # provider != "bedrock". None falls back to boto3's default credential chain.
+    aws_profile: str | None = None
     max_rounds: int = 10
     history_limit: int = 40
     # Poll settings
@@ -176,6 +179,12 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         or "us-east-1"
     )
 
+    aws_profile = (
+        overrides.get("aws_profile")
+        or claude_block.get("aws_profile")
+        or os.environ.get("AWS_PROFILE")
+    ) or None
+
     log_level = (
         overrides.get("log_level")
         or raw.get("log_level")
@@ -194,6 +203,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         api_key=api_key,
         provider=provider,
         aws_region=aws_region,
+        aws_profile=aws_profile,
         max_rounds=int(overrides.get("max_rounds", claude_block.get("max_rounds", 10))),
         history_limit=int(overrides.get("history_limit", claude_block.get("history_limit", 40))),
         poll_min_interval=int(

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -40,13 +40,15 @@ _anthropic_clients: dict[tuple, object] = {}
 def _get_anthropic_client(config: Config):
     provider = getattr(config, "provider", "anthropic") or "anthropic"
     region = getattr(config, "aws_region", None)
+    profile = getattr(config, "aws_profile", None)
     api_key = getattr(config, "api_key", None) or ""
-    cache_key = (provider.lower(), region, api_key)
+    cache_key = (provider.lower(), region, profile, api_key)
     if cache_key not in _anthropic_clients:
         _anthropic_clients[cache_key] = make_anthropic_client(
             provider=provider,
             api_key=api_key or None,
             region=region,
+            aws_profile=profile,
         )
     return _anthropic_clients[cache_key]
 

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -167,6 +167,27 @@
               />
             </datalist>
           </div>
+
+          <div class="foreman-field">
+            <label class="foreman-field-label">
+              {{ foremanProvider === 'bedrock' ? 'AWS Credentials' : 'Anthropic Credentials' }}
+            </label>
+            <div class="foreman-creds-grid">
+              <div v-for="f in wellKnownFields" :key="f.key" class="foreman-cred-field">
+                <label class="foreman-cred-label">{{ f.label }}</label>
+                <input
+                  class="settings-input"
+                  type="text"
+                  spellcheck="false"
+                  autocomplete="off"
+                  :placeholder="f.placeholder || ''"
+                  :value="wellKnownValue(f.key)"
+                  @input="setWellKnown(f.key, ($event.target as HTMLInputElement).value)"
+                />
+              </div>
+            </div>
+          </div>
+
           <div class="foreman-field">
             <label class="foreman-field-label">System Prompt Suffix</label>
             <textarea
@@ -211,48 +232,32 @@
           </div>
 
           <div class="foreman-field">
-            <label class="foreman-field-label">Environment Variables / API Keys</label>
+            <label class="foreman-field-label">Additional Environment Variables</label>
             <div class="env-var-list">
-              <div v-for="(row, i) in envVarRows" :key="i" class="env-var-row">
+              <div v-for="row in additionalEnvVarRows" :key="row.id" class="env-var-row">
                 <input
                   v-model="row.key"
                   class="settings-input env-var-key"
                   placeholder="KEY_NAME"
-                  list="foreman-env-key-hints"
-                  :readonly="row.masked"
-                  @input="onEnvKeyInput(i)"
+                  spellcheck="false"
+                  autocomplete="off"
                 />
-                <template v-if="row.masked">
-                  <input
-                    class="settings-input env-var-value env-var-value--masked"
-                    value="••••••"
-                    readonly
-                    title="Click Change to update value"
-                  />
-                  <button
-                    class="env-var-change-btn pixel-btn"
-                    @click="unlockEnvVar(i)"
-                    title="Change value"
-                  >
-                    ✎
-                  </button>
-                </template>
-                <template v-else>
-                  <input
-                    v-model="row.value"
-                    type="password"
-                    class="settings-input env-var-value"
-                    placeholder="value"
-                    autocomplete="new-password"
-                  />
-                </template>
-                <button class="env-var-delete-btn" @click="removeEnvVar(i)" title="Remove variable">
+                <input
+                  v-model="row.value"
+                  type="text"
+                  class="settings-input env-var-value"
+                  placeholder="value"
+                  spellcheck="false"
+                  autocomplete="off"
+                />
+                <button
+                  class="env-var-delete-btn"
+                  @click="removeEnvVar(row)"
+                  title="Remove variable"
+                >
                   ✕
                 </button>
               </div>
-              <datalist id="foreman-env-key-hints">
-                <option v-for="key in foremanEnvKeyHints" :key="key" :value="key" />
-              </datalist>
               <button class="pixel-btn env-var-add-btn" @click="addEnvVar">+ Add Variable</button>
             </div>
           </div>
@@ -307,15 +312,31 @@ const modelsStore = reactive(useModels())
 const foremanProviderModels = computed(() =>
   foremanProvider.value ? modelsStore.modelsForProvider(foremanProvider.value) : [],
 )
-const FOREMAN_ENV_KEY_HINTS: Record<string, string[]> = {
-  anthropic: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_API_URL'],
+// Dedicated, provider-specific credential fields. These are stored as ordinary
+// env_vars under the hood (the foreman client reads them via extra_env) but get
+// first-class inputs so users don't have to remember exact var names.
+interface WellKnownField {
+  key: string
+  label: string
+  placeholder?: string
+}
+const FOREMAN_WELL_KNOWN: Record<string, WellKnownField[]> = {
+  anthropic: [
+    { key: 'ANTHROPIC_API_KEY', label: 'API Key', placeholder: 'sk-ant-…' },
+    { key: 'ANTHROPIC_AUTH_TOKEN', label: 'Auth Token (optional)' },
+    {
+      key: 'ANTHROPIC_BASE_URL',
+      label: 'Base URL (optional)',
+      placeholder: 'https://api.anthropic.com',
+    },
+  ],
   bedrock: [
-    'AWS_ACCESS_KEY_ID',
-    'AWS_SECRET_ACCESS_KEY',
-    'AWS_SESSION_TOKEN',
-    'AWS_DEFAULT_REGION',
-    'AWS_REGION',
-    'AWS_PROFILE',
+    { key: 'AWS_DEFAULT_REGION', label: 'Region', placeholder: 'us-east-1' },
+    { key: 'AWS_PROFILE', label: 'Profile (optional)' },
+    { key: 'AWS_ACCESS_KEY_ID', label: 'Access Key ID' },
+    { key: 'AWS_SECRET_ACCESS_KEY', label: 'Secret Access Key' },
+    { key: 'AWS_SESSION_TOKEN', label: 'Session Token (optional)' },
+    { key: 'AWS_BEARER_TOKEN_BEDROCK', label: 'Bedrock Bearer Token (optional)' },
   ],
 }
 
@@ -347,17 +368,37 @@ const foremanPollMax = ref<number | ''>('')
 const foremanSaving = ref(false)
 const foremanStatus = ref<'' | 'saved' | 'error'>('')
 let foremanStatusTimer: ReturnType<typeof setTimeout> | null = null
-const foremanEnvKeyHints = computed(() => {
-  const provider = foremanProvider.value || 'anthropic'
-  return FOREMAN_ENV_KEY_HINTS[provider] ?? []
-})
+const wellKnownFields = computed(
+  () => FOREMAN_WELL_KNOWN[foremanProvider.value || 'anthropic'] ?? [],
+)
+const wellKnownKeys = computed(() => new Set(wellKnownFields.value.map((f) => f.key)))
+// Free-form list excludes keys that have a dedicated field for the current provider.
+const additionalEnvVarRows = computed(() =>
+  envVarRows.value.filter((r) => !wellKnownKeys.value.has(r.key)),
+)
 
 interface EnvVarRow {
+  id: number
   key: string
   value: string
-  masked: boolean
 }
+let envRowSeq = 0
 const envVarRows = ref<EnvVarRow[]>([])
+
+function wellKnownValue(key: string): string {
+  return envVarRows.value.find((r) => r.key === key)?.value ?? ''
+}
+
+function setWellKnown(key: string, value: string) {
+  const row = envVarRows.value.find((r) => r.key === key)
+  if (value) {
+    if (row) row.value = value
+    else envVarRows.value.push({ id: ++envRowSeq, key, value })
+  } else if (row) {
+    // Empty value → drop the row so we don't persist blank vars.
+    envVarRows.value.splice(envVarRows.value.indexOf(row), 1)
+  }
+}
 
 async function loadForemanConfig() {
   if (!currentGuild.value) return
@@ -374,11 +415,11 @@ async function loadForemanConfig() {
       foremanMaxRounds.value = cfg.max_rounds ?? ''
       foremanPollMin.value = cfg.poll_min_interval ?? ''
       foremanPollMax.value = cfg.poll_max_interval ?? ''
-      // Env vars come back with masked values (••••••); track them as masked rows
-      envVarRows.value = (cfg.env_vars ?? []).map((e: { key: string }) => ({
+      // Env var values are returned in clear text so they can be verified/edited.
+      envVarRows.value = (cfg.env_vars ?? []).map((e: { key: string; value?: string }) => ({
+        id: ++envRowSeq,
         key: e.key,
-        value: '',
-        masked: true,
+        value: e.value ?? '',
       }))
     }
   } catch {
@@ -387,25 +428,12 @@ async function loadForemanConfig() {
 }
 
 function addEnvVar() {
-  envVarRows.value.push({ key: '', value: '', masked: false })
+  envVarRows.value.push({ id: ++envRowSeq, key: '', value: '' })
 }
 
-function removeEnvVar(i: number) {
-  envVarRows.value.splice(i, 1)
-}
-
-function unlockEnvVar(i: number) {
-  envVarRows.value[i].masked = false
-  envVarRows.value[i].value = ''
-}
-
-function onEnvKeyInput(i: number) {
-  // If user edits the key of a masked row, the backend can no longer match the
-  // existing stored value, so unlock it so they must enter the value explicitly.
-  if (envVarRows.value[i].masked) {
-    envVarRows.value[i].masked = false
-    envVarRows.value[i].value = ''
-  }
+function removeEnvVar(row: EnvVarRow) {
+  const i = envVarRows.value.indexOf(row)
+  if (i >= 0) envVarRows.value.splice(i, 1)
 }
 
 async function saveForemanConfig() {
@@ -426,11 +454,11 @@ async function saveForemanConfig() {
     else body.poll_min_interval = null
     if (foremanPollMax.value !== '') body.poll_max_interval = foremanPollMax.value
     else body.poll_max_interval = null
-    // Build env_vars: masked rows send null value (keep existing), unlocked rows send actual value.
-    // Skip rows with empty keys.
+    // Send actual values for every keyed row (dedicated credential fields and
+    // free-form rows alike both live in envVarRows). Skip rows with empty keys.
     body.env_vars = envVarRows.value
       .filter((r) => r.key.trim())
-      .map((r) => ({ key: r.key.trim(), value: r.masked ? null : r.value }))
+      .map((r) => ({ key: r.key.trim(), value: r.value }))
     const res = await fetch(
       `${API_BASE}/api/guilds/${encodeURIComponent(currentGuild.value.id)}/foreman-config`,
       {
@@ -441,12 +469,12 @@ async function saveForemanConfig() {
     )
     if (res.ok) {
       foremanStatus.value = 'saved'
-      // Re-load to sync masked state with what the server now has
+      // Re-sync with the server's canonical config (clear-text values).
       const saved = await res.json()
-      envVarRows.value = (saved.env_vars ?? []).map((e: { key: string }) => ({
+      envVarRows.value = (saved.env_vars ?? []).map((e: { key: string; value?: string }) => ({
+        id: ++envRowSeq,
         key: e.key,
-        value: '',
-        masked: true,
+        value: e.value ?? '',
       }))
     } else {
       foremanStatus.value = 'error'
@@ -1057,22 +1085,23 @@ function goHome() {
   font-size: 10px;
 }
 
-.env-var-value--masked {
+.foreman-creds-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.foreman-cred-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.foreman-cred-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 9px;
   color: var(--color-text-dim);
-  letter-spacing: 2px;
-  cursor: default;
-}
-
-.env-var-change-btn {
-  font-size: 10px;
-  padding: 3px 6px;
-  flex-shrink: 0;
-  border-color: var(--color-teal);
-  color: var(--color-teal);
-}
-
-.env-var-change-btn:hover {
-  background: rgba(0, 187, 170, 0.12);
+  letter-spacing: 0.5px;
 }
 
 .env-var-delete-btn {


### PR DESCRIPTION
## Problem

Running the foreman against Bedrock failed with `could not resolve credentials from session`. That error originates in the anthropic SDK (`anthropic/lib/bedrock/_auth.py`): it builds a `boto3.Session` and raises when `session.get_credentials()` returns `None`. Two root causes:

1. `make_anthropic_client()` created `AsyncAnthropicBedrock(aws_region=…)` with **no credential context and no logging**, so the failure was completely opaque.
2. AWS credentials configured via the **guild settings dialogue** are stored as `foreman_config.env_vars`, which were only injected into **spawned worker containers** — never the foreman's own client (which runs in the backend process and resolves creds via boto3 from *that* process's env).

## Changes

### Diagnostics & credential resolution (`foreman_core/llm.py`)
- Added a boto3 credential **probe + auth-mode logging** at client creation. Instead of the SDK's opaque `RuntimeError`, the logs now state the real reason: no credentials, `ProfileNotFound`, expired SSO token, missing region, etc.
- Support `AWS_BEARER_TOKEN_BEDROCK` (bypasses SigV4/boto3 — passed as `api_key`), explicit AWS keys, and `aws_profile`.
- New `extra_env` param threads guild-configured env vars into the client for **both** providers: `AWS_*` for Bedrock, `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_BASE_URL` for the direct API.

### Runner wiring (`foreman/runner.py`)
- Extracts the guild's `env_vars` and passes them via `extra_env`; builds a per-guild client whenever the guild overrides the provider or supplies env vars.

### Standalone foreman (`pioneer_foreman/config.py`, `runner.py`)
- Added `aws_profile` config field (TOML / `AWS_PROFILE` env) threaded through to the client.

### Settings dialogue (`frontend/src/components/TopBar.vue`)
- **First-class, provider-aware credential fields**: Bedrock → Region, Profile, Access Key ID, Secret Access Key, Session Token, Bedrock Bearer Token; Anthropic → API Key, Auth Token, Base URL. Backed by the existing `env_vars` storage.
- Free-form "Additional Environment Variables" list now excludes keys that have a dedicated field.
- Fixed stale `ANTHROPIC_API_URL` hint → `ANTHROPIC_BASE_URL`.

### Masking removed (`routes/guilds.py`)
- Env var values now round-trip in **clear text** (owner-only endpoint) so they can be verified and copy/pasted. The `null` = keep-existing path is retained for API compatibility.

> ⚠️ Tradeoff: secrets are now returned in clear text over the API and rendered for guild owners. This was an explicit short-term request; the place to reintroduce protection later is the GET endpoint in `routes/guilds.py`.

## Tests
- Added a hermetic fixture stripping ambient `AWS_*` / `ANTHROPIC_*` env (this surfaced that the CI/sandbox env exports a real `AWS_BEARER_TOKEN_BEDROCK`).
- New tests: Bedrock explicit-keys / bearer-token / profile forwarding; Anthropic `extra_env` api_key+base_url / auth_token / explicit-wins; clear-text env var round-trip via the API.
- **252** foreman/guild tests pass; ruff + vue-tsc + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)