### PR TITLE
Issue viewer panel: body, comments, comment/edit

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -420,6 +420,7 @@ from routes import auth as _auth_routes  # noqa: E402
 from routes import debug as _debug_routes  # noqa: E402
 from routes import foreman as _foreman_routes  # noqa: E402
 from routes import guilds as _guilds_routes  # noqa: E402
+from routes import issues as _issues_routes  # noqa: E402
 from routes import models as _models_routes  # noqa: E402
 from routes import push as _push_routes  # noqa: E402
 from routes import tasks as _tasks_routes  # noqa: E402
@@ -443,6 +444,7 @@ app.include_router(_push_routes.router)
 app.include_router(_ws_routes.router)
 app.include_router(_debug_routes.router)
 app.include_router(_models_routes.router)
+app.include_router(_issues_routes.router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routes/issues.py
+++ b/backend/routes/issues.py
@@ -1,0 +1,134 @@
+"""GitHub issue proxy routes.
+
+Proxies GitHub API calls for issue details, comments, and updates so the
+frontend can use the backend's stored OAuth token rather than holding a
+raw GitHub token in localStorage indefinitely.
+
+Routes:
+  GET  /api/issues/{owner}/{repo}/{issue_number}
+  POST /api/issues/{owner}/{repo}/{issue_number}/comments
+  PATCH /api/issues/{owner}/{repo}/{issue_number}
+"""
+
+from __future__ import annotations
+
+import httpx
+from auth_deps import require_user
+from database import get_db_dep
+from fastapi import APIRouter, Depends, HTTPException
+from models import GithubToken
+from pydantic import BaseModel
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+router = APIRouter()
+
+GH_API = "https://api.github.com"
+
+
+async def _get_github_token(github_user_id: str, db: AsyncSession) -> str:
+    result = await db.exec(
+        select(col(GithubToken.access_token)).where(
+            col(GithubToken.github_user_id) == github_user_id
+        )
+    )
+    token = result.one_or_none()
+    if not token:
+        raise HTTPException(status_code=401, detail="No GitHub token on file — please log in")
+    return token
+
+
+def _gh_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+class CommentCreate(BaseModel):
+    body: str
+
+
+class IssueUpdate(BaseModel):
+    title: str | None = None
+    body: str | None = None
+
+
+@router.get("/api/issues/{owner}/{repo}/{issue_number}")
+async def get_issue(
+    owner: str,
+    repo: str,
+    issue_number: int,
+    github_user_id: str = Depends(require_user),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Fetch issue details and all comments from GitHub."""
+    token = await _get_github_token(github_user_id, db)
+    headers = _gh_headers(token)
+    async with httpx.AsyncClient(timeout=15) as client:
+        issue_res = await client.get(
+            f"{GH_API}/repos/{owner}/{repo}/issues/{issue_number}", headers=headers
+        )
+        if not issue_res.is_success:
+            raise HTTPException(
+                status_code=issue_res.status_code,
+                detail=f"GitHub error: {issue_res.text[:200]}",
+            )
+        comments_res = await client.get(
+            f"{GH_API}/repos/{owner}/{repo}/issues/{issue_number}/comments?per_page=100",
+            headers=headers,
+        )
+        if not comments_res.is_success:
+            raise HTTPException(
+                status_code=comments_res.status_code,
+                detail=f"GitHub error: {comments_res.text[:200]}",
+            )
+    return {"issue": issue_res.json(), "comments": comments_res.json()}
+
+
+@router.post("/api/issues/{owner}/{repo}/{issue_number}/comments")
+async def post_comment(
+    owner: str,
+    repo: str,
+    issue_number: int,
+    body: CommentCreate,
+    github_user_id: str = Depends(require_user),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Post a new comment on the issue."""
+    token = await _get_github_token(github_user_id, db)
+    async with httpx.AsyncClient(timeout=15) as client:
+        res = await client.post(
+            f"{GH_API}/repos/{owner}/{repo}/issues/{issue_number}/comments",
+            headers=_gh_headers(token),
+            json={"body": body.body},
+        )
+    if not res.is_success:
+        raise HTTPException(status_code=res.status_code, detail=f"GitHub error: {res.text[:200]}")
+    return res.json()
+
+
+@router.patch("/api/issues/{owner}/{repo}/{issue_number}")
+async def update_issue(
+    owner: str,
+    repo: str,
+    issue_number: int,
+    update: IssueUpdate,
+    github_user_id: str = Depends(require_user),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Update issue title and/or body."""
+    token = await _get_github_token(github_user_id, db)
+    payload = {k: v for k, v in update.model_dump().items() if v is not None}
+    if not payload:
+        raise HTTPException(status_code=400, detail="Nothing to update")
+    async with httpx.AsyncClient(timeout=15) as client:
+        res = await client.patch(
+            f"{GH_API}/repos/{owner}/{repo}/issues/{issue_number}",
+            headers=_gh_headers(token),
+            json=payload,
+        )
+    if not res.is_success:
+        raise HTTPException(status_code=res.status_code, detail=f"GitHub error: {res.text[:200]}")
+    return res.json()

--- a/frontend/src/components/DebugSidebar.vue
+++ b/frontend/src/components/DebugSidebar.vue
@@ -146,7 +146,7 @@ async function refreshDebug() {
     )
     debugContext.value = data?.messages ?? []
     systemPrompt.value = data?.system ?? null
-    totalMessages.value = data?.total ?? (data?.messages?.length ?? 0)
+    totalMessages.value = data?.total ?? data?.messages?.length ?? 0
   } catch (e) {
     console.error('Failed to load foreman context', e)
   } finally {

--- a/frontend/src/components/GuildMembers.vue
+++ b/frontend/src/components/GuildMembers.vue
@@ -224,10 +224,9 @@ async function cancelInvite(inv: GuildInviteRow) {
   busyInvite.value = inv.id
   inviteError.value = ''
   try {
-    await api(
-      `/api/guilds/${encodeURIComponent(props.guildId)}/invites/${inv.id}`,
-      { method: 'DELETE' },
-    )
+    await api(`/api/guilds/${encodeURIComponent(props.guildId)}/invites/${inv.id}`, {
+      method: 'DELETE',
+    })
     await loadInvites()
   } catch (e) {
     inviteError.value = e instanceof ApiError ? e.message : 'Failed to cancel invite'

--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -62,7 +62,6 @@ const tasksStore = useTasksStore()
 const agentsStore = useAgentsStore()
 
 const switchMobileTab = inject<(tab: string) => void>('switchMobileTab', () => {})
-const selectIssue = inject<(issue: GitHubIssue) => void>('selectIssue', () => {})
 
 const isConnected = computed(() => guildStore.isConnected)
 const workerCount = computed(() => agentsStore.workers.filter((w) => w.state !== 'offline').length)
@@ -80,8 +79,13 @@ function onOpenTask(taskId: string) {
 }
 
 function onSelectIssue(issue: GitHubIssue) {
-  switchMobileTab('chat')
-  selectIssue(issue)
+  // Parse owner/repo from issue.repo ("owner/repo" format)
+  const slashIdx = issue.repo.indexOf('/')
+  if (slashIdx === -1) return
+  const owner = issue.repo.slice(0, slashIdx)
+  const repo = issue.repo.slice(slashIdx + 1)
+  agentsStore.openIssueTab(owner, repo, issue.number)
+  switchMobileTab('work')
 }
 </script>
 

--- a/frontend/src/components/IssueViewer.vue
+++ b/frontend/src/components/IssueViewer.vue
@@ -1,0 +1,664 @@
+<template>
+  <div class="issue-viewer">
+    <div v-if="loading && !issue" class="issue-loading">Loading issue...</div>
+    <div v-else-if="loadError" class="issue-error">{{ loadError }}</div>
+
+    <template v-else-if="issue">
+      <!-- Header -->
+      <div class="issue-header">
+        <div class="issue-meta-row">
+          <span class="issue-repo-label">{{ owner }}/{{ repo }}</span>
+          <span class="issue-number">#{{ issueNumber }}</span>
+          <span class="issue-state" :class="issue.state">{{ issue.state }}</span>
+          <a :href="issue.html_url" target="_blank" rel="noopener noreferrer" class="gh-link">
+            ↗ GitHub
+          </a>
+        </div>
+
+        <!-- Title -->
+        <div v-if="!editingTitle" class="issue-title-row">
+          <h2 class="issue-title">{{ issue.title }}</h2>
+          <button class="pixel-btn edit-btn" @click="startEditTitle" title="Edit title">✎</button>
+        </div>
+        <div v-else class="issue-title-edit">
+          <input
+            v-model="editTitle"
+            class="title-input"
+            @keydown.enter="saveTitle"
+            @keydown.escape="cancelEditTitle"
+            ref="titleInputRef"
+          />
+          <div class="edit-actions">
+            <button class="pixel-btn save-btn" @click="saveTitle" :disabled="saving">
+              {{ saving ? '…' : 'Save' }}
+            </button>
+            <button class="pixel-btn cancel-btn" @click="cancelEditTitle">Cancel</button>
+          </div>
+        </div>
+
+        <div class="issue-submeta">
+          <img :src="issue.user.avatar_url" class="avatar" :alt="issue.user.login" />
+          <span class="issue-author">{{ issue.user.login }}</span>
+          <span class="issue-date">opened {{ formatRelative(issue.created_at) }}</span>
+          <span
+            v-for="label in issue.labels"
+            :key="label.id"
+            class="issue-label"
+            :style="{ borderColor: '#' + label.color, color: '#' + label.color }"
+            >{{ label.name }}</span
+          >
+        </div>
+      </div>
+
+      <!-- Body -->
+      <div class="issue-body-section">
+        <div class="section-header">
+          <span class="section-title">Description</span>
+          <button
+            v-if="!editingBody"
+            class="pixel-btn edit-btn"
+            @click="startEditBody"
+            title="Edit body"
+          >
+            ✎
+          </button>
+        </div>
+        <template v-if="!editingBody">
+          <div
+            v-if="issue.body"
+            class="issue-body markdown-body"
+            v-html="renderMarkdown(issue.body)"
+          ></div>
+          <div v-else class="issue-body-empty">No description provided.</div>
+        </template>
+        <div v-else class="body-edit">
+          <textarea
+            v-model="editBody"
+            class="body-textarea"
+            rows="10"
+            ref="bodyTextareaRef"
+          ></textarea>
+          <div class="edit-actions">
+            <button class="pixel-btn save-btn" @click="saveBody" :disabled="saving">
+              {{ saving ? '…' : 'Save' }}
+            </button>
+            <button class="pixel-btn cancel-btn" @click="cancelEditBody">Cancel</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Comments -->
+      <div class="comments-section">
+        <div class="section-header">
+          <span class="section-title">Comments ({{ comments.length }})</span>
+        </div>
+        <div class="comments-list">
+          <div v-for="comment in comments" :key="comment.id" class="comment">
+            <div class="comment-header">
+              <img :src="comment.user.avatar_url" class="avatar" :alt="comment.user.login" />
+              <span class="comment-author">{{ comment.user.login }}</span>
+              <span class="comment-date">{{ formatRelative(comment.created_at) }}</span>
+              <a
+                :href="comment.html_url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="gh-link-sm"
+                >↗</a
+              >
+            </div>
+            <div class="comment-body markdown-body" v-html="renderMarkdown(comment.body)"></div>
+          </div>
+          <div v-if="comments.length === 0" class="no-comments">No comments yet.</div>
+        </div>
+      </div>
+
+      <!-- Post comment -->
+      <div class="post-comment-section">
+        <div class="section-header">
+          <span class="section-title">Add a comment</span>
+        </div>
+        <textarea
+          v-model="newComment"
+          class="comment-textarea"
+          rows="4"
+          placeholder="Leave a comment..."
+        ></textarea>
+        <div class="post-actions">
+          <button
+            class="pixel-btn submit-btn"
+            @click="submitComment"
+            :disabled="!newComment.trim() || submitting"
+          >
+            {{ submitting ? 'Posting…' : 'Comment' }}
+          </button>
+          <span v-if="postError" class="post-error">{{ postError }}</span>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, nextTick } from 'vue'
+import { useGitHubStore } from '../stores/github'
+import type { GitHubIssueDetail, GitHubComment } from '../stores/github'
+import { renderMarkdown } from '../utils/markdown'
+import { formatRelative } from '../utils/format'
+
+const props = defineProps<{
+  owner: string
+  repo: string
+  issueNumber: number
+}>()
+
+const ghStore = useGitHubStore()
+
+const issue = ref<GitHubIssueDetail | null>(null)
+const comments = ref<GitHubComment[]>([])
+const loading = ref(false)
+const loadError = ref('')
+
+const editingTitle = ref(false)
+const editTitle = ref('')
+const editingBody = ref(false)
+const editBody = ref('')
+const saving = ref(false)
+
+const newComment = ref('')
+const submitting = ref(false)
+const postError = ref('')
+
+const titleInputRef = ref<HTMLInputElement | null>(null)
+const bodyTextareaRef = ref<HTMLTextAreaElement | null>(null)
+
+async function loadIssue() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const data = await ghStore.fetchIssueDetail(props.owner, props.repo, props.issueNumber)
+    issue.value = data.issue
+    comments.value = data.comments
+  } catch (e: unknown) {
+    loadError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function startEditTitle() {
+  editTitle.value = issue.value?.title ?? ''
+  editingTitle.value = true
+  nextTick(() => titleInputRef.value?.focus())
+}
+
+function cancelEditTitle() {
+  editingTitle.value = false
+}
+
+async function saveTitle() {
+  if (!issue.value || !editTitle.value.trim()) return
+  saving.value = true
+  try {
+    const updated = await ghStore.updateIssue(props.owner, props.repo, props.issueNumber, {
+      title: editTitle.value.trim(),
+    })
+    issue.value = updated
+    editingTitle.value = false
+  } catch (e: unknown) {
+    loadError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    saving.value = false
+  }
+}
+
+function startEditBody() {
+  editBody.value = issue.value?.body ?? ''
+  editingBody.value = true
+  nextTick(() => bodyTextareaRef.value?.focus())
+}
+
+function cancelEditBody() {
+  editingBody.value = false
+}
+
+async function saveBody() {
+  if (!issue.value) return
+  saving.value = true
+  try {
+    const updated = await ghStore.updateIssue(props.owner, props.repo, props.issueNumber, {
+      body: editBody.value,
+    })
+    issue.value = updated
+    editingBody.value = false
+  } catch (e: unknown) {
+    loadError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function submitComment() {
+  const body = newComment.value.trim()
+  if (!body) return
+  submitting.value = true
+  postError.value = ''
+  try {
+    const comment = await ghStore.postComment(props.owner, props.repo, props.issueNumber, body)
+    comments.value.push(comment)
+    newComment.value = ''
+  } catch (e: unknown) {
+    postError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    submitting.value = false
+  }
+}
+
+onMounted(loadIssue)
+</script>
+
+<style scoped>
+.issue-viewer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 16px 20px;
+  gap: 20px;
+  font-size: 13px;
+  color: var(--color-text);
+}
+
+.issue-loading,
+.issue-error {
+  color: var(--color-text-dim);
+  text-align: center;
+  margin-top: 40px;
+  font-style: italic;
+}
+
+.issue-error {
+  color: var(--color-red);
+}
+
+/* Header */
+.issue-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-bottom: 1px solid var(--color-brass-dark);
+  padding-bottom: 14px;
+}
+
+.issue-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.issue-repo-label {
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+
+.issue-number {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  color: var(--color-brass-dark);
+}
+
+.issue-state {
+  font-size: 9px;
+  padding: 2px 6px;
+  border-radius: 10px;
+  border: 1px solid;
+}
+
+.issue-state.open {
+  color: var(--color-green);
+  border-color: var(--color-green);
+}
+
+.issue-state.closed {
+  color: var(--color-red);
+  border-color: var(--color-red);
+}
+
+.gh-link {
+  font-size: 10px;
+  color: var(--color-teal);
+  text-decoration: none;
+  margin-left: auto;
+}
+.gh-link:hover {
+  text-decoration: underline;
+}
+
+.gh-link-sm {
+  font-size: 10px;
+  color: var(--color-teal);
+  text-decoration: none;
+  margin-left: auto;
+  opacity: 0.7;
+}
+.gh-link-sm:hover {
+  opacity: 1;
+}
+
+.issue-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.issue-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.35;
+  flex: 1;
+}
+
+.issue-title-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.title-input {
+  font-size: 15px;
+  font-family: var(--font-mono);
+  padding: 6px 8px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text);
+  border-radius: 3px;
+  width: 100%;
+}
+
+.title-input:focus {
+  outline: none;
+  border-color: var(--color-brass);
+}
+
+.issue-submeta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.issue-author {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.issue-date {
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+
+.issue-label {
+  font-size: 9px;
+  border: 1px solid;
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+/* Section layout */
+.issue-body-section,
+.comments-section,
+.post-comment-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.section-title {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-brass-light);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+.edit-btn {
+  font-size: 10px;
+  padding: 2px 6px;
+  margin-left: auto;
+}
+
+/* Body */
+.issue-body {
+  padding: 12px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-bg-tertiary);
+  border-radius: 3px;
+}
+
+.issue-body-empty {
+  color: var(--color-text-dim);
+  font-style: italic;
+  font-size: 12px;
+  padding: 8px;
+}
+
+.body-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.body-textarea,
+.comment-textarea {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 8px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text);
+  border-radius: 3px;
+  resize: vertical;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.body-textarea:focus,
+.comment-textarea:focus {
+  outline: none;
+  border-color: var(--color-brass);
+}
+
+.edit-actions,
+.post-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.save-btn {
+  background: rgba(0, 187, 170, 0.15);
+  border-color: var(--color-teal);
+  color: var(--color-teal);
+}
+
+.save-btn:hover:not(:disabled) {
+  background: rgba(0, 187, 170, 0.25);
+}
+
+.cancel-btn {
+  opacity: 0.6;
+}
+
+.cancel-btn:hover {
+  opacity: 1;
+}
+
+.submit-btn {
+  background: rgba(0, 187, 170, 0.15);
+  border-color: var(--color-teal);
+  color: var(--color-teal);
+}
+
+.submit-btn:hover:not(:disabled) {
+  background: rgba(0, 187, 170, 0.25);
+}
+
+.submit-btn:disabled,
+.save-btn:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.post-error {
+  font-size: 11px;
+  color: var(--color-red);
+}
+
+/* Comments */
+.comments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comment {
+  border: 1px solid var(--color-bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.comment-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-bg-tertiary);
+}
+
+.comment-author {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.comment-date {
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+
+.comment-body {
+  padding: 10px 12px;
+}
+
+.no-comments {
+  font-size: 11px;
+  color: var(--color-text-dim);
+  font-style: italic;
+  text-align: center;
+  padding: 12px;
+}
+
+/* Markdown styles shared by body and comments */
+.markdown-body :deep(p) {
+  margin: 0 0 8px;
+  line-height: 1.5;
+}
+
+.markdown-body :deep(p:last-child) {
+  margin-bottom: 0;
+}
+
+.markdown-body :deep(ul),
+.markdown-body :deep(ol) {
+  margin: 0 0 8px;
+  padding-left: 20px;
+}
+
+.markdown-body :deep(li) {
+  margin-bottom: 3px;
+  line-height: 1.5;
+}
+
+.markdown-body :deep(code) {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--color-bg-tertiary);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+
+.markdown-body :deep(pre) {
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-bg);
+  border-radius: 3px;
+  padding: 10px;
+  overflow-x: auto;
+  margin: 0 0 8px;
+}
+
+.markdown-body :deep(pre code) {
+  background: none;
+  padding: 0;
+}
+
+.markdown-body :deep(blockquote) {
+  border-left: 3px solid var(--color-brass-dark);
+  margin: 0 0 8px;
+  padding: 4px 10px;
+  color: var(--color-text-dim);
+}
+
+.markdown-body :deep(h1),
+.markdown-body :deep(h2),
+.markdown-body :deep(h3) {
+  margin: 10px 0 6px;
+  font-size: 13px;
+  color: var(--color-brass-light);
+}
+
+.markdown-body :deep(a) {
+  color: var(--color-teal);
+  text-decoration: none;
+}
+
+.markdown-body :deep(a:hover) {
+  text-decoration: underline;
+}
+
+.markdown-body :deep(hr) {
+  border: none;
+  border-top: 1px solid var(--color-bg-tertiary);
+  margin: 10px 0;
+}
+
+.markdown-body :deep(table) {
+  border-collapse: collapse;
+  margin: 0 0 8px;
+  font-size: 12px;
+}
+
+.markdown-body :deep(th),
+.markdown-body :deep(td) {
+  border: 1px solid var(--color-bg-tertiary);
+  padding: 4px 8px;
+}
+
+.markdown-body :deep(th) {
+  background: var(--color-bg-secondary);
+}
+</style>

--- a/frontend/src/components/MainView.vue
+++ b/frontend/src/components/MainView.vue
@@ -45,6 +45,18 @@
         <span class="tab-label">{{ task.name || task.id }}</span>
         <span class="tab-close">×</span>
       </button>
+      <!-- Issue tabs -->
+      <button
+        v-for="key in agentsStore.openedIssueKeys"
+        :key="key"
+        class="tab issue-tab"
+        :class="{ active: agentsStore.activeTab === key }"
+        @click="onIssueTabClick($event, key)"
+      >
+        <span class="issue-dot">⊙</span>
+        <span class="tab-label">{{ issueTabLabel(key) }}</span>
+        <span class="tab-close">×</span>
+      </button>
     </div>
     <div class="tab-content">
       <FactoryFloor v-if="agentsStore.activeTab === 'factory'" />
@@ -63,6 +75,10 @@
         kind="task"
         :id="agentsStore.activeTab.slice(5)"
       />
+      <IssueViewer
+        v-else-if="agentsStore.activeTab.startsWith('issue-')"
+        v-bind="parseIssueKey(agentsStore.activeTab)"
+      />
     </div>
   </div>
 </template>
@@ -73,9 +89,27 @@ import { useAgentsStore } from '../stores/agents'
 import { useTasksStore, taskTabId } from '../stores/tasks'
 import FactoryFloor from './FactoryFloor.vue'
 import LogPane from './LogPane.vue'
+import IssueViewer from './IssueViewer.vue'
 
 const agentsStore = useAgentsStore()
 const tasksStore = useTasksStore()
+
+// Parse "issue-owner/repo/123" → { owner, repo, issueNumber }
+function parseIssueKey(key: string): { owner: string; repo: string; issueNumber: number } {
+  const rest = key.slice('issue-'.length) // "owner/repo/123"
+  const lastSlash = rest.lastIndexOf('/')
+  const issueNumber = parseInt(rest.slice(lastSlash + 1), 10)
+  const repoPath = rest.slice(0, lastSlash) // "owner/repo"
+  const firstSlash = repoPath.indexOf('/')
+  const owner = repoPath.slice(0, firstSlash)
+  const repo = repoPath.slice(firstSlash + 1)
+  return { owner, repo, issueNumber }
+}
+
+function issueTabLabel(key: string): string {
+  const { repo, issueNumber } = parseIssueKey(key)
+  return `${repo}#${issueNumber}`
+}
 
 const visibleAgentTabs = computed(() =>
   agentsStore.openedAgentIds
@@ -122,6 +156,14 @@ function onTabClick(event: MouseEvent, taskId: string) {
     if (agentsStore.activeTab === taskTabId(taskId)) agentsStore.activeTab = 'factory'
   } else {
     agentsStore.openTaskTab(taskId)
+  }
+}
+
+function onIssueTabClick(event: MouseEvent, key: string) {
+  if ((event.target as HTMLElement).closest('.tab-close')) {
+    agentsStore.closeIssueTab(key)
+  } else {
+    agentsStore.activeTab = key
   }
 }
 </script>
@@ -215,6 +257,20 @@ function onTabClick(event: MouseEvent, taskId: string) {
 
 .task-tab {
   border-left: 1px solid rgba(255, 204, 0, 0.2);
+}
+
+.issue-tab {
+  border-left: 1px solid rgba(0, 187, 170, 0.2);
+}
+
+.issue-tab.active {
+  border-bottom-color: var(--color-teal);
+  color: var(--color-teal);
+}
+
+.issue-dot {
+  font-size: 11px;
+  color: currentColor;
 }
 
 .tab-close {

--- a/frontend/src/components/__tests__/GuildMembers.spec.ts
+++ b/frontend/src/components/__tests__/GuildMembers.spec.ts
@@ -102,18 +102,28 @@ describe('GuildMembers', () => {
     )
     // POST /invites → success
     fetchMock.mockResolvedValueOnce(
-      jsonResponse({ id: 1, github_login: 'ghost', github_id: null, role: 'member', status: 'pending' }),
+      jsonResponse({
+        id: 1,
+        github_login: 'ghost',
+        github_id: null,
+        role: 'member',
+        status: 'pending',
+      }),
     )
     // reload members
     fetchMock.mockResolvedValueOnce(jsonResponse([OWNER]))
     // reload invites
     fetchMock.mockResolvedValueOnce(
-      jsonResponse([{ id: 1, github_login: 'ghost', github_id: null, role: 'member', status: 'pending' }]),
+      jsonResponse([
+        { id: 1, github_login: 'ghost', github_id: null, role: 'member', status: 'pending' },
+      ]),
     )
     await wrapper.find('.invite-input').setValue('ghost')
     await wrapper.find('.invite-btn').trigger('click')
     await flushPromises()
-    expect(wrapper.find('.members-hint').text()).toContain("they'll be added when they first log in")
+    expect(wrapper.find('.members-hint').text()).toContain(
+      "they'll be added when they first log in",
+    )
     expect(wrapper.find('.members-error').exists()).toBe(false)
   })
 

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -73,7 +73,9 @@
         placeholder="4"
       />
       <label class="spawn-label">Env Vars <span class="spawn-hint">(optional)</span></label>
-      <p class="spawn-env-hint">Key-value pairs are saved to the server and restored each session.</p>
+      <p class="spawn-env-hint">
+        Key-value pairs are saved to the server and restored each session.
+      </p>
       <div class="spawn-env-list">
         <div v-for="(pair, idx) in envVars" :key="idx" class="spawn-env-row">
           <input

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -50,6 +50,10 @@ interface AssignTaskOpts {
   issueRepo?: string | null
 }
 
+export function issueTabId(owner: string, repo: string, number: number): string {
+  return `issue-${owner}/${repo}/${number}`
+}
+
 export const useAgentsStore = defineStore('agents', () => {
   const agents = ref<Agent[]>([])
   const workerLogs = ref<Record<string, LogEntry[]>>({})
@@ -57,6 +61,7 @@ export const useAgentsStore = defineStore('agents', () => {
   const openedWorkerIds = ref<string[]>([])
   const selectedAgentId = ref<string | null>(null)
   const openedAgentIds = ref<string[]>([])
+  const openedIssueKeys = ref<string[]>([])
   const activeTab = ref<string>('factory')
 
   // Unique workers derived from agent slots
@@ -198,6 +203,18 @@ export const useAgentsStore = defineStore('agents', () => {
 
   function openTaskTab(taskId: string) {
     activeTab.value = taskTabId(taskId)
+  }
+
+  function openIssueTab(owner: string, repo: string, number: number) {
+    const key = issueTabId(owner, repo, number)
+    if (!openedIssueKeys.value.includes(key)) openedIssueKeys.value.push(key)
+    activeTab.value = key
+  }
+
+  function closeIssueTab(key: string) {
+    const idx = openedIssueKeys.value.indexOf(key)
+    if (idx !== -1) openedIssueKeys.value.splice(idx, 1)
+    if (activeTab.value === key) activeTab.value = 'factory'
   }
 
   function sendMessage(agentId: string, content: string) {
@@ -347,6 +364,7 @@ export const useAgentsStore = defineStore('agents', () => {
     openedWorkerIds,
     selectedAgentId,
     openedAgentIds,
+    openedIssueKeys,
     activeTab,
     registerAgent,
     updateAgentState,
@@ -359,6 +377,8 @@ export const useAgentsStore = defineStore('agents', () => {
     selectAgent,
     closeAgent,
     openTaskTab,
+    openIssueTab,
+    closeIssueTab,
     sendMessage,
     runAgent,
     stopAgent,

--- a/frontend/src/stores/github.ts
+++ b/frontend/src/stores/github.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import { api } from '../utils/api'
 import type { GitHubIssue, GitHubRepo } from '../types'
 
 const GH_API = 'https://api.github.com'
@@ -9,6 +10,29 @@ function ghHeaders(token: string): Record<string, string> {
     Authorization: `Bearer ${token}`,
     Accept: 'application/vnd.github.v3+json',
   }
+}
+
+export interface GitHubComment {
+  id: number
+  body: string
+  user: { login: string; avatar_url: string }
+  created_at: string
+  updated_at: string
+  html_url: string
+}
+
+export interface GitHubIssueDetail {
+  id: number
+  number: number
+  title: string
+  body: string | null
+  state: string
+  user: { login: string; avatar_url: string }
+  labels: Array<{ id: number; name: string; color: string }>
+  created_at: string
+  updated_at: string
+  html_url: string
+  comments: number
 }
 
 function _readStoredRepos(): string[] {
@@ -114,6 +138,41 @@ export const useGitHubStore = defineStore('github', () => {
     }
   }
 
+  async function fetchIssueDetail(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+  ): Promise<{ issue: GitHubIssueDetail; comments: GitHubComment[] }> {
+    const data = await api<{ issue: GitHubIssueDetail; comments: GitHubComment[] }>(
+      `/api/issues/${owner}/${repo}/${issueNumber}`,
+    )
+    return data
+  }
+
+  async function postComment(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    body: string,
+  ): Promise<GitHubComment> {
+    return api<GitHubComment>(`/api/issues/${owner}/${repo}/${issueNumber}/comments`, {
+      method: 'POST',
+      json: { body },
+    })
+  }
+
+  async function updateIssue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    patch: { title?: string; body?: string },
+  ): Promise<GitHubIssueDetail> {
+    return api<GitHubIssueDetail>(`/api/issues/${owner}/${repo}/${issueNumber}`, {
+      method: 'PATCH',
+      json: patch,
+    })
+  }
+
   function logout() {
     token.value = ''
     selectedRepos.value = []
@@ -136,6 +195,9 @@ export const useGitHubStore = defineStore('github', () => {
     fetchRepos,
     setSelectedRepos,
     fetchIssues,
+    fetchIssueDetail,
+    postComment,
+    updateIssue,
     logout,
   }
 })


### PR DESCRIPTION
Closes #676

## Summary
- Added backend routes: GET/PATCH /api/issues/{owner}/{repo}/{issue_number} and POST /api/issues/{owner}/{repo}/{issue_number}/comments
- New IssueViewer.vue component with Markdown rendering, comment timeline, post-comment, and edit title/body
- Wired sidebar issue nodes to open the viewer panel
- Loading states and optimistic comment updates included