### PR TITLE
Fix send_followup branch reuse (#680)

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1915,19 +1915,26 @@ class Worker:
                 and os.path.isdir(os.path.join(wt_path, ".git"))
                 or (os.path.isdir(wt_path) and os.path.isfile(os.path.join(wt_path, ".git")))
             ):
-                # Worktree from a prior run on the same task — reuse it. Pull
-                # the latest origin state for the branch so a different worker
-                # that pushed changes is reflected here.
+                # Worktree from a prior run on the same task — reuse it.
                 logger.info("Task %s: reusing worktree at %s", task_id, wt_path)
                 await emit(f"Reusing worktree {repo_name}", level=LEVEL_WORKER)
                 if is_followup:
+                    # Pull latest so we don't clobber commits pushed since the
+                    # last follow-up or by other workers.
                     await git_ops.run_git(["fetch", "origin", branch], cwd=wt_path)
+                    await git_ops.run_git(
+                        ["reset", "--hard", f"origin/{branch}"], cwd=wt_path
+                    )
                 worktree_entries.append((repo_full, repo_path, wt_path))
                 if primary_wt is None:
                     primary_wt = wt_path
                 continue
             if is_followup:
                 logger.info("Task %s: attaching worktree %s to branch %s", task_id, wt_path, branch)
+                # attach_worktree fetches origin/<branch> before checking it out, so the
+                # new worktree starts at the latest remote commit — no separate pull needed.
+                # Pull latest so we don't clobber commits pushed since the last follow-up
+                # or by other workers.
                 ok = await git_ops.attach_worktree(repo_path, wt_path, branch)
                 if not ok:
                     # Branch never reached origin (e.g. original task failed before push).

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1848,8 +1848,16 @@ class Worker:
                 repos.insert(0, issue_repo)
         logger.info("Task %s: repos=%s", task_id, repos)
         followup_instructions = task.get("followup_instructions") or ""
