### PR TITLE
Rename claude_usage + include tool name in tracking (#661)

### DIFF
--- a/backend/alembic/versions/20260619_000000_rename_claude_usage_to_llm_usage.py
+++ b/backend/alembic/versions/20260619_000000_rename_claude_usage_to_llm_usage.py
@@ -1,0 +1,44 @@
+"""Rename claude_usage to llm_usage and add tool column.
+
+Revision ID: 20260619_000000_rename_claude_usage_to_llm_usage
+Revises: 20260614_000000_add_worker_disabled_column
+Create Date: 2026-06-19
+
+Renames the ``claude_usage`` table to ``llm_usage`` to reflect that usage
+tracking now covers multiple tool runners (claude, pi, codex, …). Adds a
+``tool`` column (TEXT, default ``'claude'``) so each row records which runner
+produced the usage data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260619_000000_rename_claude_usage_to_llm_usage"
+down_revision: str | Sequence[str] | None = "20260614_000000_add_worker_disabled_column"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.rename_table("claude_usage", "llm_usage")
+    op.drop_index("ix_claude_usage_guild_id", table_name="llm_usage")
+    op.drop_index("ix_claude_usage_task_id", table_name="llm_usage")
+    op.create_index("ix_llm_usage_guild_id", "llm_usage", ["guild_id"])
+    op.create_index("ix_llm_usage_task_id", "llm_usage", ["task_id"])
+    op.add_column(
+        "llm_usage",
+        sa.Column("tool", sa.Text(), nullable=True, server_default="'claude'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("llm_usage", "tool")
+    op.drop_index("ix_llm_usage_task_id", table_name="llm_usage")
+    op.drop_index("ix_llm_usage_guild_id", table_name="llm_usage")
+    op.create_index("ix_claude_usage_task_id", "llm_usage", ["task_id"])
+    op.create_index("ix_claude_usage_guild_id", "llm_usage", ["guild_id"])
+    op.rename_table("llm_usage", "claude_usage")

--- a/backend/models.py
+++ b/backend/models.py
@@ -406,18 +406,18 @@ class TaskEvent(SQLModel, table=True):
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
-class ClaudeUsage(SQLModel, table=True):
-    """Per-API-call usage captured from a worker's headless Claude run.
+class LlmUsage(SQLModel, table=True):
+    """Per-API-call usage captured from a worker's headless tool run.
 
-    The worker parses ``claude --output-format stream-json`` and reports one
-    row per assistant message (``kind="api_call"``) carrying that message's
-    ``message.usage``, plus one ``kind="result"`` row per run holding the
-    ``result`` event's self-reported aggregate ``usage`` and
+    The worker parses tool output (e.g. ``claude --output-format stream-json``)
+    and reports one row per assistant message (``kind="api_call"``) carrying
+    that message's ``message.usage``, plus one ``kind="result"`` row per run
+    holding the ``result`` event's self-reported aggregate ``usage`` and
     ``total_cost_usd``. Storing both lets the UI compare the per-call sum
-    against Claude's self-reported total (the two disagree in practice).
+    against the tool's self-reported total (the two disagree in practice).
     """
 
-    __tablename__ = "claude_usage"  # type: ignore[assignment]
+    __tablename__ = "llm_usage"  # type: ignore[assignment]
 
     id: int | None = Field(default=None, primary_key=True)
     # guild_id is the integer FK to guilds.id.
@@ -425,7 +425,9 @@ class ClaudeUsage(SQLModel, table=True):
     # Worker task this usage belongs to (NULL only for ad-hoc reports).
     task_id: str | None = Field(default=None, foreign_key="tasks.id")
     worker_id: str | None = Field(default=None, foreign_key="workers.id")
-    # Claude session_id (system:init) for the run this row came from.
+    # Tool runner that produced this usage (e.g. "claude", "pi", "codex").
+    tool: str = Field(default="claude", sa_column_kwargs={"server_default": "'claude'"})
+    # Session id for the run this row came from (e.g. Claude session_id from system:init).
     session_id: str | None = None
     # "api_call" (one assistant message) | "result" (the run's result event).
     kind: str

--- a/backend/routes/debug.py
+++ b/backend/routes/debug.py
@@ -19,7 +19,7 @@ import httpx
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from fastapi import APIRouter, Depends, HTTPException
-from models import ClaudeUsage, GithubEvent, GithubToken, Task, TaskLog
+from models import GithubEvent, GithubToken, LlmUsage, Task, TaskLog
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from utils import row_to_dict
@@ -462,17 +462,16 @@ async def get_task_debug_timeline(
             }
         )
 
