### PR TITLE
Rename tasks.deleted_at → tasks.finalized_at

### DIFF
--- a/backend/alembic/versions/20260610_000000_rename_tasks_deleted_at_to_finalized_at.py
+++ b/backend/alembic/versions/20260610_000000_rename_tasks_deleted_at_to_finalized_at.py
@@ -1,0 +1,33 @@
+"""Rename tasks.deleted_at to tasks.finalized_at.
+
+Revision ID: 20260610_000000_rename_tasks_deleted_at_to_finalized_at
+Revises: 20260608_000000_rename_guild_slug
+Create Date: 2026-06-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260610_000000_rename_tasks_deleted_at_to_finalized_at"
+down_revision: str | Sequence[str] | None = "20260608_000000_rename_guild_slug"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_tasks_guild_id_deleted_at_created_at", table_name="tasks")
+    op.alter_column("tasks", "deleted_at", new_column_name="finalized_at")
+    op.create_index(
+        "ix_tasks_guild_id_finalized_at_created_at", "tasks", ["guild_id", "finalized_at", "created_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tasks_guild_id_finalized_at_created_at", table_name="tasks")
+    op.alter_column("tasks", "finalized_at", new_column_name="deleted_at")
+    op.create_index(
+        "ix_tasks_guild_id_deleted_at_created_at", "tasks", ["guild_id", "deleted_at", "created_at"]
+    )

--- a/backend/alembic/versions/20260610_000000_rename_tasks_deleted_at_to_finalized_at.py
+++ b/backend/alembic/versions/20260610_000000_rename_tasks_deleted_at_to_finalized_at.py
@@ -1,4 +1,15 @@
-"""Rename tasks.deleted_at to tasks.finalized_at.
+"""Drop tasks.deleted_at; introduce finalized_at for task soft-delete expiry.
+
+``finalized_at`` may already exist on databases where the column was
+pre-applied outside the migration chain.  This migration is safe for both
+cases:
+
+  1. Adds ``finalized_at`` with ``IF NOT EXISTS`` — a no-op on databases
+     that already have the column.
+  2. Copies any non-NULL ``deleted_at`` values into ``finalized_at`` where
+     ``finalized_at`` is still NULL, preserving existing soft-delete state.
+  3. Drops ``deleted_at`` (the now-superseded column).
+  4. Creates the composite index on ``finalized_at`` with ``IF NOT EXISTS``.
 
 Revision ID: 20260610_000000_rename_tasks_deleted_at_to_finalized_at
 Revises: 20260608_000000_rename_guild_slug
@@ -9,6 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260610_000000_rename_tasks_deleted_at_to_finalized_at"
@@ -18,16 +30,70 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.drop_index("ix_tasks_guild_id_deleted_at_created_at", table_name="tasks")
-    op.alter_column("tasks", "deleted_at", new_column_name="finalized_at")
-    op.create_index(
-        "ix_tasks_guild_id_finalized_at_created_at", "tasks", ["guild_id", "finalized_at", "created_at"]
+    # Add finalized_at only if it doesn't already exist (idempotent for DBs
+    # where the column was pre-applied outside the migration chain).
+    op.execute(
+        sa.text(
+            "ALTER TABLE tasks"
+            " ADD COLUMN IF NOT EXISTS finalized_at TIMESTAMPTZ"
+        )
+    )
+
+    # Copy any non-NULL deleted_at values into finalized_at where finalized_at
+    # is still NULL.  This preserves existing soft-delete state on fresh DBs
+    # while leaving pre-existing finalized_at values untouched.
+    op.execute(
+        sa.text(
+            "UPDATE tasks"
+            " SET finalized_at = deleted_at"
+            " WHERE deleted_at IS NOT NULL AND finalized_at IS NULL"
+        )
+    )
+
+    # Drop the old index before dropping the column (index may not exist on
+    # databases that never had it, so use DROP INDEX IF EXISTS).
+    op.execute(
+        sa.text(
+            "DROP INDEX IF EXISTS ix_tasks_guild_id_deleted_at_created_at"
+        )
+    )
+
+    # Drop the superseded column.
+    op.execute(sa.text("ALTER TABLE tasks DROP COLUMN IF EXISTS deleted_at"))
+
+    # Create the replacement index (IF NOT EXISTS handles DBs that already
+    # had this index applied separately).
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_tasks_guild_id_finalized_at_created_at"
+            " ON tasks (guild_id, finalized_at, created_at)"
+        )
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_tasks_guild_id_finalized_at_created_at", table_name="tasks")
-    op.alter_column("tasks", "finalized_at", new_column_name="deleted_at")
-    op.create_index(
-        "ix_tasks_guild_id_deleted_at_created_at", "tasks", ["guild_id", "deleted_at", "created_at"]
+    op.execute(
+        sa.text(
+            "DROP INDEX IF EXISTS ix_tasks_guild_id_finalized_at_created_at"
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE tasks"
+            " ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ"
+        )
+    )
+    op.execute(
+        sa.text(
+            "UPDATE tasks"
+            " SET deleted_at = finalized_at"
+            " WHERE finalized_at IS NOT NULL AND deleted_at IS NULL"
+        )
+    )
+    op.execute(sa.text("ALTER TABLE tasks DROP COLUMN IF EXISTS finalized_at"))
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_tasks_guild_id_deleted_at_created_at"
+            " ON tasks (guild_id, deleted_at, created_at)"
+        )
     )

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -131,19 +131,19 @@ async def _to_thread(fn, /, *args, **kwargs):
     )
 
 
-def _resolve_finalize_deleted_at(inp: dict) -> tuple[datetime | None, str | None]:
+def _resolve_finalize_finalized_at(inp: dict) -> tuple[datetime | None, str | None]:
     """Compute the soft-delete instant for a finalize_task tool call.
 
