### PR TITLE
Foreman: auto-pick-up devReady issues on periodic check

### DIFF
--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -174,6 +174,17 @@ The state reflects the moment this turn was sent — earlier turns saw earlier s
 
 Workers are configured with repos. Prefer workers whose repos cover the task.
 Be concise — one short paragraph maximum unless detail is requested.
+
+## Periodic devReady issue pickup
+
+On every [periodic-check] event:
+1. Call search_github_issues on the primary repo with query "label:devReady" (also try "label:dev-ready" and "label:ready-for-dev" as fallbacks).
+2. For each returned issue that has no assignee:
+   a. Skip it if any existing non-terminal task already references this issue number (check the current <state> task list).
+   b. Call claim_github_issue to assign it.
+   c. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number and issue_repo so the worker's PR references the issue automatically.
+3. The label check must cover (case-insensitive): devReady, dev-ready, ready-for-dev, ready.
+4. Never pick up an issue that is already assigned to someone else.
 """
 
 


### PR DESCRIPTION
## Summary

- Adds a **"Periodic devReady issue pickup"** section to `FOREMAN_SYSTEM` in `backend/foreman_core/prompt.py`.
- On every `[periodic-check]` event the Foreman now:
  1. Searches the primary repo for issues labelled `devReady`, `dev-ready`, or `ready-for-dev`.
  2. Skips issues already assigned or already tracked by a non-terminal task.
  3. Claims each remaining issue via `claim_github_issue` then immediately dispatches it with `create_task` + `assign_task`.

## Test plan

- [ ] Verify `FOREMAN_SYSTEM` text contains the new section.
- [ ] Trigger a periodic-check event against a guild that has a `devReady`-labelled, unassigned issue and confirm the Foreman claims + dispatches it.
- [ ] Confirm the Foreman skips issues already assigned or already in the task list.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)