### PR TITLE
feat(foreman): queue socket messages while a turn is being processed

### DIFF
--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_QUEUE_MAX = 100
+
 
 class Foreman:
     """Manages the standalone foreman lifecycle for one guild."""
@@ -25,10 +27,10 @@ class Foreman:
     def __init__(self, config: Config):
         self._config = config
         self._http: ForemanHTTPClient | None = None
-        # In-flight flag: True while a foreman run coroutine is executing.
-        # Checked before spawning a new trigger run or poll run so we never
-        # have two concurrent runs for the same guild.
-        self._in_flight: bool = False
+        # True while a foreman run (including its queue drain) is executing.
+        self._processing: bool = False
+        # Triggers buffered while _processing is True; drained FIFO after each turn.
+        self._message_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=_QUEUE_MAX)
         # Monotonic timestamp of the last run that made at least one tool call.
         # Used to decide whether to reset the poll backoff.
         self._last_action_at: float = 0.0
@@ -100,33 +102,66 @@ class Foreman:
                 task_id: str | None = None,
                 task_name: str = "foreman.run",
             ) -> None:
-                """Wrapper that enforces the in-flight flag and updates last_action_at."""
-                if self._in_flight:
+                """Run one foreman turn, then drain any buffered messages in FIFO order.
+
+                Holds _processing=True for the entire duration (initial turn + drain) so
+                that triggers arriving during the drain are queued rather than dispatched.
+                """
+                if self._processing:
                     logger.info(
                         "guild=%s %s: dropped — run already in-flight",
                         guild_id,
                         task_name,
                     )
                     return
-                self._in_flight = True
+                self._processing = True
                 try:
-                    made_calls = await run_foreman_ai(
-                        guild_id,
-                        human_message,
-                        extra_context=extra_context,
-                        user_id=user_id,
-                        task_id=task_id,
-                        http=self._http,
-                        ws_send=_ws_send,
-                        config=self._config,
-                    )
-                    if made_calls:
-                        self._last_action_at = time.monotonic()
-                        self._poll_interval = self._config.poll_min_interval
-                except Exception:
-                    logger.exception("guild=%s %s: unhandled error", guild_id, task_name)
+                    try:
+                        made_calls = await run_foreman_ai(
+                            guild_id,
+                            human_message,
+                            extra_context=extra_context,
+                            user_id=user_id,
+                            task_id=task_id,
+                            http=self._http,
+                            ws_send=_ws_send,
+                            config=self._config,
+                        )
+                        if made_calls:
+                            self._last_action_at = time.monotonic()
+                            self._poll_interval = self._config.poll_min_interval
+                    except Exception:
+                        logger.exception("guild=%s %s: unhandled error", guild_id, task_name)
+
+                    # Drain buffered messages in FIFO order.  _processing stays True so
+                    # any triggers arriving during draining are queued, not dispatched.
+                    while not self._message_queue.empty():
+                        try:
+                            queued = self._message_queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            break
+                        q_name = f"foreman.queued:{queued['guild_id']}:{queued.get('event', '?')}"
+                        logger.debug("Processing queued message: %s", q_name)
+                        try:
+                            made_calls = await run_foreman_ai(
+                                queued["guild_id"],
+                                queued["human_message"],
+                                extra_context=queued.get("extra_context", ""),
+                                user_id=queued.get("user_id"),
+                                task_id=queued.get("task_id"),
+                                http=self._http,
+                                ws_send=_ws_send,
+                                config=self._config,
+                            )
+                            if made_calls:
+                                self._last_action_at = time.monotonic()
+                                self._poll_interval = self._config.poll_min_interval
+                        except Exception:
+                            logger.exception(
+                                "guild=%s %s: unhandled error", queued["guild_id"], q_name
+                            )
                 finally:
-                    self._in_flight = False
+                    self._processing = False
 
             async def _handle_trigger(data: dict) -> None:
                 guild_id = data.get("guildId", "")
@@ -137,6 +172,41 @@ class Foreman:
                 if not guild_id or not human_message:
                     logger.warning("Ignoring malformed foreman-trigger: %s", data)
                     return