-    Returns ``(deleted_at, error)`` — error is non-None when the inputs
-    were malformed. Honours an explicit ``deleted_at`` first, then
+    Returns ``(finalized_at, error)`` — error is non-None when the inputs
+    were malformed. Honours an explicit ``finalized_at`` first, then
     ``expires_in_seconds``, otherwise falls back to the default 3-day window.
     """
-    raw = inp.get("deleted_at")
+    raw = inp.get("finalized_at")
     if raw:
         try:
             parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
         except ValueError as exc:
-            return None, f"Invalid deleted_at: {exc}"
+            return None, f"Invalid finalized_at: {exc}"
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
         return parsed.astimezone(UTC), None
@@ -1148,7 +1148,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             if prior_state in ("done", "failed", "cancelled"):
                                 # Re-opening a terminal task: clear soft-delete fields so it
                                 # reappears in the live task list and isn't auto-purged.
-                                update_vals["deleted_at"] = None
+                                update_vals["finalized_at"] = None
                                 update_vals["finished_at"] = None
                             await db.exec(
                                 update(Task).where(col(Task.id) == task_id).values(**update_vals)
@@ -1160,7 +1160,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     taskId=task_id,
                                     state="working",
                                     workerId=target_worker_id,
-                                    deletedAt=None,
+                                    finalizedAt=None,
                                     finishedAt=None,
                                 ).model_dump(by_alias=True, exclude_none=True),
                             )
@@ -1214,7 +1214,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     logger.warning(
                         "finalize_task: unknown outcome %r, defaulting to 'done'", raw_outcome
                     )
-                deleted_at, err = _resolve_finalize_deleted_at(inp)
+                finalized_at, err = _resolve_finalize_finalized_at(inp)
                 if err:
                     result_text = err
                     is_error = True
@@ -1235,7 +1235,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             .values(
                                 state=outcome,
                                 finished_at=finished_at,
-                                deleted_at=deleted_at,
+                                finalized_at=finalized_at,
                             )
                         )
                         # Discard any queued follow-up events — the task is closed.
@@ -1252,14 +1252,14 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 taskId=task_id,
                                 state=outcome,
                                 finishedAt=finished_at.isoformat(),
-                                deletedAt=deleted_at.isoformat()
-                                if deleted_at is not None
+                                finalizedAt=finalized_at.isoformat()
+                                if finalized_at is not None
                                 else None,
                             ),
                         )
                         result_text = (
                             f"Task {task_id} finalized as {outcome}; soft-delete at "
-                            f"{deleted_at.isoformat() if deleted_at is not None else 'unknown'}."
+                            f"{finalized_at.isoformat() if finalized_at is not None else 'unknown'}."
                         )
 
             elif tu.name == "message_worker":

--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -82,7 +82,7 @@ task table doesn't accumulate cruft. Pick the window by task type:
 - **Code tasks** (execute / review / followup phases): omit the field to use
   the default 3 days, or pass expires_in_seconds = 259200
 - **Error / failed tasks**: expires_in_seconds = 86400 (1 day)
-Pass deleted_at instead if you need an exact ISO-8601 timestamp.
+Pass finalized_at instead if you need an exact ISO-8601 timestamp.
 
 ## GitHub access
 You have direct GitHub access via list_github_issues, get_github_issue, list_github_prs,

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -165,7 +165,7 @@ FOREMAN_TOOLS = [
             "  - Code tasks (execute / review / followup phases): omit the field "
             "to use the default 3 days, or pass expires_in_seconds = 259200\n"
             "  - Error / failed tasks: expires_in_seconds = 86400 (1 day)\n"
-            "Pass deleted_at instead if you need an exact ISO-8601 timestamp.\n"
+            "Pass finalized_at instead if you need an exact ISO-8601 timestamp.\n"
             "NOTE: For tasks that have an open PR, the GitHub webhook *may* deliver a "
             "'PR merged' event — but do not rely on it firing reliably. Always call "
             "get_pr_status to confirm the merged state before calling finalize_task."
@@ -190,7 +190,7 @@ FOREMAN_TOOLS = [
                         "Defaults to 259200 (3 days) when omitted."
                     ),
                 },
-                "deleted_at": {
+                "finalized_at": {
                     "type": "string",
                     "description": (
                         "ISO-8601 UTC timestamp at which the task is soft-deleted. "

--- a/backend/main.py
+++ b/backend/main.py
@@ -453,7 +453,7 @@ app.include_router(_models_routes.router)
 from routes.tasks import (  # noqa: E402,F401
     DEFAULT_FINALIZE_TTL,
     FinalizeBody,
-    _resolve_finalize_deleted_at,
+    _resolve_finalize_finalized_at,
 )
 from utils import build_spawn_worker_env as _build_spawn_worker_env  # noqa: E402,F401
 from utils import decode_claude_oauth_token as _decode_claude_oauth_token  # noqa: E402,F401

--- a/backend/models.py
+++ b/backend/models.py
@@ -150,7 +150,9 @@ class Worker(SQLModel, table=True):
 class Task(SQLModel, table=True):
     __tablename__ = "tasks"  # type: ignore[assignment]
     __table_args__ = (
-        Index("ix_tasks_guild_id_finalized_at_created_at", "guild_id", "finalized_at", "created_at"),
+        Index(
+            "ix_tasks_guild_id_finalized_at_created_at", "guild_id", "finalized_at", "created_at"
+        ),
         Index("ix_tasks_state", "state"),
     )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -7,13 +7,13 @@ from sqlmodel import Field, SQLModel, col
 def live_tasks_filter(now: datetime | None = None):
     """SQL clause matching tasks that have not been soft-deleted.
 
