### PR TITLE
Tasks pane: tree view parented to issues/PRs (#677)

### DIFF
--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -332,6 +332,9 @@ _gh_issue_cache: dict[str, tuple[dict, float]] = {}
 _gh_pr_body_cache: dict[str, tuple[str | None, float]] = {}
 
 
+_CACHE_MAX_SIZE = 1000
+
+
 def _gh_fetch_issue(repo: str, number: int, token: str) -> dict | None:
     """Fetch GitHub issue title/state. Cached for _TREE_CACHE_TTL seconds."""
     key = f"{repo}#{number}"
@@ -353,6 +356,8 @@ def _gh_fetch_issue(repo: str, number: int, token: str) -> dict | None:
             "title": data.get("title") or f"#{number}",
             "state": data.get("state") or "open",
         }
+        if len(_gh_issue_cache) >= _CACHE_MAX_SIZE:
+            _gh_issue_cache.clear()
         _gh_issue_cache[key] = (result, _monotime() + _TREE_CACHE_TTL)
         return result
     except Exception:
@@ -377,9 +382,13 @@ def _gh_fetch_pr_body(repo: str, pr_number: int, token: str) -> str | None:
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
         body: str | None = data.get("body") or ""
+        if len(_gh_pr_body_cache) >= _CACHE_MAX_SIZE:
+            _gh_pr_body_cache.clear()
         _gh_pr_body_cache[key] = (body, _monotime() + _TREE_CACHE_TTL)
         return body
     except Exception:
+        if len(_gh_pr_body_cache) >= _CACHE_MAX_SIZE:
+            _gh_pr_body_cache.clear()
         _gh_pr_body_cache[key] = (None, _monotime() + _TREE_CACHE_TTL)
         return None
 
@@ -445,7 +454,7 @@ async def get_guild_tasks_tree(
         .where(col(GuildMember.guild_id) == guild_pk, col(GuildMember.role) == "owner")
         .limit(1)
     )
-    gh_token: str | None = token_row.one_or_none()
+    gh_token: str | None = row[0] if (row := token_row.one_or_none()) else None
 
     # --- Build task_id → (issue_repo, issue_number) mapping ---
 