-    # ── 4. Claude usage / cost records ────────────────────────────────────────
+    # ── 4. LLM usage / cost records ───────────────────────────────────────────
     usage_result = await db.exec(
-        select(ClaudeUsage)
-        .where(col(ClaudeUsage.task_id) == task_id)
-        .order_by(col(ClaudeUsage.id).asc())
+        select(LlmUsage).where(col(LlmUsage.task_id) == task_id).order_by(col(LlmUsage.id).asc())
     )
     for usage in usage_result.all():
+        tool_label = usage.tool or "claude"
         if usage.kind == "result":
             cost_str = f", cost ${usage.cost_usd:.4f}" if usage.cost_usd else ""
             summary = (
-                f"Claude run complete: {usage.stop_reason or '?'}, "
+                f"{tool_label} run complete: {usage.stop_reason or '?'}, "
                 f"{usage.num_turns or 0} turns{cost_str}"
             )
         else:

--- a/backend/routes/usage.py
+++ b/backend/routes/usage.py
@@ -1,9 +1,9 @@
-"""Claude usage reporting from workers' headless runs.
+"""LLM usage reporting from workers' headless runs.
 
-Workers parse ``claude --output-format stream-json`` and POST per-API-call
-usage (one record per assistant message) plus a single ``result`` record per
-run. Rows are stored in ``claude_usage`` and a summary is broadcast so the
-frontend can surface live token/cost figures per task.
+Workers parse tool output (e.g. ``claude --output-format stream-json``) and
+POST per-API-call usage (one record per assistant message) plus a single
+``result`` record per run. Rows are stored in ``llm_usage`` and a summary is
+broadcast so the frontend can surface live token/cost figures per task.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from auth_deps import get_guild_pk, require_member, require_worker_or_member_pat
 from database import get_db_dep
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException
-from models import ClaudeUsage
+from models import LlmUsage
 from pydantic import BaseModel, ValidationError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -43,6 +43,8 @@ class UsageReport(BaseModel):
     task_id: str | None = None
     worker_id: str | None = None
     session_id: str | None = None
+    # Tool runner that produced this usage (e.g. "claude", "pi", "codex").
+    tool: str = "claude"
     repo: str | None = None
     reporter: str | None = None
     records: list[UsageRecord]