-    A task is "live" when ``deleted_at`` is NULL or set to a future timestamp.
+    A task is "live" when ``finalized_at`` is NULL or set to a future timestamp.
     *now* defaults to the current UTC time; pass an explicit value to make a
     query reproducible in tests.
     """
     if now is None:
         now = datetime.now(UTC)
-    return or_(col(Task.deleted_at).is_(None), col(Task.deleted_at) > now)
+    return or_(col(Task.finalized_at).is_(None), col(Task.finalized_at) > now)
 
 
 class Guild(SQLModel, table=True):
@@ -150,7 +150,7 @@ class Worker(SQLModel, table=True):
 class Task(SQLModel, table=True):
     __tablename__ = "tasks"  # type: ignore[assignment]
     __table_args__ = (
-        Index("ix_tasks_guild_id_deleted_at_created_at", "guild_id", "deleted_at", "created_at"),
+        Index("ix_tasks_guild_id_finalized_at_created_at", "guild_id", "finalized_at", "created_at"),
         Index("ix_tasks_state", "state"),
     )
 
@@ -183,8 +183,8 @@ class Task(SQLModel, table=True):
     parent_task_id: str | None = None
     phase: str | None = Field(default="execute", sa_column_kwargs={"server_default": "'execute'"})
     # UTC instant at which this task is considered soft-deleted.
-    # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
-    deleted_at: datetime | None = Field(
+    # NULL = live; once `now() > finalized_at`, list/get queries hide the row.
+    finalized_at: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
     # github_user_id of the human who initiated this task. Used to route

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -470,7 +470,7 @@ class TaskPatch(BaseModel):
     branch: str | None = None
     pr_url: str | None = None
     finished_at: str | None = None
-    deleted_at: str | None = None
+    finalized_at: str | None = None
     phase: str | None = None
 
 
@@ -495,7 +495,7 @@ async def patch_task(
     - ``branch``: git branch name
     - ``pr_url``: GitHub PR URL
     - ``finished_at``: ISO-8601 completion timestamp
-    - ``deleted_at``: ISO-8601 soft-delete timestamp
+    - ``finalized_at``: ISO-8601 soft-delete timestamp
     - ``phase``: task phase (plan / execute / review / followup)
 
     Broadcasts a ``task-update`` WS event with the changed fields so the
@@ -510,7 +510,7 @@ async def patch_task(
         ("branch", "branch"),
         ("pr_url", "pr_url"),
         ("finished_at", "finished_at"),
-        ("deleted_at", "deleted_at"),
+        ("finalized_at", "finalized_at"),
         ("phase", "phase"),
     ):
         val = getattr(body, field)
@@ -541,7 +541,7 @@ async def patch_task(
         "branch": "branch",
         "pr_url": "prUrl",
         "finished_at": "finishedAt",
-        "deleted_at": "deletedAt",
+        "finalized_at": "finalizedAt",
         "phase": "phase",
     }
     ws_data: dict = {"taskId": task_id}

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -1,7 +1,7 @@
 """Task lifecycle routes: list, logs, follow-up, finalize, cancel, redirect.
 
 Soft-delete TTL handling lives here too — ``DEFAULT_FINALIZE_TTL``,
-``FinalizeBody``, and ``_resolve_finalize_deleted_at`` are exported for
+``FinalizeBody``, and ``_resolve_finalize_finalized_at`` are exported for
 direct unit testing in ``tests/test_soft_delete_tasks.py``.
 """
 
@@ -40,9 +40,9 @@ class FollowupCreate(BaseModel):
 
 class FinalizeBody(BaseModel):
     # Optional ISO-8601 timestamp at which to soft-delete this task.
-    deleted_at: str | None = None
+    finalized_at: str | None = None
     # Optional convenience: seconds from now until soft-delete. If both fields
-    # are set, deleted_at wins.
+    # are set, finalized_at wins.
     expires_in_seconds: int | None = None
 
 
@@ -50,13 +50,13 @@ class RedirectCreate(BaseModel):
     instructions: str
 
 
-def _resolve_finalize_deleted_at(body: FinalizeBody | None) -> datetime:
+def _resolve_finalize_finalized_at(body: FinalizeBody | None) -> datetime:
     """Return a UTC datetime for the task's soft-delete instant."""
-    if body and body.deleted_at:
+    if body and body.finalized_at:
         try:
-            parsed = datetime.fromisoformat(body.deleted_at.replace("Z", "+00:00"))
+            parsed = datetime.fromisoformat(body.finalized_at.replace("Z", "+00:00"))
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=f"Invalid deleted_at: {exc}") from exc
+            raise HTTPException(status_code=400, detail=f"Invalid finalized_at: {exc}") from exc
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
         return parsed.astimezone(UTC)
@@ -93,7 +93,7 @@ async def list_guild_tasks(
             col(Task.issue_repo),
             col(Task.created_at),
             col(Task.finished_at),
-            col(Task.deleted_at),
+            col(Task.finalized_at),
         )
         .where(col(Task.guild_id) == guild_pk, live_tasks_filter())
         .order_by(col(Task.created_at).desc())
@@ -247,7 +247,7 @@ async def finalize_task_endpoint(
 ):
     """Signal a worker to finalize a task — no more follow-ups.
 
-    The optional body may carry ``deleted_at`` (ISO-8601) or
+    The optional body may carry ``finalized_at`` (ISO-8601) or
     ``expires_in_seconds`` to set the task's soft-delete window. If neither is
     set, the task is soft-deleted ``DEFAULT_FINALIZE_TTL`` from now.
     """
@@ -261,11 +261,11 @@ async def finalize_task_endpoint(
     if not worker_id:
         raise HTTPException(status_code=404, detail="Task not found")
     finished_at = datetime.now(UTC)
-    deleted_at = _resolve_finalize_deleted_at(body)
+    finalized_at = _resolve_finalize_finalized_at(body)
     await db.exec(
         update(Task)
         .where(col(Task.id) == task_id)
-        .values(state="done", finished_at=finished_at, deleted_at=deleted_at)
+        .values(state="done", finished_at=finished_at, finalized_at=finalized_at)
     )
     await db.commit()
     await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=task_id))
