### PR TITLE
Fix Anthropic auth token not passed to API call (#660)

### DIFF
--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -251,20 +251,24 @@ def make_anthropic_client(
 
     # Direct Anthropic API. The SDK reads ANTHROPIC_* from os.environ on its own,
     # but guild-configured env_vars never reach this process, so resolve them
-    # from the merged `env` and pass explicitly. Explicit api_key arg wins.
+    # from the merged `env` and pass explicitly.
+    # api_key and auth_token are mutually exclusive; auth_token takes precedence
+    # so a guild-configured ANTHROPIC_AUTH_TOKEN overrides a process-level
+    # ANTHROPIC_API_KEY rather than causing an SDK ValueError.
     kwargs: dict = {}
-    resolved_api_key = api_key or env.get("ANTHROPIC_API_KEY")
-    if resolved_api_key:
-        kwargs["api_key"] = resolved_api_key
     if env.get("ANTHROPIC_AUTH_TOKEN"):
         kwargs["auth_token"] = env["ANTHROPIC_AUTH_TOKEN"]
+    else:
+        resolved_api_key = api_key or env.get("ANTHROPIC_API_KEY")
+        if resolved_api_key:
+            kwargs["api_key"] = resolved_api_key
     if env.get("ANTHROPIC_BASE_URL"):
         kwargs["base_url"] = env["ANTHROPIC_BASE_URL"]
     logger.info(
         "Foreman using Anthropic API (auth=%s, base_url=%s)",
         "auth-token"
         if kwargs.get("auth_token")
-        else ("api-key" if resolved_api_key else "default"),
+        else ("api-key" if kwargs.get("api_key") else "default"),
         kwargs.get("base_url", "default"),
     )
     return _anthropic_mod.AsyncAnthropic(**kwargs)

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -306,6 +306,40 @@ class TestMakeAnthropicClient:
         )
         mock_mod.AsyncAnthropic.assert_called_once_with(api_key="sk-explicit")
 
+    def test_auth_token_wins_over_process_api_key(self, monkeypatch):
+        """Regression for #660: ANTHROPIC_AUTH_TOKEN in guild env_vars must win over a
+        process-level ANTHROPIC_API_KEY so the SDK never receives both (it raises ValueError
+        when api_key and auth_token are both supplied)."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        # Simulate a server environment where ANTHROPIC_API_KEY is set in the process env
+        # while the guild config supplies ANTHROPIC_AUTH_TOKEN via extra_env.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-process-level")
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(
+            provider="anthropic", extra_env={"ANTHROPIC_AUTH_TOKEN": "tok-guild-configured"}
+        )
+        # Must pass ONLY auth_token — not api_key — to avoid the SDK ValueError.
+        mock_mod.AsyncAnthropic.assert_called_once_with(auth_token="tok-guild-configured")
+
+    def test_auth_token_wins_over_explicit_api_key_arg(self, monkeypatch):
+        """ANTHROPIC_AUTH_TOKEN in extra_env wins even when api_key is passed explicitly."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(
+            provider="anthropic",
+            api_key="sk-explicit",
+            extra_env={"ANTHROPIC_AUTH_TOKEN": "tok-guild-configured"},
+        )
+        mock_mod.AsyncAnthropic.assert_called_once_with(auth_token="tok-guild-configured")
+
     def test_missing_anthropic_package_raises(self, monkeypatch):
         """If anthropic is not installed, make_anthropic_client must raise ImportError."""
         monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)

--- a/foreman/pioneer-foreman.toml.example
+++ b/foreman/pioneer-foreman.toml.example
@@ -14,6 +14,9 @@ backend_key = ""
 [claude]
 model         = "claude-sonnet-4-6"    # used when provider = "anthropic"
 api_key       = ""                     # falls back to ANTHROPIC_API_KEY env var
+# auth_token  = ""                     # OAuth/claude.ai token; falls back to
+                                       # ANTHROPIC_AUTH_TOKEN env var.  Mutually
+                                       # exclusive with api_key — auth_token wins.
 max_rounds    = 10
 history_limit = 40
 

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -35,6 +35,11 @@ class Config:
     # Ignored when provider != "bedrock".
     bedrock_model: str = _DEFAULT_BEDROCK_MODEL
     api_key: str | None = None
+    # Anthropic auth token (OAuth/claude.ai accounts).  Mutually exclusive with
+    # api_key; when set it is forwarded as `auth_token` to AsyncAnthropic and
+    # ANTHROPIC_API_KEY is ignored.  Reads ANTHROPIC_AUTH_TOKEN env var or
+    # [claude] auth_token in the TOML.
+    anthropic_auth_token: str | None = None
     # "anthropic" (default) or "bedrock" (Amazon Bedrock via AsyncAnthropicBedrock)
     provider: str = "anthropic"
     # AWS region for Bedrock; ignored when provider != "bedrock"
@@ -151,6 +156,12 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         or os.environ.get("ANTHROPIC_API_KEY")
     ) or None
 
