### PR TITLE
fix: prevent duplicate tasks by surfacing done tasks in context and exposing issue assignees

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -548,7 +548,6 @@ async def _run_foreman_ai(
             )
             .where(
                 col(Task.guild_id) == guild_pk_val,
-                ~col(Task.state).in_(list(_TERMINAL_STATES)),
                 live_tasks_filter(),
             )
             .order_by(col(Task.created_at).desc())

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1657,6 +1657,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     "state": i["state"],
                                     "url": i["html_url"],
                                     "labels": [l["name"] for l in i.get("labels", [])],
+                                    "assignees": [a["login"] for a in i.get("assignees", [])],
                                 }
                                 for i in items
                             ]


### PR DESCRIPTION
## Summary

- **`runner.py`**: Removed the `_TERMINAL_STATES` exclusion from the foreman prompt-context query, so recently-finalized tasks (done/failed/cancelled) are visible within their 3-day soft-delete window. `_summarize_task` already handles this gracefully — it includes terminal tasks within 24h (without description) and drops them after. The poll-loop query is unchanged so the foreman isn't woken up for guilds with only finished work.
- **`tools.py`**: Added `assignees` to the `search_github_issues` result so the foreman can see that an issue is already claimed before treating it as available work.

## Root cause

Diagnosed from DB: tasks t-3ru9vt and t-nk3dh2 were both created for issue #1065. t-3ru9vt was finalized as `done` at 18:25; five minutes later the foreman called `search_github_issues`, saw #1065 as open with no assignees in the response, found no active task for it (done tasks were filtered out of context), and created t-nk3dh2.

## Test plan

- [ ] `backend/.venv/bin/pytest tests/test_foreman.py` — all 123 tests pass (verified locally)
- [ ] After deploy: foreman context should show recently-done tasks; `search_github_issues` responses should include `assignees`

🤖 Generated with [Claude Code](https://claude.com/claude-code)