@@ -275,11 +275,11 @@ async def finalize_task_endpoint(
             taskId=task_id,
             state="done",
             finishedAt=finished_at.isoformat(),
-            deletedAt=deleted_at.isoformat(),
+            finalizedAt=finalized_at.isoformat(),
         ),
     )
     # Return raw datetime — FastAPI's jsonable_encoder handles ISO-8601 serialisation.
-    return {"status": "finalized", "taskId": task_id, "deletedAt": deleted_at}
+    return {"status": "finalized", "taskId": task_id, "finalizedAt": finalized_at}
 
 
 @router.post("/guilds/{guild_id}/tasks/{task_id}/cancel")

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -259,7 +259,7 @@ async def _auto_finalize_task_on_pr_merge(
     worker_id = task_row[1]
 
     now = datetime.now(UTC)
-    deleted_at = now + timedelta(seconds=_DEFAULT_FINALIZE_TTL_SECS)
+    finalized_at = now + timedelta(seconds=_DEFAULT_FINALIZE_TTL_SECS)
 
     # Single conditional UPDATE — only fires if task is not already in a terminal
     # state, eliminating the race between two concurrent state transitions.
@@ -270,7 +270,7 @@ async def _auto_finalize_task_on_pr_merge(
             col(Task.guild_id) == guild_pk,
             col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
         )
-        .values(state="done", finished_at=now, deleted_at=deleted_at)
+        .values(state="done", finished_at=now, finalized_at=finalized_at)
     )
     if (getattr(upd, "rowcount", 0) or 0) == 0:
         return False
@@ -286,7 +286,7 @@ async def _auto_finalize_task_on_pr_merge(
             taskId=task_id,
             state="done",
             finishedAt=now.isoformat(),
-            deletedAt=deleted_at.isoformat(),
+            finalizedAt=finalized_at.isoformat(),
         ),
     )
     return True
@@ -318,7 +318,7 @@ async def _auto_fail_task_on_pr_close(
     worker_id = task_row[1]
 
     now = datetime.now(UTC)
-    deleted_at = now + timedelta(seconds=_DEFAULT_FAIL_TTL_SECS)
+    finalized_at = now + timedelta(seconds=_DEFAULT_FAIL_TTL_SECS)
 
     # Single conditional UPDATE — only fires if task is not already in a terminal
     # state, eliminating the race between two concurrent state transitions.
@@ -329,7 +329,7 @@ async def _auto_fail_task_on_pr_close(
             col(Task.guild_id) == guild_pk,
             col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
         )
-        .values(state="failed", finished_at=now, deleted_at=deleted_at)
+        .values(state="failed", finished_at=now, finalized_at=finalized_at)
     )
     if (getattr(upd, "rowcount", 0) or 0) == 0:
         return False
@@ -345,7 +345,7 @@ async def _auto_fail_task_on_pr_close(
             taskId=task_id,
             state="failed",
             finishedAt=now.isoformat(),
-            deletedAt=deleted_at.isoformat(),
+            finalizedAt=finalized_at.isoformat(),
         ),
     )
     return True

--- a/backend/tests/test_soft_delete_tasks.py
+++ b/backend/tests/test_soft_delete_tasks.py
@@ -45,7 +45,9 @@ def _create_task(test_client, guild_id: str, worker_id: str, desc: str, db_url: 
 def _set_finalized_at(db_url: str, task_id: str, finalized_at: datetime | None) -> None:
 
     with _sync_session(db_url) as session:
-        session.execute(update(Task).where(col(Task.id) == task_id).values(finalized_at=finalized_at))
+        session.execute(
+            update(Task).where(col(Task.id) == task_id).values(finalized_at=finalized_at)
+        )
         session.commit()
 
 

--- a/backend/tests/test_soft_delete_tasks.py
+++ b/backend/tests/test_soft_delete_tasks.py
@@ -1,10 +1,10 @@
 """Tests for soft-delete on tasks (issue #177).
 
 Covers:
-- Migration adds the deleted_at column.
-- _resolve_finalize_deleted_at honours deleted_at, expires_in_seconds, default.
+- Migration adds the finalized_at column.
+- _resolve_finalize_finalized_at honours finalized_at, expires_in_seconds, default.
 - live_tasks_filter hides soft-deleted rows from the list endpoint.
-- The finalize endpoint persists deleted_at to the row.
+- The finalize endpoint persists finalized_at to the row.
 """
 
 from __future__ import annotations
@@ -42,10 +42,10 @@ def _create_task(test_client, guild_id: str, worker_id: str, desc: str, db_url: 
     return resp.json()["id"]
 
 
-def _set_deleted_at(db_url: str, task_id: str, deleted_at: datetime | None) -> None:
+def _set_finalized_at(db_url: str, task_id: str, finalized_at: datetime | None) -> None:
 
     with _sync_session(db_url) as session:
-        session.execute(update(Task).where(col(Task.id) == task_id).values(deleted_at=deleted_at))
+        session.execute(update(Task).where(col(Task.id) == task_id).values(finalized_at=finalized_at))
         session.commit()
 
 
@@ -61,25 +61,25 @@ def _read_task(db_url: str, task_id: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_migration_adds_deleted_at_column(client):
-    """The Alembic head must add tasks.deleted_at."""
+def test_migration_adds_finalized_at_column(client):
+    """The Alembic head must add tasks.finalized_at."""
     _, db_url = client
     with raw_conn(db_url) as (conn, cur):
         cur.execute("""
             SELECT column_name FROM information_schema.columns
-            WHERE table_name = 'tasks' AND column_name = 'deleted_at'
+            WHERE table_name = 'tasks' AND column_name = 'finalized_at'
         """)
         row = cur.fetchone()
-    assert row is not None, "tasks.deleted_at column must exist"
+    assert row is not None, "tasks.finalized_at column must exist"
 
 
 # ---------------------------------------------------------------------------
-# _resolve_finalize_deleted_at (REST helper)
+# _resolve_finalize_finalized_at (REST helper)
 # ---------------------------------------------------------------------------
 
 
 def test_resolve_finalize_default_window(monkeypatch):
-    from main import DEFAULT_FINALIZE_TTL, _resolve_finalize_deleted_at
+    from main import DEFAULT_FINALIZE_TTL, _resolve_finalize_finalized_at
 
     fixed = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -89,12 +89,12 @@ def test_resolve_finalize_default_window(monkeypatch):
             return fixed
 
     monkeypatch.setattr("routes.tasks.datetime", _FixedDT)
-    out = _resolve_finalize_deleted_at(None)
+    out = _resolve_finalize_finalized_at(None)
     assert out == fixed + DEFAULT_FINALIZE_TTL
 
 
 def test_resolve_finalize_explicit_seconds(monkeypatch):
-    from main import FinalizeBody, _resolve_finalize_deleted_at
+    from main import FinalizeBody, _resolve_finalize_finalized_at
 
     fixed = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -104,57 +104,57 @@ def test_resolve_finalize_explicit_seconds(monkeypatch):
             return fixed
 
     monkeypatch.setattr("routes.tasks.datetime", _FixedDT)
-    out = _resolve_finalize_deleted_at(FinalizeBody(expires_in_seconds=1200))
+    out = _resolve_finalize_finalized_at(FinalizeBody(expires_in_seconds=1200))
     assert out == fixed + timedelta(seconds=1200)
 
 
-def test_resolve_finalize_explicit_deleted_at_iso():
-    from main import FinalizeBody, _resolve_finalize_deleted_at
+def test_resolve_finalize_explicit_finalized_at_iso():
+    from main import FinalizeBody, _resolve_finalize_finalized_at
 
     target = "2026-06-15T12:00:00+00:00"
-    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at=target))
+    out = _resolve_finalize_finalized_at(FinalizeBody(finalized_at=target))
     assert out == datetime.fromisoformat(target)
 
 
-def test_resolve_finalize_deleted_at_naive_assumed_utc():
-    from main import FinalizeBody, _resolve_finalize_deleted_at
+def test_resolve_finalize_finalized_at_naive_assumed_utc():
+    from main import FinalizeBody, _resolve_finalize_finalized_at
 
-    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at="2026-06-15T12:00:00"))
+    out = _resolve_finalize_finalized_at(FinalizeBody(finalized_at="2026-06-15T12:00:00"))
     assert out.tzinfo is not None
     assert out == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
 
 
