### PR TITLE
Auto-review on review_requested webhook event

### DIFF
--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -83,9 +83,7 @@ def _log_bedrock_credentials(
         if (secret_key or env.get("AWS_SECRET_ACCESS_KEY"))
         else None,
         "AWS_SESSION_TOKEN": "set" if (session_token or env.get("AWS_SESSION_TOKEN")) else None,
-        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": env.get(
-            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
-        ),
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": env.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),
         "AWS_WEB_IDENTITY_TOKEN_FILE": env.get("AWS_WEB_IDENTITY_TOKEN_FILE"),
     }
     logger.info(
@@ -101,7 +99,7 @@ def _log_bedrock_credentials(
     except ImportError:
         logger.warning(
             "Bedrock credential probe: boto3 not importable; install "
-            'anthropic[bedrock]. Falling back to SDK credential resolution.'
+            "anthropic[bedrock]. Falling back to SDK credential resolution."
         )
         return
 
@@ -264,7 +262,9 @@ def make_anthropic_client(
         kwargs["base_url"] = env["ANTHROPIC_BASE_URL"]
     logger.info(
         "Foreman using Anthropic API (auth=%s, base_url=%s)",
-        "auth-token" if kwargs.get("auth_token") else ("api-key" if resolved_api_key else "default"),
+        "auth-token"
+        if kwargs.get("auth_token")
+        else ("api-key" if resolved_api_key else "default"),
         kwargs.get("base_url", "default"),
     )
     return _anthropic_mod.AsyncAnthropic(**kwargs)

--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -93,6 +93,23 @@ search_github_issues, create_github_issue, claim_github_issue, and get_pr_status
 Messages prefixed `[github-event]` are pushed by GitHub webhooks for PRs you opened.
 The header line names the event type, action, repo/PR number, and the linked task id.
 Use the body to decide:
+- **Review requested** (`pull_request/review_requested`): A review was requested from
+  the authenticated guild user on a PR. Unless a review task already exists for this PR
+  in the current `<state>` task list, automatically:
+  1. `create_task(name="Review PR #N: <title>", phase="review")`
+  2. `assign_task(worker_id=<any idle worker>, task_id=<task_id from step 1>,
+     description="<review instructions>")`
+
+  The review instructions passed to the worker **must** include:
+  - Check out the PR branch: `gh pr checkout <PR_NUMBER> --repo <OWNER/REPO>`
+  - Read all changed files and run available tests and lint
+  - Post findings via: `gh pr review <PR_NUMBER> --repo <OWNER/REPO> [--approve | --request-changes | --comment] --body "..."`
+  - **The worker is explicitly permitted — and encouraged — to `--approve` if the code
+    is in good shape.** Only use `--request-changes` for real blocking issues. Use
+    `--comment` for minor nits that don't block merging.
+  - Do NOT commit any files. Do NOT open a new PR.
+
+  If a review task already exists for this PR, skip task creation to avoid duplicates.
 - **PR merged** (`pull_request/closed` with `merged=true`): the webhook *may* deliver
   this event, but do not rely on it firing reliably — always call get_pr_status to
   confirm the merged state before calling finalize_task.

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -26,7 +26,7 @@ from database import get_db_dep
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from lock_service import LockService
-from models import GithubEvent, Guild, Message, Task, TaskEvent
+from models import GithubEvent, GithubToken, Guild, GuildMember, Message, Task, TaskEvent
 from pydantic import BaseModel
 from sqlalchemy import delete, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -421,6 +421,18 @@ async def _find_task(db, guild_pk: int, repo: str | None, pr_number: int | None)
     return res.first()
 
 
+async def _get_guild_owner_github_login(db: AsyncSession, guild_pk: int) -> str | None:
+    """Return the GitHub login of the guild owner, or None if not found."""
+    result = await db.exec(
+        select(col(GithubToken.github_username))
+        .join(GuildMember, col(GuildMember.user_id) == col(GithubToken.github_user_id))
+        .where(col(GuildMember.guild_id) == guild_pk, col(GuildMember.role) == "owner")
+        .limit(1)
+    )
+    row = result.first()
+    return row if isinstance(row, str) else None
+
+
 def _should_dispatch_to_foreman(
     event_type: str,
     action: str | None,
@@ -471,15 +483,36 @@ def _build_foreman_summary(
     coordinates first so the foreman can immediately route to send_followup
     / finalize_task without a get_task_status round-trip for trivial cases.
     """
+    task_part = f" (task {task_id})" if task_id else " (new)"
     header = (
         f"[github-event] {event_type}"
         + (f"/{action}" if action else "")
-        + f" on {repo}#{pr_number} (task {task_id})"
+        + f" on {repo}#{pr_number}{task_part}"
     )
     sender_line = f" by @{sender_login}" if sender_login else ""
 
     detail = ""
-    if event_type == "pull_request" and action in {"closed", "reopened"}:
+    if event_type == "pull_request" and action == "review_requested":
+        pr = payload.get("pull_request") or {}
+        title = (pr.get("title") or "")[:200]
+        requested_reviewer = (payload.get("requested_reviewer") or {}).get("login", "")
+        pr_url_val = pr.get("html_url") or ""
+        detail = (
+            f"Review requested from @{requested_reviewer}.\n"
+            f"PR title: {title}\n"
+            f"PR URL: {pr_url_val}\n"
+            "Create a review task and assign a worker to perform a full PR review. "
+            "The worker must check out the branch, run available tests/lint, and post "
+            f"findings via: gh pr review {pr_number} --repo {repo} "
+            '[--approve | --request-changes | --comment] --body "..."\n'
+            "The worker is explicitly permitted — and encouraged — to --approve if the "
+            "code looks good. Only use --request-changes for real blocking issues; "
+            "use --comment for minor nits that don't block merging. "
+            "Do NOT commit any files. Do NOT open a new PR.\n"
+            "If a review task already exists for this PR in the current task list, "
+            "skip task creation to avoid duplicates."
+        )
+    elif event_type == "pull_request" and action in {"closed", "reopened"}:
         pr = payload.get("pull_request") or {}
         merged = pr.get("merged")
         if action == "closed" and merged:
@@ -558,7 +591,11 @@ def _build_chat_line(
     pr_part = f" — {repo}#{pr_number}" if repo and pr_number else (f" — {repo}" if repo else "")
 
     extra = ""
-    if event_type == "pull_request" and action == "closed":
+    if event_type == "pull_request" and action == "review_requested":
+        requested_reviewer = (payload.get("requested_reviewer") or {}).get("login")
+        if requested_reviewer:
+            extra = f"reviewer={requested_reviewer}"
+    elif event_type == "pull_request" and action == "closed":
         pr = payload.get("pull_request") or {}
         merged = pr.get("merged")
         if merged is not None:
@@ -788,23 +825,58 @@ async def github_webhook(
     )
     await db.commit()
 
-    dispatch, skip_reason = _should_dispatch_to_foreman(
-        event_type, action, payload, sender_login, task_id
-    )
-    if dispatch:
-        summary = _build_foreman_summary(
-            event_type, action, payload, repo, pr_number, task_id or "", sender_login
-        )
-        key = f"{guild_id}:{task_id}"
-        await _debounce_queue.schedule(key, guild_id, summary, task_user_id)
+    # review_requested is handled on its own path: it creates a new task so it
+    # does not require an existing task_id, but it does require the requested
+    # reviewer to match the guild owner's GitHub login.
+    if event_type == "pull_request" and action == "review_requested":
+        requested_reviewer = (payload.get("requested_reviewer") or {}).get("login")
+        guild_owner_login = await _get_guild_owner_github_login(db, guild_pk)
+        if (
+            requested_reviewer
+            and guild_owner_login
+            and requested_reviewer.lower() == guild_owner_login.lower()
+        ):
+            summary = _build_foreman_summary(
+                event_type, action, payload, repo, pr_number, task_id or "", sender_login
+            )
+            # Key is PR-scoped so rapid re-requests for the same PR coalesce.
+            key = f"{guild_id}:review_requested:{repo}#{pr_number}"
+            await _debounce_queue.schedule(key, guild_id, summary, task_user_id)
+            logger.info(
+                "github webhook review_requested dispatched guild=%s delivery=%s repo=%s pr=%s reviewer=%s",
+                guild_id,
+                delivery_id,
+                repo,
+                pr_number,
+                requested_reviewer,
+            )
+        else:
+            logger.info(
+                "github webhook skip-foreman guild=%s delivery=%s event=pull_request/review_requested "
+                "reason=reviewer-mismatch requested=%s owner=%s",
+                guild_id,
+                delivery_id,
+                requested_reviewer,
+                guild_owner_login,
+            )
     else:
-        logger.info(
-            "github webhook skip-foreman guild=%s delivery=%s event=%s reason=%s",
-            guild_id,
-            delivery_id,
-            event_type,
-            skip_reason,
+        dispatch, skip_reason = _should_dispatch_to_foreman(
+            event_type, action, payload, sender_login, task_id
         )
+        if dispatch:
+            summary = _build_foreman_summary(
+                event_type, action, payload, repo, pr_number, task_id or "", sender_login
+            )
+            key = f"{guild_id}:{task_id}"
+            await _debounce_queue.schedule(key, guild_id, summary, task_user_id)
+        else:
+            logger.info(
+                "github webhook skip-foreman guild=%s delivery=%s event=%s reason=%s",
+                guild_id,
+                delivery_id,
+                event_type,
+                skip_reason,
+            )
 
     return Response(status_code=202)
 

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -32,13 +32,21 @@ sys.path.insert(0, os.path.dirname(__file__))
 import database as database_module  # noqa: E402
 from _test_config import TEST_DATABASE_URL  # noqa: E402
 from foreman.tools import exec_tools  # noqa: E402
-from helpers import _sync_session, create_db, insert_guild, insert_task, insert_worker  # noqa: E402
+from helpers import (  # noqa: E402
+    _sync_session,
+    create_db,
+    insert_guild,
+    insert_task,
+    insert_worker,
+    make_auth_token,
+)
 from models import (
     Guild,  # noqa: E402
     Task,  # noqa: E402
 )
 from routes.webhooks import (  # noqa: E402
     _build_foreman_summary,
+    _get_guild_owner_github_login,
     _should_dispatch_to_foreman,
 )
 from sqlalchemy import update  # noqa: E402
@@ -779,3 +787,252 @@ def test_prompt_describes_github_events():
     assert "get_pr_status" in FOREMAN_SYSTEM
     rendered = build_system_prompt("[]", "[]")
     assert "github-event" in rendered
+
+
+# ---------------------------------------------------------------------------
+# review_requested: summary builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSummaryReviewRequested:
+    def test_review_requested_summary_contains_key_fields(self):
+        payload = {
+            "pull_request": {
+                "title": "Add feature X",
+                "html_url": "https://github.com/o/r/pull/5",
+            },
+            "requested_reviewer": {"login": "guild-bot"},
+        }
+        s = _build_foreman_summary(
+            "pull_request", "review_requested", payload, "o/r", 5, "", "alice"
+        )
+        assert "[github-event] pull_request/review_requested on o/r#5 (new)" in s
+        assert "@guild-bot" in s
+        assert "Add feature X" in s
+        assert "--approve" in s
+        assert "Do NOT commit" in s
+        assert "duplicates" in s
+
+    def test_review_requested_with_task_id_shows_task(self):
+        payload = {
+            "pull_request": {"title": "Fix bug", "html_url": "https://github.com/o/r/pull/7"},
+            "requested_reviewer": {"login": "reviewer"},
+        }
+        s = _build_foreman_summary(
+            "pull_request", "review_requested", payload, "o/r", 7, "t-existing", "alice"
+        )
+        assert "(task t-existing)" in s
+
+    def test_review_requested_header_with_empty_task_id(self):
+        payload = {
+            "pull_request": {"title": "T", "html_url": ""},
+            "requested_reviewer": {"login": "r"},
+        }
+        s = _build_foreman_summary("pull_request", "review_requested", payload, "o/r", 1, "", None)
+        assert "(new)" in s
+        assert "(task )" not in s
+
+
+# ---------------------------------------------------------------------------
+# review_requested: end-to-end webhook → foreman dispatch
+# ---------------------------------------------------------------------------
+
+
+def _set_guild_owner_token(db_url: str, user_id: str, username: str) -> None:
+    """Ensure a GithubToken row exists for user_id with the given username."""
+    make_auth_token(db_url, user_id=user_id, username=username)
+
+
+def test_review_requested_dispatches_when_reviewer_matches_guild_owner(client):
+    """review_requested targeted at the guild owner must dispatch to the foreman."""
+    test_client, db_url = client
+    insert_guild(db_url, "gd-rr-1", owner_user_id="u-rr-owner")
+    _set_guild_owner_token(db_url, "u-rr-owner", "guild-bot")
+    _set_webhook_secret(db_url, "gd-rr-1", "secret-rr-1")
+
+    payload = {
+        "action": "review_requested",
+        "repository": {"full_name": "o/r"},
+        "pull_request": {
+            "number": 20,
+            "html_url": "https://github.com/o/r/pull/20",
+            "title": "Add feature X",
+        },
+        "requested_reviewer": {"login": "guild-bot"},
+        "sender": {"login": "alice"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-rr-1", body, event="pull_request", delivery="d-rr-1")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-rr-1", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 1
+    key_arg, guild_arg, summary_arg, _user_arg = mock_q.schedule.call_args.args
+    assert "gd-rr-1" in key_arg
+    assert "review_requested" in key_arg
+    assert guild_arg == "gd-rr-1"
+    assert "guild-bot" in summary_arg
+    assert "--approve" in summary_arg
+
+
+def test_review_requested_skipped_when_reviewer_does_not_match(client):
+    """review_requested for a different reviewer must not dispatch to the foreman."""
+    test_client, db_url = client
+    insert_guild(db_url, "gd-rr-2", owner_user_id="u-rr-owner2")
+    _set_guild_owner_token(db_url, "u-rr-owner2", "guild-bot")
+    _set_webhook_secret(db_url, "gd-rr-2", "secret-rr-2")
+
+    payload = {
+        "action": "review_requested",
+        "repository": {"full_name": "o/r"},
+        "pull_request": {
+            "number": 21,
+            "html_url": "https://github.com/o/r/pull/21",
+            "title": "Fix",
+        },
+        "requested_reviewer": {"login": "other-person"},
+        "sender": {"login": "alice"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-rr-2", body, event="pull_request", delivery="d-rr-2")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-rr-2", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 0
+
+
+def test_review_requested_skipped_when_no_owner_token(client):
+    """review_requested must not dispatch if the guild owner has no GitHub token."""
+    test_client, db_url = client
+    # insert_guild creates the owner user but no GithubToken
+    insert_guild(db_url, "gd-rr-3", owner_user_id="u-rr-notoken")
+    _set_webhook_secret(db_url, "gd-rr-3", "secret-rr-3")
+
+    payload = {
+        "action": "review_requested",
+        "repository": {"full_name": "o/r"},
+        "pull_request": {"number": 22, "html_url": "https://github.com/o/r/pull/22", "title": "T"},
+        "requested_reviewer": {"login": "u-rr-notoken"},
+        "sender": {"login": "alice"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-rr-3", body, event="pull_request", delivery="d-rr-3")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-rr-3", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 0
+
+
+def test_review_requested_reviewer_matching_is_case_insensitive(client):
+    """Reviewer login comparison must be case-insensitive."""
+    test_client, db_url = client
+    insert_guild(db_url, "gd-rr-4", owner_user_id="u-rr-case")
+    _set_guild_owner_token(db_url, "u-rr-case", "Guild-Bot")
+    _set_webhook_secret(db_url, "gd-rr-4", "secret-rr-4")
+
+    payload = {
+        "action": "review_requested",
+        "repository": {"full_name": "o/r"},
+        "pull_request": {"number": 23, "html_url": "https://github.com/o/r/pull/23", "title": "T"},
+        "requested_reviewer": {"login": "guild-bot"},  # lowercase vs stored "Guild-Bot"
+        "sender": {"login": "alice"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-rr-4", body, event="pull_request", delivery="d-rr-4")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-rr-4", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 1
+
+
+def test_review_requested_duplicate_delivery_is_idempotent(client):
+    """Re-delivery of the same webhook (same delivery_id) must not dispatch twice."""
+    test_client, db_url = client
+    insert_guild(db_url, "gd-rr-5", owner_user_id="u-rr-dup")
+    _set_guild_owner_token(db_url, "u-rr-dup", "guild-bot")
+    _set_webhook_secret(db_url, "gd-rr-5", "secret-rr-5")
+
+    payload = {
+        "action": "review_requested",
+        "repository": {"full_name": "o/r"},
+        "pull_request": {"number": 24, "html_url": "https://github.com/o/r/pull/24", "title": "T"},
+        "requested_reviewer": {"login": "guild-bot"},
+        "sender": {"login": "alice"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-rr-5", body, event="pull_request", delivery="d-rr-5-dup")
+
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp1 = test_client.post("/webhooks/github/gd-rr-5", content=body, headers=headers)
+        resp2 = test_client.post("/webhooks/github/gd-rr-5", content=body, headers=headers)
+
+    assert resp1.status_code == 202
+    assert resp2.status_code == 202
+    # Second delivery is idempotent — only one dispatch
+    assert mock_q.schedule.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _get_guild_owner_github_login
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_guild_owner_github_login_returns_username(db_session):
+    """_get_guild_owner_github_login must return the guild owner's GitHub username."""
+    insert_guild(db_session, "g-owner-login", owner_user_id="u-owner-x")
+    make_auth_token(db_session, user_id="u-owner-x", username="owner-login-x")
+
+    engine = create_async_engine(db_session, echo=False, poolclass=NullPool)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with session_factory() as session:
+        from models import Guild
+        from sqlmodel import col, select
+
+        guild_pk = (
+            await session.exec(select(col(Guild.id)).where(col(Guild.slug) == "g-owner-login"))
+        ).one()
+        login = await _get_guild_owner_github_login(session, guild_pk)
+
+    assert login == "owner-login-x"
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_get_guild_owner_github_login_returns_none_without_token(db_session):
+    """_get_guild_owner_github_login returns None when no GithubToken exists for the owner."""
+    insert_guild(db_session, "g-owner-notoken", owner_user_id="u-notoken")
+
+    engine = create_async_engine(db_session, echo=False, poolclass=NullPool)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with session_factory() as session:
+        from models import Guild
+        from sqlmodel import col, select
+
+        guild_pk = (
+            await session.exec(select(col(Guild.id)).where(col(Guild.slug) == "g-owner-notoken"))
+        ).one()
+        login = await _get_guild_owner_github_login(session, guild_pk)
+
+    assert login is None
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Prompt: review_requested section
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_describes_review_requested_behavior():
+    """System prompt must document the review_requested auto-dispatch behavior."""
+    from foreman.prompt import FOREMAN_SYSTEM
+
+    assert "review_requested" in FOREMAN_SYSTEM
+    assert "--approve" in FOREMAN_SYSTEM
+    assert "Do NOT commit" in FOREMAN_SYSTEM
+    assert "duplicates" in FOREMAN_SYSTEM


### PR DESCRIPTION
## Summary

- When a `pull_request` webhook fires with `action=review_requested` and `requested_reviewer.login` matches the guild owner's GitHub login, the backend now dispatches a `[github-event]` message to the Foreman automatically — no existing task required.
- The Foreman system prompt is updated to instruct the Foreman to `create_task(phase="review")` + `assign_task` with review instructions that **explicitly permit `--approve`** when the code looks good.
- Duplicate-delivery idempotency is provided at two layers: the `delivery_id` unique constraint (exact GitHub retries) and the per-PR debounce key `guild:review_requested:repo#N` (coalesces rapid re-requests within the debounce window); the prompt also instructs the Foreman to skip task creation if a review task already exists.

## Key files changed

| File | Change |
|------|--------|
| `backend/routes/webhooks.py` | `_get_guild_owner_github_login` helper; `review_requested` branch in `_build_foreman_summary`; PR-scoped debounce dispatch path |
| `backend/foreman_core/prompt.py` | New `review_requested` section in "Reacting to GitHub PR events" |
| `backend/tests/test_github_webhooks_phase2.py` | 9 new tests: summary builder, dispatch/skip E2E, case-insensitive match, duplicate delivery, helper unit tests, prompt assertion |

## Test plan

```bash
cd backend
docker compose up -d postgres-test
python -m pytest tests/test_github_webhooks_phase2.py -v -k "review_requested or owner_github_login or review_requested_behavior"
```

Resolves: t-4eg029

🤖 Generated with [Claude Code](https://claude.com/claude-code)