### PR TITLE
Optional S3 sync for worker task logs (#637)

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -116,6 +116,31 @@ The worker stays running, reconnecting if the backend restarts.
 6. Reports state changes (`working`, `done`, `failed`, branch, PR url) back
    to the backend via `task-update` WebSocket messages.
 
+## Optional S3 log sync
+
+The worker can periodically upload its raw session log files (the
+`stream-json` output captured from each `claude` subprocess) to an S3
+bucket.  This is opt-in and requires `boto3`:
+
+```bash
+pip install boto3   # or include it in your worker environment
+```
+
+Set the following environment variables before starting the worker:
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `LOG_S3_BUCKET` | yes | — | S3 bucket to upload logs to.  Leaving this unset disables the feature entirely. |
+| `LOG_S3_PREFIX` | no | `""` | Key prefix (e.g. `pioneer/logs`).  The final key is `{prefix}/{guild_id}/{worker_id}/{task_id}.jsonl`. |
+| `LOG_S3_SYNC_INTERVAL_SECONDS` | no | `60` | How often the background sync thread uploads in-progress log files.  A final upload also runs immediately when each task completes. |
+
+AWS credentials are resolved through the standard chain — environment
+variables (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`), `~/.aws/credentials`,
+EC2/ECS instance metadata, etc.  No credentials are hard-coded.
+
+If `boto3` is not installed, a warning is logged at startup and the feature
+is silently disabled — the worker continues normally.
+
 ## Control API (drive a live worker without a frontend)
 
 A real worker only acts on tasks the backend/foreman assigns over WebSocket,

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -288,6 +288,7 @@ async def run_claude_auto(
     on_usage: UsageFn | None = None,
     claude_path: str = "claude",
     resume_session_id: str | None = None,
+    log_file_path: str | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Run claude on *description* in *cwd*. Returns (success, stop_reason, last_assistant_text, session_id).
 
@@ -318,6 +319,7 @@ async def run_claude_auto(
     stop_reason = "no_events"
     event_count = 0
     session_id = None
+    _log_fh = open(log_file_path, "a", encoding="utf-8") if log_file_path else None
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -345,6 +347,13 @@ async def run_claude_auto(
             if not line_str:
                 continue
             event_count += 1
+            if _log_fh is not None:
+                try:
+                    _log_fh.write(line_str + "\n")
+                    _log_fh.flush()
+                except OSError as _log_err:
+                    logger.warning("session log write failed: %s", _log_err)
+                    _log_fh = None
             # Always log the full raw line at DEBUG so the wire format is recoverable.
             logger.debug(
                 "claude[%d] stdout#%d (%d bytes): %s",
@@ -423,3 +432,9 @@ async def run_claude_auto(
         logger.exception("claude subprocess crashed: %s", exc)
         await emit(f"[claude] ✗ {exc}")
         return False, "error_during_execution", last_text, session_id
+    finally:
+        if _log_fh is not None:
+            try:
+                _log_fh.close()
+            except OSError:
+                pass

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -319,7 +319,11 @@ async def run_claude_auto(
     stop_reason = "no_events"
     event_count = 0
     session_id = None
-    _log_fh = open(log_file_path, "a", encoding="utf-8") if log_file_path else None
+    try:
+        _log_fh = open(log_file_path, "a", encoding="utf-8") if log_file_path else None
+    except OSError as _log_err:
+        logger.warning("session log open failed: %s", _log_err)
+        _log_fh = None
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,

--- a/worker/pioneer_worker/s3_log_sync.py
+++ b/worker/pioneer_worker/s3_log_sync.py
@@ -1,0 +1,168 @@
+"""Optional S3 sync for worker task session logs.
+
+Enabled when the ``LOG_S3_BUCKET`` environment variable is set. Requires
+``boto3``; if it is not installed, a warning is logged and the feature is
+silently disabled — the worker continues normally.
+
+Environment variables
+---------------------
+LOG_S3_BUCKET
+    S3 bucket name. If absent, the feature is disabled entirely.
+LOG_S3_PREFIX
+    Optional key prefix (e.g. ``"pioneer/logs"``). Defaults to ``""``.
+LOG_S3_SYNC_INTERVAL_SECONDS
+    How often the background thread uploads registered log files.  Default 60.
+
+Credentials are resolved via the standard AWS credential chain (environment
+variables, ``~/.aws/credentials``, instance metadata, etc.).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+logger = logging.getLogger(__name__)
+
+try:
+    import boto3
+    import botocore.exceptions
+
+    _BOTO3_AVAILABLE = True
+except ImportError:
+    boto3 = None  # type: ignore[assignment]
+    botocore = None  # type: ignore[assignment]
+    _BOTO3_AVAILABLE = False
+    logger.warning(
+        "boto3 not installed — S3 log sync will be disabled even if LOG_S3_BUCKET is set"
+    )
+
+
+class S3LogSyncer:
+    """Periodically uploads task log files to an S3 bucket.
+
+    Usage::
+
+        syncer = S3LogSyncer(bucket="my-bucket", prefix="pioneer/logs", interval=60)
+        syncer.start()
+
+        # Register a file for periodic sync.
+        syncer.register("path/to/task-t-abc123.jsonl", "guild123/w-xyz/t-abc123.jsonl")
+
+        # Sync immediately (e.g. at task completion).
+        syncer.sync_file("path/to/task-t-abc123.jsonl", "guild123/w-xyz/t-abc123.jsonl")
+
+        # On shutdown.
+        syncer.stop()
+    """
+
+    def __init__(self, bucket: str, prefix: str, interval: int = 60) -> None:
+        self.bucket = bucket
+        self.prefix = prefix.rstrip("/")
+        self.interval = interval
+
+        self._files: dict[str, str] = {}  # local_path -> s3_key
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._client = boto3.client("s3") if _BOTO3_AVAILABLE else None  # type: ignore[union-attr]
+
+    def _full_key(self, s3_key: str) -> str:
+        return f"{self.prefix}/{s3_key}" if self.prefix else s3_key
+
+    def register(self, local_path: str, s3_key: str) -> None:
+        """Register *local_path* for periodic sync to *s3_key* under the configured prefix."""
+        with self._lock:
+            self._files[local_path] = s3_key
+
+    def unregister(self, local_path: str) -> None:
+        """Remove a file from periodic sync (does not delete the S3 object)."""
+        with self._lock:
+            self._files.pop(local_path, None)
+
+    def sync_file(self, local_path: str, s3_key: str) -> None:
+        """Upload *local_path* to S3 immediately.
+
+        No-op if the file does not exist yet. Errors are logged as warnings and
+        swallowed — a sync failure must never affect task outcome.
+        """
+        if not _BOTO3_AVAILABLE or self._client is None:
+            return
+        if not os.path.isfile(local_path):
+            return
+        full_key = self._full_key(s3_key)
+        try:
+            self._client.upload_file(local_path, self.bucket, full_key)
+            logger.debug("S3 sync: uploaded %s -> s3://%s/%s", local_path, self.bucket, full_key)
+        except Exception as exc:
+            logger.warning(
+                "S3 upload failed for %s -> s3://%s/%s: %s",
+                local_path,
+                self.bucket,
+                full_key,
+                exc,
+            )
+
+    def sync_all(self) -> None:
+        """Upload all registered files. Called by the background thread."""
+        with self._lock:
+            items = list(self._files.items())
+        for local_path, s3_key in items:
+            self.sync_file(local_path, s3_key)
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self.interval):
+            self.sync_all()
+
+    def start(self) -> None:
+        """Start the background sync thread."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True, name="s3-log-sync")
+        self._thread.start()
+        logger.info(
+            "S3 log syncer started (bucket=%s prefix=%r interval=%ds)",
+            self.bucket,
+            self.prefix,
+            self.interval,
+        )
+
+    def stop(self) -> None:
+        """Stop the background thread and wait for it to exit."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+
+def create_syncer() -> S3LogSyncer | None:
+    """Build an :class:`S3LogSyncer` from environment variables.
+
+    Returns ``None`` if ``LOG_S3_BUCKET`` is not set or ``boto3`` is unavailable.
+    """
+    bucket = os.environ.get("LOG_S3_BUCKET", "").strip()
+    if not bucket:
+        return None
+
+    if not _BOTO3_AVAILABLE:
+        logger.warning(
+            "LOG_S3_BUCKET=%r is set but boto3 is not installed — S3 log sync disabled",
+            bucket,
+        )
+        return None
+
+    prefix = os.environ.get("LOG_S3_PREFIX", "").strip()
+    try:
+        interval = int(os.environ.get("LOG_S3_SYNC_INTERVAL_SECONDS", "60"))
+    except ValueError:
+        logger.warning("Invalid LOG_S3_SYNC_INTERVAL_SECONDS — using default 60s")
+        interval = 60
+
+    logger.info(
+        "S3 log sync enabled: bucket=%s prefix=%r interval=%ds",
+        bucket,
+        prefix,
+        interval,
+    )
+    return S3LogSyncer(bucket=bucket, prefix=prefix, interval=interval)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -18,6 +18,7 @@ import httpx
 from . import claude_runner, codex_runner, git_ops, github_pr, pi_runner
 from . import config as config_mod
 from .control_api import ControlServer
+from .s3_log_sync import S3LogSyncer, create_syncer
 from .ws_client import WSClient
 
 logger = logging.getLogger(__name__)
@@ -150,6 +151,10 @@ class Worker:
         # so follow-ups can reuse the existing checkout without a re-clone.
         # Keyed by task_id; each entry is a list of (repo_path, wt_path, last_used_monotonic).
         self._task_worktrees: dict[str, list[tuple[str, str, float]]] = {}
+
+        # ── Optional S3 log sync ─────────────────────────────────────────────
+        # None when LOG_S3_BUCKET is not set or boto3 is unavailable.
+        self._s3_syncer: S3LogSyncer | None = create_syncer()
 
         # ── Auth / repo state ────────────────────────────────────────────────
         # Queue for auth codes received from the UI during claude auth login.
@@ -1176,6 +1181,8 @@ class Worker:
         self._loop = asyncio.get_running_loop()
         self._install_signal_handlers()
         self._start_control_api()
+        if self._s3_syncer is not None:
+            self._s3_syncer.start()
 
         await self._register()
         assert self.cfg.worker_id, "worker_id must be set after registration"
@@ -1277,6 +1284,8 @@ class Worker:
             logger.info("Worker shutting down; closing WebSocket")
             await self.ws.close()
             self._stop_control_api()
+            if self._s3_syncer is not None:
+                self._s3_syncer.stop()
 
     # ------------------------------------------------------------------ Listener
     async def _listen(self) -> None:
@@ -1837,6 +1846,15 @@ class Worker:
         )
         os.makedirs(work_dir, exist_ok=True)
 
+        # Session log: raw stream-json captured from the claude subprocess.
+        # Written whether or not S3 sync is enabled so operators can inspect locally.
+        _log_dir = os.path.join(self.cfg.work_dir, self.cfg.guild_id, self.cfg.worker_id)
+        os.makedirs(_log_dir, exist_ok=True)
+        session_log_path = os.path.join(_log_dir, f"{task_id}.jsonl")
+        _s3_key = f"{self.cfg.guild_id}/{self.cfg.worker_id}/{task_id}.jsonl"
+        if self._s3_syncer is not None:
+            self._s3_syncer.register(session_log_path, _s3_key)
+
         emit = self._task_emit(task_id, agent)
         if is_followup:
             await emit(f"Follow-up: {followup_instructions[:120]}", level=LEVEL_WORKER)
@@ -2074,6 +2092,7 @@ class Worker:
                         on_usage=_collect_usage,
                         claude_path=self.cfg.claude_path,
                         resume_session_id=resume_session_id,
+                        log_file_path=session_log_path,
                     )
 
                     _capture_session_and_clear()
@@ -2122,6 +2141,10 @@ class Worker:
                 success,
                 stop_reason,
             )
+
+            # Sync the session log to S3 immediately now that the run finished.
+            if self._s3_syncer is not None:
+                self._s3_syncer.sync_file(session_log_path, _s3_key)
 
             # Report captured per-API-call usage (claude tasks only). Best-effort.
             if usage_records:
@@ -2193,6 +2216,8 @@ class Worker:
 
         finally:
             self._redirect_queues.pop(task_id, None)
+            if self._s3_syncer is not None:
+                self._s3_syncer.unregister(session_log_path)
             # Refresh the worktree-registry timestamp so the sweeper holds
             # off on this task for another full TTL window.
             self._touch_task_worktrees(task_id)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1852,8 +1852,6 @@ class Worker:
         os.makedirs(_log_dir, exist_ok=True)
         session_log_path = os.path.join(_log_dir, f"{task_id}.jsonl")
         _s3_key = f"{self.cfg.guild_id}/{self.cfg.worker_id}/{task_id}.jsonl"
-        if self._s3_syncer is not None:
-            self._s3_syncer.register(session_log_path, _s3_key)
 
         emit = self._task_emit(task_id, agent)
         if is_followup:
@@ -1980,6 +1978,9 @@ class Worker:
             usage_records.append(rec)
 
         try:
+            # Only register for claude tasks — codex/pi don't write to session_log_path.
+            if self._s3_syncer is not None and tool == "claude":
+                self._s3_syncer.register(session_log_path, _s3_key)
             # ── Main execution with redirect loop ──────────────────────────
             if is_followup:
                 current_desc = (
@@ -2216,7 +2217,7 @@ class Worker:
 
         finally:
             self._redirect_queues.pop(task_id, None)
-            if self._s3_syncer is not None:
+            if self._s3_syncer is not None and tool == "claude":
                 self._s3_syncer.unregister(session_log_path)
             # Refresh the worktree-registry timestamp so the sweeper holds
             # off on this task for another full TTL window.

--- a/worker/tests/test_s3_log_sync.py
+++ b/worker/tests/test_s3_log_sync.py
@@ -1,0 +1,166 @@
+"""Tests for pioneer_worker.s3_log_sync."""
+
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from pioneer_worker.s3_log_sync import S3LogSyncer, create_syncer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_syncer(tmp_path, bucket="test-bucket", prefix="logs", interval=1):
+    """Return an S3LogSyncer with a mocked boto3 client."""
+    with patch("pioneer_worker.s3_log_sync._BOTO3_AVAILABLE", True):
+        with patch("pioneer_worker.s3_log_sync.boto3") as mock_boto3:
+            mock_client = MagicMock()
+            mock_boto3.client.return_value = mock_client
+            syncer = S3LogSyncer(bucket=bucket, prefix=prefix, interval=interval)
+    syncer._client = mock_client
+    return syncer, mock_client
+
+
+# ---------------------------------------------------------------------------
+# S3LogSyncer unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_sync_file_uploads_to_correct_key(tmp_path):
+    syncer, mock_client = _make_syncer(tmp_path)
+    log_file = tmp_path / "task.jsonl"
+    log_file.write_text('{"type":"result"}\n')
+
+    syncer.sync_file(str(log_file), "guild1/worker1/t-abc.jsonl")
+
+    mock_client.upload_file.assert_called_once_with(
+        str(log_file), "test-bucket", "logs/guild1/worker1/t-abc.jsonl"
+    )
+
+
+def test_sync_file_no_prefix(tmp_path):
+    syncer, mock_client = _make_syncer(tmp_path, prefix="")
+    log_file = tmp_path / "task.jsonl"
+    log_file.write_text("{}\n")
+
+    syncer.sync_file(str(log_file), "guild1/worker1/t-abc.jsonl")
+
+    mock_client.upload_file.assert_called_once_with(
+        str(log_file), "test-bucket", "guild1/worker1/t-abc.jsonl"
+    )
+
+
+def test_sync_file_missing_file_is_noop(tmp_path):
+    syncer, mock_client = _make_syncer(tmp_path)
+
+    syncer.sync_file(str(tmp_path / "nonexistent.jsonl"), "guild1/w/t.jsonl")
+
+    mock_client.upload_file.assert_not_called()
+
+
+def test_sync_file_upload_error_does_not_raise(tmp_path):
+    syncer, mock_client = _make_syncer(tmp_path)
+    mock_client.upload_file.side_effect = Exception("network error")
+    log_file = tmp_path / "task.jsonl"
+    log_file.write_text("{}\n")
+
+    # Must not raise.
+    syncer.sync_file(str(log_file), "guild1/w/t.jsonl")
+
+
+def test_sync_all_uploads_registered_files(tmp_path):
+    syncer, mock_client = _make_syncer(tmp_path)
+
+    f1 = tmp_path / "a.jsonl"
+    f1.write_text("{}\n")
+    f2 = tmp_path / "b.jsonl"
+    f2.write_text("{}\n")
+
+    syncer.register(str(f1), "g/w/a.jsonl")
+    syncer.register(str(f2), "g/w/b.jsonl")
+    syncer.sync_all()
+
+    assert mock_client.upload_file.call_count == 2
+
+
+def test_unregister_stops_periodic_uploads(tmp_path):
+    syncer, mock_client = _make_syncer(tmp_path)
+
+    f1 = tmp_path / "a.jsonl"
+    f1.write_text("{}\n")
+
+    syncer.register(str(f1), "g/w/a.jsonl")
+    syncer.unregister(str(f1))
+    syncer.sync_all()
+
+    mock_client.upload_file.assert_not_called()
+
+
+def test_sync_file_noop_when_boto3_unavailable(tmp_path):
+    with patch("pioneer_worker.s3_log_sync._BOTO3_AVAILABLE", False):
+        syncer = S3LogSyncer(bucket="b", prefix="p", interval=60)
+        syncer._client = None
+
+    log_file = tmp_path / "task.jsonl"
+    log_file.write_text("{}\n")
+
+    # Must not raise even though _client is None.
+    syncer.sync_file(str(log_file), "g/w/t.jsonl")
+
+
+def test_start_stop_thread(tmp_path):
+    syncer, _ = _make_syncer(tmp_path, interval=60)
+    syncer.start()
+    assert syncer._thread is not None
+    assert syncer._thread.is_alive()
+    thread = syncer._thread  # capture before stop() clears it
+    syncer.stop()
+    assert syncer._thread is None
+    assert not thread.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# create_syncer
+# ---------------------------------------------------------------------------
+
+
+def test_create_syncer_returns_none_when_no_bucket(monkeypatch):
+    monkeypatch.delenv("LOG_S3_BUCKET", raising=False)
+    result = create_syncer()
+    assert result is None
+
+
+def test_create_syncer_returns_none_when_boto3_missing(monkeypatch):
+    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+    with patch("pioneer_worker.s3_log_sync._BOTO3_AVAILABLE", False):
+        result = create_syncer()
+    assert result is None
+
+
+def test_create_syncer_returns_syncer_when_configured(monkeypatch):
+    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+    monkeypatch.setenv("LOG_S3_PREFIX", "pioneer/logs")
+    monkeypatch.setenv("LOG_S3_SYNC_INTERVAL_SECONDS", "30")
+    with patch("pioneer_worker.s3_log_sync._BOTO3_AVAILABLE", True):
+        with patch("pioneer_worker.s3_log_sync.boto3") as mock_boto3:
+            mock_boto3.client.return_value = MagicMock()
+            syncer = create_syncer()
+    assert syncer is not None
+    assert syncer.bucket == "my-bucket"
+    assert syncer.prefix == "pioneer/logs"
+    assert syncer.interval == 30
+
+
+def test_create_syncer_invalid_interval_defaults_to_60(monkeypatch):
+    monkeypatch.setenv("LOG_S3_BUCKET", "my-bucket")
+    monkeypatch.setenv("LOG_S3_SYNC_INTERVAL_SECONDS", "not-a-number")
+    with patch("pioneer_worker.s3_log_sync._BOTO3_AVAILABLE", True):
+        with patch("pioneer_worker.s3_log_sync.boto3") as mock_boto3:
+            mock_boto3.client.return_value = MagicMock()
+            syncer = create_syncer()
+    assert syncer is not None
+    assert syncer.interval == 60


### PR DESCRIPTION
## Summary

- Adds opt-in S3 upload of raw `stream-json` session logs for each worker task
- Enabled by setting `LOG_S3_BUCKET`; silently disabled if unset or if `boto3` is not installed
- Three new env vars: `LOG_S3_BUCKET`, `LOG_S3_PREFIX`, `LOG_S3_SYNC_INTERVAL_SECONDS` (default 60s)
- S3 key path: `{prefix}/{guild_id}/{worker_id}/{task_id}.jsonl`
- AWS credentials resolved via the standard chain — no hard-coded secrets

## Changes

**`worker/pioneer_worker/s3_log_sync.py`** (new)  
Self-contained helper module. `create_syncer()` reads env vars and returns an `S3LogSyncer` (or `None` if disabled). `S3LogSyncer` runs a daemon thread that periodically calls `sync_all()` and exposes `sync_file()` for immediate post-task uploads. `ImportError` on `boto3` is caught at module load; all sync methods are no-ops when unavailable.

**`worker/pioneer_worker/claude_runner.py`**  
`run_claude_auto` gains an optional `log_file_path` parameter. When set, each raw stdout line from the `claude` subprocess is appended to the file (flushed per line; append mode so redirect-loop reruns accumulate in one file).

**`worker/pioneer_worker/worker.py`**  
- `Worker.__init__` calls `create_syncer()` and stores `_s3_syncer`
- `run()` starts the syncer after registration and stops it in the `finally` block
- `_execute_task()` computes `session_log_path = {work_dir}/{guild_id}/{worker_id}/{task_id}.jsonl`, passes it to `run_claude_auto`, registers the file with the syncer on task start, does an immediate `sync_file()` when the run finishes, and unregisters in `finally`

**`worker/README.md`**  
New "Optional S3 log sync" section documents the env vars and credential chain.

**`worker/tests/test_s3_log_sync.py`** (new)  
12 unit tests covering: upload key construction, missing-prefix handling, missing-file no-op, upload error tolerance, `sync_all` across multiple files, unregister behaviour, boto3-absent no-op, thread start/stop lifecycle, and all `create_syncer` branches.

## Test plan

- [ ] `cd worker && python -m pytest tests/test_s3_log_sync.py -v` — all 12 pass
- [ ] `ruff check . && ruff format .` — clean
- [ ] Manual smoke: set `LOG_S3_BUCKET=<bucket>` and run a task; verify `.jsonl` appears at the expected S3 key

Closes #637