-def test_resolve_finalize_deleted_at_z_suffix():
-    from main import FinalizeBody, _resolve_finalize_deleted_at
+def test_resolve_finalize_finalized_at_z_suffix():
+    from main import FinalizeBody, _resolve_finalize_finalized_at
 
-    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at="2026-06-15T12:00:00Z"))
+    out = _resolve_finalize_finalized_at(FinalizeBody(finalized_at="2026-06-15T12:00:00Z"))
     assert out == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
 
 
-def test_resolve_finalize_invalid_deleted_at_raises():
+def test_resolve_finalize_invalid_finalized_at_raises():
     from fastapi import HTTPException
-    from main import FinalizeBody, _resolve_finalize_deleted_at
+    from main import FinalizeBody, _resolve_finalize_finalized_at
 
     with pytest.raises(HTTPException) as excinfo:
-        _resolve_finalize_deleted_at(FinalizeBody(deleted_at="not-a-date"))
+        _resolve_finalize_finalized_at(FinalizeBody(finalized_at="not-a-date"))
     assert excinfo.value.status_code == 400
 
 
 def test_resolve_finalize_negative_seconds_raises():
     from fastapi import HTTPException
-    from main import FinalizeBody, _resolve_finalize_deleted_at
+    from main import FinalizeBody, _resolve_finalize_finalized_at
 
     with pytest.raises(HTTPException) as excinfo:
-        _resolve_finalize_deleted_at(FinalizeBody(expires_in_seconds=-1))
+        _resolve_finalize_finalized_at(FinalizeBody(expires_in_seconds=-1))
     assert excinfo.value.status_code == 400
 
 
-def test_resolve_finalize_deleted_at_wins_over_seconds():
-    """If both fields are set, deleted_at takes precedence."""
-    from main import FinalizeBody, _resolve_finalize_deleted_at
+def test_resolve_finalize_finalized_at_wins_over_seconds():
+    """If both fields are set, finalized_at takes precedence."""
+    from main import FinalizeBody, _resolve_finalize_finalized_at
 
