### PR TITLE
Drop finished_at, consolidate into deleted_at

### DIFF
--- a/backend/alembic/versions/20260610_000000_drop_tasks_finished_at.py
+++ b/backend/alembic/versions/20260610_000000_drop_tasks_finished_at.py
@@ -1,0 +1,33 @@
+"""Drop tasks.finished_at column.
+
+Revision ID: 20260610_000000_drop_tasks_finished_at
+Revises: 20260608_000000_rename_guild_slug
+Create Date: 2026-06-10
+
+Consolidates the finished_at and deleted_at columns into a single deleted_at column.
+deleted_at already serves as the soft-delete expiry timestamp (set to now + 3 days on
+completion); finished_at was a redundant "when did the task complete?" marker.
+
+The completion time can be approximated as deleted_at - DEFAULT_TTL (3 days).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260610_000000_drop_tasks_finished_at"
+down_revision: str | Sequence[str] | None = "20260608_000000_rename_guild_slug"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("tasks", "finished_at")
+
+
+def downgrade() -> None:
+    import sqlalchemy as sa
+
+    op.add_column("tasks", sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True))

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -522,7 +522,7 @@ async def _run_foreman_ai(
                 col(Task.state),
                 col(Task.branch),
                 col(Task.pr_url),
-                col(Task.finished_at),
+                col(Task.deleted_at),
             )
             .where(
                 col(Task.guild_id) == guild_pk_val,

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1146,10 +1146,9 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 "worker_id": target_worker_id,
                             }
                             if prior_state in ("done", "failed", "cancelled"):
-                                # Re-opening a terminal task: clear soft-delete fields so it
+                                # Re-opening a terminal task: clear soft-delete so it
                                 # reappears in the live task list and isn't auto-purged.
                                 update_vals["deleted_at"] = None
-                                update_vals["finished_at"] = None
                             await db.exec(
                                 update(Task).where(col(Task.id) == task_id).values(**update_vals)
                             )
@@ -1161,7 +1160,6 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     state="working",
                                     workerId=target_worker_id,
                                     deletedAt=None,
-                                    finishedAt=None,
                                 ).model_dump(by_alias=True, exclude_none=True),
                             )
                             followup_worker_result = await db.exec(
@@ -1228,13 +1226,11 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     if not task:
                         result_text = f"Task {task_id} not found."
                     else:
-                        finished_at = datetime.now(UTC)
                         await db.exec(
                             update(Task)
                             .where(col(Task.id) == task_id)
                             .values(
                                 state=outcome,
-                                finished_at=finished_at,
                                 deleted_at=deleted_at,
                             )
                         )
@@ -1251,7 +1247,6 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             TaskUpdateMsg(
                                 taskId=task_id,
                                 state=outcome,
-                                finishedAt=finished_at.isoformat(),
                                 deletedAt=deleted_at.isoformat()
                                 if deleted_at is not None
                                 else None,
@@ -1316,13 +1311,15 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     if state in ("done", "failed", "cancelled"):
                         result_text = f"Task {task_id} is already {state}."
                     else:
-                        finished_at = datetime.now(UTC)
+                        deleted_at = datetime.now(UTC) + timedelta(
+                            seconds=DEFAULT_FINALIZE_TTL_SECONDS
+                        )
                         await db.exec(
                             update(Task)
                             .where(col(Task.id) == task_id)
                             .values(
                                 state="cancelled",
-                                finished_at=finished_at,
+                                deleted_at=deleted_at,
                             )
                         )
                         await LockService(db).release(f"task:{task_id}")
@@ -1336,7 +1333,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             TaskUpdateMsg(
                                 taskId=task_id,
                                 state="cancelled",
-                                finishedAt=finished_at.isoformat(),
+                                deletedAt=deleted_at.isoformat(),
                             ),
                         )
                         result_text = f"Task {task_id} cancelled." + (
@@ -1405,7 +1402,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             "branch": task.branch,
                             "pr_url": task.pr_url,
                             "created_at": task.created_at,
-                            "finished_at": task.finished_at,
+                            "deleted_at": task.deleted_at,
                             "recent_logs": [{"time": r[0], "line": r[1]} for r in log_rows],
                         },
                         default=_json_default,

--- a/backend/foreman_core/constants.py
+++ b/backend/foreman_core/constants.py
@@ -6,3 +6,6 @@ MAX_FOREMAN_ROUNDS = 10  # safety cap on tool-call rounds per invocation
 _HUMAN_TURN_WINDOW = 5  # how many non-tool-response user turns to load from DB
 _TERMINAL_STATES = frozenset({"done", "failed", "cancelled", "error"})
 _24H_SECS = 86_400
+# Default soft-delete window used when estimating completion time from deleted_at.
+# Must match routes/tasks.py DEFAULT_FINALIZE_TTL (3 days).
+_DEFAULT_TASK_TTL_SECS = 3 * 24 * 60 * 60

--- a/backend/foreman_core/message_utils.py
+++ b/backend/foreman_core/message_utils.py
@@ -7,7 +7,7 @@ import json
 from datetime import date, datetime
 from typing import Any
 
-from .constants import _TERMINAL_STATES, MAX_HISTORY_MESSAGES, MAX_TOOL_RESULT_CHARS
+from .constants import _DEFAULT_TASK_TTL_SECS, _TERMINAL_STATES, MAX_HISTORY_MESSAGES, MAX_TOOL_RESULT_CHARS
 
 
 def _json_default(obj: Any) -> Any:
@@ -176,17 +176,23 @@ def _summarize_task(task: dict, cutoff_ts: float) -> dict | None:
     Terminal tasks older than 24 h are dropped; terminal tasks within 24 h lose
     their ``description`` field to keep context lean.  Non-terminal tasks are
     returned unchanged.
+
+    Completion time is approximated as ``deleted_at - DEFAULT_TTL`` since
+    ``finished_at`` was removed in favour of the single ``deleted_at`` column.
     """
     state = task.get("state", "")
     if state not in _TERMINAL_STATES:
         return task
