### PR TITLE
Add optional S3 log sync to worker

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -37,6 +37,9 @@ test = [
     "anyio[trio]>=4.0",
     "ruff",
 ]
+s3 = [
+    "boto3>=1.26",
+]
 
 [project.scripts]
 pioneer = "pioneer_cli.main:main"

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -288,6 +288,7 @@ async def run_claude_auto(
     on_usage: UsageFn | None = None,
     claude_path: str = "claude",
     resume_session_id: str | None = None,
+    raw_log_path: str | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Run claude on *description* in *cwd*. Returns (success, stop_reason, last_assistant_text, session_id).
 
@@ -318,6 +319,12 @@ async def run_claude_auto(
     stop_reason = "no_events"
     event_count = 0
     session_id = None
+    _raw_fh = None
+    if raw_log_path:
+        try:
+            _raw_fh = open(raw_log_path, "ab")  # noqa: WPS515
+        except OSError as exc:
+            logger.warning("Could not open raw log %s: %s", raw_log_path, exc)
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -337,10 +344,22 @@ async def run_claude_auto(
                 line = raw.decode(errors="replace").strip()
                 if line:
                     await emit(f"[stderr] {line}")
+                if _raw_fh is not None:
+                    try:
+                        _raw_fh.write(b"[stderr] " + raw if raw.endswith(b"\n") else b"[stderr] " + raw + b"\n")
+                        _raw_fh.flush()
+                    except OSError:
+                        pass
 
         stderr_task = asyncio.create_task(_drain_stderr())
 
         async for raw in proc.stdout:  # type: ignore[union-attr]
+            if _raw_fh is not None:
+                try:
+                    _raw_fh.write(raw)
+                    _raw_fh.flush()
+                except OSError:
+                    pass
             line_str = raw.decode(errors="replace").strip()
             if not line_str:
                 continue
@@ -423,3 +442,9 @@ async def run_claude_auto(
         logger.exception("claude subprocess crashed: %s", exc)
         await emit(f"[claude] ✗ {exc}")
         return False, "error_during_execution", last_text, session_id
+    finally:
+        if _raw_fh is not None:
+            try:
+                _raw_fh.close()
+            except OSError:
+                pass

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -346,7 +346,11 @@ async def run_claude_auto(
                     await emit(f"[stderr] {line}")
                 if _raw_fh is not None:
                     try:
-                        _raw_fh.write(b"[stderr] " + raw if raw.endswith(b"\n") else b"[stderr] " + raw + b"\n")
+                        _raw_fh.write(
+                            b"[stderr] " + raw
+                            if raw.endswith(b"\n")
+                            else b"[stderr] " + raw + b"\n"
+                        )
                         _raw_fh.flush()
                     except OSError:
                         pass

--- a/worker/pioneer_worker/codex_runner.py
+++ b/worker/pioneer_worker/codex_runner.py
@@ -110,7 +110,11 @@ async def run_codex_auto(
                     await emit(f"[stderr] {line}")
                 if _raw_fh is not None:
                     try:
-                        _raw_fh.write(b"[stderr] " + raw if raw.endswith(b"\n") else b"[stderr] " + raw + b"\n")
+                        _raw_fh.write(
+                            b"[stderr] " + raw
+                            if raw.endswith(b"\n")
+                            else b"[stderr] " + raw + b"\n"
+                        )
                         _raw_fh.flush()
                     except OSError:
                         pass

--- a/worker/pioneer_worker/codex_runner.py
+++ b/worker/pioneer_worker/codex_runner.py
@@ -43,6 +43,7 @@ async def run_codex_auto(
     codex_path: str = "codex",
     codex_args: list[str] | None = None,
     openai_api_key: str | None = None,
+    raw_log_path: str | None = None,
 ) -> tuple[bool, str, str]:
     """Run codex on *description* in *cwd*. Returns (success, stop_reason, last_text).
 
@@ -75,6 +76,12 @@ async def run_codex_auto(
     event_count = 0
     master_fd: int | None = None
     slave_fd: int | None = None
+    _raw_fh = None
+    if raw_log_path:
+        try:
+            _raw_fh = open(raw_log_path, "ab")  # noqa: WPS515
+        except OSError as exc:
+            logger.warning("Could not open raw log %s: %s", raw_log_path, exc)
     try:
         # `codex exec` treats any non-TTY stdin, including /dev/null, as piped
         # prompt content and tries to drain it. Give it an idle TTY so the
@@ -101,10 +108,22 @@ async def run_codex_auto(
                 line = raw.decode(errors="replace").strip()
                 if line:
                     await emit(f"[stderr] {line}")
+                if _raw_fh is not None:
+                    try:
+                        _raw_fh.write(b"[stderr] " + raw if raw.endswith(b"\n") else b"[stderr] " + raw + b"\n")
+                        _raw_fh.flush()
+                    except OSError:
+                        pass
 
         stderr_task = asyncio.create_task(_drain_stderr())
 
         async for raw in proc.stdout:  # type: ignore[union-attr]
+            if _raw_fh is not None:
+                try:
+                    _raw_fh.write(raw)
+                    _raw_fh.flush()
+                except OSError:
+                    pass
             line_str = raw.decode(errors="replace").strip()
             if not line_str:
                 continue
@@ -150,3 +169,6 @@ async def run_codex_auto(
                     os.close(fd)
         with contextlib.suppress(OSError):
             os.unlink(last_message_path)
+        if _raw_fh is not None:
+            with contextlib.suppress(OSError):
+                _raw_fh.close()

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -98,6 +98,7 @@ async def run_pi_auto(
     pi_path: str = "pi",
     model: str | None = None,
     provider: str | None = None,
+    raw_log_path: str | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Run pi on *description* in *cwd*.
 
@@ -132,6 +133,12 @@ async def run_pi_auto(
     session_id: str | None = None
     proc: asyncio.subprocess.Process | None = None
     stderr_task: asyncio.Task[None] | None = None
+    _raw_fh = None
+    if raw_log_path:
+        try:
+            _raw_fh = open(raw_log_path, "ab")  # noqa: WPS515
+        except OSError as exc:
+            logger.warning("Could not open raw log %s: %s", raw_log_path, exc)
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -155,6 +162,12 @@ async def run_pi_auto(
                     line = raw.decode(errors="replace").strip()
                     if line:
                         await emit(f"[stderr] {line}")
+                    if _raw_fh is not None:
+                        try:
+                            _raw_fh.write(b"[stderr] " + raw if raw.endswith(b"\n") else b"[stderr] " + raw + b"\n")
+                            _raw_fh.flush()
+                        except OSError:
+                            pass
             except Exception:
                 logger.debug("pi[%d] stderr drain exited early", pid, exc_info=True)
 
@@ -194,6 +207,12 @@ async def run_pi_auto(
                 continue
             if not raw:  # EOF
                 break
+            if _raw_fh is not None:
+                try:
+                    _raw_fh.write(raw)
+                    _raw_fh.flush()
+                except OSError:
+                    pass
             line_str = raw.decode(errors="replace").strip()
             if not line_str:
                 continue
@@ -352,4 +371,9 @@ async def run_pi_auto(
             try:
                 await stderr_task
             except BaseException:
+                pass
+        if _raw_fh is not None:
+            try:
+                _raw_fh.close()
+            except OSError:
                 pass

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -164,7 +164,11 @@ async def run_pi_auto(
                         await emit(f"[stderr] {line}")
                     if _raw_fh is not None:
                         try:
-                            _raw_fh.write(b"[stderr] " + raw if raw.endswith(b"\n") else b"[stderr] " + raw + b"\n")
+                            _raw_fh.write(
+                                b"[stderr] " + raw
+                                if raw.endswith(b"\n")
+                                else b"[stderr] " + raw + b"\n"
+                            )
                             _raw_fh.flush()
                         except OSError:
                             pass

--- a/worker/pioneer_worker/s3_log_sync.py
+++ b/worker/pioneer_worker/s3_log_sync.py
@@ -1,0 +1,131 @@
+"""Optional S3 log sync for worker task logs.
+
+Controlled by environment variables:
+  LOG_S3_BUCKET                — bucket name; feature disabled if unset
+  LOG_S3_PREFIX                — key prefix (default: "worker-logs")
+  LOG_S3_SYNC_INTERVAL_SECONDS — periodic sync interval in seconds (default: 60)
+
+S3 key layout: {prefix}/{guild_id}/{worker_id}/{task_id}/agent.log
+
+Credentials use the standard AWS credential chain (env vars → ~/.aws → IMDS).
+If boto3 is not installed and LOG_S3_BUCKET is set, a warning is logged and
+the feature is disabled rather than crashing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _try_import_boto3():
+    try:
+        import boto3  # type: ignore[import-untyped]
+
+        return boto3
+    except ImportError:
+        return None
+
+
+class S3LogSync:
+    """Periodically syncs a task log file to S3 while a task is running.
+
+    One instance handles one task; create a fresh one per task via ``from_env()``.
+
+    Lifecycle::
+
+        syncer = S3LogSync.from_env()
+        if syncer:
+            syncer.start(log_path, guild_id="g-abc", worker_id="w-xyz", task_id="t-123")
+            # ... task runs ...
+            syncer.finish()   # stop background thread then do final upload
+    """
+
+    def __init__(self, *, bucket: str, prefix: str, interval: int, s3_client) -> None:
+        self._bucket = bucket
+        self._prefix = prefix
+        self._interval = interval
+        self._client = s3_client
+        self._log_path: Path | None = None
+        self._s3_key: str | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @classmethod
+    def from_env(cls) -> S3LogSync | None:
+        """Build an instance from environment variables, or return None if disabled.
+
+        Returns None silently when LOG_S3_BUCKET is unset (zero runtime cost).
+        Logs a warning and returns None when boto3 is missing.
+        """
+        bucket = os.environ.get("LOG_S3_BUCKET")
+        if not bucket:
+            return None
+
+        boto3 = _try_import_boto3()
+        if boto3 is None:
+            logger.warning(
+                "LOG_S3_BUCKET is set but boto3 is not installed — S3 log sync disabled. "
+                "Install it with: pip install boto3"
+            )
+            return None
+
+        prefix = os.environ.get("LOG_S3_PREFIX", "worker-logs")
+        try:
+            interval = int(os.environ.get("LOG_S3_SYNC_INTERVAL_SECONDS", "60"))
+        except ValueError:
+            logger.warning("Invalid LOG_S3_SYNC_INTERVAL_SECONDS; using default of 60s")
+            interval = 60
+
+        try:
+            client = boto3.client("s3")
+        except Exception as exc:
+            logger.warning("Failed to create S3 client — S3 log sync disabled: %s", exc)
+            return None
+
+        return cls(bucket=bucket, prefix=prefix, interval=interval, s3_client=client)
+
+    def start(self, log_path: str | Path, *, guild_id: str, worker_id: str, task_id: str) -> None:
+        """Start the periodic sync background thread for *log_path*."""
+        self._log_path = Path(log_path)
+        self._s3_key = f"{self._prefix}/{guild_id}/{worker_id}/{task_id}/agent.log"
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._sync_loop, daemon=True, name=f"s3-sync-{task_id}"
+        )
+        self._thread.start()
+        logger.info(
+            "S3 log sync started: s3://%s/%s (interval=%ds)",
+            self._bucket,
+            self._s3_key,
+            self._interval,
+        )
+
+    def finish(self) -> None:
+        """Stop the periodic sync thread and perform a final upload."""
+        if self._thread is None:
+            return
+        self._stop.set()
+        self._thread.join(timeout=15.0)
+        self._thread = None
+        self._upload()
+        logger.info("S3 log sync finished: s3://%s/%s", self._bucket, self._s3_key)
+
+    def _upload(self) -> None:
+        if self._log_path is None or self._s3_key is None:
+            return
+        if not self._log_path.exists():
+            return
+        try:
+            self._client.upload_file(str(self._log_path), self._bucket, self._s3_key)
+            logger.debug("Uploaded log to s3://%s/%s", self._bucket, self._s3_key)
+        except Exception as exc:
+            logger.warning("S3 log upload failed for %s: %s", self._s3_key, exc)
+
+    def _sync_loop(self) -> None:
+        while not self._stop.wait(timeout=self._interval):
+            self._upload()

--- a/worker/pioneer_worker/s3_log_sync.py
+++ b/worker/pioneer_worker/s3_log_sync.py
@@ -4,8 +4,14 @@ Controlled by environment variables:
   LOG_S3_BUCKET                — bucket name; feature disabled if unset
   LOG_S3_PREFIX                — key prefix (default: "worker-logs")
   LOG_S3_SYNC_INTERVAL_SECONDS — periodic sync interval in seconds (default: 60)
+  LOG_S3_STORAGE_CLASS         — S3 storage class (default: "STANDARD_IA")
 
-S3 key layout: {prefix}/{guild_id}/{worker_id}/{task_id}/agent.log
+S3 key layout:
+  Final:   {prefix}/{guild_id}/{worker_id}/{task_id}/agent.log
+  Interim: {prefix}/{guild_id}/{worker_id}/{task_id}/snapshots/{iso_timestamp}.log
+
+Each upload carries object metadata for auditability:
+  x-amz-meta-task-id, worker-id, guild-id, upload-time, upload-type
 
 Credentials use the standard AWS credential chain (env vars → ~/.aws → IMDS).
 If boto3 is not installed and LOG_S3_BUCKET is set, a warning is logged and
@@ -17,9 +23,13 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 logger = logging.getLogger(__name__)
+
+UploadType = Literal["interim", "final"]
 
 
 def _try_import_boto3():
@@ -43,15 +53,30 @@ class S3LogSync:
             syncer.start(log_path, guild_id="g-abc", worker_id="w-xyz", task_id="t-123")
             # ... task runs ...
             syncer.finish()   # stop background thread then do final upload
+
+    Interim uploads go to timestamped snapshot keys so every upload is preserved.
+    The final upload goes to the canonical agent.log key.
     """
 
-    def __init__(self, *, bucket: str, prefix: str, interval: int, s3_client) -> None:
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str,
+        interval: int,
+        storage_class: str,
+        s3_client,
+    ) -> None:
         self._bucket = bucket
         self._prefix = prefix
         self._interval = interval
+        self._storage_class = storage_class
         self._client = s3_client
         self._log_path: Path | None = None
-        self._s3_key: str | None = None
+        self._s3_key_base: str | None = None
+        self._guild_id: str | None = None
+        self._worker_id: str | None = None
+        self._task_id: str | None = None
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -75,6 +100,7 @@ class S3LogSync:
             return None
 
         prefix = os.environ.get("LOG_S3_PREFIX", "worker-logs")
+        storage_class = os.environ.get("LOG_S3_STORAGE_CLASS", "STANDARD_IA")
         try:
             interval = int(os.environ.get("LOG_S3_SYNC_INTERVAL_SECONDS", "60"))
         except ValueError:
@@ -87,22 +113,32 @@ class S3LogSync:
             logger.warning("Failed to create S3 client — S3 log sync disabled: %s", exc)
             return None
 
-        return cls(bucket=bucket, prefix=prefix, interval=interval, s3_client=client)
+        return cls(
+            bucket=bucket,
+            prefix=prefix,
+            interval=interval,
+            storage_class=storage_class,
+            s3_client=client,
+        )
 
     def start(self, log_path: str | Path, *, guild_id: str, worker_id: str, task_id: str) -> None:
         """Start the periodic sync background thread for *log_path*."""
         self._log_path = Path(log_path)
-        self._s3_key = f"{self._prefix}/{guild_id}/{worker_id}/{task_id}/agent.log"
+        self._guild_id = guild_id
+        self._worker_id = worker_id
+        self._task_id = task_id
+        self._s3_key_base = f"{self._prefix}/{guild_id}/{worker_id}/{task_id}"
         self._stop.clear()
         self._thread = threading.Thread(
             target=self._sync_loop, daemon=True, name=f"s3-sync-{task_id}"
         )
         self._thread.start()
         logger.info(
-            "S3 log sync started: s3://%s/%s (interval=%ds)",
+            "S3 log sync started: s3://%s/%s/ (interval=%ds, storage_class=%s)",
             self._bucket,
-            self._s3_key,
+            self._s3_key_base,
             self._interval,
+            self._storage_class,
         )
 
     def finish(self) -> None:
@@ -112,20 +148,43 @@ class S3LogSync:
         self._stop.set()
         self._thread.join(timeout=15.0)
         self._thread = None
-        self._upload()
-        logger.info("S3 log sync finished: s3://%s/%s", self._bucket, self._s3_key)
+        self._upload("final")
+        logger.info("S3 log sync finished: s3://%s/%s/agent.log", self._bucket, self._s3_key_base)
 
-    def _upload(self) -> None:
-        if self._log_path is None or self._s3_key is None:
+    def _upload(self, upload_type: UploadType) -> None:
+        if self._log_path is None or self._s3_key_base is None:
             return
         if not self._log_path.exists():
             return
+
+        now = datetime.now(timezone.utc)
+        iso_ts = now.strftime("%Y%m%dT%H%M%S.%fZ")
+
+        if upload_type == "final":
+            key = f"{self._s3_key_base}/agent.log"
+        else:
+            key = f"{self._s3_key_base}/snapshots/{iso_ts}.log"
+
+        extra_args = {
+            "Metadata": {
+                "task-id": self._task_id or "",
+                "worker-id": self._worker_id or "",
+                "guild-id": self._guild_id or "",
+                "upload-time": now.isoformat(),
+                "upload-type": upload_type,
+            },
+            "StorageClass": self._storage_class,
+            "ContentType": "text/plain",
+        }
+
         try:
-            self._client.upload_file(str(self._log_path), self._bucket, self._s3_key)
-            logger.debug("Uploaded log to s3://%s/%s", self._bucket, self._s3_key)
+            self._client.upload_file(
+                str(self._log_path), self._bucket, key, ExtraArgs=extra_args
+            )
+            logger.debug("Uploaded log to s3://%s/%s (%s)", self._bucket, key, upload_type)
         except Exception as exc:
-            logger.warning("S3 log upload failed for %s: %s", self._s3_key, exc)
+            logger.warning("S3 log upload failed for %s: %s", key, exc)
 
     def _sync_loop(self) -> None:
         while not self._stop.wait(timeout=self._interval):
-            self._upload()
+            self._upload("interim")

--- a/worker/pioneer_worker/s3_log_sync.py
+++ b/worker/pioneer_worker/s3_log_sync.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
@@ -157,7 +157,7 @@ class S3LogSync:
         if not self._log_path.exists():
             return
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         iso_ts = now.strftime("%Y%m%dT%H%M%S.%fZ")
 
         if upload_type == "final":
@@ -178,9 +178,7 @@ class S3LogSync:
         }
 
         try:
-            self._client.upload_file(
-                str(self._log_path), self._bucket, key, ExtraArgs=extra_args
-            )
+            self._client.upload_file(str(self._log_path), self._bucket, key, ExtraArgs=extra_args)
             logger.debug("Uploaded log to s3://%s/%s (%s)", self._bucket, key, upload_type)
         except Exception as exc:
             logger.warning("S3 log upload failed for %s: %s", key, exc)

--- a/worker/pioneer_worker/s3_log_sync.py
+++ b/worker/pioneer_worker/s3_log_sync.py
@@ -73,6 +73,7 @@ class S3LogSync:
         self._storage_class = storage_class
         self._client = s3_client
         self._log_path: Path | None = None
+        self._raw_log_path: Path | None = None
         self._s3_key_base: str | None = None
         self._guild_id: str | None = None
         self._worker_id: str | None = None
@@ -121,9 +122,22 @@ class S3LogSync:
             s3_client=client,
         )
 
-    def start(self, log_path: str | Path, *, guild_id: str, worker_id: str, task_id: str) -> None:
-        """Start the periodic sync background thread for *log_path*."""
+    def start(
+        self,
+        log_path: str | Path,
+        *,
+        guild_id: str,
+        worker_id: str,
+        task_id: str,
+        raw_log_path: str | Path | None = None,
+    ) -> None:
+        """Start the periodic sync background thread for *log_path*.
+
+        If *raw_log_path* is given, the raw subprocess output file is also
+        synced alongside the structured log under the ``raw.log`` key.
+        """
         self._log_path = Path(log_path)
+        self._raw_log_path = Path(raw_log_path) if raw_log_path is not None else None
         self._guild_id = guild_id
         self._worker_id = worker_id
         self._task_id = task_id
@@ -154,16 +168,9 @@ class S3LogSync:
     def _upload(self, upload_type: UploadType) -> None:
         if self._log_path is None or self._s3_key_base is None:
             return
-        if not self._log_path.exists():
-            return
 
         now = datetime.now(UTC)
         iso_ts = now.strftime("%Y%m%dT%H%M%S.%fZ")
-
-        if upload_type == "final":
-            key = f"{self._s3_key_base}/agent.log"
-        else:
-            key = f"{self._s3_key_base}/snapshots/{iso_ts}.log"
 
         extra_args = {
             "Metadata": {
@@ -177,11 +184,33 @@ class S3LogSync:
             "ContentType": "text/plain",
         }
 
-        try:
-            self._client.upload_file(str(self._log_path), self._bucket, key, ExtraArgs=extra_args)
-            logger.debug("Uploaded log to s3://%s/%s (%s)", self._bucket, key, upload_type)
-        except Exception as exc:
-            logger.warning("S3 log upload failed for %s: %s", key, exc)
+        if self._log_path.exists():
+            if upload_type == "final":
+                key = f"{self._s3_key_base}/agent.log"
+            else:
+                key = f"{self._s3_key_base}/snapshots/{iso_ts}.log"
+            try:
+                self._client.upload_file(
+                    str(self._log_path), self._bucket, key, ExtraArgs=extra_args
+                )
+                logger.debug("Uploaded log to s3://%s/%s (%s)", self._bucket, key, upload_type)
+            except Exception as exc:
+                logger.warning("S3 log upload failed for %s: %s", key, exc)
+
+        if self._raw_log_path is not None and self._raw_log_path.exists():
+            if upload_type == "final":
+                raw_key = f"{self._s3_key_base}/raw.log"
+            else:
+                raw_key = f"{self._s3_key_base}/snapshots/{iso_ts}.raw.log"
+            try:
+                self._client.upload_file(
+                    str(self._raw_log_path), self._bucket, raw_key, ExtraArgs=extra_args
+                )
+                logger.debug(
+                    "Uploaded raw log to s3://%s/%s (%s)", self._bucket, raw_key, upload_type
+                )
+            except Exception as exc:
+                logger.warning("S3 raw log upload failed for %s: %s", raw_key, exc)
 
     def _sync_loop(self) -> None:
         while not self._stop.wait(timeout=self._interval):

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 import anyio
 import httpx
 
-from . import claude_runner, codex_runner, git_ops, github_pr, pi_runner
+from . import claude_runner, codex_runner, git_ops, github_pr, pi_runner, s3_log_sync
 from . import config as config_mod
 from .control_api import ControlServer
 from .ws_client import WSClient
@@ -1837,7 +1837,21 @@ class Worker:
         )
         os.makedirs(work_dir, exist_ok=True)
 
-        emit = self._task_emit(task_id, agent)
+        log_path = os.path.join(work_dir, "agent.log")
+        _log_fh = open(log_path, "a", encoding="utf-8")  # noqa: WPS515
+
+        _base_emit = self._task_emit(task_id, agent)
+
+        async def emit(line: str, detail: dict | None = None, level: str = LEVEL_INFO) -> None:
+            await _base_emit(line, detail, level)
+            try:
+                _log_fh.write(line + "\n")
+                _log_fh.flush()
+            except Exception:
+                pass
+
+        _s3_syncer: s3_log_sync.S3LogSync | None = None
+
         if is_followup:
             await emit(f"Follow-up: {followup_instructions[:120]}", level=LEVEL_WORKER)
             await emit(f"Branch: {branch}", level=LEVEL_WORKER)
@@ -1920,12 +1934,22 @@ class Worker:
             await emit("✗ No worktrees — aborting.", level=LEVEL_WORKER)
             await self._task_update(task_id, agent=agent, state="failed", finishedAt=_now_iso())
             await self._set_state("error", agent)
+            _log_fh.close()
             return
 
         await self._task_update(task_id, agent=agent, branch=branch, worktreePath=primary_wt)
         # Register worktrees for the deferred sweeper — touched again below in
         # finally so the timestamp reflects the most recent activity.
         self._register_worktrees(task_id, worktree_entries)
+
+        _s3_syncer = s3_log_sync.S3LogSync.from_env()
+        if _s3_syncer:
+            _s3_syncer.start(
+                log_path,
+                guild_id=self.cfg.guild_id,
+                worker_id=self.cfg.worker_id or "",
+                task_id=task_id,
+            )
 
         tool = (task.get("tool") or "claude").lower()
 
@@ -2196,3 +2220,9 @@ class Worker:
             # Refresh the worktree-registry timestamp so the sweeper holds
             # off on this task for another full TTL window.
             self._touch_task_worktrees(task_id)
+            if _s3_syncer:
+                _s3_syncer.finish()
+            try:
+                _log_fh.close()
+            except Exception:
+                pass

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1838,6 +1838,7 @@ class Worker:
         os.makedirs(work_dir, exist_ok=True)
 
         log_path = os.path.join(work_dir, "agent.log")
+        raw_log_path = os.path.join(work_dir, "raw.log")
         _log_fh = open(log_path, "a", encoding="utf-8")  # noqa: WPS515
 
         _base_emit = self._task_emit(task_id, agent)
@@ -1949,6 +1950,7 @@ class Worker:
                 guild_id=self.cfg.guild_id,
                 worker_id=self.cfg.worker_id or "",
                 task_id=task_id,
+                raw_log_path=raw_log_path,
             )
 
         tool = (task.get("tool") or "claude").lower()
@@ -2055,6 +2057,7 @@ class Worker:
                         codex_path=self.cfg.codex_path,
                         codex_args=self.cfg.codex_args,
                         openai_api_key=self.cfg.openai_api_key,
+                        raw_log_path=raw_log_path,
                     )
                 elif tool == "pi":
                     _pi_model = task.get("model") or self.cfg.pi_model
@@ -2074,6 +2077,7 @@ class Worker:
                         model=_pi_model,
                         provider=_pi_provider,
                         on_usage=_collect_usage,
+                        raw_log_path=raw_log_path,
                     )
                     resume_session_id = _pi_session_id
                 else:
@@ -2098,6 +2102,7 @@ class Worker:
                         on_usage=_collect_usage,
                         claude_path=self.cfg.claude_path,
                         resume_session_id=resume_session_id,
+                        raw_log_path=raw_log_path,
                     )
 
                     _capture_session_and_clear()

--- a/worker/tests/test_s3_log_sync.py
+++ b/worker/tests/test_s3_log_sync.py
@@ -373,3 +373,120 @@ def test_finish_stops_background_thread(tmp_path):
 
     assert syncer._thread is None
     assert not thread.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# Raw log upload
+# ---------------------------------------------------------------------------
+
+
+def test_raw_log_final_key_follows_convention(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("structured\n")
+    raw_file = tmp_path / "raw.log"
+    raw_file.write_bytes(b'{"type":"result"}\n')
+
+    syncer.start(
+        log_file,
+        guild_id="g-abc123",
+        worker_id="w-xyz789",
+        task_id="t-def456",
+        raw_log_path=raw_file,
+    )
+    syncer.finish()
+
+    keys = [c.args[2] for c in mock_client.upload_file.call_args_list]
+    assert "worker-logs/g-abc123/w-xyz789/t-def456/agent.log" in keys
+    assert "worker-logs/g-abc123/w-xyz789/t-def456/raw.log" in keys
+
+
+def test_raw_log_uploaded_with_correct_local_path(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+    raw_file = tmp_path / "raw.log"
+    raw_file.write_bytes(b"raw output\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1", raw_log_path=raw_file)
+    syncer.finish()
+
+    raw_calls = [c for c in mock_client.upload_file.call_args_list if "raw.log" in c.args[2]]
+    assert len(raw_calls) == 1
+    assert raw_calls[0].args[0] == str(raw_file)
+    assert raw_calls[0].args[1] == "b"  # bucket from _make_syncer default
+
+
+def test_raw_log_not_uploaded_when_file_missing(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+    missing_raw = tmp_path / "raw.log"  # not created
+
+    syncer.start(
+        log_file, guild_id="g-1", worker_id="w-1", task_id="t-1", raw_log_path=missing_raw
+    )
+    syncer.finish()
+
+    keys = [c.args[2] for c in mock_client.upload_file.call_args_list]
+    assert not any("raw" in k for k in keys)
+
+
+def test_raw_log_not_uploaded_when_path_not_given(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    syncer.finish()
+
+    keys = [c.args[2] for c in mock_client.upload_file.call_args_list]
+    assert not any("raw" in k for k in keys)
+
+
+def test_raw_log_interim_key_uses_raw_suffix(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(interval=0.05, s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+    raw_file = tmp_path / "raw.log"
+    raw_file.write_bytes(b"raw\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1", raw_log_path=raw_file)
+    time.sleep(0.2)
+    syncer.finish()
+
+    interim_raw_keys = [
+        c.args[2]
+        for c in mock_client.upload_file.call_args_list
+        if "snapshots/" in c.args[2] and ".raw.log" in c.args[2]
+    ]
+    assert len(interim_raw_keys) >= 1
+    for k in interim_raw_keys:
+        assert k.startswith("worker-logs/g-1/w-1/t-1/snapshots/")
+        assert k.endswith(".raw.log")
+
+
+def test_raw_log_upload_failure_is_swallowed(tmp_path, caplog):
+    mock_client = MagicMock()
+    mock_client.upload_file.side_effect = RuntimeError("network error")
+
+    syncer = _make_syncer(s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+    raw_file = tmp_path / "raw.log"
+    raw_file.write_bytes(b"raw\n")
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        syncer.start(
+            log_file, guild_id="g-1", worker_id="w-1", task_id="t-1", raw_log_path=raw_file
+        )
+        syncer.finish()
+
+    assert any("upload failed" in r.message for r in caplog.records)

--- a/worker/tests/test_s3_log_sync.py
+++ b/worker/tests/test_s3_log_sync.py
@@ -2,13 +2,33 @@
 
 from __future__ import annotations
 
-import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from pioneer_worker.s3_log_sync import S3LogSync
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_boto3(client=None):
+    mock_boto3 = MagicMock()
+    mock_boto3.client.return_value = client or MagicMock()
+    return mock_boto3
+
+
+def _make_syncer(*, bucket="b", prefix="worker-logs", interval=60, storage_class="STANDARD_IA", s3_client=None):
+    return S3LogSync(
+        bucket=bucket,
+        prefix=prefix,
+        interval=interval,
+        storage_class=storage_class,
+        s3_client=s3_client or MagicMock(),
+    )
+
 
 # ---------------------------------------------------------------------------
 # from_env — disabled paths
@@ -51,18 +71,11 @@ def test_from_env_boto3_missing_warns_and_returns_none(monkeypatch, caplog):
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_boto3(client=None):
-    mock_boto3 = MagicMock()
-    mock_boto3.client.return_value = client or MagicMock()
-    return mock_boto3
-
-
 def test_from_env_returns_instance_when_configured(monkeypatch):
     monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
     monkeypatch.setenv("LOG_S3_PREFIX", "my-prefix")
     monkeypatch.setenv("LOG_S3_SYNC_INTERVAL_SECONDS", "30")
-    monkeypatch.delenv("LOG_S3_BUCKET", raising=False)  # reset
-    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+    monkeypatch.setenv("LOG_S3_STORAGE_CLASS", "STANDARD")
 
     with patch("pioneer_worker.s3_log_sync._try_import_boto3", return_value=_make_mock_boto3()):
         syncer = S3LogSync.from_env()
@@ -71,12 +84,14 @@ def test_from_env_returns_instance_when_configured(monkeypatch):
     assert syncer._bucket == "my-bucket"
     assert syncer._prefix == "my-prefix"
     assert syncer._interval == 30
+    assert syncer._storage_class == "STANDARD"
 
 
-def test_from_env_uses_default_prefix_and_interval(monkeypatch):
+def test_from_env_uses_default_prefix_interval_and_storage_class(monkeypatch):
     monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
     monkeypatch.delenv("LOG_S3_PREFIX", raising=False)
     monkeypatch.delenv("LOG_S3_SYNC_INTERVAL_SECONDS", raising=False)
+    monkeypatch.delenv("LOG_S3_STORAGE_CLASS", raising=False)
 
     with patch("pioneer_worker.s3_log_sync._try_import_boto3", return_value=_make_mock_boto3()):
         syncer = S3LogSync.from_env()
@@ -84,6 +99,7 @@ def test_from_env_uses_default_prefix_and_interval(monkeypatch):
     assert syncer is not None
     assert syncer._prefix == "worker-logs"
     assert syncer._interval == 60
+    assert syncer._storage_class == "STANDARD_IA"
 
 
 def test_from_env_invalid_interval_defaults_to_60(monkeypatch):
@@ -98,21 +114,65 @@ def test_from_env_invalid_interval_defaults_to_60(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# S3 key convention
+# S3 key convention — final upload
 # ---------------------------------------------------------------------------
 
 
-def test_s3_key_follows_convention(tmp_path):
+def test_final_key_follows_convention(tmp_path):
     mock_client = MagicMock()
-    syncer = S3LogSync(bucket="b", prefix="worker-logs", interval=60, s3_client=mock_client)
+    syncer = _make_syncer(s3_client=mock_client)
     log_file = tmp_path / "agent.log"
     log_file.write_text("hello\n")
 
     syncer.start(log_file, guild_id="g-abc123", worker_id="w-xyz789", task_id="t-def456")
     syncer.finish()
 
-    expected_key = "worker-logs/g-abc123/w-xyz789/t-def456/agent.log"
-    mock_client.upload_file.assert_called_with(str(log_file), "b", expected_key)
+    calls = mock_client.upload_file.call_args_list
+    final_call = calls[-1]
+    assert final_call.args[2] == "worker-logs/g-abc123/w-xyz789/t-def456/agent.log"
+
+
+# ---------------------------------------------------------------------------
+# Interim snapshot keys
+# ---------------------------------------------------------------------------
+
+
+def test_interim_key_uses_snapshot_path(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(interval=0.05, s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("hello\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    time.sleep(0.2)
+    syncer.finish()
+
+    calls = mock_client.upload_file.call_args_list
+    assert len(calls) >= 2
+    interim_keys = [c.args[2] for c in calls[:-1]]
+    assert all("snapshots/" in k for k in interim_keys)
+    # Snapshot keys should end with .log and contain a timestamp
+    for k in interim_keys:
+        assert k.startswith("worker-logs/g-1/w-1/t-1/snapshots/")
+        assert k.endswith(".log")
+
+
+def test_interim_key_is_unique_per_tick(tmp_path):
+    """Two periodic ticks must produce different keys so uploads are not overwritten."""
+    mock_client = MagicMock()
+    syncer = _make_syncer(interval=0.05, s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    time.sleep(0.3)
+    syncer.finish()
+
+    calls = mock_client.upload_file.call_args_list
+    # Collect interim keys (everything before the last final call)
+    interim_keys = [c.args[2] for c in calls[:-1]]
+    if len(interim_keys) >= 2:
+        assert len(set(interim_keys)) == len(interim_keys), "interim keys must be unique"
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +182,13 @@ def test_s3_key_follows_convention(tmp_path):
 
 def test_finish_uploads_log_file(tmp_path):
     mock_client = MagicMock()
-    syncer = S3LogSync(bucket="test-bucket", prefix="pfx", interval=3600, s3_client=mock_client)
+    syncer = S3LogSync(
+        bucket="test-bucket",
+        prefix="pfx",
+        interval=3600,
+        storage_class="STANDARD_IA",
+        s3_client=mock_client,
+    )
 
     log_file = tmp_path / "agent.log"
     log_file.write_text("task output\n")
@@ -130,21 +196,24 @@ def test_finish_uploads_log_file(tmp_path):
     syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
     syncer.finish()
 
-    mock_client.upload_file.assert_called_once_with(
-        str(log_file), "test-bucket", "pfx/g-1/w-1/t-1/agent.log"
-    )
+    assert mock_client.upload_file.call_count == 1
+    args, kwargs = mock_client.upload_file.call_args
+    assert args[0] == str(log_file)
+    assert args[1] == "test-bucket"
+    assert args[2] == "pfx/g-1/w-1/t-1/agent.log"
+    assert kwargs["ExtraArgs"]["Metadata"]["upload-type"] == "final"
 
 
 def test_finish_with_no_start_is_noop():
     mock_client = MagicMock()
-    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
-    syncer.finish()  # should not raise
+    syncer = _make_syncer(s3_client=mock_client)
+    syncer.finish()
     mock_client.upload_file.assert_not_called()
 
 
 def test_upload_skipped_when_file_missing(tmp_path):
     mock_client = MagicMock()
-    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    syncer = _make_syncer(s3_client=mock_client)
     missing = tmp_path / "nonexistent.log"
 
     syncer.start(missing, guild_id="g-1", worker_id="w-1", task_id="t-1")
@@ -157,7 +226,7 @@ def test_upload_failure_is_swallowed(tmp_path, caplog):
     mock_client = MagicMock()
     mock_client.upload_file.side_effect = RuntimeError("network error")
 
-    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    syncer = _make_syncer(s3_client=mock_client)
     log_file = tmp_path / "agent.log"
     log_file.write_text("data\n")
 
@@ -165,9 +234,98 @@ def test_upload_failure_is_swallowed(tmp_path, caplog):
 
     with caplog.at_level(logging.WARNING):
         syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
-        syncer.finish()  # must not raise
+        syncer.finish()
 
     assert any("upload failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Object metadata
+# ---------------------------------------------------------------------------
+
+
+def test_upload_includes_required_metadata(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-abc", worker_id="w-xyz", task_id="t-123")
+    syncer.finish()
+
+    _, kwargs = mock_client.upload_file.call_args
+    meta = kwargs["ExtraArgs"]["Metadata"]
+    assert meta["task-id"] == "t-123"
+    assert meta["worker-id"] == "w-xyz"
+    assert meta["guild-id"] == "g-abc"
+    assert "upload-time" in meta
+    assert meta["upload-type"] == "final"
+
+
+def test_interim_upload_metadata_type(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(interval=0.05, s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    time.sleep(0.2)
+    syncer.finish()
+
+    calls = mock_client.upload_file.call_args_list
+    assert len(calls) >= 2
+    for c in calls[:-1]:
+        assert c.kwargs["ExtraArgs"]["Metadata"]["upload-type"] == "interim"
+    assert calls[-1].kwargs["ExtraArgs"]["Metadata"]["upload-type"] == "final"
+
+
+# ---------------------------------------------------------------------------
+# Storage class
+# ---------------------------------------------------------------------------
+
+
+def test_upload_uses_default_storage_class_standard_ia(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(storage_class="STANDARD_IA", s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    syncer.finish()
+
+    _, kwargs = mock_client.upload_file.call_args
+    assert kwargs["ExtraArgs"]["StorageClass"] == "STANDARD_IA"
+
+
+def test_upload_uses_custom_storage_class(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(storage_class="GLACIER", s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    syncer.finish()
+
+    _, kwargs = mock_client.upload_file.call_args
+    assert kwargs["ExtraArgs"]["StorageClass"] == "GLACIER"
+
+
+# ---------------------------------------------------------------------------
+# Content type
+# ---------------------------------------------------------------------------
+
+
+def test_upload_sets_content_type_text_plain(tmp_path):
+    mock_client = MagicMock()
+    syncer = _make_syncer(s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    syncer.finish()
+
+    _, kwargs = mock_client.upload_file.call_args
+    assert kwargs["ExtraArgs"]["ContentType"] == "text/plain"
 
 
 # ---------------------------------------------------------------------------
@@ -177,23 +335,21 @@ def test_upload_failure_is_swallowed(tmp_path, caplog):
 
 def test_periodic_sync_calls_upload(tmp_path):
     mock_client = MagicMock()
-    # Very short interval so the test doesn't take long
-    syncer = S3LogSync(bucket="b", prefix="p", interval=0.05, s3_client=mock_client)
+    syncer = _make_syncer(interval=0.05, s3_client=mock_client)
 
     log_file = tmp_path / "agent.log"
     log_file.write_text("line 1\n")
 
     syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
-    time.sleep(0.2)  # allow at least one periodic tick
+    time.sleep(0.2)
     syncer.finish()
 
-    # upload_file should have been called at least twice: once periodic + once final
     assert mock_client.upload_file.call_count >= 2
 
 
 def test_background_thread_is_daemon(tmp_path):
     mock_client = MagicMock()
-    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    syncer = _make_syncer(s3_client=mock_client)
     log_file = tmp_path / "agent.log"
     log_file.write_text("data\n")
 
@@ -205,7 +361,7 @@ def test_background_thread_is_daemon(tmp_path):
 
 def test_finish_stops_background_thread(tmp_path):
     mock_client = MagicMock()
-    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    syncer = _make_syncer(s3_client=mock_client)
     log_file = tmp_path / "agent.log"
     log_file.write_text("data\n")
 

--- a/worker/tests/test_s3_log_sync.py
+++ b/worker/tests/test_s3_log_sync.py
@@ -1,0 +1,217 @@
+"""Unit tests for pioneer_worker.s3_log_sync."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pioneer_worker.s3_log_sync import S3LogSync
+
+# ---------------------------------------------------------------------------
+# from_env — disabled paths
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_no_bucket_returns_none(monkeypatch):
+    monkeypatch.delenv("LOG_S3_BUCKET", raising=False)
+    assert S3LogSync.from_env() is None
+
+
+def test_from_env_no_bucket_is_silent(monkeypatch, caplog):
+    monkeypatch.delenv("LOG_S3_BUCKET", raising=False)
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        S3LogSync.from_env()
+    assert not caplog.records
+
+
+def test_from_env_boto3_missing_warns_and_returns_none(monkeypatch, caplog):
+    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+    import logging
+
+    with (
+        patch(
+            "pioneer_worker.s3_log_sync._try_import_boto3",
+            return_value=None,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        result = S3LogSync.from_env()
+
+    assert result is None
+    assert any("boto3" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# from_env — happy path
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_boto3(client=None):
+    mock_boto3 = MagicMock()
+    mock_boto3.client.return_value = client or MagicMock()
+    return mock_boto3
+
+
+def test_from_env_returns_instance_when_configured(monkeypatch):
+    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+    monkeypatch.setenv("LOG_S3_PREFIX", "my-prefix")
+    monkeypatch.setenv("LOG_S3_SYNC_INTERVAL_SECONDS", "30")
+    monkeypatch.delenv("LOG_S3_BUCKET", raising=False)  # reset
+    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+
+    with patch("pioneer_worker.s3_log_sync._try_import_boto3", return_value=_make_mock_boto3()):
+        syncer = S3LogSync.from_env()
+
+    assert isinstance(syncer, S3LogSync)
+    assert syncer._bucket == "my-bucket"
+    assert syncer._prefix == "my-prefix"
+    assert syncer._interval == 30
+
+
+def test_from_env_uses_default_prefix_and_interval(monkeypatch):
+    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+    monkeypatch.delenv("LOG_S3_PREFIX", raising=False)
+    monkeypatch.delenv("LOG_S3_SYNC_INTERVAL_SECONDS", raising=False)
+
+    with patch("pioneer_worker.s3_log_sync._try_import_boto3", return_value=_make_mock_boto3()):
+        syncer = S3LogSync.from_env()
+
+    assert syncer is not None
+    assert syncer._prefix == "worker-logs"
+    assert syncer._interval == 60
+
+
+def test_from_env_invalid_interval_defaults_to_60(monkeypatch):
+    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+    monkeypatch.setenv("LOG_S3_SYNC_INTERVAL_SECONDS", "not-a-number")
+
+    with patch("pioneer_worker.s3_log_sync._try_import_boto3", return_value=_make_mock_boto3()):
+        syncer = S3LogSync.from_env()
+
+    assert syncer is not None
+    assert syncer._interval == 60
+
+
+# ---------------------------------------------------------------------------
+# S3 key convention
+# ---------------------------------------------------------------------------
+
+
+def test_s3_key_follows_convention(tmp_path):
+    mock_client = MagicMock()
+    syncer = S3LogSync(bucket="b", prefix="worker-logs", interval=60, s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("hello\n")
+
+    syncer.start(log_file, guild_id="g-abc123", worker_id="w-xyz789", task_id="t-def456")
+    syncer.finish()
+
+    expected_key = "worker-logs/g-abc123/w-xyz789/t-def456/agent.log"
+    mock_client.upload_file.assert_called_with(str(log_file), "b", expected_key)
+
+
+# ---------------------------------------------------------------------------
+# upload called on task completion (finish)
+# ---------------------------------------------------------------------------
+
+
+def test_finish_uploads_log_file(tmp_path):
+    mock_client = MagicMock()
+    syncer = S3LogSync(bucket="test-bucket", prefix="pfx", interval=3600, s3_client=mock_client)
+
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("task output\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    syncer.finish()
+
+    mock_client.upload_file.assert_called_once_with(
+        str(log_file), "test-bucket", "pfx/g-1/w-1/t-1/agent.log"
+    )
+
+
+def test_finish_with_no_start_is_noop():
+    mock_client = MagicMock()
+    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    syncer.finish()  # should not raise
+    mock_client.upload_file.assert_not_called()
+
+
+def test_upload_skipped_when_file_missing(tmp_path):
+    mock_client = MagicMock()
+    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    missing = tmp_path / "nonexistent.log"
+
+    syncer.start(missing, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    syncer.finish()
+
+    mock_client.upload_file.assert_not_called()
+
+
+def test_upload_failure_is_swallowed(tmp_path, caplog):
+    mock_client = MagicMock()
+    mock_client.upload_file.side_effect = RuntimeError("network error")
+
+    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+        syncer.finish()  # must not raise
+
+    assert any("upload failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Periodic sync
+# ---------------------------------------------------------------------------
+
+
+def test_periodic_sync_calls_upload(tmp_path):
+    mock_client = MagicMock()
+    # Very short interval so the test doesn't take long
+    syncer = S3LogSync(bucket="b", prefix="p", interval=0.05, s3_client=mock_client)
+
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("line 1\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    time.sleep(0.2)  # allow at least one periodic tick
+    syncer.finish()
+
+    # upload_file should have been called at least twice: once periodic + once final
+    assert mock_client.upload_file.call_count >= 2
+
+
+def test_background_thread_is_daemon(tmp_path):
+    mock_client = MagicMock()
+    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    assert syncer._thread is not None
+    assert syncer._thread.daemon is True
+    syncer.finish()
+
+
+def test_finish_stops_background_thread(tmp_path):
+    mock_client = MagicMock()
+    syncer = S3LogSync(bucket="b", prefix="p", interval=60, s3_client=mock_client)
+    log_file = tmp_path / "agent.log"
+    log_file.write_text("data\n")
+
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1")
+    thread = syncer._thread
+    syncer.finish()
+
+    assert syncer._thread is None
+    assert not thread.is_alive()

--- a/worker/tests/test_s3_log_sync.py
+++ b/worker/tests/test_s3_log_sync.py
@@ -426,9 +426,7 @@ def test_raw_log_not_uploaded_when_file_missing(tmp_path):
     log_file.write_text("data\n")
     missing_raw = tmp_path / "raw.log"  # not created
 
-    syncer.start(
-        log_file, guild_id="g-1", worker_id="w-1", task_id="t-1", raw_log_path=missing_raw
-    )
+    syncer.start(log_file, guild_id="g-1", worker_id="w-1", task_id="t-1", raw_log_path=missing_raw)
     syncer.finish()
 
     keys = [c.args[2] for c in mock_client.upload_file.call_args_list]

--- a/worker/tests/test_s3_log_sync.py
+++ b/worker/tests/test_s3_log_sync.py
@@ -20,7 +20,9 @@ def _make_mock_boto3(client=None):
     return mock_boto3
 
 
-def _make_syncer(*, bucket="b", prefix="worker-logs", interval=60, storage_class="STANDARD_IA", s3_client=None):
+def _make_syncer(
+    *, bucket="b", prefix="worker-logs", interval=60, storage_class="STANDARD_IA", s3_client=None
+):
     return S3LogSync(
         bucket=bucket,
         prefix=prefix,

--- a/worker/tests/test_tools_detection.py
+++ b/worker/tests/test_tools_detection.py
@@ -188,6 +188,7 @@ class TestToolsCLIFlag:
             'backend_url = "ws://x:1"\nguild_id = "g"\n[github]\nrepos = ["owner/repo"]\n',
         )
         captured = {}
+        monkeypatch.delenv("PIONEER_TOOLS", raising=False)
 
         class _FakeWorker:
             def __init__(self, cfg):


### PR DESCRIPTION
## Summary

- Adds `worker/pioneer_worker/s3_log_sync.py` — a self-contained `S3LogSync` class that periodically uploads a task log file to S3 in a background daemon thread, with a guaranteed final upload after task completion.
- Each task's terminal output is captured to `{work_dir}/agent.log` by wrapping the existing `emit` function.
- The S3 key follows the convention `{prefix}/{guild_id}/{worker_id}/{task_id}/agent.log`.
- Feature is entirely opt-in via three env vars (`LOG_S3_BUCKET`, `LOG_S3_PREFIX`, `LOG_S3_SYNC_INTERVAL_SECONDS`). Zero runtime cost when `LOG_S3_BUCKET` is unset.
- `boto3` gracefully degrades: if it's missing and `LOG_S3_BUCKET` is set, a warning is logged and the feature disables itself rather than crashing.
- `boto3` added as `[s3]` optional extra in `cli/pyproject.toml` (not a hard dependency).
- 14 unit tests covering: disabled paths, boto3 missing warning, env var defaults, S3 key convention, upload-on-finish, periodic sync, daemon thread, and upload failure swallowing.

## Test plan

- [ ] `cd worker && python -m pytest tests/test_s3_log_sync.py -v` — all 14 pass
- [ ] `cd worker && python -m pytest` — no regressions (pre-existing `test_no_tools_flag_gives_none` failure is unrelated to this PR)
- [ ] Manual: set `LOG_S3_BUCKET=my-bucket` and run a task; verify `agent.log` appears at the expected S3 key

Closes #637