### PR TITLE
Fix issues/tasks pane display bugs (#686)

### DIFF
--- a/frontend/src/components/sidebar/TaskTree.vue
+++ b/frontend/src/components/sidebar/TaskTree.vue
@@ -6,7 +6,7 @@
     <template v-else>
       <!-- Issue / PR nodes -->
       <div
-        v-for="node in treeData!.nodes"
+        v-for="node in visibleNodes"
         :key="`${node.issue_repo}#${node.issue_number}`"
         class="tree-group"
       >
@@ -167,8 +167,27 @@ function countTasks(tasks: TaskTreeNode[]): number {
   return n
 }
 
+const TASK_TERMINAL_STATES = new Set(['done', 'failed', 'cancelled'])
+
+function hasActiveTask(tasks: TaskTreeNode[]): boolean {
+  for (const task of tasks) {
+    if (!TASK_TERMINAL_STATES.has(task.state)) return true
+    if (task.children.length > 0 && hasActiveTask(task.children)) return true
+  }
+  return false
+}
+
+const visibleNodes = computed(() => {
+  if (!treeData.value) return []
+  return treeData.value.nodes.filter((node) => hasActiveTask(node.tasks))
+})
+
 const isEmpty = computed(
-  () => !loading.value && treeData.value && treeData.value.nodes.length === 0 && treeData.value.ungrouped.length === 0,
+  () =>
+    !loading.value &&
+    treeData.value &&
+    visibleNodes.value.length === 0 &&
+    treeData.value.ungrouped.length === 0,
 )
 </script>
 

--- a/frontend/src/components/sidebar/TaskTree.vue
+++ b/frontend/src/components/sidebar/TaskTree.vue
@@ -36,15 +36,15 @@
       </div>
 
       <!-- Ungrouped tasks -->
-      <div v-if="treeData!.ungrouped.length" class="tree-group">
+      <div v-if="activeUngrouped.length" class="tree-group">
         <div class="group-header" @click="toggle('__ungrouped__')">
           <span class="collapse-icon">{{ isExpanded('__ungrouped__') ? '▾' : '▸' }}</span>
           <span class="issue-title ungrouped-label">Ungrouped</span>
-          <span class="group-count">{{ countTasks(treeData!.ungrouped) }}</span>
+          <span class="group-count">{{ countTasks(activeUngrouped) }}</span>
         </div>
         <div v-if="isExpanded('__ungrouped__')" class="group-tasks">
           <TaskTreeRow
-            v-for="task in treeData!.ungrouped"
+            v-for="task in activeUngrouped"
             :key="task.id"
             :task="task"
             :depth="0"
@@ -182,12 +182,17 @@ const visibleNodes = computed(() => {
   return treeData.value.nodes.filter((node) => hasActiveTask(node.tasks))
 })
 
+const activeUngrouped = computed(() => {
+  if (!treeData.value) return []
+  return treeData.value.ungrouped.filter((task) => !TASK_TERMINAL_STATES.has(task.state))
+})
+
 const isEmpty = computed(
   () =>
     !loading.value &&
     treeData.value &&
     visibleNodes.value.length === 0 &&
-    treeData.value.ungrouped.length === 0,
+    activeUngrouped.value.length === 0,
 )
 </script>
 

--- a/frontend/src/components/sidebar/TaskTreeRow.vue
+++ b/frontend/src/components/sidebar/TaskTreeRow.vue
@@ -13,7 +13,7 @@
 
       <span class="task-dot" :class="'dot-' + dotClass(task.state)"></span>
 
-      <span class="task-name">{{ task.name || task.id }}</span>
+      <span class="task-name">{{ task.name || task.description || task.id }}</span>
 
       <span v-if="task.phase" class="phase-pill" :class="'phase-' + task.phase">
         {{ task.phase }}

--- a/frontend/src/stores/github.ts
+++ b/frontend/src/stores/github.ts
@@ -103,6 +103,11 @@ export const useGitHubStore = defineStore('github', () => {
           )
           if (!res.ok) return [] as GitHubIssue[]
           const data: Array<Record<string, unknown>> = await res.json()
+          if (data.length === 100) {
+            console.warn(
+              `[github] fetchIssues: received exactly 100 results for ${repoName} — results may be truncated (pagination not implemented)`,
+            )
+          }
           return data
             .filter((i) => !i.pull_request)
             .map((i) => ({ ...i, repo: repoName })) as GitHubIssue[]

--- a/frontend/src/stores/github.ts
+++ b/frontend/src/stores/github.ts
@@ -98,7 +98,7 @@ export const useGitHubStore = defineStore('github', () => {
       const allIssues = await Promise.all(
         reposToFetch.map(async (repoName) => {
           const res = await fetch(
-            `${GH_API}/repos/${repoName}/issues?state=all&per_page=100&sort=created&direction=desc`,
+            `${GH_API}/repos/${repoName}/issues?state=open&per_page=100&sort=created&direction=desc`,
             { headers: ghHeaders(token.value) },
           )
           if (!res.ok) return [] as GitHubIssue[]


### PR DESCRIPTION
## Summary

- **Issues pane (Bug 1):** Changed the GitHub API fetch in `stores/github.ts` from `state=all` to `state=open` so only open issues are fetched and displayed in the issues tab.
- **Tasks pane filtering (Bug 2):** Added `hasActiveTask()` helper and `visibleNodes` computed in `sidebar/TaskTree.vue` that filters out issue groups where every task is in a terminal state (`done`, `failed`, or `cancelled`). The empty-state check was also updated to use the filtered set.
- **Task row titles (Bug 3):** Updated `sidebar/TaskTreeRow.vue` to fall back to `task.description` before `task.id` when `task.name` is absent, so tasks without a stored name show their human-readable description instead of a raw UUID.

## Test plan

- [ ] Open the Issues tab in the sidebar — confirm only open GitHub issues appear (no closed badge)
- [ ] Open the Tasks tab — confirm issue groups with only done/failed/cancelled tasks are hidden
- [ ] Open the Tasks tab — confirm issue groups with at least one active task remain visible
- [ ] Confirm task rows show a readable title (name or description) rather than a UUID when the task name field is empty

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)