-    finished_at = task.get("finished_at")
-    if finished_at:
+    deleted_at = task.get("deleted_at")
+    if deleted_at:
         try:
-            finished_ts = datetime.fromisoformat(finished_at.replace("Z", "+00:00")).timestamp()
+            deleted_ts = datetime.fromisoformat(
+                deleted_at.replace("Z", "+00:00") if isinstance(deleted_at, str) else deleted_at
+            ).timestamp()
+            finished_ts = deleted_ts - _DEFAULT_TASK_TTL_SECS
             if finished_ts < cutoff_ts:
                 return None  # older than 24 h — drop entirely
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, TypeError):
             pass
     # Within 24 h or undatable: compact summary without description
     return {k: v for k, v in task.items() if k != "description"}

--- a/backend/foreman_core/message_utils.py
+++ b/backend/foreman_core/message_utils.py
@@ -7,7 +7,12 @@ import json
 from datetime import date, datetime
 from typing import Any
 
-from .constants import _DEFAULT_TASK_TTL_SECS, _TERMINAL_STATES, MAX_HISTORY_MESSAGES, MAX_TOOL_RESULT_CHARS
+from .constants import (
+    _DEFAULT_TASK_TTL_SECS,
+    _TERMINAL_STATES,
+    MAX_HISTORY_MESSAGES,
+    MAX_TOOL_RESULT_CHARS,
+)
 
 
 def _json_default(obj: Any) -> Any:

--- a/backend/models.py
+++ b/backend/models.py
@@ -176,9 +176,6 @@ class Task(SQLModel, table=True):
     pr_number: int | None = None
     pr_repo: str | None = None
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
-    finished_at: datetime | None = Field(
-        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
-    )
     name: str | None = None
     parent_task_id: str | None = None
     phase: str | None = Field(default="execute", sa_column_kwargs={"server_default": "'execute'"})

--- a/backend/routes/debug.py
+++ b/backend/routes/debug.py
@@ -387,14 +387,14 @@ async def get_task_debug_timeline(
             "detail": task_dict,
         }
     )
-    if task.finished_at:
+    if task.deleted_at:
         timeline.append(
             {
-                "timestamp": _iso(task.finished_at),
+                "timestamp": _iso(task.deleted_at),
                 "source": "db",
                 "event_type": "task_finished",
                 "summary": f"Task finished with state: {task.state}",
-                "detail": {"state": task.state, "finished_at": _iso(task.finished_at)},
+                "detail": {"state": task.state, "deleted_at": _iso(task.deleted_at)},
             }
         )
 

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -149,7 +149,7 @@ async def get_foreman_state(
             {
               "id": str, "worker_id": str, "name": str, "description": str,
               "state": str, "phase": str, "branch": str | null,
-              "pr_url": str | null, "finished_at": str | null
+              "pr_url": str | null, "deleted_at": str | null
             }
           ]
         }
