### PR TITLE
feat(frontend): add guild member invitation/management UI

### DIFF
--- a/frontend/src/components/GuildMembers.vue
+++ b/frontend/src/components/GuildMembers.vue
@@ -1,0 +1,356 @@
+<template>
+  <div class="members-section">
+    <div v-if="loading" class="members-loading">Loading…</div>
+    <div v-else>
+      <ul class="member-list">
+        <li v-for="m in members" :key="m.user_id" class="member-row">
+          <img v-if="m.avatar_url" :src="m.avatar_url" class="member-avatar" alt="" />
+          <span v-else class="member-avatar member-avatar--placeholder">{{ initials(m) }}</span>
+          <span class="member-name" :title="m.user_id">{{ memberLabel(m) }}</span>
+          <select
+            v-if="canManage && !isLastOwner(m)"
+            class="member-role-select"
+            :value="m.role"
+            :disabled="busyUser === m.user_id"
+            @change="changeRole(m, ($event.target as HTMLSelectElement).value)"
+          >
+            <option v-for="r in ROLES" :key="r" :value="r">{{ r }}</option>
+          </select>
+          <span v-else class="member-role-badge" :class="'member-role-badge--' + m.role">{{
+            m.role
+          }}</span>
+          <button
+            v-if="canManage && !isLastOwner(m)"
+            class="member-remove-btn"
+            :disabled="busyUser === m.user_id"
+            title="Remove member"
+            @click="removeMember(m)"
+          >
+            ✕
+          </button>
+        </li>
+      </ul>
+
+      <div v-if="canManage" class="invite-form">
+        <div class="invite-row">
+          <input
+            v-model="inviteValue"
+            class="settings-input invite-input"
+            placeholder="GitHub username"
+            spellcheck="false"
+            autocomplete="off"
+            :disabled="inviting"
+            @keydown.enter="invite"
+          />
+          <select v-model="inviteRole" class="member-role-select" :disabled="inviting">
+            <option v-for="r in ROLES" :key="r" :value="r">{{ r }}</option>
+          </select>
+          <button
+            class="pixel-btn invite-btn"
+            :disabled="inviting || !inviteValue.trim()"
+            @click="invite"
+          >
+            {{ inviting ? '…' : 'Invite' }}
+          </button>
+        </div>
+        <div v-if="inviteError" class="members-error">{{ inviteError }}</div>
+        <div v-else-if="inviteHint" class="members-hint">{{ inviteHint }}</div>
+      </div>
+      <div v-else-if="!loading" class="members-hint">Only owners can invite members.</div>
+
+      <div v-if="loadError" class="members-error">{{ loadError }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { api, ApiError } from '../utils/api'
+import { useAuthStore } from '../stores/auth'
+
+const ROLES = ['owner', 'member', 'viewer'] as const
+
+interface GuildMemberRow {
+  user_id: string
+  role: string
+  created_at: string
+  github_login: string | null
+  display_name: string | null
+  avatar_url: string | null
+}
+
+const props = defineProps<{ guildId: string }>()
+
+const authStore = useAuthStore()
+
+const members = ref<GuildMemberRow[]>([])
+const loading = ref(false)
+const loadError = ref('')
+
+const inviteValue = ref('')
+const inviteRole = ref<string>('member')
+const inviting = ref(false)
+const inviteError = ref('')
+const inviteHint = ref('')
+
+const busyUser = ref<string | null>(null)
+
+// The caller's role in this guild, derived from the members list.
+const myRole = computed(() => {
+  const id = authStore.user?.id
+  if (!id) return null
+  return members.value.find((m) => m.user_id === id)?.role ?? null
+})
+const canManage = computed(() => myRole.value === 'owner')
+
+const ownerCount = computed(() => members.value.filter((m) => m.role === 'owner').length)
+
+// The last remaining owner can't be demoted or removed (backend enforces this
+// too); hide the controls so the UI matches.
+function isLastOwner(m: GuildMemberRow): boolean {
+  return m.role === 'owner' && ownerCount.value <= 1
+}
+
+function memberLabel(m: GuildMemberRow): string {
+  return m.github_login || m.display_name || m.user_id
+}
+
+function initials(m: GuildMemberRow): string {
+  const label = memberLabel(m)
+  return label.slice(0, 2).toUpperCase()
+}
+
+async function load() {
+  if (!props.guildId) return
+  loading.value = true
+  loadError.value = ''
+  try {
+    members.value = await api<GuildMemberRow[]>(
+      `/api/guilds/${encodeURIComponent(props.guildId)}/members`,
+    )
+  } catch (e) {
+    loadError.value = e instanceof ApiError ? e.message : 'Failed to load members'
+    members.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+async function invite() {
+  const user = inviteValue.value.trim()
+  if (!user || inviting.value) return
+  inviting.value = true
+  inviteError.value = ''
+  inviteHint.value = ''
+  try {
+    await api(`/api/guilds/${encodeURIComponent(props.guildId)}/members`, {
+      method: 'POST',
+      json: { user, role: inviteRole.value },
+    })
+    inviteValue.value = ''
+    inviteHint.value = `Added ${user} as ${inviteRole.value}.`
+    await load()
+  } catch (e) {
+    inviteError.value = e instanceof ApiError ? e.message : 'Failed to invite member'
+  } finally {
+    inviting.value = false
+  }
+}
+
+async function changeRole(m: GuildMemberRow, role: string) {
+  if (role === m.role) return
+  busyUser.value = m.user_id
+  inviteError.value = ''
+  try {
+    await api(`/api/guilds/${encodeURIComponent(props.guildId)}/members/${m.user_id}`, {
+      method: 'PATCH',
+      json: { role },
+    })
+    await load()
+  } catch (e) {
+    inviteError.value = e instanceof ApiError ? e.message : 'Failed to change role'
+    // Reload to revert the optimistic <select> value to the server's state.
+    await load()
+  } finally {
+    busyUser.value = null
+  }
+}
+
+async function removeMember(m: GuildMemberRow) {
+  busyUser.value = m.user_id
+  inviteError.value = ''
+  try {
+    await api(`/api/guilds/${encodeURIComponent(props.guildId)}/members/${m.user_id}`, {
+      method: 'DELETE',
+    })
+    await load()
+  } catch (e) {
+    inviteError.value = e instanceof ApiError ? e.message : 'Failed to remove member'
+  } finally {
+    busyUser.value = null
+  }
+}
+
+watch(() => props.guildId, load, { immediate: true })
+</script>
+
+<style scoped>
+.members-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 6px;
+  padding: 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+}
+
+.members-loading {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+
+.member-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.member-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.member-avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1px solid var(--color-teal);
+  flex-shrink: 0;
+}
+
+.member-avatar--placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-dim);
+  font-family: var(--font-mono, monospace);
+  font-size: 8px;
+}
+
+.member-name {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.member-role-select {
+  background: var(--color-bg);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  padding: 3px 5px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.member-role-badge {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 3px 6px;
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+}
+
+.member-role-badge--owner {
+  color: var(--color-brass-light);
+  border-color: var(--color-brass);
+}
+
+.member-remove-btn {
+  background: none;
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text-dim);
+  cursor: pointer;
+  width: 22px;
+  height: 22px;
+  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  flex-shrink: 0;
+  transition:
+    border-color 0.12s,
+    color 0.12s;
+}
+
+.member-remove-btn:hover:not(:disabled) {
+  border-color: var(--color-red, #c0392b);
+  color: var(--color-red, #c0392b);
+}
+
+.member-remove-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.invite-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-top: 1px solid var(--color-brass-dark);
+  padding-top: 8px;
+}
+
+.invite-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.invite-input {
+  flex: 1;
+  font-size: 10px;
+}
+
+.invite-btn {
+  font-size: 7px;
+  padding: 5px 9px;
+  flex-shrink: 0;
+}
+
+.invite-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.members-error {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--color-red, #e74c3c);
+}
+
+.members-hint {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+</style>

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -277,6 +277,14 @@
         </div>
       </div>
 
+      <div class="settings-field">
+        <label class="settings-label">Members</label>
+        <button class="pixel-btn foreman-toggle-btn" @click="showMembers = !showMembers">
+          {{ showMembers ? 'Hide' : 'Manage' }}
+        </button>
+        <GuildMembers v-if="showMembers" :guild-id="currentGuild.id" />
+      </div>
+
       <div class="settings-field settings-meta">
         <span class="settings-meta-label">Session ID</span>
         <code class="settings-meta-value">{{ currentGuild.id }}</code>
@@ -295,6 +303,7 @@ import { useGitHubStore } from '../stores/github'
 import { useAuthStore } from '../stores/auth'
 import { useModels } from '../composables/useModels'
 import GitHubConfigModal from './GitHubConfigModal.vue'
+import GuildMembers from './GuildMembers.vue'
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
 
@@ -359,6 +368,7 @@ const claudeCredsError = ref<string | null>(null)
 const claudeCredsConfirmDelete = ref(false)
 
 const showForemanConfig = ref(false)
+const showMembers = ref(false)
 const foremanModel = ref('')
 const foremanProvider = ref('')
 const foremanSystemSuffix = ref('')
@@ -551,6 +561,7 @@ watch(
     claudeCredsError.value = null
     claudeCredsConfirmDelete.value = false
     showForemanConfig.value = false
+    showMembers.value = false
     foremanModel.value = ''
     foremanProvider.value = ''
     foremanSystemSuffix.value = ''

--- a/frontend/src/components/__tests__/GuildMembers.spec.ts
+++ b/frontend/src/components/__tests__/GuildMembers.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { flushPromises, mount } from '@vue/test-utils'
+import GuildMembers from '../GuildMembers.vue'
+import { useAuthStore } from '../../stores/auth'
+
+const OWNER = {
+  user_id: 'u-owner',
+  role: 'owner',
+  created_at: '2026-01-01T00:00:00Z',
+  github_login: 'owner',
+  display_name: 'Owner',
+  avatar_url: '',
+}
+const MEMBER = {
+  user_id: 'u-member',
+  role: 'member',
+  created_at: '2026-01-02T00:00:00Z',
+  github_login: 'bob',
+  display_name: 'Bob',
+  avatar_url: '',
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+function mountAs(userId: string | null, members: unknown[]) {
+  const auth = useAuthStore()
+  auth.user = userId ? { id: userId, login: 'me' } : null
+  auth.loginToken = 'tok'
+  const fetchMock = vi.spyOn(globalThis, 'fetch')
+  fetchMock.mockResolvedValueOnce(jsonResponse(members)) // initial load
+  const wrapper = mount(GuildMembers, { props: { guildId: 'g1' } })
+  return { wrapper, fetchMock }
+}
+
+describe('GuildMembers', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('lists members fetched from the API', async () => {
+    const { wrapper } = mountAs('u-owner', [OWNER, MEMBER])
+    await flushPromises()
+    const names = wrapper.findAll('.member-name').map((n) => n.text())
+    expect(names).toContain('owner')
+    expect(names).toContain('bob')
+  })
+
+  it('shows the invite form to owners', async () => {
+    const { wrapper } = mountAs('u-owner', [OWNER, MEMBER])
+    await flushPromises()
+    expect(wrapper.find('.invite-form').exists()).toBe(true)
+  })
+
+  it('hides invite controls for non-owners', async () => {
+    const { wrapper } = mountAs('u-member', [OWNER, MEMBER])
+    await flushPromises()
+    expect(wrapper.find('.invite-form').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Only owners can invite members')
+  })
+
+  it('posts an invite and reloads the list', async () => {
+    const { wrapper, fetchMock } = mountAs('u-owner', [OWNER])
+    await flushPromises()
+    fetchMock.mockResolvedValueOnce(jsonResponse({ user_id: 'u-member', role: 'member' })) // POST
+    fetchMock.mockResolvedValueOnce(jsonResponse([OWNER, MEMBER])) // reload
+    await wrapper.find('.invite-input').setValue('bob')
+    await wrapper.find('.invite-btn').trigger('click')
+    await flushPromises()
+    const postCall = fetchMock.mock.calls[1]
+    expect(postCall[0]).toContain('/api/guilds/g1/members')
+    expect(JSON.parse((postCall[1] as RequestInit).body as string)).toEqual({
+      user: 'bob',
+      role: 'member',
+    })
+    expect(wrapper.findAll('.member-name')).toHaveLength(2)
+  })
+
+  it('surfaces the API error when inviting an unknown user', async () => {
+    const { wrapper, fetchMock } = mountAs('u-owner', [OWNER])
+    await flushPromises()
+    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'User not found.' }, 404))
+    await wrapper.find('.invite-input').setValue('ghost')
+    await wrapper.find('.invite-btn').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.members-error').text()).toContain('User not found.')
+  })
+
+  it('does not allow removing the last owner', async () => {
+    const { wrapper } = mountAs('u-owner', [OWNER])
+    await flushPromises()
+    // Only owner present → no remove button / role select for them.
+    expect(wrapper.find('.member-remove-btn').exists()).toBe(false)
+    expect(wrapper.find('.member-role-badge--owner').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
Adds a Members section to the guild settings popover so owners can invite
members by GitHub username, change roles, and remove members — wiring up
the existing /api/guilds/{id}/members endpoints. Non-owners see a read-only
member list. The last owner can't be demoted/removed (mirrors backend).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nba33ftGZTuS5RmPHP33TH