### PR TITLE
Scope worker join/notification events to member guilds

### DIFF
--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -227,10 +227,13 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                 # Batch all stale-worker notifications into a single foreman
                 # trigger so a simultaneous mass-disconnect doesn't stampede
                 # the foreman with N concurrent embedded-foreman tasks.
-                if stale_worker_ids:
+                # Skip workers that already sent reason=shutdown via a graceful
+                # worker-disconnect message to avoid double-firing.
+                abrupt_worker_ids = stale_worker_ids - ctx.gracefully_disconnected_workers
+                if abrupt_worker_ids:
                     offline_lines = "\n".join(
                         f"[worker-offline] worker_id={wid} reason=disconnect"
-                        for wid in sorted(stale_worker_ids)
+                        for wid in sorted(abrupt_worker_ids)
                     )
                     await ws_handlers._trigger_foreman(
                         guild_id,

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -263,3 +263,141 @@ def test_task_complete_max_turns_notifies_foreman(client):
     assert "I was working on the migration" in msg, (
         f"Expected lastText snippet in message, got: {msg}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Guild-scoping tests (issue #621)
+# ---------------------------------------------------------------------------
+
+
+def test_worker_online_not_sent_to_foreign_guild(client):
+    """worker-register from a worker that belongs to guild_A must NOT trigger
+    a worker-online event in guild_B, even when the worker connects to guild_B's
+    WebSocket."""
+    test_client, db_url = client
+    guild_a = "nfy010"
+    guild_b = "nfy011"
+    worker_id = "w-nfy010"
+    agent_id = "a-nfy010"
+
+    insert_guild(db_url, guild_a, owner_user_id=None)
+    insert_guild(db_url, guild_b, owner_user_id=None)
+    # Worker belongs to guild_a only
+    insert_worker(db_url, guild_a, worker_id, state="online")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        # Worker mistakenly (or maliciously) connects to guild_b's WebSocket
+        with test_client.websocket_connect(f"/ws/{guild_b}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Foreign Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            # No agent-joined broadcast expected (join is rejected)
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+            ws.send_json(
+                {
+                    "type": "worker-register",
+                    "workerId": worker_id,
+                    "repos": ["org/repo1"],
+                    "tools": ["claude"],
+                }
+            )
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+    online = [(e, m) for e, m in triggered if e == "worker-online"]
+    assert not online, (
+        f"worker-online must not fire for guild {guild_b!r} when worker belongs to {guild_a!r}; "
+        f"got triggers: {triggered}"
+    )
+
+
+def test_worker_offline_not_sent_to_foreign_guild_on_disconnect(client):
+    """Graceful worker-disconnect from a foreign-guild worker must NOT trigger
+    a worker-offline event in the guild the worker connected to."""
+    test_client, db_url = client
+    guild_a = "nfy012"
+    guild_b = "nfy013"
+    worker_id = "w-nfy012"
+    agent_id = "a-nfy012"
+
+    insert_guild(db_url, guild_a, owner_user_id=None)
+    insert_guild(db_url, guild_b, owner_user_id=None)
+    # Worker belongs to guild_a only
+    insert_worker(db_url, guild_a, worker_id, state="online")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        # Worker connects to the wrong guild
+        with test_client.websocket_connect(f"/ws/{guild_b}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Foreign Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+            ws.send_json({"type": "worker-disconnect", "workerId": worker_id})
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+    offline = [(e, m) for e, m in triggered if e == "worker-offline"]
+    assert not offline, (
+        f"worker-offline must not fire for guild {guild_b!r} when worker belongs to {guild_a!r}; "
+        f"got triggers: {triggered}"
+    )
+
+
+def test_worker_online_fires_for_correct_guild(client):
+    """Regression: a worker connecting to its own guild still gets worker-online."""
+    test_client, db_url = client
+    guild_id = "nfy014"
+    worker_id = "w-nfy014"
+    agent_id = "a-nfy014"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    triggered, fake_trigger = _make_trigger_spy()
+
+    with patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Correct Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json(
+                {
+                    "type": "worker-register",
+                    "workerId": worker_id,
+                    "repos": ["org/repo"],
+                    "tools": ["claude"],
+                }
+            )
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+    online = [(e, m) for e, m in triggered if e == "worker-online"]
+    assert online, f"Expected worker-online for own guild, got: {triggered}"

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -221,6 +221,7 @@ class WSContext:
     db: AsyncSession
     joined_agents: set[str] = field(default_factory=set)
     gracefully_disconnected_workers: set[str] = field(default_factory=set)
+    registered_worker_ids: set[str] = field(default_factory=set)
     ws_user_id: str | None = None
     guild_pk: int | None = None
 
@@ -304,6 +305,8 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         await ctx.db.commit()
     if agent_id:
         ctx.joined_agents.add(agent_id)
+        if agent_type == "worker" and worker_id:
+            ctx.registered_worker_ids.add(worker_id)
         # Take the per-guild ownership lock so a concurrent disconnect-cleanup
         # for the previous socket can't read a stale ``agent_owners`` entry,
         # decide it owns the agent, and stamp the just-joined agent offline.
@@ -657,15 +660,13 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
             AgentStateMsg(agentId=agent_id, state="offline"),
         )
     if worker_id:
-        # Only notify the foreman if the worker actually belongs to this guild.
-        member_res = await ctx.db.exec(
-            select(col(Worker.id)).where(
-                col(Worker.id) == worker_id,
-                col(Worker.guild_id) == ctx.guild_pk,
-            )
-        )
-        if member_res.one_or_none() is not None:
-            ctx.gracefully_disconnected_workers.add(worker_id)
+        # Always mark as gracefully disconnected so the finally block does not
+        # redundantly emit reason=disconnect for a worker that sent worker-disconnect.
+        ctx.gracefully_disconnected_workers.add(worker_id)
+        # Only notify the foreman if the worker was approved for this guild
+        # during handle_join (avoids a redundant DB round-trip and is immune
+        # to session state after the commit above).
+        if worker_id in ctx.registered_worker_ids:
             await _trigger_foreman(
                 ctx.guild_id,
                 "worker-offline",

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -250,6 +250,24 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     worker_id = data.get("workerId")
     joined_at = datetime.now(UTC)
     is_external_foreman = agent_type == "foreman" and data.get("external") is True
+    # Validate that the worker actually belongs to this guild before proceeding.
+    # A misconfigured or misbehaving worker could connect to the wrong guild's
+    # WebSocket; without this check it would create agent rows and broadcast
+    # events into a guild it doesn't belong to.
+    if agent_type == "worker" and worker_id:
+        member_res = await ctx.db.exec(
+            select(col(Worker.id)).where(
+                col(Worker.id) == worker_id,
+                col(Worker.guild_id) == ctx.guild_pk,
+            )
+        )
+        if member_res.one_or_none() is None:
+            logger.warning(
+                "join: worker %s is not a member of guild %s — ignoring",
+                worker_id,
+                ctx.guild_id,
+            )
+            return
     if not is_external_foreman:
         stmt = pg_insert(Agent).values(
             id=agent_id,
@@ -566,6 +584,20 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
     worker_id = data.get("workerId")
     if not worker_id:
         return
+    # Guard: only process worker-register from workers that belong to this guild.
+    member_res = await ctx.db.exec(
+        select(col(Worker.id)).where(
+            col(Worker.id) == worker_id,
+            col(Worker.guild_id) == ctx.guild_pk,
+        )
+    )
+    if member_res.one_or_none() is None:
+        logger.warning(
+            "worker-register: worker %s is not a member of guild %s — ignoring",
+            worker_id,
+            ctx.guild_id,
+        )
+        return
     repos = data.get("repos") or []
     tools = data.get("tools") or []
     user_ident = data.get("user")
@@ -624,12 +656,26 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
             AgentStateMsg(agentId=agent_id, state="offline"),
         )
     if worker_id:
-        await _trigger_foreman(
-            ctx.guild_id,
-            "worker-offline",
-            f"[worker-offline] worker_id={worker_id} reason=shutdown",
-            task_name=f"foreman.worker-offline:{worker_id}",
+        # Only notify the foreman if the worker actually belongs to this guild.
+        member_res = await ctx.db.exec(
+            select(col(Worker.id)).where(
+                col(Worker.id) == worker_id,
+                col(Worker.guild_id) == ctx.guild_pk,
+            )
         )
+        if member_res.one_or_none() is not None:
+            await _trigger_foreman(
+                ctx.guild_id,
+                "worker-offline",
+                f"[worker-offline] worker_id={worker_id} reason=shutdown",
+                task_name=f"foreman.worker-offline:{worker_id}",
+            )
+        else:
+            logger.warning(
+                "worker-disconnect: worker %s is not a member of guild %s — skipping foreman trigger",
+                worker_id,
+                ctx.guild_id,
+            )
     reset_foreman_poll(ctx.guild_id)
 
 

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -220,6 +220,7 @@ class WSContext:
     guild_id: str
     db: AsyncSession
     joined_agents: set[str] = field(default_factory=set)
+    gracefully_disconnected_workers: set[str] = field(default_factory=set)
     ws_user_id: str | None = None
     guild_pk: int | None = None
 
@@ -664,6 +665,7 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
             )
         )
         if member_res.one_or_none() is not None:
+            ctx.gracefully_disconnected_workers.add(worker_id)
             await _trigger_foreman(
                 ctx.guild_id,
                 "worker-offline",


### PR DESCRIPTION
Fixes #621

Adds guild membership checks in ws_handlers.py so worker-online/offline events are only broadcast to guilds the worker belongs to. Includes new tests covering the scoping behaviour.