@@ -210,7 +210,7 @@ async def get_foreman_state(
             col(Task.phase),
             col(Task.branch),
             col(Task.pr_url),
-            col(Task.finished_at),
+            col(Task.deleted_at),
             col(Task.created_at),
             col(Task.user_id),
         )
@@ -469,7 +469,6 @@ class TaskPatch(BaseModel):
     worker_id: str | None = None
     branch: str | None = None
     pr_url: str | None = None
-    finished_at: str | None = None
     deleted_at: str | None = None
     phase: str | None = None
 
@@ -494,8 +493,7 @@ async def patch_task(
     - ``worker_id``: reassign to a different worker
     - ``branch``: git branch name
     - ``pr_url``: GitHub PR URL
-    - ``finished_at``: ISO-8601 completion timestamp
-    - ``deleted_at``: ISO-8601 soft-delete timestamp
+    - ``deleted_at``: ISO-8601 soft-delete / expiry timestamp
     - ``phase``: task phase (plan / execute / review / followup)
 
     Broadcasts a ``task-update`` WS event with the changed fields so the
@@ -509,7 +507,6 @@ async def patch_task(
         ("worker_id", "worker_id"),
         ("branch", "branch"),
         ("pr_url", "pr_url"),
-        ("finished_at", "finished_at"),
         ("deleted_at", "deleted_at"),
         ("phase", "phase"),
     ):
@@ -540,7 +537,6 @@ async def patch_task(
         "worker_id": "workerId",
         "branch": "branch",
         "pr_url": "prUrl",
-        "finished_at": "finishedAt",
         "deleted_at": "deletedAt",
         "phase": "phase",
     }

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -92,7 +92,6 @@ async def list_guild_tasks(
             col(Task.issue_number),
             col(Task.issue_repo),
             col(Task.created_at),
-            col(Task.finished_at),
             col(Task.deleted_at),
         )
         .where(col(Task.guild_id) == guild_pk, live_tasks_filter())
@@ -260,12 +259,11 @@ async def finalize_task_endpoint(
     worker_id = result.one_or_none()
     if not worker_id:
         raise HTTPException(status_code=404, detail="Task not found")
-    finished_at = datetime.now(UTC)
     deleted_at = _resolve_finalize_deleted_at(body)
     await db.exec(
         update(Task)
         .where(col(Task.id) == task_id)
-        .values(state="done", finished_at=finished_at, deleted_at=deleted_at)
+        .values(state="done", deleted_at=deleted_at)
     )
     await db.commit()
     await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=task_id))
@@ -274,7 +272,6 @@ async def finalize_task_endpoint(
         TaskUpdateMsg(
             taskId=task_id,
             state="done",
-            finishedAt=finished_at.isoformat(),
             deletedAt=deleted_at.isoformat(),
         ),
     )
@@ -304,18 +301,18 @@ async def cancel_task_endpoint(
     worker_id, state = row
     if state in ("done", "failed", "cancelled"):
         raise HTTPException(status_code=409, detail=f"Task is already {state}")
-    finished_at = datetime.now(UTC)
+    deleted_at = datetime.now(UTC) + DEFAULT_FINALIZE_TTL
     await db.exec(
         update(Task)
         .where(col(Task.id) == task_id)
-        .values(state="cancelled", finished_at=finished_at)
+        .values(state="cancelled", deleted_at=deleted_at)
     )
     await LockService(db).release(f"task:{task_id}")
     await db.commit()
     await broadcast_msg(guild_id, TaskCancelMsg(workerId=worker_id, taskId=task_id))
     await broadcast_msg(
         guild_id,
-        TaskUpdateMsg(taskId=task_id, state="cancelled", finishedAt=finished_at.isoformat()),
+        TaskUpdateMsg(taskId=task_id, state="cancelled", deletedAt=deleted_at.isoformat()),
     )
     return {"status": "cancelled", "taskId": task_id}
 

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -261,9 +261,7 @@ async def finalize_task_endpoint(
         raise HTTPException(status_code=404, detail="Task not found")
     deleted_at = _resolve_finalize_deleted_at(body)
     await db.exec(
-        update(Task)
-        .where(col(Task.id) == task_id)
-        .values(state="done", deleted_at=deleted_at)
+        update(Task).where(col(Task.id) == task_id).values(state="done", deleted_at=deleted_at)
     )
     await db.commit()
     await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=task_id))