@@ -481,8 +490,11 @@ async def get_guild_tasks_tree(
 
     # Pass 3: propagate issue assignment through parent_task_id chains
     changed = True
-    while changed:
+    max_iters = len(raw_tasks)
+    iters = 0
+    while changed and iters < max_iters:
         changed = False
+        iters += 1
         for task in raw_tasks:
             if task["id"] in task_issue:
                 continue

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -7,15 +7,20 @@ direct unit testing in ``tests/test_soft_delete_tasks.py``.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import re
+import urllib.request
+from collections import defaultdict
 from datetime import UTC, datetime, timedelta
+from time import time as _monotime
 
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException
 from lock_service import LockService
-from models import Guild, Task, TaskLog, live_tasks_filter
+from models import GithubToken, Guild, GuildMember, Task, TaskLog, live_tasks_filter
 from pydantic import BaseModel
 from sqlalchemy import update
 from sqlmodel import col, select
@@ -312,6 +317,222 @@ async def cancel_task_endpoint(
         TaskUpdateMsg(taskId=task_id, state="cancelled", deletedAt=deleted_at.isoformat()),
     )
     return {"status": "cancelled", "taskId": task_id}
+
+
+# ---------------------------------------------------------------------------
+# Task tree endpoint helpers
+# ---------------------------------------------------------------------------
+
+_CLOSES_RE = re.compile(r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE)
+_GH_PR_URL_RE = re.compile(r"https://github\.com/([^/\s]+/[^/\s]+)/pull/(\d+)")
+
+# Simple in-process TTL caches (key → (value, expires_at))
+_TREE_CACHE_TTL = 600.0  # 10 minutes
+_gh_issue_cache: dict[str, tuple[dict, float]] = {}
+_gh_pr_body_cache: dict[str, tuple[str | None, float]] = {}
+
+
+def _gh_fetch_issue(repo: str, number: int, token: str) -> dict | None:
+    """Fetch GitHub issue title/state. Cached for _TREE_CACHE_TTL seconds."""
+    key = f"{repo}#{number}"
+    cached = _gh_issue_cache.get(key)
+    if cached and cached[1] > _monotime():
+        return cached[0]
+    try:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/issues/{number}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "pioneer-square",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+        result: dict = {
+            "title": data.get("title") or f"#{number}",
+            "state": data.get("state") or "open",
+        }
+        _gh_issue_cache[key] = (result, _monotime() + _TREE_CACHE_TTL)
+        return result
+    except Exception:
+        return None
+
+
+def _gh_fetch_pr_body(repo: str, pr_number: int, token: str) -> str | None:
+    """Fetch a GitHub PR body for closes-reference extraction. Cached."""
+    key = f"{repo}#pr{pr_number}"
+    cached = _gh_pr_body_cache.get(key)
+    if cached and cached[1] > _monotime():
+        return cached[0]
+    try:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "pioneer-square",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+        body: str | None = data.get("body") or ""
+        _gh_pr_body_cache[key] = (body, _monotime() + _TREE_CACHE_TTL)
+        return body
+    except Exception:
+        _gh_pr_body_cache[key] = (None, _monotime() + _TREE_CACHE_TTL)
+        return None
+
+
+def _nest_tasks(tasks: list[dict]) -> list[dict]:
+    """Build a parent/child tree from a flat task list using parent_task_id."""
+    by_id = {t["id"]: dict(t, children=[]) for t in tasks}
+    roots: list[dict] = []
+    for t in by_id.values():
+        parent_id = t.get("parent_task_id")
+        if parent_id and parent_id in by_id:
+            by_id[parent_id]["children"].append(t)
+        else:
+            roots.append(t)
+    return roots
+
+
+@router.get("/guilds/{guild_id}/tasks/tree")
+async def get_guild_tasks_tree(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Return tasks grouped hierarchically under their GitHub issues/PRs.
+
+    Top-level nodes are GitHub issues (identified by issue_number+issue_repo on
+    the task).  Review tasks whose PR body contains a ``closes #N`` reference are
+    also parented to that issue.  Tasks with parent_task_id are nested under their
+    parent task within the group.  Remaining tasks go in ``ungrouped``.
+    """
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+
+    result = await db.exec(
+        select(
+            col(Task.id),
+            col(Task.worker_id),
+            col(Task.name),
+            col(Task.description),
+            col(Task.phase),
+            col(Task.state),
+            col(Task.parent_task_id),
+            col(Task.branch),
+            col(Task.pr_url),
+            col(Task.pr_number),
+            col(Task.pr_repo),
+            col(Task.issue_number),
+            col(Task.issue_repo),
+            col(Task.created_at),
+            col(Task.deleted_at),
+        )
+        .where(col(Task.guild_id) == guild_pk, live_tasks_filter())
+        .order_by(col(Task.created_at).asc())
+        .limit(200)
+    )
+    raw_tasks = [dict(r._mapping) for r in result.all()]
+
+    # Fetch the guild owner's GitHub token (may be None)
+    token_row = await db.exec(
+        select(col(GithubToken.access_token))
+        .join(GuildMember, col(GuildMember.user_id) == col(GithubToken.github_user_id))
+        .where(col(GuildMember.guild_id) == guild_pk, col(GuildMember.role) == "owner")
+        .limit(1)
+    )
+    gh_token: str | None = token_row.one_or_none()
+
+    # --- Build task_id → (issue_repo, issue_number) mapping ---
+
+    task_issue: dict[str, tuple[str, int]] = {}
+
+    # Pass 1: tasks with explicit issue linkage
+    pr_tasks: list[tuple[str, str, int]] = []
+    for task in raw_tasks:
+        if task["issue_number"] and task["issue_repo"]:
+            task_issue[task["id"]] = (task["issue_repo"], task["issue_number"])
+        elif task["pr_url"] and gh_token:
+            # Use stored pr_repo/pr_number when available; fall back to URL parse
+            if task["pr_repo"] and task["pr_number"]:
+                pr_tasks.append((task["id"], task["pr_repo"], task["pr_number"]))
+            else:
+                m = _GH_PR_URL_RE.match(task["pr_url"])
+                if m:
+                    pr_tasks.append((task["id"], m.group(1), int(m.group(2))))
+
+    # Pass 2: resolve PR bodies to find closing issue references
+    if pr_tasks and gh_token:
+        bodies = await asyncio.gather(
+            *[
+                asyncio.to_thread(_gh_fetch_pr_body, repo, pr_num, gh_token)
+                for _, repo, pr_num in pr_tasks
+            ]
+        )
+        for (task_id, repo, _), body in zip(pr_tasks, bodies, strict=False):
+            if body:
+                m = _CLOSES_RE.search(body)
+                if m:
+                    task_issue[task_id] = (repo, int(m.group(1)))
+
+    # Pass 3: propagate issue assignment through parent_task_id chains
+    changed = True
+    while changed:
+        changed = False
+        for task in raw_tasks:
+            if task["id"] in task_issue:
+                continue
+            pid = task.get("parent_task_id")
+            if pid and pid in task_issue:
+                task_issue[task["id"]] = task_issue[pid]
+                changed = True
+
+    # --- Group tasks ---
+    issue_groups: dict[tuple[str, int], list[dict]] = defaultdict(list)
+    ungrouped: list[dict] = []
+    for task in raw_tasks:
+        key = task_issue.get(task["id"])
+        if key:
+            issue_groups[key].append(task)
+        else:
+            ungrouped.append(task)
+
+    # --- Fetch issue metadata in parallel ---
+    issue_info: dict[tuple[str, int], dict] = {}
+    if issue_groups and gh_token:
+        keys = list(issue_groups.keys())
+        infos = await asyncio.gather(
+            *[asyncio.to_thread(_gh_fetch_issue, repo, num, gh_token) for repo, num in keys]
+        )
+        for key, info in zip(keys, infos, strict=False):
+            issue_info[key] = info or {"title": f"#{key[1]}", "state": "open"}
+    else:
+        for key in issue_groups:
+            issue_info[key] = {"title": f"#{key[1]}", "state": "open"}
+
+    # --- Build response ---
+    nodes = []
+    for (repo, num), group_tasks in issue_groups.items():
+        info = issue_info.get((repo, num), {"title": f"#{num}", "state": "open"})
+        nodes.append(
+            {
+                "type": "issue",
+                "issue_number": num,
+                "issue_repo": repo,
+                "title": info["title"],
+                "state": info["state"],
+                "tasks": _nest_tasks(group_tasks),
+            }
+        )
+
+    # Sort: open issues first, then by issue number descending (newest first)
+    nodes.sort(key=lambda n: (0 if n["state"] == "open" else 1, -n["issue_number"]))
+
+    return {"nodes": nodes, "ungrouped": _nest_tasks(ungrouped)}
 
 
 @router.post("/guilds/{guild_id}/tasks/{task_id}/redirect")

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -28,7 +28,7 @@
     </div>
 
     <div class="tab-content">
-      <TaskList v-if="activeTab === 'tasks'" @open-task="onOpenTask" />
+      <TaskTree v-if="activeTab === 'tasks'" @open-task="onOpenTask" />
       <WorkerList v-if="activeTab === 'workers'" />
       <IssuesTab
         v-if="activeTab === 'issues' && ghStore.isConfigured"
@@ -51,7 +51,7 @@ import { useGuildStore } from '../stores/guild'
 import { useGitHubStore } from '../stores/github'
 import { useTasksStore } from '../stores/tasks'
 import { useAgentsStore } from '../stores/agents'
-import TaskList from './sidebar/TaskList.vue'
+import TaskTree from './sidebar/TaskTree.vue'
 import WorkerList from './sidebar/WorkerList.vue'
 import IssuesTab from './chat-pane/IssuesTab.vue'
 import type { GitHubIssue } from '../types'

--- a/frontend/src/components/sidebar/TaskTree.vue
+++ b/frontend/src/components/sidebar/TaskTree.vue
@@ -1,0 +1,289 @@
+<template>
+  <div class="tasks-tree">
+    <div v-if="loading && !treeData" class="empty-state">Loading…</div>
+    <div v-else-if="isEmpty" class="empty-state">No tasks yet</div>
+
+    <template v-else>
+      <!-- Issue / PR nodes -->
+      <div
+        v-for="node in treeData!.nodes"
+        :key="`${node.issue_repo}#${node.issue_number}`"
+        class="tree-group"
+      >
+        <div
+          class="group-header"
+          @click="toggle(`${node.issue_repo}#${node.issue_number}`)"
+        >
+          <span class="collapse-icon">{{
+            isExpanded(`${node.issue_repo}#${node.issue_number}`) ? '▾' : '▸'
+          }}</span>
+          <span class="issue-ref">#{{ node.issue_number }}</span>
+          <span class="issue-title">{{ node.title }}</span>
+          <span class="state-badge" :class="'badge-' + node.state">{{ node.state }}</span>
+          <span class="group-count">{{ countTasks(node.tasks) }}</span>
+        </div>
+
+        <div v-if="isExpanded(`${node.issue_repo}#${node.issue_number}`)" class="group-tasks">
+          <TaskTreeRow
+            v-for="task in node.tasks"
+            :key="task.id"
+            :task="task"
+            :depth="0"
+            :selected-task-id="tasksStore.selectedTaskId"
+            @open-task="$emit('open-task', $event)"
+          />
+        </div>
+      </div>
+
+      <!-- Ungrouped tasks -->
+      <div v-if="treeData!.ungrouped.length" class="tree-group">
+        <div class="group-header" @click="toggle('__ungrouped__')">
+          <span class="collapse-icon">{{ isExpanded('__ungrouped__') ? '▾' : '▸' }}</span>
+          <span class="issue-title ungrouped-label">Ungrouped</span>
+          <span class="group-count">{{ countTasks(treeData!.ungrouped) }}</span>
+        </div>
+        <div v-if="isExpanded('__ungrouped__')" class="group-tasks">
+          <TaskTreeRow
+            v-for="task in treeData!.ungrouped"
+            :key="task.id"
+            :task="task"
+            :depth="0"
+            :selected-task-id="tasksStore.selectedTaskId"
+            @open-task="$emit('open-task', $event)"
+          />
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useGuildStore } from '../../stores/guild'
+import { useTasksStore } from '../../stores/tasks'
+import { api } from '../../utils/api'
+import type { TaskTreeData, TaskTreeNode } from '../../types'
+import TaskTreeRow from './TaskTreeRow.vue'
+
+defineEmits<{ (e: 'open-task', id: string): void }>()
+
+const guildStore = useGuildStore()
+const tasksStore = useTasksStore()
+
+const treeData = ref<TaskTreeData | null>(null)
+const loading = ref(false)
+
+// ---------------------------------------------------------------------------
+// Expand / collapse — persisted to localStorage
+// ---------------------------------------------------------------------------
+const LS_KEY = 'pioneer_tree_expanded'
+
+function _loadExpanded(): Set<string> {
+  try {
+    const raw = localStorage.getItem(LS_KEY)
+    return new Set(raw ? JSON.parse(raw) : [])
+  } catch {
+    return new Set()
+  }
+}
+
+function _saveExpanded(s: Set<string>) {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify([...s]))
+  } catch {
+    // ignore quota errors
+  }
+}
+
+const expandedKeys = ref<Set<string>>(_loadExpanded())
+
+function isExpanded(key: string): boolean {
+  // Default: expanded for all nodes unless explicitly collapsed
+  return !expandedKeys.value.has(`__collapsed__${key}`)
+}
+
+function toggle(key: string) {
+  const collapseKey = `__collapsed__${key}`
+  const next = new Set(expandedKeys.value)
+  if (next.has(collapseKey)) {
+    next.delete(collapseKey)
+  } else {
+    next.add(collapseKey)
+  }
+  expandedKeys.value = next
+  _saveExpanded(next)
+}
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+async function fetchTree(guildId: string) {
+  if (!guildId) return
+  loading.value = true
+  try {
+    treeData.value = await api<TaskTreeData>(`/guilds/${guildId}/tasks/tree`)
+  } catch (e) {
+    console.error('Failed to fetch task tree', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+// Debounce helper (avoids hammering the endpoint on every WS event)
+let _debounceTimer: ReturnType<typeof setTimeout> | null = null
+function debouncedFetch(guildId: string, delay = 1500) {
+  if (_debounceTimer) clearTimeout(_debounceTimer)
+  _debounceTimer = setTimeout(() => {
+    _debounceTimer = null
+    fetchTree(guildId)
+  }, delay)
+}
+
+// Refetch when the guild changes (immediate)
+watch(
+  () => guildStore.currentGuild?.id,
+  (guildId) => {
+    treeData.value = null
+    if (guildId) fetchTree(guildId)
+  },
+  { immediate: true },
+)
+
+// Refetch (debounced) when the flat tasks list changes — covers WS task events
+watch(
+  () => tasksStore.tasks.length,
+  () => {
+    const guildId = guildStore.currentGuild?.id
+    if (guildId) debouncedFetch(guildId)
+  },
+)
+
+// Also watch for state changes on individual tasks
+watch(
+  () => tasksStore.tasks.map((t) => t.state).join(','),
+  () => {
+    const guildId = guildStore.currentGuild?.id
+    if (guildId) debouncedFetch(guildId)
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function countTasks(tasks: TaskTreeNode[]): number {
+  let n = tasks.length
+  for (const t of tasks) n += countTasks(t.children)
+  return n
+}
+
+const isEmpty = computed(
+  () => !loading.value && treeData.value && treeData.value.nodes.length === 0 && treeData.value.ungrouped.length === 0,
+)
+</script>
+
+<style scoped>
+.tasks-tree {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.empty-state {
+  padding: 24px 12px;
+  text-align: center;
+  color: var(--color-text-dim);
+  font-size: 11px;
+  font-style: italic;
+}
+
+.tree-group {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.group-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 10px;
+  cursor: pointer;
+  position: sticky;
+  top: 0;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-brass-dark);
+  z-index: 1;
+  transition: background 0.12s;
+}
+
+.group-header:hover {
+  background: rgba(232, 170, 0, 0.06);
+}
+
+.collapse-icon {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+  width: 10px;
+  user-select: none;
+}
+
+.issue-ref {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass);
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.issue-title {
+  font-size: 11px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.ungrouped-label {
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+
+.state-badge {
+  font-family: var(--font-pixel);
+  font-size: 5px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 1px 4px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.badge-open {
+  background: rgba(80, 200, 120, 0.2);
+  color: var(--color-green);
+}
+
+.badge-closed {
+  background: rgba(200, 80, 80, 0.2);
+  color: var(--color-red);
+}
+
+.badge-merged {
+  background: rgba(130, 80, 200, 0.2);
+  color: #a07de0;
+}
+
+.group-count {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  background: var(--color-bg);
+  padding: 1px 5px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.group-tasks {
+  /* tasks rendered by TaskTreeRow */
+}
+</style>

--- a/frontend/src/components/sidebar/TaskTree.vue
+++ b/frontend/src/components/sidebar/TaskTree.vue
@@ -149,23 +149,14 @@ watch(
   { immediate: true },
 )
 
-// Refetch (debounced) when the flat tasks list changes — covers WS task events
-watch(
-  () => tasksStore.tasks.length,
-  () => {
-    const guildId = guildStore.currentGuild?.id
-    if (guildId) debouncedFetch(guildId)
-  },
+// Single watcher covers both task count changes and individual state changes
+const taskWatchKey = computed(
+  () => `${tasksStore.tasks.length}:${tasksStore.tasks.map((t) => t.state).join(',')}`,
 )
-
-// Also watch for state changes on individual tasks
-watch(
-  () => tasksStore.tasks.map((t) => t.state).join(','),
-  () => {
-    const guildId = guildStore.currentGuild?.id
-    if (guildId) debouncedFetch(guildId)
-  },
-)
+watch(taskWatchKey, () => {
+  const guildId = guildStore.currentGuild?.id
+  if (guildId) debouncedFetch(guildId)
+})
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/frontend/src/components/sidebar/TaskTreeRow.vue
+++ b/frontend/src/components/sidebar/TaskTreeRow.vue
@@ -1,0 +1,246 @@
+<template>
+  <div class="tree-row-group">
+    <div
+      class="task-row"
+      :class="{ selected: selectedTaskId === task.id, 'has-indent': depth > 0 }"
+      :style="{ paddingLeft: `${10 + depth * 14}px` }"
+      @click="$emit('open-task', task.id)"
+    >
+      <span v-if="task.children.length" class="row-toggle" @click.stop="expanded = !expanded">
+        {{ expanded ? '▾' : '▸' }}
+      </span>
+      <span v-else class="row-toggle-spacer"></span>
+
+      <span class="task-dot" :class="'dot-' + dotClass(task.state)"></span>
+
+      <span class="task-name">{{ task.name || task.id }}</span>
+
+      <span v-if="task.phase" class="phase-pill" :class="'phase-' + task.phase">
+        {{ task.phase }}
+      </span>
+
+      <span class="state-pill" :class="'state-' + dotClass(task.state)">
+        {{ stateLabel(task.state) }}
+      </span>
+
+      <span v-if="task.worker_id && isActiveState(task.state)" class="worker-id">
+        {{ task.worker_id.slice(0, 10) }}
+      </span>
+    </div>
+
+    <template v-if="expanded && task.children.length">
+      <TaskTreeRow
+        v-for="child in task.children"
+        :key="child.id"
+        :task="child"
+        :depth="depth + 1"
+        :selected-task-id="selectedTaskId"
+        @open-task="$emit('open-task', $event)"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { TaskTreeNode } from '../../types'
+
+defineProps<{
+  task: TaskTreeNode
+  depth: number
+  selectedTaskId: string | null
+}>()
+
+defineEmits<{ (e: 'open-task', id: string): void }>()
+
+const ACTIVE_STATES = new Set(['pending', 'planning', 'working', 'followup'])
+const expanded = ref(true)
+
+function dotClass(state: string): string {
+  return (state || 'pending').replace(/[^a-z]/g, '-')
+}
+
+const STATE_LABELS: Record<string, string> = {
+  pending: 'pending',
+  planning: 'planning',
+  working: 'working',
+  'awaiting-review': 'review',
+  done: 'done',
+  failed: 'failed',
+  followup: 'follow-up',
+  cancelled: 'cancelled',
+}
+
+function stateLabel(state: string): string {
+  return STATE_LABELS[state] || state
+}
+
+function isActiveState(state: string): boolean {
+  return ACTIVE_STATES.has(state)
+}
+</script>
+
+<style scoped>
+.tree-row-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.task-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  padding-right: 8px;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  transition: background 0.12s;
+  min-width: 0;
+}
+
+.task-row:hover {
+  background: rgba(232, 170, 0, 0.06);
+}
+
+.task-row.selected {
+  background: rgba(232, 170, 0, 0.12);
+  border-left: 3px solid var(--color-brass);
+}
+
+.row-toggle {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+  width: 12px;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.row-toggle:hover {
+  color: var(--color-brass);
+}
+
+.row-toggle-spacer {
+  width: 12px;
+  flex-shrink: 0;
+}
+
+.task-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.dot-pending {
+  background: var(--color-text-dim);
+}
+.dot-planning {
+  background: var(--color-blue);
+}
+.dot-working {
+  background: var(--color-green);
+  animation: pulse 0.5s infinite;
+}
+.dot-awaiting-review {
+  background: var(--color-amber);
+  animation: pulse 1.5s infinite;
+}
+.dot-done {
+  background: var(--color-teal);
+}
+.dot-failed,
+.dot-cancelled {
+  background: var(--color-red);
+}
+.dot-follow-up,
+.dot-followup {
+  background: var(--color-orange);
+  animation: pulse 0.8s infinite;
+}
+
+.task-name {
+  font-size: 11px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.phase-pill {
+  font-family: var(--font-pixel);
+  font-size: 5px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 1px 3px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.phase-plan {
+  background: rgba(100, 149, 237, 0.25);
+  color: var(--color-blue);
+}
+.phase-execute {
+  background: rgba(80, 200, 120, 0.2);
+  color: var(--color-green);
+}
+.phase-review {
+  background: rgba(232, 170, 0, 0.2);
+  color: var(--color-amber);
+}
+.phase-followup {
+  background: rgba(255, 165, 0, 0.2);
+  color: var(--color-orange);
+}
+
+.state-pill {
+  font-family: var(--font-pixel);
+  font-size: 5px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 1px 3px;
+  border-radius: 2px;
+  flex-shrink: 0;
+  opacity: 0.75;
+}
+
+.state-working,
+.state-planning {
+  color: var(--color-green);
+}
+.state-awaiting-review {
+  color: var(--color-amber);
+}
+.state-done {
+  color: var(--color-teal);
+}
+.state-failed,
+.state-cancelled {
+  color: var(--color-red);
+}
+.state-pending {
+  color: var(--color-text-dim);
+}
+
+.worker-id {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  flex-shrink: 0;
+  font-family: monospace;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+</style>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -96,7 +96,7 @@ export interface IssueTreeNode {
   issue_number: number
   issue_repo: string
   title: string
-  state: 'open' | 'closed'
+  state: 'open' | 'closed' | 'merged'
   tasks: TaskTreeNode[]
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -81,8 +81,28 @@ export interface Task {
   branch?: string
   pr_url?: string
   worktree_path?: string
+  issue_number?: number | null
+  issue_repo?: string | null
   created_at?: string
   deleted_at?: string | null
+}
+
+export interface TaskTreeNode extends Task {
+  children: TaskTreeNode[]
+}
+
+export interface IssueTreeNode {
+  type: 'issue'
+  issue_number: number
+  issue_repo: string
+  title: string
+  state: 'open' | 'closed'
+  tasks: TaskTreeNode[]
+}
+
+export interface TaskTreeData {
+  nodes: IssueTreeNode[]
+  ungrouped: TaskTreeNode[]
 }
 
 export interface Guild {


### PR DESCRIPTION
## Summary

- **Backend**: New `GET /guilds/{guild_id}/tasks/tree` endpoint groups live tasks hierarchically under their GitHub issues/PRs. For each unique issue it fetches the title and open/closed state from the GitHub API (results cached in-process for 10 minutes). Review tasks whose PR body contains a `closes #N` / `fixes #N` reference are automatically parented to that issue node. Tasks with `parent_task_id` are nested under their parent within the group. Remaining tasks appear in an `ungrouped` array. All GitHub API calls run concurrently via `asyncio.gather + to_thread`.
- **Frontend**: Replaced the flat `TaskList` with two new components — `TaskTree.vue` (top-level) and `TaskTreeRow.vue` (recursive task row). Issue nodes are collapsible and show `#number`, title, open/closed badge, and task count. Each task row shows the task name, phase pill (plan/execute/review/followup), state dot + label, and worker ID when active. Expand/collapse state is persisted to `localStorage` per node key so it survives page refreshes. The tree re-fetches (debounced 1.5 s) whenever the flat tasks list changes via WebSocket events.

## Test plan

- [ ] Tasks with `issue_number` + `issue_repo` appear under the correct issue node
- [ ] A review task whose PR body contains `closes #N` is parented to that issue
- [ ] Tasks with `parent_task_id` are nested under their parent task row
- [ ] Tasks with no issue linkage appear in the Ungrouped section
- [ ] Collapse an issue node → refresh → node is still collapsed (localStorage)
- [ ] Clicking a task row opens the task detail pane as before
- [ ] No GitHub token → issues render as `#N` placeholders (no crash)

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)