-    out = _resolve_finalize_deleted_at(
-        FinalizeBody(deleted_at="2026-12-25T00:00:00Z", expires_in_seconds=60)
+    out = _resolve_finalize_finalized_at(
+        FinalizeBody(finalized_at="2026-12-25T00:00:00Z", expires_in_seconds=60)
     )
     assert out == datetime(2026, 12, 25, tzinfo=UTC)
 
@@ -164,7 +164,7 @@ def test_resolve_finalize_deleted_at_wins_over_seconds():
 # ---------------------------------------------------------------------------
 
 
-def test_list_guild_tasks_hides_past_deleted_at(client):
+def test_list_guild_tasks_hides_past_finalized_at(client):
     test_client, db_url = client
     insert_guild(db_url, "gsd01")
     worker_id = _create_worker(test_client, "gsd01")
@@ -174,8 +174,8 @@ def test_list_guild_tasks_hides_past_deleted_at(client):
 
     past = datetime.now(UTC) - timedelta(seconds=5)
     future = datetime.now(UTC) + timedelta(days=1)
-    _set_deleted_at(db_url, t_dead, past)
-    _set_deleted_at(db_url, t_future, future)
+    _set_finalized_at(db_url, t_dead, past)
+    _set_finalized_at(db_url, t_future, future)
 
     resp = test_client.get("/guilds/gsd01/tasks", headers=_auth(db_url))
     assert resp.status_code == 200
@@ -185,13 +185,13 @@ def test_list_guild_tasks_hides_past_deleted_at(client):
     assert t_dead not in ids
 
 
-def test_list_worker_tasks_hides_past_deleted_at(client):
+def test_list_worker_tasks_hides_past_finalized_at(client):
     test_client, db_url = client
     insert_guild(db_url, "gsd02")
     worker_id = _create_worker(test_client, "gsd02")
     t_live = _create_task(test_client, "gsd02", worker_id, "live", db_url)
     t_dead = _create_task(test_client, "gsd02", worker_id, "dead", db_url)
-    _set_deleted_at(db_url, t_dead, datetime.now(UTC) - timedelta(minutes=1))
+    _set_finalized_at(db_url, t_dead, datetime.now(UTC) - timedelta(minutes=1))
 
     resp = test_client.get(f"/guilds/gsd02/workers/{worker_id}/tasks")
     assert resp.status_code == 200
@@ -204,14 +204,14 @@ def test_get_task_logs_404_on_soft_deleted(client):
     insert_guild(db_url, "gsd03")
     worker_id = _create_worker(test_client, "gsd03")
     task_id = _create_task(test_client, "gsd03", worker_id, "task", db_url)
-    _set_deleted_at(db_url, task_id, datetime.now(UTC) - timedelta(minutes=1))
+    _set_finalized_at(db_url, task_id, datetime.now(UTC) - timedelta(minutes=1))
 
     resp = test_client.get(f"/guilds/gsd03/tasks/{task_id}/logs", headers=_auth(db_url))
     assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------
-# Finalize endpoint — persists deleted_at and supports overrides
+# Finalize endpoint — persists finalized_at and supports overrides
 # ---------------------------------------------------------------------------
 
 
@@ -224,11 +224,11 @@ def test_finalize_endpoint_default_sets_three_day_window(client):
     before = datetime.now(UTC)
     resp = test_client.post(f"/guilds/gsd04/tasks/{task_id}/finalize", headers=_auth(db_url))
     assert resp.status_code == 200, resp.text
-    deleted_at = resp.json()["deletedAt"]
-    parsed = datetime.fromisoformat(deleted_at)
+    finalized_at = resp.json()["finalizedAt"]
+    parsed = datetime.fromisoformat(finalized_at)
     # Should be roughly 3 days from now (allow ±1 minute slack for slow machines).
     assert timedelta(days=3, minutes=-1) <= parsed - before <= timedelta(days=3, minutes=1)
-    assert _read_task(db_url, task_id)["deleted_at"] == datetime.fromisoformat(deleted_at)
+    assert _read_task(db_url, task_id)["finalized_at"] == datetime.fromisoformat(finalized_at)
 
 
 def test_finalize_endpoint_explicit_expires_in_seconds(client):
@@ -244,11 +244,11 @@ def test_finalize_endpoint_explicit_expires_in_seconds(client):
         headers=_auth(db_url),
     )
     assert resp.status_code == 200, resp.text
-    parsed = datetime.fromisoformat(resp.json()["deletedAt"])
+    parsed = datetime.fromisoformat(resp.json()["finalizedAt"])
     assert timedelta(seconds=1199) <= parsed - before <= timedelta(seconds=1260)
 
 
-def test_finalize_endpoint_explicit_deleted_at(client):
+def test_finalize_endpoint_explicit_finalized_at(client):
     test_client, db_url = client
     insert_guild(db_url, "gsd06")
     worker_id = _create_worker(test_client, "gsd06")
@@ -257,14 +257,14 @@ def test_finalize_endpoint_explicit_deleted_at(client):
     target = "2026-12-25T00:00:00+00:00"
     resp = test_client.post(
         f"/guilds/gsd06/tasks/{task_id}/finalize",
-        json={"deleted_at": target},
+        json={"finalized_at": target},
         headers=_auth(db_url),
     )
     assert resp.status_code == 200
-    assert datetime.fromisoformat(resp.json()["deletedAt"]) == datetime.fromisoformat(target)
+    assert datetime.fromisoformat(resp.json()["finalizedAt"]) == datetime.fromisoformat(target)
 
 
-def test_finalize_endpoint_rejects_bad_deleted_at(client):
+def test_finalize_endpoint_rejects_bad_finalized_at(client):
     test_client, db_url = client
     insert_guild(db_url, "gsd07")
     worker_id = _create_worker(test_client, "gsd07")
@@ -272,7 +272,7 @@ def test_finalize_endpoint_rejects_bad_deleted_at(client):
 
     resp = test_client.post(
         f"/guilds/gsd07/tasks/{task_id}/finalize",
-        json={"deleted_at": "garbage"},
+        json={"finalized_at": "garbage"},
         headers=_auth(db_url),
     )
     assert resp.status_code == 400
@@ -292,22 +292,22 @@ def test_finalize_then_list_hides_after_window_passes(client):
     )
     # Backdate by 1 second so the strict `>` comparison hides it.
     past = datetime.now(UTC) - timedelta(seconds=1)
-    _set_deleted_at(db_url, task_id, past)
+    _set_finalized_at(db_url, task_id, past)
     resp = test_client.get("/guilds/gsd08/tasks", headers=_auth(db_url))
     ids = {t["id"] for t in resp.json()}
     assert task_id not in ids
 
 
 # ---------------------------------------------------------------------------
-# Foreman tool helper — _resolve_finalize_deleted_at in foreman/tools.py
+# Foreman tool helper — _resolve_finalize_finalized_at in foreman/tools.py
 # ---------------------------------------------------------------------------
 
 
 def test_foreman_tool_resolver_default():
-    from foreman.tools import DEFAULT_FINALIZE_TTL_SECONDS, _resolve_finalize_deleted_at
+    from foreman.tools import DEFAULT_FINALIZE_TTL_SECONDS, _resolve_finalize_finalized_at
 
     before = datetime.now(UTC)
-    out, err = _resolve_finalize_deleted_at({})
+    out, err = _resolve_finalize_finalized_at({})
     assert err is None
     assert out is not None
     delta = out - before
