### PR TITLE
feat(worker): add optional S3 uploader for session log sync

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -313,4 +313,18 @@ def build_spawn_worker_env(
         env["PIONEER_MAX_AGENTS"] = str(agent_count)
     if tools:
         env["PIONEER_TOOLS"] = ",".join(tools)
+    # S3 session-log sync — forward bucket, prefix, interval, and AWS creds so
+    # spawned workers can upload without needing their own config file entries.
+    for _key in (
+        "PIONEER_S3_BUCKET",
+        "PIONEER_S3_PREFIX",
+        "PIONEER_S3_SYNC_INTERVAL",
+        "AWS_DEFAULT_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+    ):
+        _val = source_env.get(_key, "")
+        if _val:
+            env[_key] = _val
     return env

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "httpx>=0.27",
     "anyio>=4.0",
     "anthropic[bedrock]>=0.49",
+    "boto3>=1.34",
 ]
 
 [project.optional-dependencies]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,14 @@ services:
       WORKER_LOG_LEVEL: ${WORKER_LOG_LEVEL:-}
       TEST_MODE: ${TEST_MODE:-}
       PIONEER_FOREMAN_KEY: ${PIONEER_FOREMAN_KEY:-}
+      # S3 session-log sync — forwarded to spawned worker containers.
+      PIONEER_S3_BUCKET: ${PIONEER_S3_BUCKET:-}
+      PIONEER_S3_PREFIX: ${PIONEER_S3_PREFIX:-}
+      PIONEER_S3_SYNC_INTERVAL: ${PIONEER_S3_SYNC_INTERVAL:-}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "cd backend && alembic upgrade head && cd .. && pioneer serve"
@@ -103,6 +111,13 @@ services:
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       WORKER_LOG_LEVEL: ${WORKER_LOG_LEVEL:-INFO}
+      PIONEER_S3_BUCKET: ${PIONEER_S3_BUCKET:-}
+      PIONEER_S3_PREFIX: ${PIONEER_S3_PREFIX:-}
+      PIONEER_S3_SYNC_INTERVAL: ${PIONEER_S3_SYNC_INTERVAL:-}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
     volumes:
       # Provide pioneer-worker.toml at ./worker/pioneer-worker.toml
       - ./worker/pioneer-worker.toml:/config/pioneer-worker.toml:ro

--- a/worker/pioneer-worker.toml.example
+++ b/worker/pioneer-worker.toml.example
@@ -63,3 +63,13 @@ max_turns = 50
 
 # Run `codex doctor` at worker startup and log the result (non-fatal).
 doctor = true
+
+# [s3]
+# Periodically sync session-log dot-directories to S3 using `aws s3 sync`.
+# Requires the awscli to be installed and AWS credentials to be configured
+# (IAM role, ~/.aws/credentials, or AWS_* env vars).
+# Disabled unless bucket is set. Also reads PIONEER_S3_BUCKET env var.
+# bucket = "my-bucket"
+# prefix = "pioneer-logs"          # optional key prefix (default: no prefix)
+# interval = 600                   # seconds between syncs (default: 600)
+# paths = ["~/.codex", "~/.claude", "~/.pi"]   # directories to sync

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -75,6 +75,13 @@ class Config:
     # only checks the listed names and warns about any that are absent from PATH.
     tools: list[str] | None = None
 
+    # Optional S3 session-log sync. Disabled unless s3_bucket is set.
+    # Periodically runs `aws s3 sync` for each path in s3_paths.
+    s3_bucket: str | None = None
+    s3_prefix: str = ""
+    s3_sync_interval: float = 600.0
+    s3_paths: list[str] = field(default_factory=lambda: ["~/.codex", "~/.claude", "~/.pi"])
+
     config_path: Path = field(default_factory=Path)
 
     @property
@@ -150,6 +157,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
     codex_block = raw.get("codex") or {}
     api_block = raw.get("api") or {}
     pi_block = raw.get("pi") or {}
+    s3_block = raw.get("s3") or {}
 
     _api_port = (
         overrides.get("api_port")
@@ -320,5 +328,21 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         api_port=_api_port,
         api_host=_api_host,
         tools=_tools_val,
+        s3_bucket=overrides.get("s3_bucket")
+        or s3_block.get("bucket")
+        or os.environ.get("PIONEER_S3_BUCKET")
+        or None,
+        s3_prefix=overrides.get("s3_prefix")
+        or s3_block.get("prefix")
+        or os.environ.get("PIONEER_S3_PREFIX")
+        or "",
+        s3_sync_interval=float(
+            overrides.get("s3_sync_interval")
+            if overrides.get("s3_sync_interval") is not None
+            else s3_block.get("interval", 600.0)
+        ),
+        s3_paths=list(
+            overrides.get("s3_paths") or s3_block.get("paths") or ["~/.codex", "~/.claude", "~/.pi"]
+        ),
         config_path=cfg_path,
     )

--- a/worker/pioneer_worker/s3_uploader.py
+++ b/worker/pioneer_worker/s3_uploader.py
@@ -1,0 +1,62 @@
+"""Optional S3 sync: upload session-log dot-directories to an S3 bucket."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATHS = ["~/.codex", "~/.claude", "~/.pi"]
+
+
+def _walk(root: Path) -> list[Path]:
+    """Return all regular files under *root* recursively."""
+    files: list[Path] = []
+    for dirpath, _dirs, filenames in os.walk(root):
+        for name in filenames:
+            files.append(Path(dirpath) / name)
+    return files
+
+
+def _sync_paths_sync(*, bucket: str, prefix: str, paths: list[str]) -> None:
+    """Blocking sync of *paths* to S3. Run via asyncio.to_thread."""
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    s3 = boto3.client("s3")
+
+    for raw_path in paths:
+        src = Path(os.path.expanduser(raw_path))
+        if not src.exists():
+            logger.debug("S3 sync: %s does not exist, skipping", src)
+            continue
+
+        key_prefix = f"{prefix.rstrip('/')}/{src.name}" if prefix else src.name
+        uploaded = 0
+
+        for local_file in _walk(src):
+            rel = local_file.relative_to(src)
+            s3_key = f"{key_prefix}/{rel.as_posix()}"
+            try:
+                s3.upload_file(str(local_file), bucket, s3_key)
+                uploaded += 1
+            except (BotoCoreError, ClientError) as exc:
+                logger.warning("S3 upload failed for %s → %s: %s", local_file, s3_key, exc)
+
+        logger.info("S3 sync: %s → s3://%s/%s (%d file(s))", src, bucket, key_prefix, uploaded)
+
+
+async def sync_paths(*, bucket: str, prefix: str, paths: list[str]) -> None:
+    """Async wrapper: sync each path to ``s3://<bucket>/<prefix>/<basename>``.
+
+    Failures are logged and swallowed — sync must never affect task execution.
+    """
+    try:
+        await asyncio.to_thread(_sync_paths_sync, bucket=bucket, prefix=prefix, paths=paths)
+    except ImportError:
+        logger.warning("boto3 not installed — S3 sync disabled. Run: pip install boto3")
+    except Exception as exc:
+        logger.warning("S3 sync error: %s", exc)

--- a/worker/pioneer_worker/s3_uploader.py
+++ b/worker/pioneer_worker/s3_uploader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import socket
@@ -20,6 +21,33 @@ def _walk(root: Path) -> list[Path]:
         for name in filenames:
             files.append(Path(dirpath) / name)
     return files
+
+
+def _md5_hex(path: Path) -> str:
+    """Return the hex MD5 of a local file — matches S3 ETag for single-part uploads."""
+    h = hashlib.md5()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _already_uploaded(s3, bucket: str, key: str, local_file: Path) -> bool:
+    """Return True if S3 already has this file with the same content (ETag == MD5)."""
+    from botocore.exceptions import ClientError
+
+    try:
+        head = s3.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] in ("404", "NoSuchKey"):
+            return False
+        raise
+    remote_etag = head["ETag"].strip('"')
+    # Multi-part ETags contain a dash (e.g. "abc123-4") and can't be compared
+    # to a plain MD5. Upload unconditionally in that case.
+    if "-" in remote_etag:
+        return False
+    return remote_etag == _md5_hex(local_file)
 
 
 def _sync_paths_sync(*, bucket: str, prefix: str, paths: list[str]) -> None:
@@ -40,18 +68,28 @@ def _sync_paths_sync(*, bucket: str, prefix: str, paths: list[str]) -> None:
         # hostname disambiguates uploads from different worker machines.
         parts = [p for p in [prefix.rstrip("/"), hostname, src.name] if p]
         key_prefix = "/".join(parts)
-        uploaded = 0
+        uploaded = skipped = 0
 
         for local_file in _walk(src):
             rel = local_file.relative_to(src)
             s3_key = f"{key_prefix}/{rel.as_posix()}"
             try:
+                if _already_uploaded(s3, bucket, s3_key, local_file):
+                    skipped += 1
+                    continue
                 s3.upload_file(str(local_file), bucket, s3_key)
                 uploaded += 1
             except (BotoCoreError, ClientError) as exc:
                 logger.warning("S3 upload failed for %s → %s: %s", local_file, s3_key, exc)
 
-        logger.info("S3 sync: %s → s3://%s/%s (%d file(s))", src, bucket, key_prefix, uploaded)
+        logger.info(
+            "S3 sync: %s → s3://%s/%s (uploaded=%d skipped=%d)",
+            src,
+            bucket,
+            key_prefix,
+            uploaded,
+            skipped,
+        )
 
 
 async def sync_paths(*, bucket: str, prefix: str, paths: list[str]) -> None:

--- a/worker/pioneer_worker/s3_uploader.py
+++ b/worker/pioneer_worker/s3_uploader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import socket
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ def _sync_paths_sync(*, bucket: str, prefix: str, paths: list[str]) -> None:
     from botocore.exceptions import BotoCoreError, ClientError
 
     s3 = boto3.client("s3")
+    hostname = socket.gethostname()
 
     for raw_path in paths:
         src = Path(os.path.expanduser(raw_path))
@@ -34,7 +36,10 @@ def _sync_paths_sync(*, bucket: str, prefix: str, paths: list[str]) -> None:
             logger.debug("S3 sync: %s does not exist, skipping", src)
             continue
 
-        key_prefix = f"{prefix.rstrip('/')}/{src.name}" if prefix else src.name
+        # Path layout: <prefix>/<hostname>/<basename>/…
+        # hostname disambiguates uploads from different worker machines.
+        parts = [p for p in [prefix.rstrip("/"), hostname, src.name] if p]
+        key_prefix = "/".join(parts)
         uploaded = 0
 
         for local_file in _walk(src):

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 import anyio
 import httpx
 
-from . import claude_runner, codex_runner, git_ops, github_pr, pi_runner
+from . import claude_runner, codex_runner, git_ops, github_pr, pi_runner, s3_uploader
 from . import config as config_mod
 from .control_api import ControlServer
 from .ws_client import WSClient
@@ -1240,11 +1240,13 @@ class Worker:
         runners = [asyncio.create_task(self._agent_loop(slot)) for slot in self.agents]
         puller = asyncio.create_task(self._idle_puller())
         sweeper = asyncio.create_task(self._worktree_sweeper())
+        s3_syncer = asyncio.create_task(self._s3_syncer()) if self.cfg.s3_bucket else None
+        aux_tasks = [listener, puller, sweeper, *([] if s3_syncer is None else [s3_syncer])]
         try:
             # Wait for either: all runners exit (graceful shutdown), or one of
             # the auxiliary tasks crashes (unexpected).
             done, _pending = await asyncio.wait(
-                [listener, puller, sweeper, *runners],
+                [*aux_tasks, *runners],
                 return_when=asyncio.FIRST_COMPLETED,
             )
             # Surface any non-cancellation exception that fired first.
@@ -1263,11 +1265,10 @@ class Worker:
                 await self._initiate_shutdown(reason)
 
             # Stop the auxiliary tasks; the agent loops drain themselves.
-            listener.cancel()
-            puller.cancel()
-            sweeper.cancel()
+            for t in aux_tasks:
+                t.cancel()
 
-            await asyncio.gather(listener, puller, sweeper, *runners, return_exceptions=True)
+            await asyncio.gather(*aux_tasks, *runners, return_exceptions=True)
 
             if first_exc is not None:
                 raise first_exc
@@ -1713,6 +1714,37 @@ class Worker:
             for tid in stale:
                 logger.info("Sweeper: retiring worktrees for task %s", tid)
                 await self._release_task_worktrees(tid)
+
+    # ------------------------------------------------------------------ S3 syncer
+    async def _s3_syncer(self) -> None:
+        """Periodically sync session-log directories to S3."""
+        logger.info(
+            "S3 syncer started (bucket=%s prefix=%r paths=%s interval=%.0fs)",
+            self.cfg.s3_bucket,
+            self.cfg.s3_prefix,
+            self.cfg.s3_paths,
+            self.cfg.s3_sync_interval,
+        )
+        # Sync immediately at startup so the most recent session state is captured.
+        await s3_uploader.sync_paths(
+            bucket=self.cfg.s3_bucket,
+            prefix=self.cfg.s3_prefix,
+            paths=self.cfg.s3_paths,
+        )
+        while not self._shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._shutdown_event.wait(),
+                    timeout=self.cfg.s3_sync_interval,
+                )
+                break  # shutdown
+            except TimeoutError:
+                pass
+            await s3_uploader.sync_paths(
+                bucket=self.cfg.s3_bucket,
+                prefix=self.cfg.s3_prefix,
+                paths=self.cfg.s3_paths,
+            )
 
     # ------------------------------------------------------------------ Idle puller
     async def _idle_puller(self) -> None:


### PR DESCRIPTION
## Summary

- New `s3_uploader.py` module syncs `~/.codex`, `~/.claude`, and `~/.pi` to S3 using **boto3** (added as a direct dependency)
- Runs as a background `asyncio` task in the worker, alongside the existing sweeper and puller; uses `asyncio.to_thread` so uploads don't block the event loop
- Disabled by default — enabled by setting `[s3] bucket` in `pioneer-worker.toml` or `PIONEER_S3_BUCKET` env var
- Syncs immediately at startup, then every `interval` seconds (default 600); configurable prefix and path list
- All failures are caught and logged; S3 errors never surface to task execution

## Configuration

```toml
[s3]
bucket = "my-bucket"
prefix = "pioneer-logs"   # optional key prefix
interval = 600            # seconds between syncs
# paths = ["~/.codex", "~/.claude", "~/.pi"]  # default
```

AWS credentials are resolved via the standard boto3 chain (IAM role, `~/.aws/credentials`, `AWS_*` env vars).

## Test plan

- [ ] `cd worker && python -m pytest` — existing tests pass
- [ ] Manually verify S3 sync fires at startup and on interval with a real bucket
- [ ] Confirm worker starts cleanly with no `[s3]` block (sync task not created)

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)