@@ -303,9 +301,7 @@ async def cancel_task_endpoint(
         raise HTTPException(status_code=409, detail=f"Task is already {state}")
     deleted_at = datetime.now(UTC) + DEFAULT_FINALIZE_TTL
     await db.exec(
-        update(Task)
-        .where(col(Task.id) == task_id)
-        .values(state="cancelled", deleted_at=deleted_at)
+        update(Task).where(col(Task.id) == task_id).values(state="cancelled", deleted_at=deleted_at)
     )
     await LockService(db).release(f"task:{task_id}")
     await db.commit()

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -270,7 +270,7 @@ async def _auto_finalize_task_on_pr_merge(
             col(Task.guild_id) == guild_pk,
             col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
         )
-        .values(state="done", finished_at=now, deleted_at=deleted_at)
+        .values(state="done", deleted_at=deleted_at)
     )
     if (getattr(upd, "rowcount", 0) or 0) == 0:
         return False
@@ -285,7 +285,6 @@ async def _auto_finalize_task_on_pr_merge(
         TaskUpdateMsg(
             taskId=task_id,
             state="done",
-            finishedAt=now.isoformat(),
             deletedAt=deleted_at.isoformat(),
         ),
     )
@@ -329,7 +328,7 @@ async def _auto_fail_task_on_pr_close(
             col(Task.guild_id) == guild_pk,
             col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
         )
-        .values(state="failed", finished_at=now, deleted_at=deleted_at)
+        .values(state="failed", deleted_at=deleted_at)
     )
     if (getattr(upd, "rowcount", 0) or 0) == 0:
         return False
@@ -344,7 +343,6 @@ async def _auto_fail_task_on_pr_close(
         TaskUpdateMsg(
             taskId=task_id,
             state="failed",
-            finishedAt=now.isoformat(),
             deletedAt=deleted_at.isoformat(),
         ),
     )

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1687,6 +1687,8 @@ class TestSummarizeTask:
     """Terminal tasks are summarised/excluded; non-terminal tasks are kept in full."""
 
     _24H = 86_400
+    # Must match foreman_core/constants._DEFAULT_TASK_TTL_SECS (3 days)
+    _TTL = 3 * 24 * 60 * 60
 
     def _now_ts(self):
         return datetime.now(UTC).timestamp()
@@ -1724,7 +1726,8 @@ class TestSummarizeTask:
             "description": "Implement OAuth",
             "branch": "claude/feat",
             "pr_url": "https://github.com/x/y/pull/42",
-            "finished_at": self._iso(-3600),  # 1 hour ago
+            # finished 1 hour ago → deleted_at = now + (TTL - 3600)
+            "deleted_at": self._iso(self._TTL - 3600),
         }
         result = _summarize_task(task, self._cutoff_ts())
         assert result is not None
@@ -1738,7 +1741,8 @@ class TestSummarizeTask:
             "id": "t-5",
             "state": "failed",
             "description": "Big description text",
-            "finished_at": self._iso(-1800),  # 30 min ago
+            # finished 30 min ago → deleted_at = now + (TTL - 1800)
+            "deleted_at": self._iso(self._TTL - 1800),
         }
         result = _summarize_task(task, self._cutoff_ts())
         assert result is not None
@@ -1749,7 +1753,8 @@ class TestSummarizeTask:
             "id": "t-6",
             "state": "cancelled",
             "description": "Cancelled work",
-            "finished_at": self._iso(-7200),  # 2 hours ago
+            # finished 2 hours ago → deleted_at = now + (TTL - 7200)
+            "deleted_at": self._iso(self._TTL - 7200),
         }
         result = _summarize_task(task, self._cutoff_ts())
         assert result is not None
@@ -1760,7 +1765,8 @@ class TestSummarizeTask:
             "id": "t-7",
             "state": "done",
             "description": "Old work",
-            "finished_at": self._iso(-(self._24H + 3600)),  # 25 hours ago
+            # finished 25 hours ago → deleted_at = now + (TTL - 24H - 3600)
+            "deleted_at": self._iso(self._TTL - self._24H - 3600),
         }
         result = _summarize_task(task, self._cutoff_ts())
         assert result is None
