### PR TITLE
Re-apply PR #666: per-task Foreman context-splitting design

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -7,8 +7,11 @@ this module re-exports for backward-compatibility with existing imports
 
 from foreman_core.prompt import (
     _EMPTY_WORKERS_BLOCKS,
+    CHILD_FOREMAN_SYSTEM,
     FOREMAN_SYSTEM,
     _stable_system_text,
+    build_child_state_preamble,
+    build_child_system_blocks,
     build_state_preamble,
     build_system_blocks,
     build_system_prompt,
@@ -16,8 +19,11 @@ from foreman_core.prompt import (
 
 __all__ = [
     "FOREMAN_SYSTEM",
+    "CHILD_FOREMAN_SYSTEM",
     "_EMPTY_WORKERS_BLOCKS",
     "_stable_system_text",
+    "build_child_state_preamble",
+    "build_child_system_blocks",
     "build_state_preamble",
     "build_system_blocks",
     "build_system_prompt",

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -10,7 +10,13 @@ from datetime import UTC, datetime
 from auth_deps import get_guild_pk
 from database import AsyncSessionLocal, get_db
 from events import broadcast_msg
-from foreman.prompt import build_state_preamble, build_system_blocks, build_system_prompt
+from foreman.prompt import (
+    build_child_state_preamble,
+    build_child_system_blocks,
+    build_state_preamble,
+    build_system_blocks,
+    build_system_prompt,
+)
 from foreman.tools import exec_tools
 from foreman_core.constants import (
     _24H_SECS,
@@ -29,7 +35,7 @@ from foreman_core.message_utils import (
     strip_orphaned_tool_results,
     truncate_tool_result,
 )
-from foreman_core.tools_schema import FOREMAN_TOOLS
+from foreman_core.tools_schema import CHILD_FOREMAN_TOOLS, FOREMAN_TOOLS
 from models import (
     Agent,
     ApiRequestLog,
@@ -116,22 +122,42 @@ async def _get_guild_user_id(guild_id: str) -> str | None:
         await db.close()
 
 
-async def _load_history(guild_id: str, user_id: str) -> list[dict]:
+def _child_contexts_enabled() -> bool:
+    """Whether per-task child contexts are enabled for the embedded foreman.
+
+    Mirrors the standalone foreman's ``child_contexts`` config flag. Defaults on;
+    set ``FOREMAN_CHILD_CONTEXTS`` to a falsy value (0/false/no/off) to fall back
+    to the legacy single whole-guild context. See docs/foreman-per-task-context.md.
+    """
+    return os.environ.get("FOREMAN_CHILD_CONTEXTS", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+        "",
+    )
+
+
+async def _load_history(guild_id: str, user_id: str, task_id: str | None = None) -> list[dict]:
     """Load the last _HUMAN_TURN_WINDOW non-tool-response turns (plus all tool exchange
     turns between them) as a list of Anthropic-API-compatible message dicts.
 
     Because the cutoff always lands on a human-initiated user turn, every
     assistant-turn / tool_result-user-turn pair that follows it is guaranteed to
     be included intact — no orphaned tool_use blocks, no synthetic repairs needed.
+
+    When ``task_id`` is set, only turns tagged with that task are loaded — the
+    isolated conversation thread for a per-task child context.
     """
     db = await get_db()
     try:
         guild_pk_val = await get_guild_pk(db, guild_id)
-        result = await db.exec(
-            select(ForemanTurn)
-            .where(col(ForemanTurn.guild_id) == guild_pk_val, col(ForemanTurn.user_id) == user_id)
-            .order_by(col(ForemanTurn.id))
+        stmt = select(ForemanTurn).where(
+            col(ForemanTurn.guild_id) == guild_pk_val, col(ForemanTurn.user_id) == user_id
         )
+        if task_id is not None:
+            stmt = stmt.where(col(ForemanTurn.task_id) == task_id)
+        result = await db.exec(stmt.order_by(col(ForemanTurn.id)))
         turns = result.all()
     finally:
         await db.close()
@@ -446,34 +472,44 @@ async def run_foreman_ai(
     extra_context: str = "",
     user_id: str | None = None,
     task_id: str | None = None,
+    *,
+    child: bool = False,
 ) -> None:
-    """Serialise per-(guild, user) and delegate to ``_run_foreman_ai``.
+    """Serialise per-context and delegate to ``_run_foreman_ai``.
 
-    Uses a per-(guild, user) ``asyncio.Lock`` stored in ``_guild_locks``.  If
-    the lock is already held the invocation is dropped; the poll loop
-    re-triggers on the next tick.  Dropping is preferred over queuing to avoid
-    unbounded build-up.
+    Uses an ``asyncio.Lock`` stored in ``_guild_locks``.  If the lock is already
+    held the invocation is dropped; the poll loop re-triggers on the next tick.
+    Dropping is preferred over queuing to avoid unbounded build-up.
+
+    Whole-guild (parent) runs key the lock on ``(guild_id, user_id)``.  Per-task
+    child runs (``child=True`` with a ``task_id``, gated by FOREMAN_CHILD_CONTEXTS)
+    key on ``(guild_id, task_id)`` so different tasks run concurrently while a
+    single task's review loop still serialises against itself.  See
+    docs/foreman-per-task-context.md.
 
     lock.locked() + lock.acquire() is atomic here: asyncio is single-threaded
     and cooperative, so no other coroutine can run between the check and the
     acquire (there is no ``await`` between them).
     """
+    use_child = child and bool(task_id) and _child_contexts_enabled()
     # When user_id is None (system-triggered/poll runs), all such invocations
     # within the same guild share key (guild_id, None) and serialize against
     # each other.  This is intentional — system runs are per-guild work and
     # should not overlap with themselves.
-    lock_key = (guild_id, user_id)
+    lock_key = (guild_id, f"task:{task_id}") if use_child else (guild_id, user_id)
     lock = _guild_locks.setdefault(lock_key, asyncio.Lock())
     if lock.locked():
         logger.info(
-            "guild=%s user=%s run_foreman_ai: dropping concurrent invocation (foreman already running)",
+            "guild=%s key=%s run_foreman_ai: dropping concurrent invocation (already running)",
             guild_id,
-            user_id,
+            lock_key[1],
         )
         return
     await lock.acquire()
     try:
-        await _run_foreman_ai(guild_id, human_message, extra_context, user_id, task_id=task_id)
+        await _run_foreman_ai(
+            guild_id, human_message, extra_context, user_id, task_id=task_id, child=use_child
+        )
     finally:
         lock.release()
         _guild_locks.pop(lock_key, None)
@@ -485,8 +521,15 @@ async def _run_foreman_ai(
     extra_context: str = "",
     user_id: str | None = None,
     task_id: str | None = None,
+    *,
+    child: bool = False,
 ):
-    """Process a human message (or system escalation) through the Claude foreman AI."""
+    """Process a human message (or system escalation) through the Claude foreman AI.
+
+    When ``child`` is True (with a ``task_id``) the run is scoped to a single task:
+    worker/task rows, system prompt, state preamble, tool set, and loaded history
+    are all narrowed to that one task. See docs/foreman-per-task-context.md.
+    """
     if not HAS_ANTHROPIC:
         now = datetime.now(UTC).isoformat()
         await broadcast_msg(
@@ -542,6 +585,8 @@ async def _run_foreman_ai(
                 col(Task.name),
                 col(Task.description),
                 col(Task.state),
+                col(Task.phase),
+                col(Task.issue_repo),
                 col(Task.branch),
                 col(Task.pr_url),
                 col(Task.deleted_at),
@@ -556,7 +601,18 @@ async def _run_foreman_ai(
             {**dict(r._mapping), "description": dict(r._mapping).get("description") or ""}
             for r in task_result.all()
         ]
-        _task_id: str | None = task_id
+        # Per-task child context: narrow worker/task rows to just this task and
+        # its assigned worker. Falls back to a minimal stub if the task is no
+        # longer in the active set (e.g. just finalized).
+        child_task_row: dict | None = None
+        if child and task_id:
+            child_task_row = next((t for t in task_rows if t.get("id") == task_id), None)
+            child_worker_id = child_task_row.get("worker_id") if child_task_row else None
+            worker_rows = [r for r in worker_rows if r["id"] == child_worker_id]
+            task_rows = [child_task_row] if child_task_row else []
+            _task_id: str | None = task_id
+        else:
+            _task_id = task_rows[0]["id"] if len(task_rows) == 1 else None
     except Exception:
         await db.close()
         raise
@@ -582,10 +638,24 @@ async def _run_foreman_ai(
             s for row in task_rows if (s := _summarize_task(row, cutoff_ts)) is not None
         ]
         tasks_block = json.dumps(summarized_tasks, indent=2, default=_json_default)
-        system_blocks = build_system_blocks(
-            primary_repo=primary_repo, system_prompt_suffix=cfg_system_prompt_suffix
-        )
-        state_preamble = build_state_preamble(workers_block, tasks_block, extra_context)
+        if child and task_id:
+            _t = child_task_row or {}
+            tools = CHILD_FOREMAN_TOOLS
+            system_blocks = build_child_system_blocks(
+                task_id=task_id,
+                task_name=_t.get("name") or task_id,
+                worker_id=_t.get("worker_id"),
+                phase=_t.get("phase"),
+                repo=_t.get("issue_repo") or primary_repo,
+                system_prompt_suffix=cfg_system_prompt_suffix,
+            )
+            state_preamble = build_child_state_preamble(workers_block, tasks_block, extra_context)
+        else:
+            tools = FOREMAN_TOOLS
+            system_blocks = build_system_blocks(
+                primary_repo=primary_repo, system_prompt_suffix=cfg_system_prompt_suffix
+            )
+            state_preamble = build_state_preamble(workers_block, tasks_block, extra_context)
         # Legacy single-string render — persisted for audit only, not sent to the API.
         audit_system = build_system_prompt(
             workers_block,
@@ -612,7 +682,7 @@ async def _run_foreman_ai(
         # `system_blocks` (cacheable) and the state preamble injected at send time.
         await _save_turn(guild_id, user_id, "system", audit_system, task_id=_task_id)
         await _save_turn(guild_id, user_id, "user", human_message, task_id=_task_id)
-        messages = await _load_history(guild_id, user_id)
+        messages = await _load_history(guild_id, user_id, task_id=_task_id if child else None)
 
         logger.info(
             "guild=%s run_foreman_ai: %d messages loaded from history; human_message_chars=%d",
@@ -653,7 +723,7 @@ async def _run_foreman_ai(
                 model=foreman_model,
                 system_blocks=system_blocks,
                 messages=messages,
-                extra={"max_tokens": 1024, "tools": FOREMAN_TOOLS},
+                extra={"max_tokens": 1024, "tools": tools},
                 task_id=_task_id,
             )
             _raw = await client.messages.with_raw_response.create(
@@ -661,7 +731,7 @@ async def _run_foreman_ai(
                 max_tokens=1024,
                 system=system_blocks,  # type: ignore[arg-type]
                 messages=messages,  # type: ignore[arg-type]
-                tools=FOREMAN_TOOLS,  # type: ignore[arg-type]
+                tools=tools,  # type: ignore[arg-type]
             )
             resp = _raw.parse()
             usage = resp.usage
@@ -876,7 +946,7 @@ async def _run_foreman_ai(
                 messages=messages,
                 extra={
                     "max_tokens": 1024,
-                    "tools": FOREMAN_TOOLS,
+                    "tools": tools,
                     "tool_choice": {"type": "none"},
                 },
                 task_id=_task_id,
@@ -886,7 +956,7 @@ async def _run_foreman_ai(
                 max_tokens=1024,
                 system=system_blocks,  # type: ignore[arg-type]
                 messages=messages,  # type: ignore[arg-type]
-                tools=FOREMAN_TOOLS,  # type: ignore[arg-type]
+                tools=tools,  # type: ignore[arg-type]
                 tool_choice={"type": "none"},  # type: ignore[arg-type]
             )
             wrap_resp = _wrap_raw.parse()

--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -188,6 +188,51 @@ On every [periodic-check] event:
 """
 
 
+CHILD_FOREMAN_SYSTEM = """\
+You are the Foreman AI in Pioneer Square, a multi-agent coding workshop. You are a
+single-task context: a lightweight parent Foreman has handed you one already-assigned
+task and you own its lifecycle from here until it is finalized.
+
+## Your responsibilities for this task
+- Monitor this one task to completion. Ignore other tasks — they are handled by their
+  own contexts.
+- After the worker finishes (task-complete) the task parks in awaiting-review and the
+  worker returns to its idle pool — you own the lifecycle from here. Default behaviour:
+  leave PR-bearing tasks open for human review. Call send_followup when a comment, CI
+  failure, or new requirement asks for an iteration on the same branch. Call
+  finalize_task only when the work is genuinely closed (PR merged, abandoned, or it was
+  an ephemeral/automation task).
+- CI failures, lint errors, test failures, and other post-PR corrections on this same
+  piece of work → always send_followup on this task, never a new issue or PR.
+- Use message_worker to send mid-task context, redirect_task to course-correct, and
+  cancel_task if the work is going wrong or is no longer needed.
+- React to [github-event] messages for this task's PR exactly as the parent would: review
+  requests, CI results, review submissions, merges, and PR-closed events. Use
+  get_pr_status to confirm merged state before finalizing.
+- Escalate to the human only when genuinely stuck (e.g. a needs-input you cannot answer,
+  or no worker is available to continue). You cannot create or assign new tasks — that is
+  the parent's job; surface anything that needs a new task to the human.
+
+## Finalize expiry windows
+Every finalize_task call sets a soft-delete window via expires_in_seconds:
+- Ephemeral/automation tasks: expires_in_seconds = 1200 (20 minutes)
+- Code tasks (execute / review / followup): omit to use the default 3 days
+- Error / failed tasks: expires_in_seconds = 86400 (1 day)
+
+## Checking task progress
+Use get_task_status to verify this task is making progress — it returns the current
+state, the active agent and its state, and the last log lines. If it looks stalled, use
+redirect_task to course-correct or cancel_task if it's going in the wrong direction.
+
+## Live state
+Each user turn is preceded by a `<state>` block containing only this task's row and the
+worker assigned to it. Treat it as an operational briefing, not part of the human's
+message. The state reflects the moment this turn was sent.
+
+Be concise — one short paragraph maximum unless detail is requested.
+"""
+
+
 _EMPTY_WORKERS_BLOCKS = {"[]", "[\n]"}
 
 
@@ -237,6 +282,72 @@ def build_state_preamble(
         workers_section = f"## Current workers\n```json\n{workers_block}\n```\n\n"
 
     body = f"{workers_section}## Recent tasks\n```json\n{tasks_block}\n```"
+    if extra_context:
+        body += f"\n\n## Context\n{extra_context}"
+    return f"<state>\n{body}\n</state>"
+
+
+def _stable_child_system_text(
+    task_id: str,
+    task_name: str,
+    worker_id: str | None,
+    phase: str | None,
+    repo: str | None,
+    system_prompt_suffix: str | None = None,
+) -> str:
+    """The cacheable persona prefix for a per-task child context."""
+    header = (
+        f"\n\n## This task\n"
+        f"- task_id: {task_id}\n"
+        f"- name: {task_name}\n"
+        f"- worker: {worker_id or '(unassigned)'}\n"
+        f"- phase: {phase or '(none)'}\n"
+        f"- repo: {repo or '(none)'}"
+    )
+    suffix = f"\n\n{system_prompt_suffix.strip()}" if system_prompt_suffix else ""
+    return f"{CHILD_FOREMAN_SYSTEM}{header}{suffix}"
+
+
+def build_child_system_blocks(
+    task_id: str,
+    task_name: str,
+    worker_id: str | None = None,
+    phase: str | None = None,
+    repo: str | None = None,
+    system_prompt_suffix: str | None = None,
+) -> list[dict]:
+    """System prompt for a per-task child context, as a single cache-controlled block.
+
+    Narrowed persona scoped to one task. Live state (the single task row + its worker)
+    is injected into the user turn via ``build_child_state_preamble``.
+    """
+    return [
+        {
+            "type": "text",
+            "text": _stable_child_system_text(
+                task_id, task_name, worker_id, phase, repo, system_prompt_suffix
+            ),
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def build_child_state_preamble(
+    worker_block: str,
+    task_block: str,
+    extra_context: str = "",
+) -> str:
+    """Render the live state for a child context: only this task's worker and row."""
+    if worker_block.strip() in _EMPTY_WORKERS_BLOCKS:
+        worker_section = (
+            "## Assigned worker\n"
+            "_The assigned worker is not currently online. If work needs to continue, "
+            "send_followup will route to any idle worker; otherwise escalate to the human._\n\n"
+        )
+    else:
+        worker_section = f"## Assigned worker\n```json\n{worker_block}\n```\n\n"
+
+    body = f"{worker_section}## This task\n```json\n{task_block}\n```"
     if extra_context:
         body += f"\n\n## Context\n{extra_context}"
     return f"<state>\n{body}\n</state>"

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -556,3 +556,12 @@ FOREMAN_TOOLS = [
     },
     # spawn_worker intentionally disabled — see issues #551, #564, #566, #567
 ]
+
+# Tools excluded from per-task child contexts. Child contexts manage a single,
+# already-assigned task; creating or assigning new tasks remains the parent
+# foreman's responsibility. See docs/foreman-per-task-context.md.
+_CHILD_EXCLUDED_TOOLS = frozenset({"create_task", "assign_task"})
+
+# Tool set handed to a per-task child context (FOREMAN_TOOLS minus the
+# create/assign pair). Same JSON schemas, narrowed scope.
+CHILD_FOREMAN_TOOLS = [t for t in FOREMAN_TOOLS if t["name"] not in _CHILD_EXCLUDED_TOOLS]

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -232,6 +232,10 @@ async def get_foreman_history_for_user(
     guild_id: str,
     user_id: str = Query(..., description="GitHub user_id whose thread to fetch"),
     limit: int | None = Query(default=None, description="Max rows to return (newest first)"),
+    task_id: str | None = Query(
+        default=None,
+        description="When set, return only turns tagged with this task_id (per-task child context).",
+    ),
     _caller: str = Depends(require_worker_or_member_path),
     db: AsyncSession = Depends(get_db_dep),
 ):
@@ -271,6 +275,8 @@ async def get_foreman_history_for_user(
         .where(col(ForemanTurn.guild_id) == guild_pk, col(ForemanTurn.user_id) == user_id)
         .order_by(col(ForemanTurn.id))
     )
+    if task_id is not None:
+        stmt = stmt.where(col(ForemanTurn.task_id) == task_id)
     if limit is not None and limit > 0:
         stmt = stmt.limit(limit)
     result = await db.exec(stmt)

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -236,6 +236,7 @@ async def create_task_followup(
             "branch from GitHub.",
             user_id=github_user_id,
             task_id=task_id,
+            child=True,
         ),
         name=f"foreman.user-followup:{task_id}",
     )

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -139,8 +139,12 @@ class DebounceQueue:
             (uid for _, uid, _ in items if uid and not uid.endswith("[bot]")),
             next((uid for _, uid, _ in items if uid), None),
         )
+        # All events buffered under one key share a task (key is "{guild}:{task_id}");
+        # github events for a known task run in that task's isolated child context.
         task_id = next((tid for _, _, tid in items if tid), None)
-        await run_foreman_ai(guild_id, combined, user_id=user_id, task_id=task_id)
+        await run_foreman_ai(
+            guild_id, combined, user_id=user_id, task_id=task_id, child=bool(task_id)
+        )
         reset_foreman_poll(guild_id)
         logger.info(
             "github webhook debounce fired key=%s events=%d guild=%s",

--- a/backend/tests/test_child_prompt.py
+++ b/backend/tests/test_child_prompt.py
@@ -1,0 +1,70 @@
+"""Tests for per-task child context prompt builders and tool set
+(backend.foreman_core)."""
+
+from __future__ import annotations
+
+from backend.foreman_core.prompt import (
+    build_child_state_preamble,
+    build_child_system_blocks,
+)
+from backend.foreman_core.tools_schema import CHILD_FOREMAN_TOOLS, FOREMAN_TOOLS
+
+
+def test_child_tools_exclude_create_and_assign():
+    names = {t["name"] for t in CHILD_FOREMAN_TOOLS}
+    assert "create_task" not in names
+    assert "assign_task" not in names
+    # Everything else carries over.
+    assert names == {t["name"] for t in FOREMAN_TOOLS} - {"create_task", "assign_task"}
+
+
+def test_child_tools_keep_lifecycle_tools():
+    names = {t["name"] for t in CHILD_FOREMAN_TOOLS}
+    for expected in ("send_followup", "finalize_task", "get_pr_status", "redirect_task"):
+        assert expected in names
+
+
+def test_child_system_blocks_single_cached_block():
+    blocks = build_child_system_blocks(
+        task_id="t-abc", task_name="Fix CI", worker_id="w-1", phase="execute", repo="o/r"
+    )
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert block["type"] == "text"
+    assert block["cache_control"] == {"type": "ephemeral"}
+    text = block["text"]
+    # Task metadata is embedded.
+    assert "t-abc" in text
+    assert "Fix CI" in text
+    assert "w-1" in text
+    assert "execute" in text
+    assert "o/r" in text
+    # Single-task framing, not whole-guild.
+    assert "single-task context" in text
+
+
+def test_child_system_blocks_tolerates_missing_fields():
+    blocks = build_child_system_blocks(task_id="t-abc", task_name="t-abc")
+    text = blocks[0]["text"]
+    assert "(unassigned)" in text
+    assert "(none)" in text
+
+
+def test_child_state_preamble_includes_worker_and_task():
+    out = build_child_state_preamble('{"id": "w-1"}', '{"id": "t-abc"}')
+    assert "<state>" in out and "</state>" in out
+    assert "Assigned worker" in out
+    assert "w-1" in out
+    assert "t-abc" in out
+
+
+def test_child_state_preamble_handles_offline_worker():
+    out = build_child_state_preamble("[]", '{"id": "t-abc"}')
+    assert "not currently online" in out
+    assert "t-abc" in out
+
+
+def test_child_state_preamble_appends_extra_context():
+    out = build_child_state_preamble('{"id": "w-1"}', '{"id": "t-abc"}', "CI is red")
+    assert "## Context" in out
+    assert "CI is red" in out

--- a/backend/tests/test_foreman_child_context.py
+++ b/backend/tests/test_foreman_child_context.py
@@ -1,0 +1,204 @@
+"""Tests for the embedded foreman's per-task child context wiring (issue #649).
+
+Covers the feature gate, the per-task lock-key selection in run_foreman_ai, and
+the child-event routing in ws_handlers._trigger_foreman. The actual Claude turn
+(_run_foreman_ai) is patched out — these exercise the routing/serialization
+plumbing, not the LLM loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+# ── feature gate ─────────────────────────────────────────────────────────────
+
+
+def test_child_contexts_enabled_default_on(monkeypatch):
+    import foreman.runner as runner
+
+    monkeypatch.delenv("FOREMAN_CHILD_CONTEXTS", raising=False)
+    assert runner._child_contexts_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+def test_child_contexts_disabled_values(monkeypatch, val):
+    import foreman.runner as runner
+
+    monkeypatch.setenv("FOREMAN_CHILD_CONTEXTS", val)
+    assert runner._child_contexts_enabled() is False
+
+
+def test_child_contexts_enabled_truthy(monkeypatch):
+    import foreman.runner as runner
+
+    monkeypatch.setenv("FOREMAN_CHILD_CONTEXTS", "1")
+    assert runner._child_contexts_enabled() is True
+
+
+# ── per-task lock key in run_foreman_ai ──────────────────────────────────────
+
+
+async def test_child_run_uses_per_task_lock_key(monkeypatch):
+    """A child run keys its lock on (guild, task:<id>), not (guild, user)."""
+    import foreman.runner as runner
+
+    seen_keys = []
+
+    async def fake_run(*a, **k):
+        # Snapshot the lock keys present while the run holds its lock.
+        seen_keys.extend(list(runner._guild_locks.keys()))
+
+    monkeypatch.setattr(runner, "_run_foreman_ai", fake_run)
+    monkeypatch.setattr(runner, "_child_contexts_enabled", lambda: True)
+
+    await runner.run_foreman_ai("g1", "task-complete", user_id="u-1", task_id="t-abc", child=True)
+
+    assert ("g1", "task:t-abc") in seen_keys
+    assert ("g1", "u-1") not in seen_keys
+
+
+async def test_parent_run_uses_guild_user_lock_key(monkeypatch):
+    import foreman.runner as runner
+
+    seen_keys = []
+
+    async def fake_run(*a, **k):
+        seen_keys.extend(list(runner._guild_locks.keys()))
+
+    monkeypatch.setattr(runner, "_run_foreman_ai", fake_run)
+
+    await runner.run_foreman_ai("g1", "hi", user_id="u-1")
+
+    assert ("g1", "u-1") in seen_keys
+
+
+async def test_child_gate_off_falls_back_to_parent_key(monkeypatch):
+    import foreman.runner as runner
+
+    seen_keys = []
+
+    async def fake_run(*a, **k):
+        seen_keys.extend(list(runner._guild_locks.keys()))
+        # child must be coerced to False when the gate is off
+        assert k.get("child") is False
+
+    monkeypatch.setattr(runner, "_run_foreman_ai", fake_run)
+    monkeypatch.setattr(runner, "_child_contexts_enabled", lambda: False)
+
+    await runner.run_foreman_ai("g1", "task-complete", user_id="u-1", task_id="t-abc", child=True)
+
+    assert ("g1", "u-1") in seen_keys
+    assert ("g1", "task:t-abc") not in seen_keys
+
+
+async def test_different_tasks_run_concurrently(monkeypatch):
+    """Two child runs for different tasks must not block each other."""
+    import foreman.runner as runner
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    overlap = {"value": False}
+    active = 0
+
+    async def fake_run(*a, **k):
+        nonlocal active
+        active += 1
+        if active > 1:
+            overlap["value"] = True
+        started.set()
+        await release.wait()
+        active -= 1
+
+    monkeypatch.setattr(runner, "_run_foreman_ai", fake_run)
+    monkeypatch.setattr(runner, "_child_contexts_enabled", lambda: True)
+
+    t1 = asyncio.create_task(
+        runner.run_foreman_ai("g1", "x", user_id="u", task_id="t-1", child=True)
+    )
+    t2 = asyncio.create_task(
+        runner.run_foreman_ai("g1", "y", user_id="u", task_id="t-2", child=True)
+    )
+    await asyncio.sleep(0.01)
+    release.set()
+    await asyncio.gather(t1, t2)
+
+    assert overlap["value"] is True
+
+
+async def test_same_task_drops_concurrent_run(monkeypatch):
+    """A second child run for the same task while one is in-flight is dropped."""
+    import foreman.runner as runner
+
+    runner._guild_locks.pop(("g1", "task:t-dup"), None)
+    calls = 0
+    release = asyncio.Event()
+
+    async def fake_run(*a, **k):
+        nonlocal calls
+        calls += 1
+        await release.wait()
+
+    monkeypatch.setattr(runner, "_run_foreman_ai", fake_run)
+    monkeypatch.setattr(runner, "_child_contexts_enabled", lambda: True)
+
+    t1 = asyncio.create_task(
+        runner.run_foreman_ai("g1", "x", user_id="u", task_id="t-dup", child=True)
+    )
+    await asyncio.sleep(0.01)  # let t1 acquire the lock
+    # Second invocation should see the lock held and drop immediately.
+    await runner.run_foreman_ai("g1", "x2", user_id="u", task_id="t-dup", child=True)
+    release.set()
+    await t1
+
+    assert calls == 1
+
+
+# ── _trigger_foreman child-event routing ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "event,expect_child",
+    [
+        ("task-complete", True),
+        ("followup-done", True),
+        ("needs-input", True),
+        ("task-error", True),
+        ("chat", False),
+        ("worker-online", False),
+        ("periodic-check", False),
+        ("claude-auth", False),
+    ],
+)
+async def test_trigger_foreman_child_routing(monkeypatch, event, expect_child):
+    import ws_handlers
+
+    captured = {}
+
+    def fake_spawn(coro, name=None):
+        # Drain the coroutine so there's no "never awaited" warning.
+        coro.close()
+        return None
+
+    def capturing_run(guild_id, human_message, **kwargs):
+        captured["kwargs"] = kwargs
+        captured["guild_id"] = guild_id
+
+        async def _coro():
+            return None
+
+        return _coro()
+
+    # No external foreman connected → embedded fallback path.
+    monkeypatch.setattr(ws_handlers, "foreman_connections", {})
+    monkeypatch.setattr(ws_handlers, "spawn", fake_spawn)
+    monkeypatch.setattr(ws_handlers, "run_foreman_ai", capturing_run)
+
+    await ws_handlers._trigger_foreman(
+        "g1", event, "msg", user_id="u-1", task_id="t-xyz" if expect_child else None
+    )
+
+    assert captured["kwargs"].get("child") is expect_child
+    if expect_child:
+        assert captured["kwargs"].get("task_id") == "t-xyz"

--- a/backend/tests/test_foreman_guild_lock.py
+++ b/backend/tests/test_foreman_guild_lock.py
@@ -18,7 +18,7 @@ async def _run_foreman_ai_patched(guild_id: str, impl_event: asyncio.Event | Non
     """
     import foreman.runner as runner
 
-    async def _slow_impl(gid, msg, extra="", uid=None, task_id=None):
+    async def _slow_impl(gid, msg, extra="", uid=None, task_id=None, child=False):
         if impl_event is not None:
             await impl_event.wait()
 
@@ -47,7 +47,7 @@ def test_concurrent_same_guild_drops_second():
         call_count = 0
         hold = asyncio.Event()
 
-        async def _impl(gid, msg, extra="", uid=None, task_id=None):
+        async def _impl(gid, msg, extra="", uid=None, task_id=None, child=False):
             nonlocal call_count
             call_count += 1
             await hold.wait()
@@ -81,7 +81,7 @@ def test_concurrent_different_guilds_both_run():
         call_log: list[str] = []
         hold = asyncio.Event()
 
-        async def _impl(gid, msg, extra="", uid=None, task_id=None):
+        async def _impl(gid, msg, extra="", uid=None, task_id=None, child=False):
             call_log.append(gid)
             await hold.wait()
 
@@ -107,7 +107,7 @@ def test_lock_released_after_completion():
 
         call_count = 0
 
-        async def _impl(gid, msg, extra="", uid=None, task_id=None):
+        async def _impl(gid, msg, extra="", uid=None, task_id=None, child=False):
             nonlocal call_count
             call_count += 1
 
@@ -130,7 +130,7 @@ def test_lock_released_after_impl_exception():
 
         call_count = 0
 
-        async def _impl(gid, msg, extra="", uid=None, task_id=None):
+        async def _impl(gid, msg, extra="", uid=None, task_id=None, child=False):
             nonlocal call_count
             call_count += 1
             if call_count == 1:

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -462,8 +462,8 @@ class TestDebounce:
         """
         self._foreman_calls: list[tuple[str, str, str | None, str | None]] = []
 
-        async def fake_run_foreman(guild_id, summary, *, user_id=None, task_id=None):
-            self._foreman_calls.append((guild_id, summary, user_id, task_id))
+        async def fake_run_foreman(guild_id, summary, *, user_id=None, task_id=None, child=False):
+            self._foreman_calls.append((guild_id, summary, user_id))
 
         queue = wh.DebounceQueue(window_seconds=0.05)
         with (

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -463,7 +463,7 @@ class TestDebounce:
         self._foreman_calls: list[tuple[str, str, str | None, str | None]] = []
 
         async def fake_run_foreman(guild_id, summary, *, user_id=None, task_id=None, child=False):
-            self._foreman_calls.append((guild_id, summary, user_id))
+            self._foreman_calls.append((guild_id, summary, user_id, task_id))
 
         queue = wh.DebounceQueue(window_seconds=0.05)
         with (

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -144,6 +144,13 @@ async def _task_user_id(db, task_id: str | None) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+# Trigger events that concern a single task's review loop. When the embedded
+# foreman handles these (and a task_id is present), it runs in an isolated
+# per-task child context. All other events stay on the whole-guild parent
+# context. See docs/foreman-per-task-context.md.
+_CHILD_FOREMAN_EVENTS = frozenset({"task-complete", "followup-done", "needs-input", "task-error"})
+
+
 async def _trigger_foreman(
     guild_id: str,
     event: str,
@@ -203,9 +210,13 @@ async def _trigger_foreman(
             )
             foreman_connections.pop(guild_id, None)
             resume_foreman_poll(guild_id)
-    # Embedded fallback — identical to the pre-Phase-2 behaviour.
+    # Embedded fallback. Task-specific review events run in an isolated per-task
+    # child context (see docs/foreman-per-task-context.md); cross-cutting events
+    # (chat, worker lifecycle, periodic-check, claude-auth) stay on the parent
+    # whole-guild context.
+    child = bool(task_id) and event in _CHILD_FOREMAN_EVENTS
     spawn(
-        run_foreman_ai(guild_id, human_message, user_id=user_id, task_id=task_id),
+        run_foreman_ai(guild_id, human_message, user_id=user_id, task_id=task_id, child=child),
         name=task_name,
     )
 

--- a/docs/foreman-per-task-context.md
+++ b/docs/foreman-per-task-context.md
@@ -1,0 +1,443 @@
+# Design: Per-Task Context Splitting for the Foreman
+
+**Status:** Phases 0–2 implemented in **both** the standalone foreman (`foreman/`) and
+the embedded foreman (`backend/foreman/`). Phase 3 (escalation queue, stall watchdog)
+and Phase 4 (observability) not yet done.
+**Issue:** [#649](https://github.com/jmelloy/pioneer-square/issues/649)
+**Date:** 2026-06-21
+
+---
+
+## 1. Motivation & Problem Statement
+
+### What the Foreman does today
+
+The Foreman is a Claude agent that manages all active tasks in a single conversation
+thread per guild. Every trigger — `task-complete`, `[github-event]`, `needs-input`, human
+chat, and the periodic poll — is serialized through one `_processing` flag and appended to
+one shared conversation history (`foreman/pioneer_foreman/foreman.py`). Each turn injects
+the full `<state>` block (all workers, all tasks) into the message via
+`build_state_preamble` (`runner.py:184`).
+
+History today is loaded by **`user_id`**, not by task: `_load_history` in
+`foreman/pioneer_foreman/runner.py` calls `http.get_history(user_id)` and applies a
+sliding window of `_HUMAN_TURN_WINDOW = 5` non-tool-response user turns, capped to
+`MAX_HISTORY_MESSAGES = 20` messages sent to Anthropic. Turns are already persisted with a
+`task_id` (`_save_turn(..., task_id=task_id)`), but nothing reads them back filtered by
+task — the FK is written but unused for retrieval.
+
+### What breaks as task count grows
+
+**Context bloat.** The state preamble grows linearly with task count. With 10 active tasks,
+each Claude call carries a wall of JSON that's largely irrelevant to the specific event
+being handled. Because the history window is small, real decision context gets squeezed
+out by task-list noise.
+
+**Cross-task interference.** Tool results, follow-up reasoning, and GitHub event details for
+task A interleave with task B's context in the same conversation thread. A `send_followup`
+intended for task A might reference task B's branch name if the history is dense enough.
+
+**Serial throughput.** The `_processing` flag ensures exactly one foreman run at a time. If
+task A's `task-complete` review triggers a 10-round Claude conversation (CI failure
+analysis, redirect, follow-up), task B's `task-complete` event waits in the 100-slot
+`_message_queue`. With N concurrent tasks, p99 latency scales with N × average-run-duration.
+
+**Single point of failure.** A crash or hang during one task's review blocks all other tasks
+until the connection resets and the queue is drained.
+
+**Periodic-check noise.** The poll loop (`_poll_loop` in `foreman.py`) sends all
+non-terminal tasks to the foreman every cycle (`[periodic-check] ... {task_summary}`). As
+task count grows, every poll turn carries more tasks and more history, making it harder for
+Claude to spot a genuinely stalled task.
+
+---
+
+## 2. Architecture Overview
+
+### Model: Parent orchestrator + N child task-contexts
+
+Each active task gets its own isolated Claude conversation thread. A lightweight parent
+foreman handles cross-cutting orchestration (task creation/assignment, worker lifecycle,
+human chat, routing events to the right child). Child contexts own the full lifecycle of a
+single task from assignment through finalization.
+
+```
+                        ┌─────────────────────────────────────┐
+  Browser ──────────────│  Backend WebSocket / REST            │
+  GitHub webhooks ───── │  (unchanged; event routing lives     │
+  Worker WS messages ── │   here via foreman-trigger)          │
+                        └──────────────┬──────────────────────┘
+                                       │  foreman-trigger messages
+                                       ▼
+                        ┌─────────────────────────────────────┐
+                        │   Parent Foreman                    │
+                        │   (one per guild, always on)        │
+                        │                                     │
+                        │  - Receives all triggers            │
+                        │  - Routes task-specific events      │
+                        │    to the right child context       │
+                        │  - Handles human chat               │
+                        │  - Handles worker lifecycle events  │
+                        │  - Handles task creation/assignment │
+                        │  - Runs periodic health check       │
+                        │    (summarizes child states only)   │
+                        └──────┬────────────┬────────┬────────┘
+                               │            │        │
+                   ┌───────────┘   ┌────────┘        └────────────┐
+                   ▼               ▼                              ▼
+          ┌──────────────┐ ┌──────────────┐             ┌──────────────┐
+          │ Child ctx    │ │ Child ctx    │    . . .    │ Child ctx    │
+          │ task t-aaa   │ │ task t-bbb   │             │ task t-zzz   │
+          │              │ │              │             │              │
+          │ Own history  │ │ Own history  │             │ Own history  │
+          │ Own flag     │ │ Own flag     │             │ Own flag     │
+          │ Own queue    │ │ Own queue    │             │ Own queue    │
+          └──────────────┘ └──────────────┘             └──────────────┘
+```
+
+### What child contexts ARE
+
+Child contexts are **separate asyncio tasks running isolated conversation threads** within
+the same foreman process. They are not separate OS processes and not separate WebSocket
+connections. Each child is an instance of a new `TaskContext` class that wraps:
+
+- Its own Claude conversation history (loaded by `task_id` from the DB — the `task_id`
+  column already exists on history rows and is already populated; only the *read* path
+  needs a task filter).
+- Its own `_processing` flag and trigger queue.
+- Its own `run_foreman_ai`-style loop, but with a narrowed system prompt and state preamble
+  scoped to one task.
+
+This keeps the implementation close to the current code, avoids IPC complexity, and lets the
+existing `foreman-broadcast` / `foreman-trigger` WS protocol (see `docs/foreman-split-plan.md`)
+remain unchanged. The child reuses the same `ws_send` closure and the same
+`ForemanHTTPClient` instance as the parent.
+
+---
+
+## 3. Child Context Lifecycle (creation, handoff, teardown)
+
+### What triggers spawning a child context
+
+A child context is spawned when the parent foreman successfully calls `assign_task` (i.e.,
+when a task transitions from `pending` to `working`). This is the natural boundary: before
+assignment the parent owns the task; after assignment a worker owns execution and the child
+context owns the foreman's review loop.
+
+The parent does **not** spawn a child for `create_task` alone — a task with no worker
+assigned is still entirely the parent's concern.
+
+### Initial state / system prompt the child receives
+
+The child receives a slimmed-down system prompt built by a new
+`build_child_system_blocks(task_id, task_name, worker_id, phase)`:
+
+```
+You are the Foreman AI in Pioneer Square managing a single task.
+
+Task: {task_name} ({task_id})
+Phase: {phase}
+Worker: {worker_id}
+Repo: {issue_repo or primary_repo}
+
+## Your responsibilities for this task
+- Monitor this task to completion
+- Decide send_followup vs finalize_task after task-complete or task-followup-done
+- Handle CI failures, [github-event], and needs-input for this task
+- Escalate to the human (or to the parent foreman) when genuinely stuck
+
+## Available tools
+[CHILD_FOREMAN_TOOLS — FOREMAN_TOOLS minus create_task / assign_task]
+```
+
+The `<state>` preamble injected per turn (a new `build_child_state_preamble(worker_row,
+task_row)`) contains **only** the assigned worker and **only** this task's row — not the
+global task list. This is the primary context-size win.
+
+### What state lives where
+
+| State | Lives in |
+|---|---|
+| Task conversation history (Claude messages) | Child (DB rows filtered by `task_id`) |
+| Task follow-up instructions, CI context | Child |
+| Worker assignment, task name/phase | Parent (authoritative copy in DB) |
+| Human chat history | Parent |
+| Guild-level state (all tasks, all workers) | Parent |
+| Routing map: `task_id → child handle` | Parent (in-memory dict) |
+
+### How a child is torn down
+
+1. **`finalize_task` is called** by the child — it completes its current Claude run, then
+   removes itself from the parent's routing map and cancels its poll loop.
+2. **The task reaches a terminal state** (`done`, `failed`, `cancelled`) in the DB — the
+   parent's periodic health check detects this and cancels any orphaned child context.
+3. **The parent reconnects** after a crash — it re-enumerates non-terminal tasks from
+   `GET /guilds/{id}/foreman/state` and re-spawns child contexts for those that are not
+   terminal (see §6).
+4. **Abandonment** — if a child has been idle (no events, no activity) longer than a
+   configurable TTL (default 2 hours), it tears itself down and logs a warning.
+
+---
+
+## 4. Parent ↔ Child Communication & Aggregation
+
+### Handoff
+
+After `assign_task` succeeds, the parent:
+
+1. Instantiates `TaskContext(task_id, worker_id, task_name, phase, http, ws_send, config)`.
+2. Starts it as an `asyncio.Task` (`asyncio.create_task(child.run())`).
+3. Registers it in `self._child_contexts: dict[str, TaskContext]`.
+4. Flushes any pre-spawn buffered triggers for that `task_id` (see §5) into the child queue.
+
+### How children report back
+
+Children do **not** call back into the parent object directly:
+
+- **Normal chat/broadcasts** go through the shared `ws_send` / `foreman-broadcast`
+  mechanism, identical to today.
+- **Finalization** — the child calls `finalize_task` via `/exec_tool` (no parent
+  involvement), then signals its own teardown.
+- **Escalation** uses a shared `asyncio.Queue[EscalationRequest]` that the parent drains
+  after each of its own turns.
+
+### How the parent surfaces aggregate status to the human
+
+All authoritative state is in the DB, so the parent does not query child memory. On a human
+status query it:
+
+1. Reads the full task list via `GET /guilds/{id}/foreman/state` (unchanged).
+2. Annotates each task with whether a live child context exists in `_child_contexts`.
+3. Summarizes and responds — same behavior as today, just with no cross-task tool-call
+   history polluting its own context.
+
+### Escalation
+
+A child that cannot decide (e.g., a `needs-input` it can't answer) enqueues:
+
+```python
+@dataclass
+class EscalationRequest:
+    task_id: str
+    task_name: str
+    reason: str            # human-readable summary
+    trigger_payload: dict  # original trigger so the parent can re-handle it
+```
+
+The parent drains this queue after each of its own turns, handles the escalation with full
+guild state, and — if resolved — re-enqueues the resolved trigger back to the child via
+`child.enqueue(resolved_payload)`.
+
+---
+
+## 5. Event Routing
+
+### Events that go to the parent
+
+| Event | Reason |
+|---|---|
+| Human chat messages | Parent owns the human conversation |
+| `[worker-online]` / `[worker-offline]` | Cross-cutting; may affect multiple tasks |
+| `create_task` + `assign_task` flows | Parent spawns the child after assignment |
+| `[periodic-check]` poll | Parent runs the health check, delegating per-task checks |
+| Any trigger with no matching `task_id` | Default: parent handles unknown-task events |
+
+### Events that go to the child (routing key = `task_id`)
+
+`task-complete`, `task-followup-done`, `needs-input`, `[github-event]` for a PR belonging to
+a task, and `check_run` CI success/failure. The `taskId` is already present on
+`foreman-trigger` payloads (`_handle_trigger` reads `data.get("taskId")` today), so routing
+needs no new backend protocol.
+
+### Routing algorithm
+
+```python
+def route_trigger(self, trigger: dict) -> None:
+    task_id = trigger.get("taskId")
+    if task_id and task_id in self._child_contexts:
+        child = self._child_contexts[task_id]
+        if child.is_alive():
+            child.enqueue(trigger)
+            return
+    # Task assigned but child not yet spawned: buffer for flush-on-spawn.
+    if task_id and task_id in self._pending_for_task:
+        self._pending_for_task[task_id].append(trigger)
+        return
+    # Fall through to the parent.
+    self._parent_dispatch(trigger)
+```
+
+### Pre-spawn race
+
+There is a small window between `assign_task` completing (backend sets task to `working`)
+and the child being registered. A `_pending_for_task: dict[str, list[dict]]` buffer in the
+parent holds triggers for that `task_id`; the parent flushes them into the child's queue at
+the end of handoff (§4). Triggers are buffered, never dropped.
+
+---
+
+## 6. Failure Modes & Recovery
+
+### Child context crashes or stalls
+
+**Crash.** The asyncio task raises an unhandled exception. The parent's task-done callback
+logs the error, removes the child from `_child_contexts`, and `ws_send`s an alert to the
+human. The DB task is left in its last-known state; the parent's next periodic check notices
+it's non-terminal with no live child and either re-spawns it or surfaces it for human review.
+
+**Stall.** The child's `_processing` flag stays `True` longer than `child_stall_timeout`
+(configurable, default 5 minutes). A per-child watchdog cancels the in-flight Claude call,
+clears the flag, logs the stall, and resumes draining the queue.
+
+### Parent crash while children are active
+
+The process exits; all child asyncio tasks are cancelled. On reconnect (`foreman-registered`):
+
+1. The parent reads all non-terminal tasks from `GET /guilds/{id}/foreman/state`.
+2. For each non-terminal task with a `worker_id`, it spawns a fresh child context.
+3. Each new child sends itself a synthetic `[reconnect]` trigger: "I just reconnected; the
+   task was in state `{state}`. Check if it still needs action."
+4. The child loads its DB-backed history (filtered by `task_id`) on its first turn —
+   continuity is preserved because history is persisted, not in-memory.
+
+### Worker goes offline while a child holds a task
+
+The parent receives `[worker-offline]` and notifies the affected child via
+`child.enqueue(worker_offline_trigger)`. The child decides whether to `send_followup` to a
+different worker or escalate. If no other worker is available, it escalates through the
+`EscalationQueue`.
+
+---
+
+## 7. Implementation Path
+
+> **Implementation note (2026-06-21):** Phases 0–2 are implemented in **both** foremen.
+> `FOREMAN_CHILD_CONTEXTS` (env) / `child_contexts` (standalone config), default on, gate
+> the behaviour. Shared: `build_child_system_blocks` / `build_child_state_preamble` and
+> `CHILD_FOREMAN_TOOLS` in `backend/foreman_core/`, plus a `task_id` filter on the history
+> read path.
+>
+> **Standalone** (`foreman/`) uses a persistent `TaskContext` per task
+> (`task_context.py`) because it has a single WebSocket connection and needs concurrent
+> asyncio loops; the `Foreman` class does routing, spawn-on-assign, teardown-on-finalize,
+> reconnect-respawn, and orphan-recovery.
+>
+> **Embedded** (`backend/foreman/`) does **not** need a persistent `TaskContext`: it is
+> in-process with direct DB access and already gets concurrency from independent
+> `run_foreman_ai` asyncio tasks. Per-task isolation is achieved with three primitives
+> instead: (1) `task_id`-filtered history in `_load_history`, (2) child-mode
+> prompt/state/tools in `_run_foreman_ai(child=True, task_id=...)`, and (3) a per-task
+> lock key `(guild_id, "task:<id>")` in `run_foreman_ai` so different tasks run
+> concurrently while one task's review loop serialises against itself. "Spawn on assign"
+> and "teardown on finalize" are implicit — each task-specific event runs an ephemeral
+> child-mode turn, with continuity provided by DB-backed history. Routing lives at the
+> trigger sites: `ws_handlers._trigger_foreman` (task-complete / followup-done /
+> needs-input / task-error), the webhook debounce path (github events for a known task),
+> and the user-followup task route. Cross-cutting events (human chat, worker lifecycle,
+> periodic-check, claude-auth) stay on the whole-guild parent context.
+>
+> Phase 3 (escalation queue, stall watchdog) and Phase 4 (observability) remain.
+
+### Phase 0 — Plumbing (no behavior change) ✅
+
+1. **Verify `task_id` population.** Confirm the `task_id` column on history rows is
+   populated for all trigger types (it is written by `_save_turn` today; audit that callers
+   always pass it).
+2. **Task-scoped history read.** Add an optional `task_id` filter to `get_history`
+   (`http_client.py`) and the backing `GET /guilds/{id}/foreman/history` endpoint, then a
+   `_load_history(..., task_id=...)` path in `runner.py` that loads only that task's turns.
+3. **`TaskContext` skeleton** in `foreman/pioneer_foreman/task_context.py`: wraps a
+   `task_id`, with `enqueue()`, `run()`, `is_alive()`, and a `_processing` flag mirroring the
+   parent's run/drain loop.
+4. **Routing map + escalation queue** on `Foreman` (`foreman.py`).
+
+### Phase 1 — Spawn children on assign_task ✅
+
+5. **Intercept successful `assign_task` results** in the parent's run loop; spawn a
+   `TaskContext` for the returned `task_id`.
+6. **`build_child_system_blocks`** and **`build_child_state_preamble`** in
+   `foreman/pioneer_foreman/prompt.py` (and the shared `backend/foreman_core/prompt.py`).
+7. **`CHILD_FOREMAN_TOOLS`** in `backend/foreman_core/tools_schema.py` = `FOREMAN_TOOLS`
+   minus `create_task` / `assign_task`.
+
+### Phase 2 — Route events to children ✅
+
+8. **Apply the routing map** in `_handle_trigger` using the existing `taskId`.
+9. **`_pending_for_task` buffer** + flush-on-spawn.
+10. **Child teardown** on `finalize_task` (deregister, cancel poll loop).
+
+### Phase 3 — Escalation & recovery
+
+11. **`EscalationQueue`** drained by the parent after each of its turns.
+12. **Reconnect re-spawn** on `foreman-registered`.
+13. **Per-child stall watchdog.**
+
+### Phase 4 — Observability & tuning
+
+14. **Per-child token logging** to compare child vs. parent context sizes.
+15. **`child_context_count`** added to `foreman-poll-status` broadcasts so the frontend can
+    show "N task contexts active".
+16. **Independent history caps** — parent may want a smaller `MAX_HISTORY_MESSAGES`;
+    long-running children may want larger.
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `foreman/pioneer_foreman/task_context.py` | `TaskContext` — the child context runner |
+| `foreman/pioneer_foreman/escalation.py` | `EscalationRequest` dataclass + queue helpers |
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `foreman/pioneer_foreman/foreman.py` | Routing map, child spawn/teardown, escalation drain, pre-spawn buffer |
+| `foreman/pioneer_foreman/runner.py` | `task_id`-filtered history loader; `child=True` flag to narrow state |
+| `foreman/pioneer_foreman/prompt.py` | `build_child_system_blocks`, `build_child_state_preamble` |
+| `foreman/pioneer_foreman/http_client.py` | `task_id` param on `get_history` |
+| `backend/foreman_core/tools_schema.py` | Export `CHILD_FOREMAN_TOOLS` |
+| `backend/routes/foreman.py` | `task_id` filter on the history endpoint |
+
+The embedded foreman (`backend/foreman/`) follows the same design with `TaskContext` objects
+running inside the backend process; the class can be shared via `backend/foreman_core/`. Note
+that `docs/foreman-split-plan.md` Phase 5 anticipates removing the embedded foreman entirely,
+so this design should be prototyped in the standalone foreman first (see open question 7).
+
+---
+
+## 8. Open Questions
+
+1. **Re-spawning children for pre-existing tasks.** On reconnect the parent sees tasks
+   already `working` / `awaiting-review`. Re-spawning children is good for reliability but
+   requires the child to reconstruct context from DB history alone — is that enough, or does
+   the child need a richer "resumption briefing"?
+
+2. **Child tool set.** The proposal excludes `create_task` / `assign_task` from children. But
+   a child handling a complex task might legitimately want to spawn a sub-task. Should
+   children be allowed `create_task` → `assign_task` with `parent_task_id`? Does that spawn a
+   grandchild context?
+
+3. **Periodic health check.** With per-task contexts the parent's poll only needs to find
+   orphaned tasks (non-terminal, no live child). Should the parent also tick each child with
+   an "are you still alive?", or is the stall watchdog sufficient?
+
+4. **Follow-up history.** `send_followup` reuses the same task and branch. Should the child's
+   history accumulate across the original task and all follow-ups (same `task_id`), or should
+   each follow-up start fresh? Accumulating gives useful prior context; fresh avoids bloat on
+   long-lived tasks.
+
+5. **Concurrency cap.** There is no limit in this design. With 20 tasks, 20 child contexts
+   could hit the Anthropic API simultaneously. Should the parent rate-limit child spawning or
+   use a semaphore on Claude calls?
+
+6. **Parent history partitioning.** The parent's own history grows as it handles assignment,
+   human chat, and escalations. Is the existing sliding window enough, or should the parent's
+   history be partitioned by topic?
+
+7. **Embedded vs. standalone divergence.** Both share `backend/foreman_core/` but have
+   different runner entry points. Prototype in the standalone foreman first, then port — or
+   update both in parallel? (See `docs/foreman-split-plan.md` Phase 5.)
+
+8. **WS message attribution.** Today all foreman chat carries `"from": "foreman"`. With child
+   contexts, should messages carry a `taskId` so the frontend can show "Foreman [task t-aaa]"
+   vs. "Foreman [parent]"? This is a frontend + WS-protocol change.

--- a/foreman/pioneer-foreman.toml.example
+++ b/foreman/pioneer-foreman.toml.example
@@ -11,6 +11,12 @@ backend_key = ""
 # auth_token. Ignored when backend_key is provided.
 # auth_token = ""
 
+# Per-task child contexts: spawn an isolated conversation thread per assigned
+# task and route task-specific events to it (see docs/foreman-per-task-context.md).
+# Defaults to true; set false (or FOREMAN_CHILD_CONTEXTS=0) for the legacy
+# single-context behaviour.
+# child_contexts = true
+
 [claude]
 model         = "claude-sonnet-4-6"    # used when provider = "anthropic"
 api_key       = ""                     # falls back to ANTHROPIC_API_KEY env var

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -49,6 +49,11 @@ class Config:
     aws_profile: str | None = None
     max_rounds: int = 10
     history_limit: int = 40
+    # When True, the foreman spawns an isolated per-task child context on each
+    # assign_task and routes task-specific events to it. See
+    # docs/foreman-per-task-context.md. Set false to fall back to the legacy
+    # single-context behaviour.
+    child_contexts: bool = True
     # Poll settings
     poll_min_interval: int = 60
     poll_max_interval: int = 14400
@@ -82,6 +87,18 @@ class Config:
         scheme = {"http": "ws", "https": "wss"}.get(parsed.scheme, parsed.scheme or "ws")
         base = urlunparse((scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
         return f"{base}/ws/{self.guild_id}"
+
+
+def _as_bool(*values, default: bool) -> bool:
+    """Return the first non-None value coerced to bool (TOML bools pass through,
+    strings like '0'/'false'/'no'/'off' are falsy)."""
+    for v in values:
+        if v is None:
+            continue
+        if isinstance(v, bool):
+            return v
+        return str(v).strip().lower() not in ("0", "false", "no", "off", "")
+    return default
 
 
 def _resolve_config_path(explicit: str | None) -> Path:
@@ -218,6 +235,12 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         aws_profile=aws_profile,
         max_rounds=int(overrides.get("max_rounds", claude_block.get("max_rounds", 10))),
         history_limit=int(overrides.get("history_limit", claude_block.get("history_limit", 40))),
+        child_contexts=_as_bool(
+            overrides.get("child_contexts"),
+            raw.get("child_contexts"),
+            os.environ.get("FOREMAN_CHILD_CONTEXTS"),
+            default=True,
+        ),
         poll_min_interval=int(
             overrides.get("poll_min_interval", poll_block.get("min_interval", 60))
         ),

--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 import websockets
 
 from .http_client import ForemanHTTPClient
 from .runner import run_foreman_ai
+from .task_context import _TERMINAL_TASK_STATES, TaskContext
 
 if TYPE_CHECKING:
     from .config import Config
@@ -19,6 +22,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _QUEUE_MAX = 100
+
+# Matches a task id (e.g. "t-abc123") in an assign_task tool result like
+# "Task t-abc123 assigned to w-1." / "Task t-abc123 queued for w-1."
+_TASK_ID_RE = re.compile(r"\bt-[a-z0-9]+\b")
 
 
 class Foreman:
@@ -37,6 +44,141 @@ class Foreman:
         # Current poll interval in seconds.  Reset to poll_min_interval when
         # the foreman makes tool calls; otherwise advanced exponentially each tick.
         self._poll_interval: int = config.poll_min_interval
+        # Per-task child contexts (task_id → TaskContext), populated on assign_task
+        # when config.child_contexts is enabled.  See docs/foreman-per-task-context.md.
+        self._child_contexts: dict[str, TaskContext] = {}
+        # Triggers that arrived for a task between assign_task and the child being
+        # registered; flushed into the child's queue on spawn.
+        self._pending_for_task: dict[str, list[dict]] = {}
+        # Per-connection broadcast closure; set in _run_connection, cleared on exit.
+        self._ws_send: Callable[[dict], Awaitable[None]] | None = None
+
+    # ── per-task child contexts ────────────────────────────────────────────
+
+    @staticmethod
+    def _normalize_trigger(data: dict) -> dict:
+        """Convert a foreman-trigger WS payload into the internal trigger dict
+        shared by the parent queue and child queues."""
+        return {
+            "guild_id": data.get("guildId", ""),
+            "human_message": data.get("humanMessage", ""),
+            "extra_context": data.get("extraContext", ""),
+            "user_id": data.get("userId"),
+            "task_id": data.get("taskId"),
+            "event": data.get("event", "?"),
+        }
+
+    def _route_to_child(self, trigger: dict) -> bool:
+        """Route a task-specific trigger to its child context if one exists or is
+        pending. Returns True if the trigger was consumed by a child, False if the
+        parent should handle it."""
+        if not self._config.child_contexts:
+            return False
+        task_id = trigger.get("task_id")
+        if not task_id:
+            return False
+        child = self._child_contexts.get(task_id)
+        if child is not None and child.is_alive():
+            child.enqueue(trigger)
+            return True
+        # Assignment in flight — buffer until the child is registered.
+        if task_id in self._pending_for_task:
+            self._pending_for_task[task_id].append(trigger)
+            return True
+        return False
+
+    def _spawn_child(self, task_id: str) -> None:
+        """Create and start a child context for an assigned task, then flush any
+        buffered pre-spawn triggers into it. Idempotent."""
+        if not self._config.child_contexts or self._ws_send is None or self._http is None:
+            return
+        if task_id in self._child_contexts and self._child_contexts[task_id].is_alive():
+            return
+        child = TaskContext(
+            task_id,
+            guild_id=self._config.guild_id,
+            user_id=None,
+            http=self._http,
+            ws_send=self._ws_send,
+            config=self._config,
+            on_finalize=self._deregister_child,
+        )
+        self._child_contexts[task_id] = child
+        child.start()
+        logger.info("spawned child context for task %s", task_id)
+        for buffered in self._pending_for_task.pop(task_id, []):
+            child.enqueue(buffered)
+
+    def _deregister_child(self, task_id: str) -> None:
+        """Remove a finalized/dead child from the routing map (called by the child)."""
+        self._child_contexts.pop(task_id, None)
+        self._pending_for_task.pop(task_id, None)
+        logger.debug("deregistered child context for task %s", task_id)
+
+    def _parent_tool_observer(self, tool_name: str, tool_input: dict, result: dict) -> None:
+        """React to the parent's task lifecycle tool calls: spawn a child on
+        assign_task, tear one down if the parent finalizes/cancels a task itself."""
+        if result.get("is_error"):
+            return
+        if tool_name == "assign_task":
+            content = result.get("content") or ""
+            match = _TASK_ID_RE.search(content)
+            task_id = match.group(0) if match else tool_input.get("task_id")
+            if not task_id:
+                logger.warning("assign_task succeeded but no task_id found in result: %r", content)
+                return
+            # Open the pre-spawn buffer before starting the child so events arriving
+            # during spawn are captured, then create and flush the child.
+            self._pending_for_task.setdefault(task_id, [])
+            self._spawn_child(task_id)
+        elif tool_name in ("finalize_task", "cancel_task"):
+            task_id = tool_input.get("task_id")
+            child = self._child_contexts.get(task_id) if task_id else None
+            if child is not None:
+                logger.info("parent %s task %s — tearing down its child", tool_name, task_id)
+                asyncio.create_task(child.stop(), name=f"foreman.child-stop:{task_id}")
+
+    async def _respawn_children_from_state(self) -> None:
+        """On (re)connect, spawn a child for every non-terminal task with a worker.
+
+        History is DB-backed, so each child reconstructs its own context on first
+        turn. A synthetic [reconnect] trigger nudges it to re-check the task."""
+        if not self._config.child_contexts or self._http is None:
+            return
+        try:
+            state = await self._http.get_state()
+            for t in state.get("tasks") or []:
+                task_id = t.get("id")
+                if not task_id or t.get("state") in _TERMINAL_TASK_STATES or not t.get("worker_id"):
+                    continue
+                if task_id in self._child_contexts and self._child_contexts[task_id].is_alive():
+                    continue
+                self._spawn_child(task_id)
+                child = self._child_contexts.get(task_id)
+                if child is not None:
+                    child.enqueue(
+                        {
+                            "guild_id": self._config.guild_id,
+                            "human_message": (
+                                f"[reconnect] Foreman reconnected; task {task_id} is in state "
+                                f"'{t.get('state')}'. Check whether it still needs action."
+                            ),
+                            "extra_context": "",
+                            "user_id": None,
+                            "task_id": task_id,
+                            "event": "reconnect",
+                        }
+                    )
+        except Exception:
+            logger.exception("respawn: failed to re-establish child contexts")
+
+    async def _cancel_all_children(self) -> None:
+        """Cancel every child context (on disconnect/eviction)."""
+        children = list(self._child_contexts.values())
+        self._child_contexts.clear()
+        self._pending_for_task.clear()
+        for child in children:
+            await child.stop()
 
     async def run(self) -> None:
         """Connect to the backend and handle triggers until stopped."""
@@ -124,6 +266,9 @@ class Foreman:
                 except Exception as exc:
                     logger.warning("_ws_send failed: %s", exc)
 
+            # Expose the broadcast closure to child contexts spawned this connection.
+            self._ws_send = _ws_send
+
             async def _run_foreman(
                 guild_id: str,
                 human_message: str,
@@ -157,6 +302,7 @@ class Foreman:
                             http=self._http,
                             ws_send=_ws_send,
                             config=self._config,
+                            tool_observer=self._parent_tool_observer,
                         )
                         if made_calls:
                             self._last_action_at = time.monotonic()
@@ -183,6 +329,7 @@ class Foreman:
                                 http=self._http,
                                 ws_send=_ws_send,
                                 config=self._config,
+                                tool_observer=self._parent_tool_observer,
                             )
                             if made_calls:
                                 self._last_action_at = time.monotonic()
@@ -202,6 +349,15 @@ class Foreman:
                 trigger_task_id = data.get("taskId")
                 if not guild_id or not human_message:
                     logger.warning("Ignoring malformed foreman-trigger: %s", data)
+                    return
+
+                # Route task-specific events to their isolated child context.
+                if self._route_to_child(self._normalize_trigger(data)):
+                    logger.debug(
+                        "Routed trigger to child context: task=%s event=%s",
+                        trigger_task_id,
+                        data.get("event", "?"),
+                    )
                     return
 
                 if self._processing:
@@ -268,6 +424,32 @@ class Foreman:
                             for t in (state.get("tasks") or [])
                             if t.get("state") not in ("done", "failed", "cancelled")
                         ]
+
+                        # Orphan recovery + ownership split: when child contexts are
+                        # enabled, each assigned task is monitored by its own child, so
+                        # the parent's periodic check only covers tasks WITHOUT a live
+                        # child (unassigned/pending or orphaned). Spawn a child for any
+                        # assigned task missing one.
+                        if self._config.child_contexts:
+                            for t in active:
+                                tid = t.get("id")
+                                if (
+                                    tid
+                                    and t.get("worker_id")
+                                    and not (
+                                        tid in self._child_contexts
+                                        and self._child_contexts[tid].is_alive()
+                                    )
+                                ):
+                                    self._spawn_child(tid)
+                            active = [
+                                t
+                                for t in active
+                                if not (
+                                    t.get("id") in self._child_contexts
+                                    and self._child_contexts[t["id"]].is_alive()
+                                )
+                            ]
                         n = len(active)
 
                         # Advance the interval for the next tick.  If a triggered run
@@ -331,6 +513,9 @@ class Foreman:
                             msg.get("agentId"),
                             self._config.guild_id,
                         )
+                        # Re-establish per-task child contexts for any tasks that
+                        # were already in flight (e.g. after a reconnect).
+                        await self._respawn_children_from_state()
                     elif msg_type == "foreman-trigger":
                         logger.debug(
                             "Received foreman-trigger: event=%s",
@@ -362,5 +547,9 @@ class Foreman:
                         await poll_task
                     except asyncio.CancelledError:
                         pass
+                # Child contexts hold this connection's ws_send; tear them down so
+                # the next connection respawns them cleanly from state.
+                await self._cancel_all_children()
+                self._ws_send = None
 
         return evicted

--- a/foreman/pioneer_foreman/http_client.py
+++ b/foreman/pioneer_foreman/http_client.py
@@ -111,11 +111,19 @@ class ForemanHTTPClient:
         """Fetch guild state: workers, tasks, guild metadata (including owner_user_id)."""
         return await self._get(self._guild_url("/foreman/state"))
 
-    async def get_history(self, user_id: str, limit: int | None = None) -> list[dict]:
-        """Fetch raw ForemanTurn rows for a user, ordered oldest→newest."""
+    async def get_history(
+        self, user_id: str, limit: int | None = None, *, task_id: str | None = None
+    ) -> list[dict]:
+        """Fetch raw ForemanTurn rows for a user, ordered oldest→newest.
+
+        When ``task_id`` is set, only turns tagged with that task are returned —
+        used by per-task child contexts to load their own isolated history.
+        """
         params: dict = {"user_id": user_id}
         if limit is not None:
             params["limit"] = limit
+        if task_id is not None:
+            params["task_id"] = task_id
         return await self._get(self._guild_url("/foreman/history"), **params)
 
     async def get_guild_key(self) -> dict:

--- a/foreman/pioneer_foreman/prompt.py
+++ b/foreman/pioneer_foreman/prompt.py
@@ -6,8 +6,11 @@ backward-compatibility with existing imports (from pioneer_foreman.prompt import
 
 from backend.foreman_core.prompt import (
     _EMPTY_WORKERS_BLOCKS,
+    CHILD_FOREMAN_SYSTEM,
     FOREMAN_SYSTEM,
     _stable_system_text,
+    build_child_state_preamble,
+    build_child_system_blocks,
     build_state_preamble,
     build_system_blocks,
     build_system_prompt,
@@ -15,8 +18,11 @@ from backend.foreman_core.prompt import (
 
 __all__ = [
     "FOREMAN_SYSTEM",
+    "CHILD_FOREMAN_SYSTEM",
     "_EMPTY_WORKERS_BLOCKS",
     "_stable_system_text",
+    "build_child_state_preamble",
+    "build_child_system_blocks",
     "build_state_preamble",
     "build_system_blocks",
     "build_system_prompt",

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -24,11 +24,21 @@ from backend.foreman_core.message_utils import (
     truncate_tool_result,
 )
 
-from .prompt import build_state_preamble, build_system_blocks, build_system_prompt
+from .prompt import (
+    build_child_state_preamble,
+    build_child_system_blocks,
+    build_state_preamble,
+    build_system_blocks,
+    build_system_prompt,
+)
 
 if TYPE_CHECKING:
     from .config import Config
     from .http_client import ForemanHTTPClient
+
+# Callback invoked once per executed tool result: (tool_name, tool_input, result_dict).
+# The parent foreman uses it to spawn/teardown child contexts on assign/finalize.
+ToolObserver = Callable[[str, dict, dict], None]
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +68,15 @@ def _get_anthropic_client(config: Config):
     return _anthropic_clients[cache_key]
 
 
-async def _load_history(guild_id: str, user_id: str, *, http: ForemanHTTPClient) -> list[dict]:
-    """Load history via REST and apply the same sliding-window as the embedded runner."""
-    turns = await http.get_history(user_id)
+async def _load_history(
+    guild_id: str, user_id: str, *, http: ForemanHTTPClient, task_id: str | None = None
+) -> list[dict]:
+    """Load history via REST and apply the same sliding-window as the embedded runner.
+
+    When ``task_id`` is set, only that task's turns are loaded — the isolated
+    conversation thread for a per-task child context.
+    """
+    turns = await http.get_history(user_id, task_id=task_id)
 
     if not turns:
         return []
@@ -123,6 +139,8 @@ async def run_foreman_ai(
     http: ForemanHTTPClient,
     ws_send: Callable[[dict], Awaitable[None]],
     config: Config,
+    child: bool = False,
+    tool_observer: ToolObserver | None = None,
 ) -> bool:
     """Process a human message (or system escalation) through the Claude foreman AI.
 
@@ -130,10 +148,23 @@ async def run_foreman_ai(
     ``task_id`` must be passed explicitly by the caller; it is not inferred from
     guild state so there is no ambiguity when multiple tasks are active.
 
+    When ``child`` is True the run is scoped to a single task (``task_id`` is
+    required): history, system prompt, state preamble, and tool set are all
+    narrowed to that one task (see docs/foreman-per-task-context.md). When False
+    this is the parent/legacy whole-guild run.
+
+    ``tool_observer``, if given, is called once per executed tool result with
+    ``(tool_name, tool_input, result_dict)`` — the parent uses it to spawn or
+    tear down child contexts in reaction to assign_task / finalize_task.
+
     Returns True if the foreman made at least one tool call, False otherwise.
     Callers use this to decide whether to reset the poll backoff.
     """
-    from .tools import FOREMAN_TOOLS, exec_tools
+    from .tools import CHILD_FOREMAN_TOOLS, FOREMAN_TOOLS, exec_tools
+
+    if child and not task_id:
+        raise ValueError("run_foreman_ai(child=True) requires a task_id")
+    tools = CHILD_FOREMAN_TOOLS if child else FOREMAN_TOOLS
 
     if not HAS_ANTHROPIC:
         now = datetime.now(UTC).isoformat()
@@ -159,6 +190,14 @@ async def run_foreman_ai(
     if not user_id:
         user_id = guild_data.get("owner_user_id") or guild_id
 
+    # In child mode, narrow worker/task rows to just this task and its worker.
+    task_row: dict | None = None
+    if child:
+        task_row = next((t for t in task_rows if t.get("id") == task_id), None)
+        child_worker_id = task_row.get("worker_id") if task_row else None
+        worker_rows = [r for r in worker_rows if r.get("id") == child_worker_id]
+        task_rows = [task_row] if task_row else []
+
     made_tool_calls = False
     try:
         workers_block = json.dumps(
@@ -180,8 +219,20 @@ async def run_foreman_ai(
             s for row in task_rows if (s := _summarize_task(row, cutoff_ts)) is not None
         ]
         tasks_block = json.dumps(summarized_tasks, indent=2)
-        system_blocks = build_system_blocks(primary_repo=primary_repo)
-        state_preamble = build_state_preamble(workers_block, tasks_block, extra_context)
+
+        if child:
+            _t = task_row or {}
+            system_blocks = build_child_system_blocks(
+                task_id=task_id,
+                task_name=_t.get("name") or task_id,
+                worker_id=_t.get("worker_id"),
+                phase=_t.get("phase"),
+                repo=_t.get("issue_repo") or primary_repo,
+            )
+            state_preamble = build_child_state_preamble(workers_block, tasks_block, extra_context)
+        else:
+            system_blocks = build_system_blocks(primary_repo=primary_repo)
+            state_preamble = build_state_preamble(workers_block, tasks_block, extra_context)
         audit_system = build_system_prompt(
             workers_block, tasks_block, extra_context, primary_repo=primary_repo
         )
@@ -200,7 +251,9 @@ async def run_foreman_ai(
 
         await _save_turn(guild_id, user_id, "system", audit_system, http=http, task_id=task_id)
         await _save_turn(guild_id, user_id, "user", human_message, http=http, task_id=task_id)
-        messages = await _load_history(guild_id, user_id, http=http)
+        messages = await _load_history(
+            guild_id, user_id, http=http, task_id=task_id if child else None
+        )
 
         _inject_state_preamble(messages, state_preamble)
 
@@ -222,7 +275,7 @@ async def run_foreman_ai(
                 max_tokens=1024,
                 system=system_blocks,
                 messages=messages,
-                tools=FOREMAN_TOOLS,
+                tools=tools,
             )
             resp = _raw.parse()
             usage = resp.usage
@@ -317,6 +370,17 @@ async def run_foreman_ai(
                     entry = {**entry, "content": truncate_tool_result(entry["content"])}
                 trimmed.append(entry)
 
+            if tool_observer is not None:
+                _tool_by_id = {tu.id: tu for tu in tool_uses}
+                for r in trimmed:
+                    tu = _tool_by_id.get(r.get("tool_use_id"))
+                    if tu is None:
+                        continue
+                    try:
+                        tool_observer(tu.name, dict(tu.input) if tu.input else {}, r)
+                    except Exception:
+                        logger.exception("tool_observer raised for %s", tu.name)
+
             _now = datetime.now(UTC).isoformat()
             for result in trimmed:
                 await ws_send(
@@ -365,7 +429,7 @@ async def run_foreman_ai(
                 max_tokens=1024,
                 system=system_blocks,
                 messages=messages,
-                tools=FOREMAN_TOOLS,
+                tools=tools,
                 tool_choice={"type": "none"},
             )
             wrap_resp = _wrap_raw.parse()

--- a/foreman/pioneer_foreman/task_context.py
+++ b/foreman/pioneer_foreman/task_context.py
@@ -1,0 +1,154 @@
+"""Per-task child context for the standalone Foreman.
+
+A ``TaskContext`` is a lightweight, isolated conversation thread that owns the
+foreman's review loop for a single already-assigned task. It runs as its own
+asyncio task inside the foreman process — not a separate OS process or WebSocket
+connection — and reuses the parent's ``ForemanHTTPClient`` and ``ws_send``.
+
+Isolation comes from two narrowings applied by ``run_foreman_ai(child=True)``:
+history is loaded filtered by ``task_id``, and the system prompt / state preamble
+/ tool set are scoped to this one task. See docs/foreman-per-task-context.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from .runner import run_foreman_ai
+
+if TYPE_CHECKING:
+    from .config import Config
+    from .http_client import ForemanHTTPClient
+
+logger = logging.getLogger(__name__)
+
+_CHILD_QUEUE_MAX = 50
+
+# States that mean the underlying task is closed and the child should stop.
+_TERMINAL_TASK_STATES = frozenset({"done", "failed", "cancelled"})
+
+
+class TaskContext:
+    """Isolated conversation thread for one task, driven by a serial queue.
+
+    Triggers routed by the parent are enqueued via :meth:`enqueue` and consumed
+    one at a time by :meth:`run`. Each trigger runs a child-scoped foreman turn.
+    When the child calls ``finalize_task`` it signals teardown via ``on_finalize``.
+    """
+
+    def __init__(
+        self,
+        task_id: str,
+        *,
+        guild_id: str,
+        user_id: str | None,
+        http: ForemanHTTPClient,
+        ws_send: Callable[[dict], Awaitable[None]],
+        config: Config,
+        on_finalize: Callable[[str], None] | None = None,
+    ):
+        self.task_id = task_id
+        self._guild_id = guild_id
+        self._user_id = user_id
+        self._http = http
+        self._ws_send = ws_send
+        self._config = config
+        self._on_finalize = on_finalize
+        self._queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=_CHILD_QUEUE_MAX)
+        self._task: asyncio.Task | None = None
+        # True once finalize_task has fired for this task — the loop drains its
+        # current item and then exits.
+        self._finalized = False
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Spawn the consumer loop as an asyncio task."""
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self.run(), name=f"foreman.child:{self.task_id}")
+
+    def is_alive(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    def enqueue(self, trigger: dict) -> bool:
+        """Queue a trigger for this task. Returns False if the queue is full."""
+        try:
+            self._queue.put_nowait(trigger)
+            return True
+        except asyncio.QueueFull:
+            logger.warning(
+                "child %s: queue full (%d); dropping event=%s",
+                self.task_id,
+                _CHILD_QUEUE_MAX,
+                trigger.get("event", "?"),
+            )
+            return False
+
+    async def stop(self) -> None:
+        """Cancel the consumer loop and wait for it to unwind."""
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    # ── consumer loop ─────────────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        """Drain triggers one at a time until finalized or cancelled."""
+        logger.info("child %s: started", self.task_id)
+        try:
+            while True:
+                trigger = await self._queue.get()
+                try:
+                    await self._handle(trigger)
+                except Exception:
+                    logger.exception("child %s: error handling trigger", self.task_id)
+                finally:
+                    self._queue.task_done()
+                if self._finalized:
+                    logger.info("child %s: finalized — exiting loop", self.task_id)
+                    break
+        except asyncio.CancelledError:
+            logger.debug("child %s: cancelled", self.task_id)
+            raise
+        finally:
+            if self._on_finalize is not None:
+                self._on_finalize(self.task_id)
+
+    async def _handle(self, trigger: dict) -> None:
+        human_message = trigger.get("human_message", "")
+        if not human_message:
+            return
+        await run_foreman_ai(
+            self._guild_id,
+            human_message,
+            extra_context=trigger.get("extra_context", ""),
+            user_id=trigger.get("user_id") or self._user_id,
+            task_id=self.task_id,
+            http=self._http,
+            ws_send=self._ws_send,
+            config=self._config,
+            child=True,
+            tool_observer=self._observe_tool,
+        )
+
+    # ── tool observation ──────────────────────────────────────────────────────
+
+    def _observe_tool(self, tool_name: str, tool_input: dict, result: dict) -> None:
+        """Detect terminal tool calls so the child can tear itself down.
+
+        ``finalize_task`` / ``cancel_task`` close the task; once one succeeds the
+        loop exits after the current turn.
+        """
+        if result.get("is_error"):
+            return
+        if tool_name in ("finalize_task", "cancel_task"):
+            tid = tool_input.get("task_id") or self.task_id
+            if tid == self.task_id:
+                logger.info("child %s: %s observed — scheduling teardown", self.task_id, tool_name)
+                self._finalized = True

--- a/foreman/pioneer_foreman/tools.py
+++ b/foreman/pioneer_foreman/tools.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 
 from backend.foreman_core.tools_schema import (
+    CHILD_FOREMAN_TOOLS,  # noqa: F401  – re-exported for runner.py (child contexts)
     FOREMAN_TOOLS,  # noqa: F401  – re-exported for runner.py
 )
 

--- a/foreman/tests/test_child_routing.py
+++ b/foreman/tests/test_child_routing.py
@@ -1,0 +1,186 @@
+"""Unit tests for the parent Foreman's per-task child-context routing/spawn logic.
+
+These poke the routing helpers directly (no WebSocket loop) and patch
+run_foreman_ai out via the TaskContext layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pioneer_foreman.config import Config
+from pioneer_foreman.foreman import Foreman
+
+
+def _make_config(**kwargs) -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="g1",
+        backend_key="k",
+        poll_min_interval=3600,
+        **kwargs,
+    )
+
+
+def _make_foreman(**cfg) -> Foreman:
+    f = Foreman(_make_config(**cfg))
+    f._http = AsyncMock()
+    f._ws_send = AsyncMock()
+    return f
+
+
+def _norm(**kwargs) -> dict:
+    base = {
+        "guild_id": "g1",
+        "human_message": "hi",
+        "extra_context": "",
+        "user_id": None,
+        "task_id": None,
+        "event": "?",
+    }
+    base.update(kwargs)
+    return base
+
+
+# ── normalize ──────────────────────────────────────────────────────────────
+
+
+def test_normalize_trigger_maps_ws_fields():
+    out = Foreman._normalize_trigger(
+        {
+            "guildId": "g1",
+            "humanMessage": "do it",
+            "extraContext": "ctx",
+            "userId": "u-9",
+            "taskId": "t-1",
+            "event": "task-complete",
+        }
+    )
+    assert out == {
+        "guild_id": "g1",
+        "human_message": "do it",
+        "extra_context": "ctx",
+        "user_id": "u-9",
+        "task_id": "t-1",
+        "event": "task-complete",
+    }
+
+
+# ── routing ────────────────────────────────────────────────────────────────
+
+
+def test_route_no_task_id_goes_to_parent():
+    f = _make_foreman()
+    assert f._route_to_child(_norm(task_id=None)) is False
+
+
+def test_route_unknown_task_goes_to_parent():
+    f = _make_foreman()
+    assert f._route_to_child(_norm(task_id="t-unknown")) is False
+
+
+def test_route_disabled_goes_to_parent():
+    f = _make_foreman(child_contexts=False)
+    f._pending_for_task["t-1"] = []
+    assert f._route_to_child(_norm(task_id="t-1")) is False
+
+
+def test_route_to_live_child():
+    f = _make_foreman()
+    child = MagicMock()
+    child.is_alive.return_value = True
+    f._child_contexts["t-1"] = child
+    trigger = _norm(task_id="t-1")
+    assert f._route_to_child(trigger) is True
+    child.enqueue.assert_called_once_with(trigger)
+
+
+def test_route_buffers_during_pending_spawn():
+    f = _make_foreman()
+    f._pending_for_task["t-1"] = []
+    trigger = _norm(task_id="t-1")
+    assert f._route_to_child(trigger) is True
+    assert f._pending_for_task["t-1"] == [trigger]
+
+
+# ── spawn / observer ───────────────────────────────────────────────────────
+
+
+async def test_observer_spawns_child_on_assign(monkeypatch):
+    f = _make_foreman()
+    # Keep TaskContext.run from doing anything real.
+    monkeypatch.setattr("pioneer_foreman.task_context.run_foreman_ai", AsyncMock(return_value=True))
+    f._parent_tool_observer(
+        "assign_task",
+        {"worker_id": "w-1"},
+        {"content": "Task t-xyz assigned to w-1.", "is_error": False},
+    )
+    assert "t-xyz" in f._child_contexts
+    assert f._child_contexts["t-xyz"].is_alive()
+    await f._cancel_all_children()
+
+
+async def test_observer_flushes_pending_on_spawn(monkeypatch):
+    f = _make_foreman()
+    monkeypatch.setattr("pioneer_foreman.task_context.run_foreman_ai", AsyncMock(return_value=True))
+    # An event arrived for the task before assignment completed.
+    early = _norm(task_id="t-xyz", human_message="early task-complete")
+    f._pending_for_task["t-xyz"] = [early]
+    f._parent_tool_observer(
+        "assign_task",
+        {"worker_id": "w-1"},
+        {"content": "Task t-xyz queued for w-1.", "is_error": False},
+    )
+    child = f._child_contexts["t-xyz"]
+    # The buffered trigger should have been flushed into the child's queue.
+    assert child._queue.qsize() == 1
+    assert "t-xyz" not in f._pending_for_task
+    await f._cancel_all_children()
+
+
+def test_observer_ignores_errored_assign():
+    f = _make_foreman()
+    f._parent_tool_observer(
+        "assign_task",
+        {"worker_id": "w-1"},
+        {"content": "no idle worker", "is_error": True},
+    )
+    assert f._child_contexts == {}
+
+
+def test_observer_ignores_non_assign_tools():
+    f = _make_foreman()
+    f._parent_tool_observer(
+        "get_task_status",
+        {"task_id": "t-1"},
+        {"content": "Task t-1 working", "is_error": False},
+    )
+    assert f._child_contexts == {}
+
+
+async def test_observer_tears_down_child_on_parent_finalize(monkeypatch):
+    f = _make_foreman()
+    child = MagicMock()
+    child.stop = AsyncMock()
+    f._child_contexts["t-1"] = child
+    f._parent_tool_observer(
+        "finalize_task",
+        {"task_id": "t-1"},
+        {"content": "Task t-1 finalized.", "is_error": False},
+    )
+    await asyncio.sleep(0)  # let the scheduled stop() task run
+    child.stop.assert_awaited_once()
+
+
+# ── teardown ───────────────────────────────────────────────────────────────
+
+
+def test_deregister_child_clears_maps():
+    f = _make_foreman()
+    f._child_contexts["t-1"] = MagicMock()
+    f._pending_for_task["t-1"] = []
+    f._deregister_child("t-1")
+    assert "t-1" not in f._child_contexts
+    assert "t-1" not in f._pending_for_task

--- a/foreman/tests/test_config.py
+++ b/foreman/tests/test_config.py
@@ -124,6 +124,24 @@ def test_load_overrides_defaults_preserved(tmp_path):
     assert cfg.history_limit == 40
     assert cfg.model == "claude-sonnet-4-6"
     assert cfg.provider == "anthropic"
+    # Per-task child contexts default on.
+    assert cfg.child_contexts is True
+
+
+def test_child_contexts_disabled_via_toml(tmp_path):
+    toml_path = tmp_path / "pioneer-foreman.toml"
+    toml_path.write_text('backend_url = "ws://x:1"\nguild_id = "g"\nchild_contexts = false\n')
+    cfg = load(str(toml_path))
+    assert cfg.child_contexts is False
+
+
+def test_child_contexts_disabled_via_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOREMAN_CHILD_CONTEXTS", "0")
+    cfg = load(
+        str(tmp_path / "missing.toml"),
+        overrides={"backend_url": "ws://x:1", "guild_id": "g"},
+    )
+    assert cfg.child_contexts is False
 
 
 # ── load() — from TOML file ──────────────────────────────────────────────

--- a/foreman/tests/test_task_context.py
+++ b/foreman/tests/test_task_context.py
@@ -1,0 +1,140 @@
+"""Unit tests for pioneer_foreman.task_context.TaskContext.
+
+run_foreman_ai is patched out so these exercise the queue/lifecycle/observer
+wiring without an LLM or backend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pioneer_foreman.config import Config
+from pioneer_foreman.task_context import TaskContext
+
+
+def _make_config(**kwargs) -> Config:
+    return Config(backend_url="ws://localhost:8000", guild_id="g1", backend_key="k", **kwargs)
+
+
+def _make_ctx(on_finalize=None, **kwargs) -> TaskContext:
+    return TaskContext(
+        "t-abc",
+        guild_id="g1",
+        user_id="u-1",
+        http=AsyncMock(),
+        ws_send=AsyncMock(),
+        config=_make_config(),
+        on_finalize=on_finalize,
+        **kwargs,
+    )
+
+
+async def _drain(ctx: TaskContext) -> None:
+    """Wait until the context's queue is empty and the in-flight item is done."""
+    await ctx._queue.join()
+
+
+async def test_enqueue_runs_child_foreman():
+    calls = []
+
+    async def fake_run(guild_id, human_message, **kw):
+        calls.append((guild_id, human_message, kw))
+        return True
+
+    ctx = _make_ctx()
+    with patch("pioneer_foreman.task_context.run_foreman_ai", side_effect=fake_run):
+        ctx.start()
+        ctx.enqueue({"human_message": "task-complete for t-abc", "task_id": "t-abc"})
+        await _drain(ctx)
+        await ctx.stop()
+
+    assert len(calls) == 1
+    guild_id, msg, kw = calls[0]
+    assert guild_id == "g1"
+    assert msg == "task-complete for t-abc"
+    # Child mode wiring
+    assert kw["child"] is True
+    assert kw["task_id"] == "t-abc"
+    assert kw["tool_observer"] == ctx._observe_tool
+
+
+async def test_empty_human_message_is_skipped():
+    ran = []
+
+    async def fake_run(*a, **k):
+        ran.append(1)
+        return True
+
+    ctx = _make_ctx()
+    with patch("pioneer_foreman.task_context.run_foreman_ai", side_effect=fake_run):
+        ctx.start()
+        ctx.enqueue({"task_id": "t-abc"})  # no human_message
+        await _drain(ctx)
+        await ctx.stop()
+
+    assert ran == []
+
+
+async def test_finalize_observer_triggers_teardown():
+    finalized = []
+    ctx = _make_ctx(on_finalize=finalized.append)
+
+    async def fake_run(guild_id, human_message, *, tool_observer=None, **kw):
+        # Simulate the child calling finalize_task successfully.
+        tool_observer(
+            "finalize_task",
+            {"task_id": "t-abc"},
+            {"content": "Task t-abc finalized.", "is_error": False},
+        )
+        return True
+
+    with patch("pioneer_foreman.task_context.run_foreman_ai", side_effect=fake_run):
+        ctx.start()
+        ctx.enqueue({"human_message": "wrap it up", "task_id": "t-abc"})
+        # Loop should exit on its own after the finalized turn.
+        await asyncio.wait_for(ctx._task, timeout=2)
+
+    assert ctx.is_alive() is False
+    assert finalized == ["t-abc"]
+
+
+async def test_observer_ignores_other_task_finalize():
+    ctx = _make_ctx()
+    ctx._observe_tool(
+        "finalize_task",
+        {"task_id": "t-other"},
+        {"content": "Task t-other finalized.", "is_error": False},
+    )
+    assert ctx._finalized is False
+
+
+async def test_observer_ignores_errored_finalize():
+    ctx = _make_ctx()
+    ctx._observe_tool(
+        "finalize_task",
+        {"task_id": "t-abc"},
+        {"content": "boom", "is_error": True},
+    )
+    assert ctx._finalized is False
+
+
+async def test_enqueue_returns_false_when_full():
+    ctx = _make_ctx()
+    # Don't start the loop, so nothing drains the queue.
+    from pioneer_foreman.task_context import _CHILD_QUEUE_MAX
+
+    for _ in range(_CHILD_QUEUE_MAX):
+        assert ctx.enqueue({"human_message": "x", "task_id": "t-abc"}) is True
+    assert ctx.enqueue({"human_message": "overflow", "task_id": "t-abc"}) is False
+
+
+async def test_on_finalize_called_on_cancel():
+    finalized = []
+    ctx = _make_ctx(on_finalize=finalized.append)
+    ctx.start()
+    await asyncio.sleep(0)  # let the loop start and block on the queue
+    await ctx.stop()
+    assert finalized == ["t-abc"]
+    assert ctx.is_alive() is False

--- a/foreman/tests/test_ws_integration.py
+++ b/foreman/tests/test_ws_integration.py
@@ -109,6 +109,7 @@ async def test_ws_join_sent_before_first_message_processed():
     with patch("pioneer_foreman.foreman.websockets.connect", return_value=ws):
         foreman = Foreman(_make_config())
         foreman._http = AsyncMock()
+        foreman._http.get_state.return_value = {"tasks": [], "workers": [], "guild": {}}
         await foreman._run_connection()
 
     assert joined_before_registered[0] is True, "join should be sent before first message"
@@ -126,6 +127,7 @@ async def test_ws_foreman_registered_accepted():
     with patch("pioneer_foreman.foreman.websockets.connect", return_value=ws):
         foreman = Foreman(_make_config())
         foreman._http = AsyncMock()
+        foreman._http.get_state.return_value = {"tasks": [], "workers": [], "guild": {}}
         evicted = await foreman._run_connection()
 
     # Reaching here without exception means foreman-registered was handled
@@ -142,6 +144,7 @@ async def test_ws_evicted_returns_true():
     with patch("pioneer_foreman.foreman.websockets.connect", return_value=ws):
         foreman = Foreman(_make_config())
         foreman._http = AsyncMock()
+        foreman._http.get_state.return_value = {"tasks": [], "workers": [], "guild": {}}
         evicted = await foreman._run_connection()
 
     assert evicted is True
@@ -159,6 +162,7 @@ async def test_ws_clean_disconnect_returns_false():
     with patch("pioneer_foreman.foreman.websockets.connect", return_value=ws):
         foreman = Foreman(_make_config())
         foreman._http = AsyncMock()
+        foreman._http.get_state.return_value = {"tasks": [], "workers": [], "guild": {}}
         evicted = await foreman._run_connection()
 
     assert evicted is False


### PR DESCRIPTION
## Summary

This PR re-applies the changes from #666 ("docs: add per-task Foreman context-splitting design"), which was reverted by #671.

## Background

- **Original PR #666** added per-task Foreman context splitting across 25 files (docs, backend, foreman service) — 1795 insertions.
- **Revert PR #671** reverted those changes wholesale.
- This PR re-applies the original changes by reverting the revert commit (f8489c1).

## What's included

The changes from PR #666 implement per-task child contexts for the Foreman AI:

- `docs/foreman-per-task-context.md` — full design document
- `foreman/pioneer_foreman/task_context.py` — per-task context management
- `foreman/pioneer_foreman/foreman.py` — child routing logic
- `foreman/pioneer_foreman/config.py` — config additions
- `foreman/pioneer_foreman/runner.py` — runner updates
- `backend/foreman_core/prompt.py` — child prompt logic
- `backend/foreman/runner.py`, `backend/foreman/prompt.py` — embedded foreman updates
- `backend/routes/foreman.py`, `backend/routes/tasks.py`, `backend/routes/webhooks.py`, `backend/ws_handlers.py` — route/WS updates
- Tests: `test_child_prompt.py`, `test_foreman_child_context.py`, `test_child_routing.py`, `test_task_context.py`, `test_config.py`

## How this was re-applied

`git revert f8489c1` (revert of the revert) applied cleanly with no conflicts.

## Test plan

- [ ] Existing test suite passes
- [ ] New tests in `test_child_routing.py`, `test_task_context.py`, `test_child_prompt.py`, `test_foreman_child_context.py` pass
- [ ] Foreman per-task context splitting works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)