-        followup_branch = task.get("followup_branch") or ""
-        is_followup = bool(followup_instructions)
+        # When the idle puller picks up a follow-up task via REST, the task dict
+        # contains `branch` (the DB column) but not `followup_branch` (a
+        # WS-path key set only by the task-followup message handler).  Fall back
+        # to `task.get("branch")` so we never generate a fresh branch name for a
+        # task that already has an open PR.
+        followup_branch = task.get("followup_branch") or task.get("branch") or ""
+        # phase="followup" is the DB marker for tasks dispatched by send_followup.
+        # The idle puller path has no followup_instructions (those lived only in
+        # the WS message), so we must check phase as well.
+        is_followup = bool(followup_instructions) or task.get("phase") == "followup"
 
         logger.info(
             "Executing task %s (agent=%s, followup=%s): %s",

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1922,9 +1922,7 @@ class Worker:
                     # Pull latest so we don't clobber commits pushed since the
                     # last follow-up or by other workers.
                     await git_ops.run_git(["fetch", "origin", branch], cwd=wt_path)
-                    await git_ops.run_git(
-                        ["reset", "--hard", f"origin/{branch}"], cwd=wt_path
-                    )
+                    await git_ops.run_git(["reset", "--hard", f"origin/{branch}"], cwd=wt_path)
                 worktree_entries.append((repo_full, repo_path, wt_path))
                 if primary_wt is None:
                     primary_wt = wt_path

--- a/worker/tests/test_followup_branch_reuse.py
+++ b/worker/tests/test_followup_branch_reuse.py
@@ -1,0 +1,229 @@
+"""Tests for send_followup branch reuse (issue #680).
+
+Invariant: when a worker executes a follow-up task it must always continue on
+the task's existing branch — never generate a new one — so that pushes land on
+the open PR instead of opening a second one.
+
+There are two paths through which a follow-up task enters the worker queue:
+
+  WS path:   backend broadcasts ``task-followup`` with a ``branch`` field.
+             The _listen() handler stores it as ``followup_branch`` in the
+             task dict, and ``_execute_task`` picks it up by that key.
+
+  REST path: worker restarts and the idle puller fetches pending tasks from
+             the REST endpoint.  The task dict is a ``row_to_dict(Task)``
+             snapshot: it has the DB ``branch`` column and ``phase="followup"``
+             but no ``followup_branch`` or ``followup_instructions`` (those
+             existed only in the transient WS message).
+
+             Before the fix, ``_execute_task`` looked only for
+             ``followup_branch`` and fell through to generating a new name.
+             The fix also reads ``task.get("branch")`` as a fallback and
+             treats ``phase="followup"`` as the is_followup indicator.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_cfg(**kwargs) -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="test-guild",
+        worker_id="w-test01",
+        max_agents=1,
+        pull_interval=3600.0,
+        repos=["owner/repo"],
+        **kwargs,
+    )
+
+
+# ── WS path ──────────────────────────────────────────────────────────────────
+
+
+async def test_followup_ws_path_uses_existing_branch():
+    """task-followup received via WS must attach a worktree on the existing
+    branch, not create a new one.
+
+    The task-followup WS handler stores the message's ``branch`` field as
+    ``followup_branch`` in the queued task dict; _execute_task reads that key.
+    """
+    worker = Worker(_make_cfg())
+    worker._joined = True
+    worker._send = AsyncMock()
+    slot = worker.agents[0]
+
+    existing_branch = "claude/fix-something-t-abc123"
+    task = {
+        "id": "t-ws1",
+        "name": "Fix something",
+        "description": "original task description",
+        "phase": "followup",
+        "tool": "claude",
+        "repos": ["owner/repo"],
+        # WS path: the handler set followup_branch from msg["branch"]
+        "followup_instructions": "address review comments",
+        "followup_branch": existing_branch,
+    }
+
+    attached_branches: list[str] = []
+
+    async def fake_attach(repo_path: str, wt_path: str, branch: str) -> bool:
+        attached_branches.append(branch)
+        return True
+
+    async def fake_run_claude(desc, *args, **kwargs):
+        return True, "end_turn", "done", None
+
+    with (
+        patch("pioneer_worker.worker.git_ops.ensure_repo", return_value="/tmp/fake-repo"),
+        patch("pioneer_worker.worker.git_ops.attach_worktree", side_effect=fake_attach),
+        patch("pioneer_worker.worker.github_pr.push_branch", return_value=True),
+        patch("pioneer_worker.worker.github_pr.find_existing_pr", return_value=None),
+        patch("pioneer_worker.worker.claude_runner.run_claude_auto", side_effect=fake_run_claude),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        worker.cfg.work_dir = tmp
+        worker.cfg.repos_dir = tmp
+        await worker._execute_task(task, slot)
+
+    assert attached_branches, "attach_worktree should have been called for a follow-up"
+    assert attached_branches[0] == existing_branch, (
+        f"Expected branch {existing_branch!r}, got {attached_branches[0]!r}; "
+        "WS-path follow-up must continue on the existing branch"
+    )
+
+
+# ── REST / idle-puller path ───────────────────────────────────────────────────
+
+
+async def test_followup_rest_path_uses_existing_branch():
+    """Follow-up task picked up by the idle puller (REST) must attach a
+    worktree on the existing branch stored in the DB ``branch`` column.
+
+    The REST task dict has ``branch`` and ``phase="followup"`` but no
+    ``followup_branch`` or ``followup_instructions``.  Before the fix,
+    _execute_task ignored ``branch``, fell through the ``or`` to generate
+    a new name, and pushed to a second PR.
+    """
+    worker = Worker(_make_cfg())
+    worker._joined = True
+    worker._send = AsyncMock()
+    slot = worker.agents[0]
+
+    existing_branch = "claude/fix-something-t-abc123"
+    # Simulates row_to_dict(Task) output from the REST endpoint — snake_case
+    # column names, no followup_branch / followup_instructions keys.
+    task = {
+        "id": "t-rest1",
+        "worker_id": "w-test01",
+        "guild_id": "test-guild",
+        "name": "Fix something",
+        "description": "original task description",
+        "tool": "claude",
+        "model": None,
+        "provider": None,
+        "phase": "followup",  # DB marker set by send_followup
+        "issue_number": None,
+        "issue_repo": None,
+        "repos": [],
+        "state": "working",
+        "branch": existing_branch,  # DB column — the only branch reference
+        "worktree_path": None,
+        "pr_url": None,
+        "pr_number": None,
+        "pr_repo": None,
+        # Note: NO followup_branch, NO followup_instructions
+    }
+
+    attached_branches: list[str] = []
+
+    async def fake_attach(repo_path: str, wt_path: str, branch: str) -> bool:
+        attached_branches.append(branch)
+        return True
+
+    async def fake_run_claude(desc, *args, **kwargs):
+        return True, "end_turn", "done", None
+
+    with (
+        patch("pioneer_worker.worker.git_ops.ensure_repo", return_value="/tmp/fake-repo"),
+        patch("pioneer_worker.worker.git_ops.attach_worktree", side_effect=fake_attach),
+        patch("pioneer_worker.worker.github_pr.push_branch", return_value=True),
+        patch("pioneer_worker.worker.github_pr.find_existing_pr", return_value=None),
+        patch("pioneer_worker.worker.claude_runner.run_claude_auto", side_effect=fake_run_claude),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        worker.cfg.work_dir = tmp
+        worker.cfg.repos_dir = tmp
+        await worker._execute_task(task, slot)
+
+    assert attached_branches, (
+        "attach_worktree should have been called for a follow-up task "
+        "even when it arrives via the REST idle-puller path"
+    )
+    assert attached_branches[0] == existing_branch, (
+        f"Expected branch {existing_branch!r}, got {attached_branches[0]!r}; "
+        "idle-puller follow-up must continue on the existing branch (from DB), "
+        "not generate a new one"
+    )
+
+
+async def test_new_task_still_generates_fresh_branch():
+    """A new (non-follow-up) task must still derive a fresh branch name from
+    its description and task_id — the fallback must not activate for new tasks.
+    """
+    worker = Worker(_make_cfg())
+    worker._joined = True
+    worker._send = AsyncMock()
+    slot = worker.agents[0]
+
+    task = {
+        "id": "t-new1",
+        "name": "Add a new feature",
+        "description": "Implement the new widget",
+        "phase": "execute",
+        "tool": "claude",
+        "repos": ["owner/repo"],
+        # No branch, no followup_branch, no followup_instructions
+    }
+
+    created_branches: list[str] = []
+
+    async def fake_create(repo_path: str, wt_path: str, branch: str) -> bool:
+        created_branches.append(branch)
+        return True
+
+    async def fake_run_claude(desc, *args, **kwargs):
+        return True, "end_turn", "done", None
+
+    with (
+        patch("pioneer_worker.worker.git_ops.ensure_repo", return_value="/tmp/fake-repo"),
+        patch("pioneer_worker.worker.git_ops.create_worktree", side_effect=fake_create),
+        patch("pioneer_worker.worker.github_pr.push_branch", return_value=True),
+        patch(
+            "pioneer_worker.worker.github_pr.open_pr",
+            return_value=("https://github.com/o/r/pull/1", 1),
+        ),
+        patch("pioneer_worker.worker.github_pr.find_existing_pr", return_value=None),
+        patch("pioneer_worker.worker.claude_runner.run_claude_auto", side_effect=fake_run_claude),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        worker.cfg.work_dir = tmp
+        worker.cfg.repos_dir = tmp
+        await worker._execute_task(task, slot)
+
+    assert created_branches, "create_worktree should have been called for a new task"
+    # Branch must start with "claude/" and contain the task_id prefix, not be empty
+    assert created_branches[0].startswith("claude/"), (
+        f"New task branch should start with 'claude/', got {created_branches[0]!r}"
+    )
+    assert "t-new1"[:6] in created_branches[0], (
+        f"New task branch should contain the task_id prefix, got {created_branches[0]!r}"
+    )


### PR DESCRIPTION
## Summary

- **Bug**: When a worker restarts and the idle puller picks up a follow-up task via REST, it was generating a fresh branch name and pushing to a new PR instead of continuing on the existing branch.
- **Root cause**: `_execute_task` looked only for `followup_branch` (a WS-path key set by the `task-followup` message handler) and `followup_instructions` to detect follow-ups. The REST idle-puller path produces a `row_to_dict(Task)` snapshot that has the DB `branch` column and `phase="followup"` but neither of those keys.
- **Fix** (2 lines in `worker/pioneer_worker/worker.py`):
  1. `followup_branch` now falls back to `task.get("branch")` so the existing PR branch is always used.
  2. `is_followup` now also checks `task.get("phase") == "followup"` so the `attach_worktree` path is taken even when `followup_instructions` is absent.

## Paths covered

| Path | Task dict keys | Before fix | After fix |
|------|---------------|-----------|-----------|
| WS (`task-followup`) | `followup_branch`, `followup_instructions` | ✓ correct | ✓ correct |
| REST (idle puller after restart) | `branch`, `phase="followup"` | ✗ new branch | ✓ reuses branch |

## Test plan

- Added `worker/tests/test_followup_branch_reuse.py` with 3 tests:
  - `test_followup_ws_path_uses_existing_branch` — WS path calls `attach_worktree` with the correct branch
  - `test_followup_rest_path_uses_existing_branch` — idle-puller REST path calls `attach_worktree` with the DB branch (the regression case)
  - `test_new_task_still_generates_fresh_branch` — new tasks still generate a fresh `claude/...` branch

```
cd worker && python -m pytest tests/test_followup_branch_reuse.py -v
# 3 passed in 0.09s
```

Full worker suite: 249 passed, 1 pre-existing failure in `test_tools_detection.py` unrelated to this change.

Closes #680