@@ -1770,21 +1776,22 @@ class TestSummarizeTask:
             "id": "t-8",
             "state": "failed",
             "description": "Old fail",
-            "finished_at": self._iso(-(self._24H * 2)),  # 48 hours ago
+            # finished 48 hours ago → deleted_at = now + (TTL - 2*24H)
+            "deleted_at": self._iso(self._TTL - self._24H * 2),
         }
         result = _summarize_task(task, self._cutoff_ts())
         assert result is None
 
-    def test_terminal_task_no_finished_at_included(self):
-        """Terminal task with no finished_at cannot be aged out — include it."""
-        task = {"id": "t-9", "state": "done", "description": "Unknown age", "finished_at": None}
+    def test_terminal_task_no_deleted_at_included(self):
+        """Terminal task with no deleted_at cannot be aged out — include it."""
+        task = {"id": "t-9", "state": "done", "description": "Unknown age", "deleted_at": None}
         result = _summarize_task(task, self._cutoff_ts())
         assert result is not None
         assert "description" not in result
 
-    def test_terminal_task_invalid_finished_at_included(self):
-        """Malformed finished_at should not cause exclusion."""
-        task = {"id": "t-10", "state": "done", "description": "Bad ts", "finished_at": "not-a-date"}
+    def test_terminal_task_invalid_deleted_at_included(self):
+        """Malformed deleted_at should not cause exclusion."""
+        task = {"id": "t-10", "state": "done", "description": "Bad ts", "deleted_at": "not-a-date"}
         result = _summarize_task(task, self._cutoff_ts())
         assert result is not None
         assert "description" not in result
@@ -1795,7 +1802,8 @@ class TestSummarizeTask:
             "id": "t-11",
             "state": "done",
             "description": "Boundary",
-            "finished_at": self._iso(-(self._24H + 1)),  # 24h + 1s ago
+            # finished 24h+1s ago → deleted_at = now + (TTL - 24H - 1)
+            "deleted_at": self._iso(self._TTL - self._24H - 1),
         }
         result = _summarize_task(task, self._cutoff_ts())
         assert result is None

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -695,18 +695,6 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
     ):
         if src in data:
             update_values[col_name] = data[src]
-    if "finishedAt" in data:
-        raw = data.get("finishedAt")
-        if raw is not None:
-            try:
-                parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
-                if parsed.tzinfo is None:
-                    parsed = parsed.replace(tzinfo=UTC)
-                update_values["finished_at"] = parsed
-            except (ValueError, TypeError):
-                pass
-        else:
-            update_values["finished_at"] = None
     # When the worker reports a PR URL, derive pr_number + pr_repo so github
     # webhook deliveries can be linked back to this task without fragile URL
     # substring matching at receive time.

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -143,7 +143,6 @@ class TaskUpdateMsg(_WS):
     branch: str | None = None
     worktreePath: str | None = None
     prUrl: str | None = None
-    finishedAt: str | None = None
     deletedAt: str | None = None
     phase: str | None = None
 

--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -73,7 +73,7 @@ describe('useTasksStore', () => {
         state: 'working',
         branch: 'claude/fix-1',
         prUrl: 'https://github.com/x/y/pull/1',
-        deletedAt: '2025-01-05T00:00:00Z',
+        deletedAt: '2030-01-05T00:00:00Z',
         worktreePath: '/tmp/wt',
       })
 
@@ -81,7 +81,7 @@ describe('useTasksStore', () => {
       expect(task.state).toBe('working')
       expect(task.branch).toBe('claude/fix-1')
       expect(task.pr_url).toBe('https://github.com/x/y/pull/1')
-      expect(task.deleted_at).toBe('2025-01-05T00:00:00Z')
+      expect(task.deleted_at).toBe('2030-01-05T00:00:00Z')
       expect(task.worktree_path).toBe('/tmp/wt')
     })
 

--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -63,7 +63,7 @@ describe('useTasksStore', () => {
       expect(store.tasks[0].name).toBe('a'.repeat(60))
     })
 