+    anthropic_auth_token = (
+        overrides.get("anthropic_auth_token")
+        or claude_block.get("auth_token")
+        or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+    ) or None
+
     model = (
         overrides.get("model")
         or claude_block.get("model")
@@ -201,6 +212,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         model=model,
         bedrock_model=bedrock_model,
         api_key=api_key,
+        anthropic_auth_token=anthropic_auth_token,
         provider=provider,
         aws_region=aws_region,
         aws_profile=aws_profile,

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -42,13 +42,18 @@ def _get_anthropic_client(config: Config):
     region = getattr(config, "aws_region", None)
     profile = getattr(config, "aws_profile", None)
     api_key = getattr(config, "api_key", None) or ""
-    cache_key = (provider.lower(), region, profile, api_key)
+    anthropic_auth_token = getattr(config, "anthropic_auth_token", None) or ""
+    cache_key = (provider.lower(), region, profile, api_key, anthropic_auth_token)
     if cache_key not in _anthropic_clients:
+        extra_env: dict[str, str] = {}
+        if anthropic_auth_token:
+            extra_env["ANTHROPIC_AUTH_TOKEN"] = anthropic_auth_token
         _anthropic_clients[cache_key] = make_anthropic_client(
             provider=provider,
             api_key=api_key or None,
             region=region,
             aws_profile=profile,
+            extra_env=extra_env or None,
         )
     return _anthropic_clients[cache_key]
 

--- a/foreman/tests/test_config.py
+++ b/foreman/tests/test_config.py
@@ -256,3 +256,44 @@ def test_backend_url_trailing_slash_stripped(tmp_path):
     toml_path.write_text('backend_url = "ws://x:1/"\nguild_id = "g"\n')
     cfg = load(str(toml_path))
     assert not cfg.backend_url.endswith("/")
+
+
+# ── Anthropic auth_token ──────────────────────────────────────────────────
+
+
+def test_load_toml_claude_auth_token(tmp_path):
+    """[claude] auth_token in TOML is loaded as anthropic_auth_token."""
+    toml_path = tmp_path / "pioneer-foreman.toml"
+    toml_path.write_text(
+        'backend_url = "ws://x:1"\nguild_id = "g"\n[claude]\nauth_token = "tok-toml"\n'
+    )
+    cfg = load(str(toml_path))
+    assert cfg.anthropic_auth_token == "tok-toml"
+
+
+def test_load_env_anthropic_auth_token(tmp_path, monkeypatch):
+    """ANTHROPIC_AUTH_TOKEN env var is loaded as anthropic_auth_token."""
+    monkeypatch.setenv("PIONEER_BACKEND_URL", "ws://x:1")
+    monkeypatch.setenv("PIONEER_GUILD_ID", "g")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-env")
+    cfg = load(str(tmp_path / "missing.toml"))
+    assert cfg.anthropic_auth_token == "tok-env"
+
+
+def test_load_toml_auth_token_beats_env(tmp_path, monkeypatch):
+    """TOML [claude] auth_token takes precedence over ANTHROPIC_AUTH_TOKEN env var."""
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-env")
+    toml_path = tmp_path / "pioneer-foreman.toml"
+    toml_path.write_text(
+        'backend_url = "ws://x:1"\nguild_id = "g"\n[claude]\nauth_token = "tok-toml"\n'
+    )
+    cfg = load(str(toml_path))
+    assert cfg.anthropic_auth_token == "tok-toml"
+
+
+def test_load_anthropic_auth_token_defaults_to_none(tmp_path):
+    """anthropic_auth_token is None when not configured anywhere."""
+    toml_path = tmp_path / "pioneer-foreman.toml"
+    toml_path.write_text('backend_url = "ws://x:1"\nguild_id = "g"\n')
+    cfg = load(str(toml_path))
+    assert cfg.anthropic_auth_token is None


### PR DESCRIPTION
## Summary

- **Root cause**: `make_anthropic_client()` in `backend/foreman_core/llm.py` was building kwargs with both `api_key` (from the server's process-level `ANTHROPIC_API_KEY`) and `auth_token` (from the guild's configured `ANTHROPIC_AUTH_TOKEN`). The Anthropic SDK raises `ValueError` when both are supplied — they are mutually exclusive — so the configured auth token never reached the API call.

- **Embedded foreman fix**: `auth_token` now takes unconditional precedence over `api_key` in `make_anthropic_client()`. When `ANTHROPIC_AUTH_TOKEN` is present in the effective env (process env merged with guild `extra_env`), `api_key` is skipped entirely.

- **Standalone foreman fix**: The `pioneer-foreman.toml` config had no field for an Anthropic `auth_token`. Added `anthropic_auth_token` to `Config`, reads it from `[claude] auth_token` in TOML or `ANTHROPIC_AUTH_TOKEN` env var, and forwards it to `make_anthropic_client()` via `extra_env` in `_get_anthropic_client()`.

## Files changed

- `backend/foreman_core/llm.py` — core fix: `auth_token` wins over `api_key`
- `foreman/pioneer_foreman/config.py` — new `anthropic_auth_token` field + loading
- `foreman/pioneer_foreman/runner.py` — pass `auth_token` via `extra_env`
- `foreman/pioneer-foreman.toml.example` — document the new option
- `backend/tests/test_foreman_llm.py` — regression tests for the conflict case
- `foreman/tests/test_config.py` — tests for TOML/env loading of `auth_token`

## Test plan

- [x] `cd backend && python -m pytest tests/test_foreman_llm.py -v` — 24 passed (2 new)
- [x] `cd foreman && python -m pytest tests/test_config.py -v` — 34 passed (4 new)
- [x] `ruff check . --fix && ruff format .` — clean

Closes #660