### PR TITLE
Replace pgweb with Metabase in docker-compose (#654)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,19 +115,19 @@ services:
     restart: unless-stopped
 
   pgweb:
-    image: sosedoff/pgweb:0.17.0
+    image: metabase/metabase:latest
     profiles: [ "tools" ]
     ports:
-      - "${PGWEB_PORT:-8081}:8081"
+      - "${PGWEB_PORT:-8081}:3000"
     environment:
-      PGHOST: postgres
-      PGUSER: ${POSTGRES_USER:-pioneer}
-      # dev-only: PGPASSWORD is intentionally passed as a plain env var for local development convenience.
+      MB_DB_TYPE: postgres
+      MB_DB_HOST: postgres
+      MB_DB_PORT: "5432"
+      MB_DB_USER: ${POSTGRES_USER:-pioneer}
+      # dev-only: MB_DB_PASS is intentionally passed as a plain env var for local development convenience.
       # Do not use this service configuration in shared/staging/production environments.
-      PGPASSWORD: ${POSTGRES_PASSWORD:-pioneer_password}
-      PGDATABASE: ${POSTGRES_DB:-pioneer_square}
-      PGPORT: "5432"
-      PGSSLMODE: disable
+      MB_DB_PASS: ${POSTGRES_PASSWORD:-pioneer_password}
+      MB_DB_DBNAME: ${POSTGRES_DB:-pioneer_square}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Replaces `sosedoff/pgweb:0.17.0` with `metabase/metabase:latest` in the `pgweb` service (service name kept as `pgweb`)
- Updates the port mapping from `${PGWEB_PORT:-8081}:8081` to `${PGWEB_PORT:-8081}:3000` (Metabase listens on 3000)
- Replaces pgweb-specific env vars (`PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, `PGPORT`, `PGSSLMODE`) with Metabase's `MB_DB_*` equivalents, pointing at the existing `postgres` service

## Test plan

- [ ] Run `docker compose --profile tools up pgweb` and confirm Metabase UI loads at `http://localhost:8081`
- [ ] Verify Metabase connects to the `pioneer_square` Postgres database on first-run setup

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)