@@ -90,11 +92,12 @@ async def report_usage(
     created_at = datetime.now(UTC)
     for rec in data.records:
         db.add(
-            ClaudeUsage(
+            LlmUsage(
                 guild_id=guild_pk,
                 task_id=data.task_id,
                 worker_id=data.worker_id,
                 session_id=data.session_id,
+                tool=data.tool,
                 kind=rec.kind,
                 call_index=rec.call_index,
                 model=rec.model,
@@ -117,6 +120,7 @@ async def report_usage(
             taskId=data.task_id,
             workerId=data.worker_id,
             sessionId=data.session_id,
+            tool=data.tool,
             model=next((r.model for r in data.records if r.model), None),
             repo=data.repo,
             reporter=data.reporter,
@@ -141,9 +145,9 @@ async def list_usage(
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
-    query = select(ClaudeUsage).where(col(ClaudeUsage.guild_id) == guild_pk)
+    query = select(LlmUsage).where(col(LlmUsage.guild_id) == guild_pk)
     if task_id is not None:
-        query = query.where(col(ClaudeUsage.task_id) == task_id)
-    query = query.order_by(col(ClaudeUsage.id).desc()).limit(min(limit, 2000))
+        query = query.where(col(LlmUsage.task_id) == task_id)
+    query = query.order_by(col(LlmUsage.id).desc()).limit(min(limit, 2000))
     result = await db.exec(query)
     return [row_to_dict(r) for r in result.all()]

--- a/backend/tests/test_debug_timeline.py
+++ b/backend/tests/test_debug_timeline.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 sys.path.insert(0, os.path.dirname(__file__))
 
 from helpers import _sync_session, insert_guild, insert_task, insert_worker, make_auth_token
-from models import ClaudeUsage, TaskLog
+from models import LlmUsage, TaskLog
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col
 
@@ -65,7 +65,7 @@ def _insert_usage(db_url: str, guild_id: str, task_id: str) -> None:
         )
         assert guild_pk is not None
         session.execute(
-            pg_insert(ClaudeUsage).values(
+            pg_insert(LlmUsage).values(
                 guild_id=guild_pk,
                 task_id=task_id,
                 kind="result",

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -307,7 +307,7 @@ class GithubEventMsg(_WS):
 
 
 class ClaudeUsageMsg(_WS):
-    """Claude session usage stats. Extra fields from _summarize() are allowed."""
+    """LLM session usage stats. Extra fields from _summarize() are allowed."""
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
@@ -315,6 +315,8 @@ class ClaudeUsageMsg(_WS):
     taskId: str | None = None
     workerId: str | None = None
     sessionId: str | None = None
+    # Tool runner that produced this usage (e.g. "claude", "pi", "codex").
+    tool: str | None = None
     model: str | None = None
     repo: str | None = None
     reporter: str | None = None

--- a/frontend/src/stores/usage.ts
+++ b/frontend/src/stores/usage.ts
@@ -7,11 +7,12 @@ import type { ClaudeUsageWS, WSInbound } from '../types'
 // REST rows into so the UI has a single type to render.
 export type UsageSummary = Omit<ClaudeUsageWS, 'type'>
 
-// One raw row as stored in claude_usage (per API call or the run's result).
+// One raw row as stored in llm_usage (per API call or the run's result).
 interface UsageRow {
   task_id: string | null
   worker_id: string | null
   session_id: string | null
+  tool: string | null
   kind: string
   call_index: number | null
   model: string | null
@@ -29,6 +30,7 @@ interface UsageRow {
 function _emptySummary(taskId: string | null): UsageSummary {
   return {
     taskId,
+    tool: null,
     apiCalls: 0,
     summedInputTokens: 0,
     summedOutputTokens: 0,
@@ -49,6 +51,7 @@ function _aggregate(rows: UsageRow[]): Record<string, UsageSummary> {
   for (const r of rows) {
     if (!r.task_id) continue
     const s = (out[r.task_id] ??= _emptySummary(r.task_id))
+    s.tool ??= r.tool
     s.model ??= r.model
     s.repo ??= r.repo
     s.reporter ??= r.reporter

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -289,6 +289,8 @@ export interface ClaudeUsageWS {
   taskId: string | null
   workerId?: string | null
   sessionId?: string | null
+  /** Tool runner that produced this usage (e.g. "claude", "pi", "codex"). */
+  tool?: string | null
   model?: string | null
   repo?: string | null
   reporter?: string | null

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -223,6 +223,7 @@ class Worker:
         self,
         *,
         task_id: str,
+        tool: str,
         session_id: str | None,
         repo: str | None,
         records: list[dict],
@@ -237,6 +238,7 @@ class Worker:
             "task_id": task_id,
             "worker_id": self.cfg.worker_id,
             "session_id": session_id,
+            "tool": tool,
             "repo": repo,
             "reporter": self._worker_name or self.cfg.worker_id,
             "records": records,
@@ -2155,10 +2157,11 @@ class Worker:
                 stop_reason,
             )
 
-            # Report captured per-API-call usage (claude tasks only). Best-effort.
+            # Report captured per-API-call usage. Best-effort.
             if usage_records:
                 await self._report_usage(
                     task_id=task_id,
+                    tool=tool,
                     session_id=resume_session_id,
                     repo=repos[0] if repos else None,
                     records=usage_records,


### PR DESCRIPTION
## Summary

- **Rename** the `claude_usage` DB table → `llm_usage` so usage tracking is not Claude-specific and can represent any tool runner (`claude`, `pi`, `codex`, …). Renames `ClaudeUsage` ORM model → `LlmUsage` throughout the backend.
- **Add `tool` column** (TEXT, default `'claude'`) to `llm_usage` — records which runner produced each usage row. Propagated through the full stack: DB migration → ORM → REST payload (`UsageReport`) → WebSocket broadcast (`ClaudeUsageMsg`) → frontend store (`UsageRow`, `_emptySummary`, `_aggregate`).
- **DB migration** (`20260619_000000_rename_claude_usage_to_llm_usage`): renames table + indexes, adds `tool` column with a downgrade path.
- **Worker** (`_report_usage`): accepts a `tool` kwarg and includes it in the POST body.
- **Debug timeline** (routes/debug.py): uses `LlmUsage`; timeline summary lines now include the tool name (e.g. `"pi run complete: end_turn, 5 turns"`).

The WebSocket message type stays `"claude-usage"` (stable protocol identifier — renaming it would be a breaking wire-protocol change).

## Test plan

- [ ] `cd backend && python -m pytest tests/test_usage_api.py tests/test_debug_timeline.py` (requires `docker compose up -d postgres-test`)
- [ ] `cd frontend && npm run type-check` — passes (verified locally)
- [ ] `ruff check . && ruff format .` — passes (verified locally)
- [ ] Spin up the full stack, have a worker complete a task, confirm `llm_usage` rows appear with the correct `tool` value

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)