@@ -319,10 +319,10 @@ def test_foreman_tool_resolver_default():
 
 
 def test_foreman_tool_resolver_explicit_seconds():
-    from foreman.tools import _resolve_finalize_deleted_at
+    from foreman.tools import _resolve_finalize_finalized_at
 
     before = datetime.now(UTC)
-    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": 1200})
+    out, err = _resolve_finalize_finalized_at({"expires_in_seconds": 1200})
     assert err is None
     assert out is not None
     delta = out - before
@@ -330,48 +330,48 @@ def test_foreman_tool_resolver_explicit_seconds():
 
 
 def test_foreman_tool_resolver_invalid_seconds():
-    from foreman.tools import _resolve_finalize_deleted_at
+    from foreman.tools import _resolve_finalize_finalized_at
 
-    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": "not-an-int"})
+    out, err = _resolve_finalize_finalized_at({"expires_in_seconds": "not-an-int"})
     assert out is None
     assert err and "Invalid expires_in_seconds" in err
 
 
 def test_foreman_tool_resolver_negative_seconds():
-    from foreman.tools import _resolve_finalize_deleted_at
+    from foreman.tools import _resolve_finalize_finalized_at
 
-    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": -5})
+    out, err = _resolve_finalize_finalized_at({"expires_in_seconds": -5})
     assert out is None
     assert err and ">=" in err
 
 
-def test_foreman_tool_resolver_explicit_deleted_at():
-    from foreman.tools import _resolve_finalize_deleted_at
+def test_foreman_tool_resolver_explicit_finalized_at():
+    from foreman.tools import _resolve_finalize_finalized_at
 
     target = "2026-12-25T00:00:00Z"
-    out, err = _resolve_finalize_deleted_at({"deleted_at": target})
+    out, err = _resolve_finalize_finalized_at({"finalized_at": target})
     assert err is None
     assert out == datetime(2026, 12, 25, tzinfo=UTC)
 
 
-def test_foreman_tool_resolver_invalid_deleted_at():
-    from foreman.tools import _resolve_finalize_deleted_at
+def test_foreman_tool_resolver_invalid_finalized_at():
+    from foreman.tools import _resolve_finalize_finalized_at
 
-    out, err = _resolve_finalize_deleted_at({"deleted_at": "garbage"})
+    out, err = _resolve_finalize_finalized_at({"finalized_at": "garbage"})
     assert out is None
-    assert err and "Invalid deleted_at" in err
+    assert err and "Invalid finalized_at" in err
 
 
 def test_foreman_tool_definition_advertises_expiry_fields():
-    """Schema must expose expires_in_seconds and deleted_at on finalize_task."""
+    """Schema must expose expires_in_seconds and finalized_at on finalize_task."""
     from foreman.tools import FOREMAN_TOOLS
 
     finalize = next(t for t in FOREMAN_TOOLS if t["name"] == "finalize_task")
     props = finalize["input_schema"]["properties"]
     assert "expires_in_seconds" in props
     assert props["expires_in_seconds"]["type"] == "integer"
-    assert "deleted_at" in props
-    assert props["deleted_at"]["type"] == "string"
+    assert "finalized_at" in props
+    assert props["finalized_at"]["type"] == "string"
     # task_id is the only required field; expiry fields stay optional.
     assert finalize["input_schema"]["required"] == ["task_id"]
 

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -144,7 +144,7 @@ class TaskUpdateMsg(_WS):
     worktreePath: str | None = None
     prUrl: str | None = None
     finishedAt: str | None = None
-    deletedAt: str | None = None
+    finalizedAt: str | None = None
     phase: str | None = None
 
 

