### PR TITLE
feat(members): invite users by GitHub username or ID

### DIFF
--- a/backend/alembic/versions/20260621_000000_add_guild_invites.py
+++ b/backend/alembic/versions/20260621_000000_add_guild_invites.py
@@ -38,8 +38,26 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("ix_guild_invites_guild_id_status", "guild_invites", ["guild_id", "status"])
+    # Partial unique indexes prevent duplicate pending invites at the DB level,
+    # closing the TOCTOU race that application-level one_or_none() checks leave open.
+    op.create_index(
+        "uq_guild_invites_login_pending",
+        "guild_invites",
+        ["guild_id", "github_login"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending' AND github_login IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_guild_invites_github_id_pending",
+        "guild_invites",
+        ["guild_id", "github_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending' AND github_id IS NOT NULL"),
+    )
 
 
 def downgrade() -> None:
+    op.drop_index("uq_guild_invites_github_id_pending", table_name="guild_invites")
+    op.drop_index("uq_guild_invites_login_pending", table_name="guild_invites")
     op.drop_index("ix_guild_invites_guild_id_status", table_name="guild_invites")
     op.drop_table("guild_invites")

--- a/backend/alembic/versions/20260621_000000_add_guild_invites.py
+++ b/backend/alembic/versions/20260621_000000_add_guild_invites.py
@@ -1,0 +1,45 @@
+"""Add guild_invites table for pending GitHub-username invites.
+
+Revision ID: 20260621_000000_add_guild_invites
+Revises: 20260619_000000_rename_claude_usage_to_llm_usage
+Create Date: 2026-06-21
+
+Adds ``guild_invites`` to track pending invites addressed to a GitHub
+username or numeric ID. When the invited user logs in, ``oauth.create_session``
+auto-accepts matching invites and adds them as guild members.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260621_000000_add_guild_invites"
+down_revision: str | Sequence[str] | None = "20260619_000000_rename_claude_usage_to_llm_usage"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "guild_invites",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("guild_id", sa.Integer(), nullable=False),
+        sa.Column("github_login", sa.Text(), nullable=True),
+        sa.Column("github_id", sa.Text(), nullable=True),
+        sa.Column("role", sa.Text(), nullable=False, server_default="'member'"),
+        sa.Column("invited_by", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="'pending'"),
+        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"]),
+        sa.ForeignKeyConstraint(["invited_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_guild_invites_guild_id_status", "guild_invites", ["guild_id", "status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_guild_invites_guild_id_status", table_name="guild_invites")
+    op.drop_table("guild_invites")

--- a/backend/alembic/versions/20260621_000000_add_guild_invites.py
+++ b/backend/alembic/versions/20260621_000000_add_guild_invites.py
@@ -26,15 +26,14 @@ def upgrade() -> None:
     op.create_table(
         "guild_invites",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("guild_id", sa.Integer(), nullable=False),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
         sa.Column("github_login", sa.Text(), nullable=True),
         sa.Column("github_id", sa.Text(), nullable=True),
         sa.Column("role", sa.Text(), nullable=False, server_default="'member'"),
-        sa.Column("invited_by", sa.Text(), nullable=False),
+        # users.id is sa.Text() — GitHub numeric user ID stored as text.
+        sa.Column("invited_by", sa.Text(), sa.ForeignKey("users.id"), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("status", sa.Text(), nullable=False, server_default="'pending'"),
-        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"]),
-        sa.ForeignKeyConstraint(["invited_by"], ["users.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("ix_guild_invites_guild_id_status", "guild_invites", ["guild_id", "status"])

--- a/backend/models.py
+++ b/backend/models.py
@@ -246,6 +246,24 @@ class GuildMember(SQLModel, table=True):
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
+class GuildInvite(SQLModel, table=True):
+    __tablename__ = "guild_invites"  # type: ignore[assignment]
+    __table_args__ = (Index("ix_guild_invites_guild_id_status", "guild_id", "status"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    guild_id: int = Field(foreign_key="guilds.id")
+    # Exactly one of github_login / github_id is non-null, depending on what the inviter typed.
+    github_login: str | None = None  # GitHub username (stored lowercase)
+    github_id: str | None = None  # GitHub numeric user ID
+    role: str = Field(
+        default="member", sa_column_kwargs={"server_default": "'member'"}
+    )  # owner | member | viewer
+    invited_by: str = Field(foreign_key="users.id")
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    # pending | accepted | cancelled
+    status: str = Field(default="pending", sa_column_kwargs={"server_default": "'pending'"})
+
+
 class TaskLog(SQLModel, table=True):
     __tablename__ = "task_logs"  # type: ignore[assignment]
 

--- a/backend/oauth.py
+++ b/backend/oauth.py
@@ -207,14 +207,18 @@ async def create_session(code: str, state: str) -> dict:
         db.add(UserSession(token=login_token, github_user_id=github_user_id, created_at=now))
 
         # Auto-accept any pending invites addressed to this user's login or numeric ID.
+        # with_for_update() locks matching rows so two concurrent logins for the same
+        # user can't both read status='pending' and double-process the same invite.
         pending_res = await db.exec(
-            select(GuildInvite).where(
+            select(GuildInvite)
+            .where(
                 col(GuildInvite.status) == "pending",
                 or_(
                     col(GuildInvite.github_login) == github_username.lower(),
                     col(GuildInvite.github_id) == github_user_id,
                 ),
             )
+            .with_for_update()
         )
         for invite in pending_res.all():
             member_stmt = pg_insert(GuildMember).values(

--- a/backend/oauth.py
+++ b/backend/oauth.py
@@ -21,8 +21,10 @@ from datetime import UTC, datetime
 
 from database import get_db
 from fastapi import HTTPException
-from models import GithubToken, User, UserSession
+from models import GithubToken, GuildInvite, GuildMember, User, UserSession
+from sqlalchemy import or_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import col, select
 
 # ---------------------------------------------------------------------------
 # Config (read at import time from environment)
@@ -203,6 +205,31 @@ async def create_session(code: str, state: str) -> dict:
         )
         await db.exec(user_stmt)
         db.add(UserSession(token=login_token, github_user_id=github_user_id, created_at=now))
+
+        # Auto-accept any pending invites addressed to this user's login or numeric ID.
+        pending_res = await db.exec(
+            select(GuildInvite).where(
+                col(GuildInvite.status) == "pending",
+                or_(
+                    col(GuildInvite.github_login) == github_username.lower(),
+                    col(GuildInvite.github_id) == github_user_id,
+                ),
+            )
+        )
+        for invite in pending_res.all():
+            member_stmt = pg_insert(GuildMember).values(
+                guild_id=invite.guild_id,
+                user_id=github_user_id,
+                role=invite.role,
+                created_at=now,
+            )
+            member_stmt = member_stmt.on_conflict_do_update(
+                index_elements=["guild_id", "user_id"],
+                set_={"role": member_stmt.excluded.role},
+            )
+            await db.exec(member_stmt)
+            invite.status = "accepted"
+
         await db.commit()
     finally:
         await db.close()

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -16,7 +16,7 @@ from auth_deps import get_guild_pk, require_member, require_user, require_worker
 from database import get_db_dep
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException
-from models import Agent, Guild, GuildMember, Message, User, Worker
+from models import Agent, Guild, GuildInvite, GuildMember, Message, User, Worker
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import delete, func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -108,6 +108,12 @@ class MemberCreate(BaseModel):
 
 class MemberUpdate(BaseModel):
     role: str  # owner | member | viewer
+
+
+class InviteCreate(BaseModel):
+    # GitHub username or numeric GitHub ID of the person to invite.
+    user: str
+    role: str = "member"  # owner | member | viewer
 
 
 @router.post("/guilds")
@@ -473,6 +479,148 @@ async def update_foreman_config(
     guild.foreman_config = config
     await db.commit()
     return config
+
+
+@router.post("/api/guilds/{guild_id}/invites")
+async def create_guild_invite(
+    guild_id: str,
+    data: InviteCreate,
+    github_user_id: str = Depends(require_member("owner")),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Create a pending invite for a GitHub user by username or numeric ID (owner only).
+
+    The invite is stored and automatically applied when the target user first logs in.
+    If a pending invite already exists for the same identifier, the role is updated.
+    """
+    if data.role not in _VALID_ROLES:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid role; must be one of {sorted(_VALID_ROLES)}"
+        )
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+
+    identifier = data.user.strip()
+    if not identifier:
+        raise HTTPException(status_code=400, detail="GitHub username or ID is required")
+
+    # Numeric strings are treated as GitHub user IDs; everything else is a username.
+    is_numeric = identifier.isdigit()
+    github_login = None if is_numeric else identifier.lower()
+    github_id_val = identifier if is_numeric else None
+
+    now = datetime.now(UTC)
+
+    # Upsert: update role on an existing pending invite for the same identifier.
+    if github_login is not None:
+        existing_res = await db.exec(
+            select(GuildInvite).where(
+                col(GuildInvite.guild_id) == guild_pk,
+                col(GuildInvite.github_login) == github_login,
+                col(GuildInvite.status) == "pending",
+            )
+        )
+    else:
+        existing_res = await db.exec(
+            select(GuildInvite).where(
+                col(GuildInvite.guild_id) == guild_pk,
+                col(GuildInvite.github_id) == github_id_val,
+                col(GuildInvite.status) == "pending",
+            )
+        )
+    existing = existing_res.one_or_none()
+    if existing:
+        existing.role = data.role
+        await db.commit()
+        await db.refresh(existing)
+        return {
+            "id": existing.id,
+            "guild_id": guild_id,
+            "github_login": existing.github_login,
+            "github_id": existing.github_id,
+            "role": existing.role,
+            "created_at": existing.created_at,
+            "status": existing.status,
+        }
+
+    invite = GuildInvite(
+        guild_id=guild_pk,
+        github_login=github_login,
+        github_id=github_id_val,
+        role=data.role,
+        invited_by=github_user_id,
+        created_at=now,
+        status="pending",
+    )
+    db.add(invite)
+    await db.commit()
+    await db.refresh(invite)
+    return {
+        "id": invite.id,
+        "guild_id": guild_id,
+        "github_login": invite.github_login,
+        "github_id": invite.github_id,
+        "role": invite.role,
+        "created_at": invite.created_at,
+        "status": invite.status,
+    }
+
+
+@router.get("/api/guilds/{guild_id}/invites")
+async def list_guild_invites(
+    guild_id: str,
+    github_user_id: str = Depends(require_member("owner")),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """List pending invites for a guild (owner only)."""
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    result = await db.exec(
+        select(GuildInvite)
+        .where(
+            col(GuildInvite.guild_id) == guild_pk,
+            col(GuildInvite.status) == "pending",
+        )
+        .order_by(col(GuildInvite.created_at).asc())
+    )
+    return [
+        {
+            "id": inv.id,
+            "github_login": inv.github_login,
+            "github_id": inv.github_id,
+            "role": inv.role,
+            "created_at": inv.created_at,
+            "status": inv.status,
+        }
+        for inv in result.all()
+    ]
+
+
+@router.delete("/api/guilds/{guild_id}/invites/{invite_id}")
+async def cancel_guild_invite(
+    guild_id: str,
+    invite_id: int,
+    github_user_id: str = Depends(require_member("owner")),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Cancel a pending invite (owner only)."""
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    res = await db.exec(
+        select(GuildInvite).where(
+            col(GuildInvite.id) == invite_id,
+            col(GuildInvite.guild_id) == guild_pk,
+        )
+    )
+    invite = res.one_or_none()
+    if not invite:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    invite.status = "cancelled"
+    await db.commit()
+    return {"status": "cancelled", "id": invite_id}
 
 
 @router.delete("/api/guilds/{guild_id}/members/{user_id}")

--- a/backend/tests/test_user_members_api.py
+++ b/backend/tests/test_user_members_api.py
@@ -10,8 +10,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
 from helpers import _sync_session, insert_guild, insert_member, make_auth_token
-from models import Guild, User
+from models import Guild, GuildInvite, GuildMember, User
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import col
 
 
 def _insert_guild_legacy_only(db_url: str, guild_id: str, user_id: str) -> None:
@@ -215,3 +217,250 @@ def test_api_me_excludes_legacy_guilds(client):
     assert resp.status_code == 200
     guild_ids = [m["guild_id"] for m in resp.json()["memberships"]]
     assert "gm-legacy" not in guild_ids
+
+
+# ---------------------------------------------------------------------------
+# Pending invite (GitHub username/ID invite flow)
+# ---------------------------------------------------------------------------
+
+
+def test_create_invite_by_username(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gi-create")
+    token = make_auth_token(db_url)
+    resp = test_client.post(
+        "/api/guilds/gi-create/invites",
+        json={"user": "newgithubuser", "role": "member"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["github_login"] == "newgithubuser"
+    assert body["github_id"] is None
+    assert body["role"] == "member"
+    assert body["status"] == "pending"
+
+
+def test_create_invite_by_numeric_id(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gi-numeric")
+    token = make_auth_token(db_url)
+    resp = test_client.post(
+        "/api/guilds/gi-numeric/invites",
+        json={"user": "12345678", "role": "viewer"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["github_id"] == "12345678"
+    assert body["github_login"] is None
+    assert body["role"] == "viewer"
+    assert body["status"] == "pending"
+
+
+def test_invite_username_stored_lowercase(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gi-case")
+    token = make_auth_token(db_url)
+    resp = test_client.post(
+        "/api/guilds/gi-case/invites",
+        json={"user": "MixedCaseUser"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["github_login"] == "mixedcaseuser"
+
+
+def test_duplicate_invite_updates_role(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gi-dup")
+    token = make_auth_token(db_url)
+    test_client.post(
+        "/api/guilds/gi-dup/invites",
+        json={"user": "someone", "role": "viewer"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    resp = test_client.post(
+        "/api/guilds/gi-dup/invites",
+        json={"user": "someone", "role": "owner"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["role"] == "owner"
+
+
+def test_list_invites(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gi-list")
+    token = make_auth_token(db_url)
+    test_client.post(
+        "/api/guilds/gi-list/invites",
+        json={"user": "alice"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    test_client.post(
+        "/api/guilds/gi-list/invites",
+        json={"user": "bob"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    resp = test_client.get(
+        "/api/guilds/gi-list/invites",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    logins = [i["github_login"] for i in resp.json()]
+    assert "alice" in logins
+    assert "bob" in logins
+
+
+def test_list_invites_requires_owner(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gi-perm")
+    insert_member(db_url, "gi-perm", "user-bob", role="member")
+    bob_token = make_auth_token(db_url, user_id="user-bob", username="bob")
+    resp = test_client.get(
+        "/api/guilds/gi-perm/invites",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_cancel_invite(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gi-cancel")
+    token = make_auth_token(db_url)
+    create_resp = test_client.post(
+        "/api/guilds/gi-cancel/invites",
+        json={"user": "tocancel"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    invite_id = create_resp.json()["id"]
+    resp = test_client.delete(
+        f"/api/guilds/gi-cancel/invites/{invite_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cancelled"
+    # Should no longer appear in the list
+    list_resp = test_client.get(
+        "/api/guilds/gi-cancel/invites",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert all(i["id"] != invite_id for i in list_resp.json())
+
+
+def test_invalid_role_rejected_for_invite(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gi-badrole")
+    token = make_auth_token(db_url)
+    resp = test_client.post(
+        "/api/guilds/gi-badrole/invites",
+        json={"user": "someone", "role": "superuser"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+
+
+def _insert_pending_invite(
+    db_url: str, guild_id: str, github_login: str, role: str = "member"
+) -> None:
+    """Insert a pending guild invite row directly."""
+    now = datetime.now(UTC)
+    with _sync_session(db_url) as session:
+        from sqlalchemy import select as sa_select
+
+        guild_pk = session.scalar(
+            sa_select(Guild.id).where(Guild.slug == guild_id, Guild.deleted_at.is_(None))
+        )
+        assert guild_pk is not None
+        owner_id = session.scalar(
+            sa_select(GuildMember.user_id).where(
+                GuildMember.guild_id == guild_pk, GuildMember.role == "owner"
+            )
+        )
+        session.execute(
+            pg_insert(GuildInvite)
+            .values(
+                guild_id=guild_pk,
+                github_login=github_login.lower(),
+                github_id=None,
+                role=role,
+                invited_by=owner_id,
+                created_at=now,
+                status="pending",
+            )
+            .on_conflict_do_nothing()
+        )
+        session.commit()
+
+
+def test_pending_invite_accepted_on_login(client):
+    """A pending invite for a GitHub username is auto-accepted when that user logs in."""
+    test_client, db_url = client
+    insert_guild(db_url, "gi-login")
+    _insert_pending_invite(db_url, "gi-login", "newbie")
+
+    # Simulate the user logging in via the dev guest endpoint (which upserts a User row
+    # and runs the same invite-acceptance logic). We instead call the internal path
+    # directly by inserting the user row and checking the DB reflects acceptance.
+    # Here we verify via the REST invite list: after accepting, no pending invites remain.
+
+    # Insert user row as if they logged in.
+    now = datetime.now(UTC)
+    with _sync_session(db_url) as session:
+        session.execute(
+            pg_insert(User)
+            .values(
+                id="newbie-id",
+                github_id="newbie-id",
+                github_login="newbie",
+                created_at=now,
+                updated_at=now,
+            )
+            .on_conflict_do_nothing(index_elements=["id"])
+        )
+        # Manually run the invite-acceptance logic (mirrors oauth.create_session).
+        guild_pk = session.scalar(
+            select(Guild.id).where(Guild.slug == "gi-login", Guild.deleted_at.is_(None))
+        )
+        invite = session.scalar(
+            select(GuildInvite).where(
+                GuildInvite.guild_id == guild_pk,
+                GuildInvite.github_login == "newbie",
+                GuildInvite.status == "pending",
+            )
+        )
+        assert invite is not None
+        session.execute(
+            pg_insert(GuildMember)
+            .values(
+                guild_id=guild_pk,
+                user_id="newbie-id",
+                role=invite.role,
+                created_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=["guild_id", "user_id"],
+                set_={"role": pg_insert(GuildMember).excluded.role},
+            )
+        )
+        invite.status = "accepted"
+        session.commit()
+
+    # The new user should now be a member.
+    token = make_auth_token(db_url)
+    resp = test_client.get(
+        "/api/guilds/gi-login/members",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    user_ids = [m["user_id"] for m in resp.json()]
+    assert "newbie-id" in user_ids
+
+    # The invite should be gone from the pending list.
+    invite_resp = test_client.get(
+        "/api/guilds/gi-login/invites",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert invite_resp.status_code == 200
+    assert all(i["github_login"] != "newbie" for i in invite_resp.json())

--- a/backend/tests/test_user_members_api.py
+++ b/backend/tests/test_user_members_api.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import os
 import sys
 from datetime import UTC, datetime
+from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
+import oauth as oauth_module
 from helpers import _sync_session, insert_guild, insert_member, make_auth_token
 from models import Guild, GuildInvite, GuildMember, User
 from sqlalchemy import select
@@ -464,3 +466,59 @@ def test_pending_invite_accepted_on_login(client):
     )
     assert invite_resp.status_code == 200
     assert all(i["github_login"] != "newbie" for i in invite_resp.json())
+
+
+def test_pending_invite_accepted_via_oauth_exchange(client):
+    """Pending invite is auto-accepted when the invited user goes through the real OAuth exchange.
+
+    This exercises ``oauth.create_session`` end-to-end (including the invite-acceptance
+    block) via the ``/auth/github/exchange`` endpoint rather than duplicating the logic
+    inline, so a regression in ``create_session`` will cause this test to fail.
+    """
+    test_client, db_url = client
+    insert_guild(db_url, "gi-oauth")
+    _insert_pending_invite(db_url, "gi-oauth", "oauthuser")
+
+    fake_state = "test-state-oauth-invite"
+    oauth_module.oauth_states[fake_state] = None
+
+    fake_token_resp = {"access_token": "ghs_fake", "token_type": "bearer", "scope": "repo"}
+    fake_user_resp = {
+        "id": 9999,  # numeric GitHub user ID
+        "login": "oauthuser",
+        "name": "OAuth User",
+        "avatar_url": "https://example.com/avatar.png",
+        "email": None,
+    }
+    # Patch GitHub HTTP helpers so no real network call is made.
+    with (
+        mock.patch.object(oauth_module, "_gh_exchange_code", return_value=fake_token_resp),
+        mock.patch.object(oauth_module, "_gh_get_user", return_value=fake_user_resp),
+    ):
+        exchange_resp = test_client.post(
+            "/auth/github/exchange",
+            json={"code": "fake-code", "state": fake_state},
+        )
+
+    assert exchange_resp.status_code == 200, exchange_resp.text
+    payload = exchange_resp.json()
+    assert payload["gh_login"] == "oauthuser"
+    assert "login_token" in payload
+
+    # The invited user should now be a member.
+    owner_token = make_auth_token(db_url)
+    members_resp = test_client.get(
+        "/api/guilds/gi-oauth/members",
+        headers={"Authorization": f"Bearer {owner_token}"},
+    )
+    assert members_resp.status_code == 200
+    user_ids = [m["user_id"] for m in members_resp.json()]
+    assert str(fake_user_resp["id"]) in user_ids
+
+    # The invite should no longer appear in the pending list.
+    invites_resp = test_client.get(
+        "/api/guilds/gi-oauth/invites",
+        headers={"Authorization": f"Bearer {owner_token}"},
+    )
+    assert invites_resp.status_code == 200
+    assert all(i["github_login"] != "oauthuser" for i in invites_resp.json())

--- a/frontend/src/components/GuildMembers.vue
+++ b/frontend/src/components/GuildMembers.vue
@@ -195,8 +195,12 @@ async function invite() {
     inviteHint.value = `Added ${user} as ${inviteRole.value}.`
     await load()
   } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
-      // User hasn't logged in yet — create a pending invite instead.
+    // Only fall back to a pending invite when the server says the user hasn't
+    // logged in yet. Any other 404 (guild not found, gateway misconfiguration,
+    // etc.) should surface as a real error so the problem isn't silently eaten.
+    const isUserNotFound =
+      e instanceof ApiError && e.status === 404 && e.message.startsWith("User '")
+    if (isUserNotFound) {
       try {
         await api(`/api/guilds/${encodeURIComponent(props.guildId)}/invites`, {
           method: 'POST',

--- a/frontend/src/components/GuildMembers.vue
+++ b/frontend/src/components/GuildMembers.vue
@@ -31,12 +31,31 @@
         </li>
       </ul>
 
+      <div v-if="canManage && pendingInvites.length" class="pending-invites">
+        <div class="pending-invites-label">Pending invites</div>
+        <ul class="member-list">
+          <li v-for="inv in pendingInvites" :key="inv.id" class="member-row">
+            <span class="member-avatar member-avatar--placeholder">?</span>
+            <span class="member-name">{{ inv.github_login || inv.github_id }}</span>
+            <span class="member-role-badge">{{ inv.role }}</span>
+            <button
+              class="member-remove-btn"
+              :disabled="busyInvite === inv.id"
+              title="Cancel invite"
+              @click="cancelInvite(inv)"
+            >
+              ✕
+            </button>
+          </li>
+        </ul>
+      </div>
+
       <div v-if="canManage" class="invite-form">
         <div class="invite-row">
           <input
             v-model="inviteValue"
             class="settings-input invite-input"
-            placeholder="GitHub username"
+            placeholder="GitHub username or ID"
             spellcheck="false"
             autocomplete="off"
             :disabled="inviting"
@@ -79,6 +98,15 @@ interface GuildMemberRow {
   avatar_url: string | null
 }
 
+interface GuildInviteRow {
+  id: number
+  github_login: string | null
+  github_id: string | null
+  role: string
+  created_at: string
+  status: string
+}
+
 const props = defineProps<{ guildId: string }>()
 
 const authStore = useAuthStore()
@@ -86,6 +114,9 @@ const authStore = useAuthStore()
 const members = ref<GuildMemberRow[]>([])
 const loading = ref(false)
 const loadError = ref('')
+
+const pendingInvites = ref<GuildInviteRow[]>([])
+const busyInvite = ref<number | null>(null)
 
 const inviteValue = ref('')
 const inviteRole = ref<string>('member')
@@ -134,6 +165,18 @@ async function load() {
   } finally {
     loading.value = false
   }
+  await loadInvites()
+}
+
+async function loadInvites() {
+  if (!canManage.value) return
+  try {
+    pendingInvites.value = await api<GuildInviteRow[]>(
+      `/api/guilds/${encodeURIComponent(props.guildId)}/invites`,
+    )
+  } catch {
+    pendingInvites.value = []
+  }
 }
 
 async function invite() {
@@ -143,6 +186,7 @@ async function invite() {
   inviteError.value = ''
   inviteHint.value = ''
   try {
+    // Try direct add first (user has already logged in).
     await api(`/api/guilds/${encodeURIComponent(props.guildId)}/members`, {
       method: 'POST',
       json: { user, role: inviteRole.value },
@@ -151,9 +195,40 @@ async function invite() {
     inviteHint.value = `Added ${user} as ${inviteRole.value}.`
     await load()
   } catch (e) {
-    inviteError.value = e instanceof ApiError ? e.message : 'Failed to invite member'
+    if (e instanceof ApiError && e.status === 404) {
+      // User hasn't logged in yet — create a pending invite instead.
+      try {
+        await api(`/api/guilds/${encodeURIComponent(props.guildId)}/invites`, {
+          method: 'POST',
+          json: { user, role: inviteRole.value },
+        })
+        inviteValue.value = ''
+        inviteHint.value = `Invite sent to ${user} — they'll be added when they first log in.`
+        await load()
+      } catch (e2) {
+        inviteError.value = e2 instanceof ApiError ? e2.message : 'Failed to invite member'
+      }
+    } else {
+      inviteError.value = e instanceof ApiError ? e.message : 'Failed to invite member'
+    }
   } finally {
     inviting.value = false
+  }
+}
+
+async function cancelInvite(inv: GuildInviteRow) {
+  busyInvite.value = inv.id
+  inviteError.value = ''
+  try {
+    await api(
+      `/api/guilds/${encodeURIComponent(props.guildId)}/invites/${inv.id}`,
+      { method: 'DELETE' },
+    )
+    await loadInvites()
+  } catch (e) {
+    inviteError.value = e instanceof ApiError ? e.message : 'Failed to cancel invite'
+  } finally {
+    busyInvite.value = null
   }
 }
 
@@ -310,6 +385,24 @@ watch(() => props.guildId, load, { immediate: true })
 .member-remove-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.pending-invites {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-top: 1px solid var(--color-brass-dark);
+  padding-top: 8px;
+  margin-top: 4px;
+}
+
+.pending-invites-label {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--color-text-dim);
+  margin-bottom: 2px;
 }
 
 .invite-form {

--- a/frontend/src/components/__tests__/GuildMembers.spec.ts
+++ b/frontend/src/components/__tests__/GuildMembers.spec.ts
@@ -29,12 +29,13 @@ function jsonResponse(body: unknown, status = 200) {
   } as Response
 }
 
-function mountAs(userId: string | null, members: unknown[]) {
+function mountAs(userId: string | null, members: unknown[], invites: unknown[] = []) {
   const auth = useAuthStore()
   auth.user = userId ? { id: userId, login: 'me' } : null
   auth.loginToken = 'tok'
   const fetchMock = vi.spyOn(globalThis, 'fetch')
-  fetchMock.mockResolvedValueOnce(jsonResponse(members)) // initial load
+  fetchMock.mockResolvedValueOnce(jsonResponse(members)) // initial load members
+  fetchMock.mockResolvedValueOnce(jsonResponse(invites)) // initial load invites
   const wrapper = mount(GuildMembers, { props: { guildId: 'g1' } })
   return { wrapper, fetchMock }
 }
@@ -71,12 +72,13 @@ describe('GuildMembers', () => {
   it('posts an invite and reloads the list', async () => {
     const { wrapper, fetchMock } = mountAs('u-owner', [OWNER])
     await flushPromises()
-    fetchMock.mockResolvedValueOnce(jsonResponse({ user_id: 'u-member', role: 'member' })) // POST
-    fetchMock.mockResolvedValueOnce(jsonResponse([OWNER, MEMBER])) // reload
+    fetchMock.mockResolvedValueOnce(jsonResponse({ user_id: 'u-member', role: 'member' })) // POST members
+    fetchMock.mockResolvedValueOnce(jsonResponse([OWNER, MEMBER])) // reload members
+    fetchMock.mockResolvedValueOnce(jsonResponse([])) // reload invites
     await wrapper.find('.invite-input').setValue('bob')
     await wrapper.find('.invite-btn').trigger('click')
     await flushPromises()
-    const postCall = fetchMock.mock.calls[1]
+    const postCall = fetchMock.mock.calls[2] // calls[0]=members, calls[1]=invites, calls[2]=POST
     expect(postCall[0]).toContain('/api/guilds/g1/members')
     expect(JSON.parse((postCall[1] as RequestInit).body as string)).toEqual({
       user: 'bob',
@@ -85,14 +87,37 @@ describe('GuildMembers', () => {
     expect(wrapper.findAll('.member-name')).toHaveLength(2)
   })
 
-  it('surfaces the API error when inviting an unknown user', async () => {
+  it('falls back to a pending invite when the user has not logged in (404)', async () => {
     const { wrapper, fetchMock } = mountAs('u-owner', [OWNER])
     await flushPromises()
+    // POST /members → 404 (user not found)
     fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'User not found.' }, 404))
+    // POST /invites → success
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ id: 1, github_login: 'ghost', github_id: null, role: 'member', status: 'pending' }),
+    )
+    // reload members
+    fetchMock.mockResolvedValueOnce(jsonResponse([OWNER]))
+    // reload invites
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([{ id: 1, github_login: 'ghost', github_id: null, role: 'member', status: 'pending' }]),
+    )
     await wrapper.find('.invite-input').setValue('ghost')
     await wrapper.find('.invite-btn').trigger('click')
     await flushPromises()
-    expect(wrapper.find('.members-error').text()).toContain('User not found.')
+    expect(wrapper.find('.members-hint').text()).toContain("they'll be added when they first log in")
+    expect(wrapper.find('.members-error').exists()).toBe(false)
+  })
+
+  it('shows an error when both direct add and pending invite fail', async () => {
+    const { wrapper, fetchMock } = mountAs('u-owner', [OWNER])
+    await flushPromises()
+    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'User not found.' }, 404))
+    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'Guild not found.' }, 404))
+    await wrapper.find('.invite-input').setValue('ghost')
+    await wrapper.find('.invite-btn').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.members-error').exists()).toBe(true)
   })
 
   it('does not allow removing the last owner', async () => {

--- a/frontend/src/components/__tests__/GuildMembers.spec.ts
+++ b/frontend/src/components/__tests__/GuildMembers.spec.ts
@@ -90,8 +90,16 @@ describe('GuildMembers', () => {
   it('falls back to a pending invite when the user has not logged in (404)', async () => {
     const { wrapper, fetchMock } = mountAs('u-owner', [OWNER])
     await flushPromises()
-    // POST /members → 404 (user not found)
-    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'User not found.' }, 404))
+    // POST /members → 404 with the exact backend "user not found" message format
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          detail:
+            "User 'ghost' not found. They must log in to Pioneer Square once before they can be added.",
+        },
+        404,
+      ),
+    )
     // POST /invites → success
     fetchMock.mockResolvedValueOnce(
       jsonResponse({ id: 1, github_login: 'ghost', github_id: null, role: 'member', status: 'pending' }),
@@ -112,12 +120,35 @@ describe('GuildMembers', () => {
   it('shows an error when both direct add and pending invite fail', async () => {
     const { wrapper, fetchMock } = mountAs('u-owner', [OWNER])
     await flushPromises()
-    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'User not found.' }, 404))
+    // POST /members → 404 with user-not-found message, triggering the invite fallback
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          detail:
+            "User 'ghost' not found. They must log in to Pioneer Square once before they can be added.",
+        },
+        404,
+      ),
+    )
+    // POST /invites → also fails
     fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'Guild not found.' }, 404))
     await wrapper.find('.invite-input').setValue('ghost')
     await wrapper.find('.invite-btn').trigger('click')
     await flushPromises()
     expect(wrapper.find('.members-error').exists()).toBe(true)
+  })
+
+  it('surfaces a non-user-not-found 404 as an error without attempting an invite', async () => {
+    const { wrapper, fetchMock } = mountAs('u-owner', [OWNER])
+    await flushPromises()
+    // POST /members → 404 with a guild-level error (should NOT fall back to invite)
+    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'Guild not found.' }, 404))
+    await wrapper.find('.invite-input').setValue('ghost')
+    await wrapper.find('.invite-btn').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.members-error').text()).toContain('Guild not found.')
+    // Only 3 fetch calls total: load members, load invites, POST members (no POST invites)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
   it('does not allow removing the last owner', async () => {


### PR DESCRIPTION
## Summary

- Adds a `guild_invites` table (new Alembic migration) to store pending invites keyed to a GitHub username or numeric ID
- New owner-only REST endpoints: `POST/GET/DELETE /api/guilds/{id}/invites`
- `oauth.create_session` auto-accepts pending invites the moment the invited user first logs in, adding them as a guild member
- `GuildMembers.vue` invite form now falls back to creating a pending invite when the direct add returns 404 (user hasn't logged in yet); shows a "Pending invites" section with cancel controls
- New backend tests for create/list/cancel invites and the auto-accept-on-login flow
- Updated frontend spec to cover the 404→pending-invite fallback

## How it works

1. Owner types a GitHub username (or numeric ID) in the invite form
2. Backend tries to add them directly (`POST /members`)
3. If 404 (not in DB yet), falls back to `POST /invites` — stores a `guild_invites` row
4. When the user logs in via GitHub OAuth, `create_session` matches their `github_login`/`github_id` against pending invites and materializes the `guild_members` row automatically

## Test plan

- [ ] `cd backend && docker compose up -d postgres-test && python -m pytest tests/test_user_members_api.py -v`
- [ ] `cd frontend && npm test`
- [ ] Manual: invite a username that hasn't logged in → verify pending invite appears → log in as that user → verify they appear in the members list

Closes #668