### PR TITLE
fix(frontend): preserve foreman model when toggling provider off bedrock and back

### DIFF
--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -142,7 +142,7 @@
         <div v-if="showForemanConfig" class="foreman-config-section">
           <div class="foreman-field">
             <label class="foreman-field-label">Provider</label>
-            <select v-model="foremanProvider" class="settings-input" @change="foremanModel = ''">
+            <select v-model="foremanProvider" class="settings-input" @change="onProviderChange">
               <option value="">default (anthropic)</option>
               <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
                 {{ p.name }}
@@ -371,6 +371,20 @@ const showForemanConfig = ref(false)
 const showMembers = ref(false)
 const foremanModel = ref('')
 const foremanProvider = ref('')
+// Remember the model entered for each provider. Models are provider-specific
+// (a Bedrock inference-profile ARN is invalid for the direct Anthropic API and
+// vice versa), so switching providers swaps the model out — but toggling off a
+// provider and back restores its model instead of wiping it.
+const modelByProvider = ref<Record<string, string>>({})
+let prevProvider = ''
+
+function onProviderChange() {
+  // v-model has already updated foremanProvider to the new value; foremanModel
+  // still holds the previous provider's model, so stash it under prevProvider.
+  modelByProvider.value[prevProvider] = foremanModel.value
+  foremanModel.value = modelByProvider.value[foremanProvider.value] ?? ''
+  prevProvider = foremanProvider.value
+}
 const foremanSystemSuffix = ref('')
 const foremanMaxRounds = ref<number | ''>('')
 const foremanPollMin = ref<number | ''>('')
@@ -421,6 +435,10 @@ async function loadForemanConfig() {
       const cfg = await res.json()
       foremanModel.value = cfg.model ?? ''
       foremanProvider.value = cfg.provider ?? ''
+      // Seed the per-provider model memory with the persisted pairing so a later
+      // provider toggle can restore this model.
+      prevProvider = foremanProvider.value
+      modelByProvider.value = { [foremanProvider.value]: foremanModel.value }
       foremanSystemSuffix.value = cfg.system_prompt_suffix ?? ''
       foremanMaxRounds.value = cfg.max_rounds ?? ''
       foremanPollMin.value = cfg.poll_min_interval ?? ''
@@ -564,6 +582,8 @@ watch(
     showMembers.value = false
     foremanModel.value = ''
     foremanProvider.value = ''
+    modelByProvider.value = {}
+    prevProvider = ''
     foremanSystemSuffix.value = ''
     foremanMaxRounds.value = ''
     foremanPollMin.value = ''

--- a/frontend/src/components/__tests__/TopBar.spec.ts
+++ b/frontend/src/components/__tests__/TopBar.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import TopBar from '../TopBar.vue'
+import { useGuildStore } from '../../stores/guild'
+import { useAuthStore } from '../../stores/auth'
+
+const BEDROCK_ARN =
+  'arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6'
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', component: { template: '<div />' } }],
+})
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+// Route fetches by URL so the test doesn't depend on call ordering (the
+// useModels composable caches its result across calls).
+function mockFetch(foremanConfig: Record<string, unknown>) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/models')) {
+      return Promise.resolve(
+        jsonResponse([
+          { id: 'bedrock', name: 'Bedrock', models: [] },
+          { id: 'anthropic', name: 'Anthropic', models: [] },
+        ]),
+      )
+    }
+    if (url.includes('/foreman-config')) return Promise.resolve(jsonResponse(foremanConfig))
+    if (url.includes('/auth/claude-credentials')) {
+      return Promise.resolve(jsonResponse({ saved: false }))
+    }
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+async function openForemanConfig(foremanConfig: Record<string, unknown>) {
+  mockFetch(foremanConfig)
+  const guild = useGuildStore()
+  guild.currentGuild = { id: 'g1', name: 'Test Guild' }
+  const auth = useAuthStore()
+  auth.loginToken = 'tok'
+  const wrapper = mount(TopBar, { global: { plugins: [router] } })
+  await flushPromises()
+  await wrapper.find('.settings-btn').trigger('click') // open settings popover
+  await flushPromises()
+  await wrapper.find('.foreman-toggle-btn').trigger('click') // open foreman config
+  await flushPromises()
+  return wrapper
+}
+
+describe('TopBar foreman provider/model', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('preserves the bedrock model when toggling the provider off and back', async () => {
+    const wrapper = await openForemanConfig({ provider: 'bedrock', model: BEDROCK_ARN })
+
+    const select = wrapper.find('.foreman-config-section select')
+    const modelInput = () =>
+      wrapper.find('input[list="foreman-model-hints"]').element as HTMLInputElement
+
+    // Loaded config: bedrock provider with its custom ARN model.
+    expect((select.element as HTMLSelectElement).value).toBe('bedrock')
+    expect(modelInput().value).toBe(BEDROCK_ARN)
+
+    // Switch off bedrock → the bedrock-specific model is swapped out (anthropic
+    // would reject the ARN), so the field clears.
+    await select.setValue('')
+    expect(modelInput().value).toBe('')
+
+    // Switch back to bedrock → the ARN is restored rather than lost.
+    await select.setValue('bedrock')
+    expect(modelInput().value).toBe(BEDROCK_ARN)
+  })
+})


### PR DESCRIPTION
Switching the foreman provider unconditionally cleared the model field
(`@change="foremanModel = ''"`). A user with a custom Bedrock
inference-profile ARN configured would lose it by switching off Bedrock and
back: the ARN was wiped, never restored, and on save persisted as null so the
foreman silently fell back to the default model — the "invalidated URL".

Remember the model per provider so toggling providers swaps the model out
(models are provider-specific) but restores the previously entered one when
switching back. Seed the memory from the loaded config and reset it on guild
change.

Add a TopBar regression test covering the off-and-back toggle.