--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -236,7 +236,7 @@ describe('useTasksStore', () => {
       store.handleWebSocketMessage({
         type: 'task-update',
         taskId: 't-1',
-        deletedAt: new Date(Date.now() + 30_000).toISOString(),
+        finalizedAt: new Date(Date.now() + 30_000).toISOString(),
       })
 
       store.clearTasks()
@@ -247,20 +247,20 @@ describe('useTasksStore', () => {
       expect(store.tasks).toEqual([])
     })
 
-    it('reschedules when deletedAt changes on a subsequent task-update', () => {
+    it('reschedules when finalizedAt changes on a subsequent task-update', () => {
       const store = useTasksStore()
       store.tasks.push({ id: 't-1', state: 'done' })
 
       store.handleWebSocketMessage({
         type: 'task-update',
         taskId: 't-1',
-        deletedAt: new Date(Date.now() + 1_000).toISOString(),
+        finalizedAt: new Date(Date.now() + 1_000).toISOString(),
       })
       // Replace with a much later expiry before the first one fires.
       store.handleWebSocketMessage({
         type: 'task-update',
         taskId: 't-1',
-        deletedAt: new Date(Date.now() + 60_000).toISOString(),
+        finalizedAt: new Date(Date.now() + 60_000).toISOString(),
       })
 
       vi.advanceTimersByTime(2_000)

--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -185,7 +185,7 @@ describe('useTasksStore', () => {
       vi.useRealTimers()
     })
 
-    it('stores deletedAt from task-update and drops the row when the timer fires', () => {
+    it('stores finalizedAt from task-update and drops the row when the timer fires', () => {
       const store = useTasksStore()
       store.tasks.push({ id: 't-1', state: 'working' })
 
@@ -194,35 +194,35 @@ describe('useTasksStore', () => {
         type: 'task-update',
         taskId: 't-1',
         state: 'done',
-        deletedAt: future,
+        finalizedAt: future,
       })
-      expect(store.tasks[0].deleted_at).toBe(future)
+      expect(store.tasks[0].finalized_at).toBe(future)
       expect(store.tasks).toHaveLength(1)
 
       vi.advanceTimersByTime(60_001)
       expect(store.tasks).toHaveLength(0)
     })
 
-    it('drops a task immediately when deletedAt is already in the past', () => {
+    it('drops a task immediately when finalizedAt is already in the past', () => {
       const store = useTasksStore()
       store.tasks.push({ id: 't-1', state: 'done' })
 
       store.handleWebSocketMessage({
         type: 'task-update',
         taskId: 't-1',
-        deletedAt: new Date(Date.now() - 1000).toISOString(),
+        finalizedAt: new Date(Date.now() - 1000).toISOString(),
       })
       expect(store.tasks).toHaveLength(0)
     })
 
-    it('liveTasks excludes rows whose deleted_at has passed even before the timer fires', () => {
+    it('liveTasks excludes rows whose finalized_at has passed even before the timer fires', () => {
       const store = useTasksStore()
       const past = new Date(Date.now() - 5_000).toISOString()
       const future = new Date(Date.now() + 5_000).toISOString()
       // Push directly (bypass the WS handler that would also schedule removal).
       store.tasks.push({ id: 't-live', state: 'done' })
-      store.tasks.push({ id: 't-future', state: 'done', deleted_at: future })
-      store.tasks.push({ id: 't-past', state: 'done', deleted_at: past })
+      store.tasks.push({ id: 't-future', state: 'done', finalized_at: future })
+      store.tasks.push({ id: 't-past', state: 'done', finalized_at: past })
 
       const ids = store.liveTasks.map((t) => t.id)
       expect(ids).toContain('t-live')
@@ -269,14 +269,14 @@ describe('useTasksStore', () => {
       expect(store.tasks).toHaveLength(0)
     })
 
-    it('fetchTasks schedules expiry for rows whose deleted_at is in the future', async () => {
+    it('fetchTasks schedules expiry for rows whose finalized_at is in the future', async () => {
       const store = useTasksStore()
       const future = new Date(Date.now() + 1_000).toISOString()
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
-          json: () => Promise.resolve([{ id: 't-1', state: 'done', deleted_at: future }]),
+          json: () => Promise.resolve([{ id: 't-1', state: 'done', finalized_at: future }]),
         }),
       )
       await store.fetchTasks('g-1')

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -78,7 +78,7 @@ export const useTasksStore = defineStore('tasks', () => {
     try {
       tasks.value = await api<Task[]>(`/guilds/${guildId}/tasks`)
       for (const t of tasks.value) {
-        if (t.deleted_at) _scheduleExpiry(t.id, t.deleted_at)
+        if (t.finalized_at) _scheduleExpiry(t.id, t.finalized_at)
       }
     } catch (e) {
       console.error('Failed to fetch tasks', e)
@@ -181,9 +181,9 @@ export const useTasksStore = defineStore('tasks', () => {
         if (data.prUrl) task.pr_url = data.prUrl
         if (data.finishedAt) task.finished_at = data.finishedAt
         if (data.worktreePath) task.worktree_path = data.worktreePath
-        if (data.deletedAt !== undefined) {
-          task.deleted_at = data.deletedAt
-          _scheduleExpiry(task.id, data.deletedAt)
+        if (data.finalizedAt !== undefined) {
+          task.finalized_at = data.finalizedAt
+          _scheduleExpiry(task.id, data.finalizedAt)
         }
       }
     } else if (data.type === 'task-complete') {
@@ -234,12 +234,12 @@ export const useTasksStore = defineStore('tasks', () => {
 
   // Tasks whose soft-delete window has not yet elapsed. Components that filter
   // for display should prefer this over `tasks` so a row disappears the moment
-  // its `deleted_at` passes, even before the per-task timer fires.
+  // its `finalized_at` passes, even before the per-task timer fires.
   const liveTasks = computed(() => {
     const now = Date.now()
     return tasks.value.filter((t) => {
-      if (!t.deleted_at) return true
-      const ts = new Date(t.deleted_at).getTime()
+      if (!t.finalized_at) return true
+      const ts = new Date(t.finalized_at).getTime()
       return Number.isNaN(ts) || ts > now
     })
   })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -83,7 +83,7 @@ export interface Task {
   worktree_path?: string
   created_at?: string
   finished_at?: string
-  deleted_at?: string | null
+  finalized_at?: string | null
 }
 
 export interface Guild {
@@ -241,7 +241,7 @@ export interface TaskUpdateWS {
   prUrl?: string
   finishedAt?: string
   worktreePath?: string
-  deletedAt?: string | null
+  finalizedAt?: string | null
 }
 
 export interface TaskCompleteWS {

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -339,7 +339,7 @@ def migrate_tasks(sq: sqlite3.Connection, pg: Any, guild_map: dict[str, int]) ->
                     (id, worker_id, guild_pk, description, tool,
                      issue_number, issue_repo, state, branch, worktree_path,
                      pr_url, pr_number, pr_repo, created_at, finished_at,
-                     name, parent_task_id, phase, deleted_at, user_id,
+                     name, parent_task_id, phase, finalized_at, user_id,
                      locked_at, lock_holder)
                 VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
                 ON CONFLICT (id) DO NOTHING
@@ -363,7 +363,7 @@ def migrate_tasks(sq: sqlite3.Connection, pg: Any, guild_map: dict[str, int]) ->
                     d.get("name"),
                     d.get("parent_task_id"),
                     d.get("phase", "execute"),
-                    d.get("deleted_at"),
+                    d.get("finalized_at"),
                     d.get("user_id"),
                     d.get("locked_at"),
                     d.get("lock_holder"),

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -363,7 +363,7 @@ def migrate_tasks(sq: sqlite3.Connection, pg: Any, guild_map: dict[str, int]) ->
                     d.get("name"),
                     d.get("parent_task_id"),
                     d.get("phase", "execute"),
-                    d.get("finalized_at"),
+                    d.get("deleted_at"),  # SQLite source uses the old column name
                     d.get("user_id"),
                     d.get("locked_at"),
                     d.get("lock_holder"),


### PR DESCRIPTION
Closes #624

Renames the `deleted_at` column on the `tasks` table to `finalized_at` throughout the entire codebase: DB migration, ORM model, API routes, WS types, frontend types/store, and all tests.