-    it('updates state, branch, prUrl, finishedAt, worktreePath on task-update', () => {
+    it('updates state, branch, prUrl, deletedAt, worktreePath on task-update', () => {
       const store = useTasksStore()
       store.tasks.push({ id: 't-1', state: 'pending' })
 
@@ -73,7 +73,7 @@ describe('useTasksStore', () => {
         state: 'working',
         branch: 'claude/fix-1',
         prUrl: 'https://github.com/x/y/pull/1',
-        finishedAt: '2025-01-02T00:00:00Z',
+        deletedAt: '2025-01-05T00:00:00Z',
         worktreePath: '/tmp/wt',
       })
 
@@ -81,7 +81,7 @@ describe('useTasksStore', () => {
       expect(task.state).toBe('working')
       expect(task.branch).toBe('claude/fix-1')
       expect(task.pr_url).toBe('https://github.com/x/y/pull/1')
-      expect(task.finished_at).toBe('2025-01-02T00:00:00Z')
+      expect(task.deleted_at).toBe('2025-01-05T00:00:00Z')
       expect(task.worktree_path).toBe('/tmp/wt')
     })
 
@@ -428,7 +428,7 @@ describe('useTasksStore', () => {
       const promise = store.cancelTask('g-1', 't-1')
       // State must be updated before the API call resolves
       expect(store.tasks[0].state).toBe('cancelled')
-      expect(store.tasks[0].finished_at).toBeDefined()
+      expect(store.tasks[0].deleted_at).toBeDefined()
 
       resolveApi()
       await promise
@@ -442,7 +442,7 @@ describe('useTasksStore', () => {
 
       await expect(store.cancelTask('g-1', 't-1')).rejects.toThrow('HTTP 500')
       expect(store.tasks[0].state).toBe('working')
-      expect(store.tasks[0].finished_at).toBeUndefined()
+      expect(store.tasks[0].deleted_at).toBeUndefined()
     })
 
     it('throws when the API returns non-2xx', async () => {

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -118,17 +118,18 @@ export const useTasksStore = defineStore('tasks', () => {
   async function cancelTask(guildId: string, taskId: string) {
     const task = tasks.value.find((t) => t.id === taskId)
     const prevState = task?.state
-    const prevFinishedAt = task?.finished_at
+    const prevDeletedAt = task?.deleted_at
     if (task) {
       task.state = 'cancelled'
-      task.finished_at = new Date().toISOString()
+      // Optimistic: set deleted_at to now + 3 days (matches backend DEFAULT_FINALIZE_TTL)
+      task.deleted_at = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString()
     }
     try {
       await api(`/guilds/${guildId}/tasks/${taskId}/cancel`, { method: 'POST' })
     } catch (err) {
       if (task) {
         task.state = prevState!
-        task.finished_at = prevFinishedAt
+        task.deleted_at = prevDeletedAt
       }
       throw err
     }
@@ -179,7 +180,6 @@ export const useTasksStore = defineStore('tasks', () => {
         if (data.state) task.state = data.state
         if (data.branch) task.branch = data.branch
         if (data.prUrl) task.pr_url = data.prUrl
-        if (data.finishedAt) task.finished_at = data.finishedAt
         if (data.worktreePath) task.worktree_path = data.worktreePath
         if (data.deletedAt !== undefined) {
           task.deleted_at = data.deletedAt

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -82,7 +82,6 @@ export interface Task {
   pr_url?: string
   worktree_path?: string
   created_at?: string
-  finished_at?: string
   deleted_at?: string | null
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -238,7 +238,6 @@ export interface TaskUpdateWS {
   state?: TaskState
   branch?: string
   prUrl?: string
-  finishedAt?: string
   worktreePath?: string
   deletedAt?: string | null
 }


### PR DESCRIPTION
## Summary

Consolidates `tasks.finished_at` into `deleted_at`, dropping the redundant column.

## Changes
- `backend/alembic/versions/20260610_000000_drop_tasks_finished_at.py` — migration dropping `finished_at`
- `backend/ws_handlers.py` — removed `finishedAt` handling block
- `backend/routes/debug.py` — uses `deleted_at` instead of `finished_at`
- `backend/routes/foreman.py` — removed `finished_at` from `TaskPatch`, query, WS key map
- `frontend/src/types.ts` — removed `finishedAt?: string` from `TaskUpdateWS`
- `frontend/src/stores/tasks.ts` — `cancelTask` sets `deleted_at` instead of `finished_at`; WS handler updated
- `frontend/src/stores/__tests__/tasks.spec.ts` — tests updated
- `backend/tests/test_foreman.py` — `TestSummarizeTask` updated to use `deleted_at`

Closes #632