### PR TITLE
Fix foreman debug to show next-API-call context only

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -991,16 +991,19 @@ async def clear_foreman_history(guild_id: str, user_id: str) -> int:
 async def get_foreman_history(guild_id: str, user_id: str) -> dict:
     """Return stored turns structured for the debug view.
 
+    Applies the same windowing pipeline used before each real API call so the
+    debug pane shows exactly the messages that would be submitted next:
+      1. ``_HUMAN_TURN_WINDOW`` sliding-window cutoff (same as ``_load_history``)
+      2. ``prune_history`` cap (``MAX_HISTORY_MESSAGES``)
+      3. ``strip_orphaned_tool_results`` cleanup
+
     Returns::
 
         {
             "system": <str | None>,   # most-recent audit system prompt text
-            "messages": [...],        # non-system turns only, in DB order
+            "messages": [...],        # windowed messages (what would be sent next)
+            "total": <int>,           # total non-system turns stored (before windowing)
         }
-
-    System turns are persisted for auditing but are never part of the
-    ``messages[]`` array sent to the Anthropic API — they appear here once
-    at the top so the debug pane accurately mirrors what would be sent.
     """
     db = await get_db()
     try:
@@ -1023,7 +1026,25 @@ async def get_foreman_history(guild_id: str, user_id: str) -> dict:
             system_content = raw if isinstance(raw, str) else json.dumps(raw)
             break
 
-    messages = [
+    # Count total non-system turns before any windowing for the summary line.
+    total = sum(1 for t in turns if t.role != "system")
+
+    if not turns:
+        return {"system": system_content, "messages": [], "total": 0}
+
+    # Apply the same human-turn-window cutoff as _load_history().
+    cutoff = 0
+    human_count = 0
+    for i in range(len(turns) - 1, -1, -1):
+        t = turns[i]
+        if t.role == "user" and not t.is_tool_response:
+            human_count += 1
+            if human_count >= _HUMAN_TURN_WINDOW:
+                cutoff = i
+                break
+
+    # Build metadata-rich messages from the windowed slice (system turns excluded).
+    messages: list[dict] = [
         {
             "id": t.id,
             "role": t.role,
@@ -1035,8 +1056,16 @@ async def get_foreman_history(guild_id: str, user_id: str) -> dict:
             "output_tokens": t.output_tokens,
             "api_calls": json.loads(t.api_calls_json) if t.api_calls_json else None,
         }
-        for t in turns
+        for t in turns[cutoff:]
         if t.role != "system"
     ]
 
-    return {"system": system_content, "messages": messages}
+    # Ensure the list starts with a user turn (mirrors _load_history).
+    while messages and messages[0]["role"] != "user":
+        messages.pop(0)
+
+    # Apply the same post-load trimming used before every real API call.
+    messages = prune_history(messages)
+    messages = strip_orphaned_tool_results(messages)
+
+    return {"system": system_content, "messages": messages, "total": total}

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -95,6 +95,7 @@ async def get_foreman_context(
         "system": history["system"],
         "messages": history["messages"],
         "count": len(history["messages"]),
+        "total": history["total"],
     }
 
 

--- a/frontend/src/components/DebugSidebar.vue
+++ b/frontend/src/components/DebugSidebar.vue
@@ -4,10 +4,14 @@
       <div class="debug-sidebar-header">
         <span class="debug-sidebar-title">⚙ FOREMAN DEBUG</span>
         <div class="debug-sidebar-actions">
-          <span class="debug-count"
-            >{{ debugContext.length }} msg{{ debugContext.length !== 1 ? 's' : '' }} in
-            context</span
-          >
+          <span class="debug-count">
+            <template v-if="totalMessages > debugContext.length">
+              Showing {{ debugContext.length }} of {{ totalMessages.toLocaleString() }} messages
+            </template>
+            <template v-else>
+              {{ debugContext.length }} msg{{ debugContext.length !== 1 ? 's' : '' }} in context
+            </template>
+          </span>
           <button class="pixel-btn refresh-btn" @click="refreshDebug" :disabled="debugLoading">
             {{ debugLoading ? '...' : '↻' }}
           </button>
@@ -119,6 +123,7 @@ interface DebugMessage {
 
 const debugContext = ref<DebugMessage[]>([])
 const systemPrompt = ref<string | null>(null)
+const totalMessages = ref(0)
 const debugLoading = ref(false)
 const debugClearing = ref(false)
 const debugEl = ref<HTMLElement | null>(null)
@@ -136,11 +141,12 @@ async function refreshDebug() {
   if (!guildId) return
   debugLoading.value = true
   try {
-    const data = await api<{ messages?: DebugMessage[]; system?: string | null }>(
+    const data = await api<{ messages?: DebugMessage[]; system?: string | null; total?: number }>(
       `/guilds/${guildId}/foreman/context`,
     )
     debugContext.value = data?.messages ?? []
     systemPrompt.value = data?.system ?? null
+    totalMessages.value = data?.total ?? (data?.messages?.length ?? 0)
   } catch (e) {
     console.error('Failed to load foreman context', e)
   } finally {
@@ -158,6 +164,7 @@ async function clearContext() {
     await api(`/guilds/${guildId}/foreman/clear-context`, { method: 'POST' })
     debugContext.value = []
     systemPrompt.value = null
+    totalMessages.value = 0
   } catch (e) {
     console.error('Failed to clear foreman context', e)
   } finally {


### PR DESCRIPTION
## Problem

The foreman debug panel was showing the entire accumulated message history (~25,000 messages), making it useless for understanding what the foreman would actually send to the LLM.

## Solution

Modified `get_foreman_history()` in `backend/foreman/runner.py` to apply the same trimming pipeline used before every real API call:

1. **`_HUMAN_TURN_WINDOW` sliding-window cutoff** — walks backwards to find the 5th-from-last non-tool-response user turn, then includes only turns from that cutoff onwards (same logic as `_load_history()`)
2. **`prune_history()`** — caps at `MAX_HISTORY_MESSAGES` (20) and ensures the list starts with a user turn
3. **`strip_orphaned_tool_results()`** — removes orphaned tool_use/tool_result blocks

The `total` count of all stored non-system turns is also returned so the debug panel can display a summary line.

### Changes

- **`backend/foreman/runner.py`** — `get_foreman_history()` now applies windowing pipeline and returns `total`
- **`backend/routes/foreman.py`** — `GET /guilds/{guild_id}/foreman/context` passes `total` through in the response
- **`frontend/src/components/DebugSidebar.vue`** — header shows "Showing 42 of 25,312 messages" when windowed, otherwise "N msgs in context"

## Testing

- `ruff check . --fix && ruff format .` — all clean
- `npm run type-check` (from `frontend/`) — no errors

Closes #638