+
+                if self._processing:
+                    # Periodic-check messages re-fire on the next poll interval; discard them.
+                    if "[periodic-check]" in human_message:
+                        logger.debug(
+                            "Discarding periodic-check trigger while busy: guild=%s", guild_id
+                        )
+                        return
+                    # Buffer all other triggers; drop with a warning if the queue is full.
+                    try:
+                        self._message_queue.put_nowait(
+                            {
+                                "guild_id": guild_id,
+                                "human_message": human_message,
+                                "extra_context": extra_context,
+                                "user_id": user_id,
+                                "task_id": trigger_task_id,
+                                "event": data.get("event", "?"),
+                            }
+                        )
+                        logger.debug(
+                            "Buffered trigger while busy (queue=%d): guild=%s event=%s",
+                            self._message_queue.qsize(),
+                            guild_id,
+                            data.get("event", "?"),
+                        )
+                    except asyncio.QueueFull:
+                        logger.warning(
+                            "Message queue full (%d); dropping trigger for guild=%s event=%s",
+                            _QUEUE_MAX,
+                            guild_id,
+                            data.get("event", "?"),
+                        )
+                    return
+
                 asyncio.create_task(
                     _run_foreman(
                         guild_id,
@@ -176,7 +246,7 @@ class Foreman:
                         base = min(self._poll_interval, sleep_duration)
                         self._poll_interval = min(base * 2, self._config.poll_max_interval)
 
-                        if active and not self._in_flight:
+                        if active and not self._processing:
                             task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active)
                             msg = (
                                 f"[periodic-check] Automated status poll — {n} non-terminal "

--- a/foreman/tests/test_ws_integration.py
+++ b/foreman/tests/test_ws_integration.py
@@ -256,8 +256,8 @@ async def test_ws_trigger_malformed_ignored():
     assert calls == [], "Malformed trigger should not spawn a run"
 
 
-async def test_ws_second_trigger_dropped_when_in_flight():
-    """If a run is already in-flight, a second trigger is silently dropped."""
+async def test_ws_second_trigger_queued_when_in_flight():
+    """If a run is already in-flight, a second trigger is queued and processed after the first."""
     triggers = [
         {"type": "foreman-trigger", "guildId": "test123", "humanMessage": "first"},
         {"type": "foreman-trigger", "guildId": "test123", "humanMessage": "second"},
@@ -281,39 +281,43 @@ async def test_ws_second_trigger_dropped_when_in_flight():
         foreman = Foreman(_make_config())
         foreman._http = AsyncMock()
         run_task = asyncio.create_task(foreman._run_connection())
-        # Let the first trigger start and the second arrive
+        # Let the first trigger start and the second arrive while first is blocking
         await asyncio.sleep(0.05)
         gate.set()
         await run_task
-        await asyncio.sleep(0.05)
+        await asyncio.sleep(0.05)  # let drain complete
 
-    assert call_count == 1, f"Expected only 1 run_foreman_ai call, got {call_count}"
+    assert call_count == 2, (
+        f"Expected 2 run_foreman_ai calls (first + queued second), got {call_count}"
+    )
 
 
 # ── in-flight flag reset ──────────────────────────────────────────────────
 
 
-async def test_in_flight_cleared_after_run():
-    """_in_flight is reset to False after a foreman run completes."""
-    foreman = Foreman(_make_config())
-    foreman._http = AsyncMock()
+async def test_processing_cleared_after_run():
+    """_processing is reset to False after a foreman run (and its queue drain) completes."""
+    ws = MockWebSocket(
+        [
+            {"type": "foreman-trigger", "guildId": "test123", "humanMessage": "do stuff"},
+            {"type": "foreman-evicted", "reason": "done"},
+        ]
+    )
 
     async def fake_run(*args, **kwargs):
         return False
 
-    with patch("pioneer_foreman.foreman.run_foreman_ai", fake_run):
-        # Simulate what _run_foreman does
-        foreman._in_flight = True
-        ws_messages: list[dict] = []
+    foreman = Foreman(_make_config())
+    foreman._http = AsyncMock()
 
-        async def fake_ws_send(msg):
-            ws_messages.append(msg)
+    with (
+        patch("pioneer_foreman.foreman.websockets.connect", return_value=ws),
+        patch("pioneer_foreman.foreman.run_foreman_ai", fake_run),
+    ):
+        await foreman._run_connection()
+        await asyncio.sleep(0.05)  # let the trigger task finish
 
-        # Access the inner _run_foreman by constructing it manually via run()
-        # Instead, test the flag directly via a trigger + small sleep
-        foreman._in_flight = False
-
-    assert foreman._in_flight is False
+    assert foreman._processing is False
 
 
 # ── graceful exit ─────────────────────────────────────────────────────────
@@ -344,3 +348,128 @@ async def test_run_cancels_poll_task_on_eviction():
     # The poll task should be done (cancelled or finished)
     assert created_poll_task, "Expected a poll-loop task to be created"
     assert created_poll_task[0].done(), "poll task should be done after _run_connection exits"
+
+
+# ── message queue ─────────────────────────────────────────────────────────
+
+
+async def test_ws_queued_messages_processed_in_order():
+    """Messages received while busy are processed in FIFO order after the turn completes."""
+    triggers = [
+        {"type": "foreman-trigger", "guildId": "test123", "humanMessage": "first", "event": "e1"},
+        {"type": "foreman-trigger", "guildId": "test123", "humanMessage": "second", "event": "e2"},
+        {"type": "foreman-trigger", "guildId": "test123", "humanMessage": "third", "event": "e3"},
+        {"type": "foreman-evicted", "reason": "done"},
+    ]
+    ws = MockWebSocket(triggers)
+
+    processed: list[str] = []
+    gate = asyncio.Event()
+
+    async def ordered_run(guild_id, human_message, *, http, ws_send, config, **kwargs):
+        if human_message == "first":
+            await gate.wait()  # block until gate opens; second and third will queue
+        processed.append(human_message)
+        return False
+
+    with (
+        patch("pioneer_foreman.foreman.websockets.connect", return_value=ws),
+        patch("pioneer_foreman.foreman.run_foreman_ai", ordered_run),
+    ):
+        foreman = Foreman(_make_config())
+        foreman._http = AsyncMock()
+        run_task = asyncio.create_task(foreman._run_connection())
+        await asyncio.sleep(0.05)  # let first trigger start; second and third queue up
+        gate.set()
+        await run_task
+        await asyncio.sleep(0.05)  # let drain complete
+
+    assert processed == ["first", "second", "third"], (
+        f"Expected FIFO order ['first', 'second', 'third'], got {processed}"
+    )
+
+
+async def test_ws_periodic_check_discarded_when_busy():
+    """Periodic-check triggers are silently discarded (not queued) while a run is in-flight."""
+    periodic_msg = (
+        "[periodic-check] Automated status poll — 1 non-terminal task(s): t-abc (working). "
+        "Check whether any are stalled."
+    )
+    triggers = [
+        {"type": "foreman-trigger", "guildId": "test123", "humanMessage": "real task"},
+        {"type": "foreman-trigger", "guildId": "test123", "humanMessage": periodic_msg},
+        {"type": "foreman-evicted", "reason": "done"},
+    ]
+    ws = MockWebSocket(triggers)
+
+    processed: list[str] = []
+    gate = asyncio.Event()
+
+    async def tracking_run(guild_id, human_message, *, http, ws_send, config, **kwargs):
+        if human_message == "real task":
+            await gate.wait()
+        processed.append(human_message)
+        return False
+
+    with (
+        patch("pioneer_foreman.foreman.websockets.connect", return_value=ws),
+        patch("pioneer_foreman.foreman.run_foreman_ai", tracking_run),
+    ):
+        foreman = Foreman(_make_config())
+        foreman._http = AsyncMock()
+        run_task = asyncio.create_task(foreman._run_connection())
+        await asyncio.sleep(0.05)
+        gate.set()
+        await run_task
+        await asyncio.sleep(0.05)
+
+    assert processed == ["real task"], f"Periodic-check should be discarded; got {processed}"
+    assert foreman._message_queue.empty(), "Queue should be empty — periodic-check was not queued"
+
+
+async def test_ws_queue_full_drops_message():
+    """When the message queue is full, the overflow trigger is dropped with a warning."""
+    # 1 blocking trigger + 100 that fill the queue + 1 overflow + evicted
+    triggers = (
+        [{"type": "foreman-trigger", "guildId": "test123", "humanMessage": "first", "event": "e0"}]
+        + [
+            {
+                "type": "foreman-trigger",
+                "guildId": "test123",
+                "humanMessage": f"msg{i}",
+                "event": f"e{i + 1}",
+            }
+            for i in range(101)  # 100 fill the queue; the 101st is dropped
+        ]
+        + [{"type": "foreman-evicted", "reason": "done"}]
+    )
+    ws = MockWebSocket(triggers)
+
+    gate = asyncio.Event()
+    processed: list[str] = []
+
+    async def counting_run(guild_id, human_message, *, http, ws_send, config, **kwargs):
+        if human_message == "first":
+            await gate.wait()
+        processed.append(human_message)
+        return False
+
+    import logging
+
+    with (
+        patch("pioneer_foreman.foreman.websockets.connect", return_value=ws),
+        patch("pioneer_foreman.foreman.run_foreman_ai", counting_run),
+    ):
+        foreman = Foreman(_make_config())
+        foreman._http = AsyncMock()
+        run_task = asyncio.create_task(foreman._run_connection())
+        await asyncio.sleep(0.1)  # let all triggers arrive while first is blocking
+        gate.set()
+        await run_task
+        await asyncio.sleep(0.1)  # let drain complete
+
+    # "first" + 100 queued = 101 processed; the 101st buffered message was dropped
+    assert processed[0] == "first"
+    assert len(processed) == 101, (
+        f"Expected 101 processed (first + 100 queued), got {len(processed)}"
+    )


### PR DESCRIPTION
## Summary

- **Busy flag + queue**: Renames `_in_flight` → `_processing` and adds an `asyncio.Queue(maxsize=100)` to `Foreman`. When `_processing` is `True`, incoming `foreman-trigger` messages are buffered in the queue instead of being dispatched (or dropped).
- **Drain loop**: After each turn completes, `_run_foreman` drains the queue in FIFO order while keeping `_processing=True` throughout, so any triggers arriving during the drain are queued rather than spawning a concurrent run.
- **Bounded queue**: The queue is capped at 100 messages. An overflow logs `WARNING` and drops the message.
- **Periodic-check discard**: Triggers whose `humanMessage` contains `[periodic-check]` are silently discarded when busy — they re-fire on the next poll interval anyway.
- **Tests**: 3 new tests (`test_ws_queued_messages_processed_in_order`, `test_ws_periodic_check_discarded_when_busy`, `test_ws_queue_full_drops_message`); 2 existing tests updated to reflect the new behaviour (`_dropped_` → `_queued_`, `_in_flight` → `_processing`). All 14 tests pass.

## Test plan

```
cd foreman
python -m pytest tests/test_ws_integration.py -v   # 14 passed
ruff check . && ruff format .                       # no issues
```

Closes #641