### PR TITLE
Fix issues/tasks pane display bugs (#686)

### DIFF
--- a/frontend/src/components/chat-pane/IssuesTab.vue
+++ b/frontend/src/components/chat-pane/IssuesTab.vue
@@ -7,7 +7,7 @@
     >
       {{ ghStore.loading ? '...' : '↻' }}
     </button>
-    <span class="issues-count">{{ ghStore.issues.length }} issue{{ ghStore.issues.length !== 1 ? 's' : '' }}</span>
+    <span class="issues-count">{{ openIssues.length }} issue{{ openIssues.length !== 1 ? 's' : '' }}</span>
     <span class="issues-repos">{{
       guildStore.currentGuild?.primary_repo ??
       ghStore.selectedRepos.length + ' repo' + (ghStore.selectedRepos.length !== 1 ? 's' : '')
@@ -15,13 +15,13 @@
   </div>
 
   <div class="issues-list" ref="issuesEl">
-    <div v-if="ghStore.issues.length === 0 && !ghStore.loading" class="chat-empty">
+    <div v-if="openIssues.length === 0 && !ghStore.loading" class="chat-empty">
       No issues found.
     </div>
     <div v-if="ghStore.loading" class="chat-empty">Loading issues...</div>
 
     <div
-      v-for="issue in ghStore.issues"
+      v-for="issue in openIssues"
       :key="issue.id"
       class="issue-row"
       @click="$emit('select-issue', issue)"
@@ -51,7 +51,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import { useGuildStore } from '../../stores/guild'
 import { useGitHubStore } from '../../stores/github'
 import { formatAge } from '../../utils/format'
@@ -61,6 +61,8 @@ defineEmits<{ (e: 'select-issue', issue: GitHubIssue): void }>()
 
 const guildStore = useGuildStore()
 const ghStore = useGitHubStore()
+
+const openIssues = computed(() => ghStore.issues.filter((i) => i.state === 'open'))
 
 const ISSUE_REFRESH_MS = 3 * 60 * 1000
 let issueRefreshInterval: ReturnType<typeof setInterval> | null = null

--- a/frontend/src/components/sidebar/TaskTree.vue
+++ b/frontend/src/components/sidebar/TaskTree.vue
@@ -6,7 +6,7 @@
     <template v-else>
       <!-- Issue / PR nodes -->
       <div
-        v-for="node in treeData!.nodes"
+        v-for="node in activeNodes"
         :key="`${node.issue_repo}#${node.issue_number}`"
         class="tree-group"
       >
@@ -18,8 +18,8 @@
             isExpanded(`${node.issue_repo}#${node.issue_number}`) ? '▾' : '▸'
           }}</span>
           <span class="issue-ref">#{{ node.issue_number }}</span>
-          <span class="issue-title">{{ node.title }}</span>
-          <span class="state-badge" :class="'badge-' + node.state">{{ node.state }}</span>
+          <span class="issue-title">{{ resolveIssueTitle(node) }}</span>
+          <span class="state-badge" :class="'badge-' + resolveIssueState(node)">{{ resolveIssueState(node) }}</span>
           <span class="group-count">{{ countTasks(node.tasks) }}</span>
         </div>
 
@@ -61,14 +61,16 @@
 import { computed, ref, watch } from 'vue'
 import { useGuildStore } from '../../stores/guild'
 import { useTasksStore } from '../../stores/tasks'
+import { useGitHubStore } from '../../stores/github'
 import { api } from '../../utils/api'
-import type { TaskTreeData, TaskTreeNode } from '../../types'
+import type { IssueTreeNode, TaskTreeData, TaskTreeNode } from '../../types'
 import TaskTreeRow from './TaskTreeRow.vue'
 
 defineEmits<{ (e: 'open-task', id: string): void }>()
 
 const guildStore = useGuildStore()
 const tasksStore = useTasksStore()
+const ghStore = useGitHubStore()
 
 const treeData = ref<TaskTreeData | null>(null)
 const loading = ref(false)
@@ -161,14 +163,45 @@ watch(taskWatchKey, () => {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled', 'error'])
+
+function hasActiveTasks(tasks: TaskTreeNode[]): boolean {
+  return tasks.some((t) => !TERMINAL_STATES.has(t.state) || hasActiveTasks(t.children))
+}
+
+function resolveIssueTitle(node: IssueTreeNode): string {
+  const gh = ghStore.issues.find(
+    (i) => i.repo === node.issue_repo && i.number === node.issue_number,
+  )
+  return gh?.title || node.title
+}
+
+function resolveIssueState(node: IssueTreeNode): string {
+  const gh = ghStore.issues.find(
+    (i) => i.repo === node.issue_repo && i.number === node.issue_number,
+  )
+  if (gh) return gh.state
+  // Infer closed when the backend didn't fetch state and all tasks are terminal
+  if (node.state === 'open' && !hasActiveTasks(node.tasks)) return 'closed'
+  return node.state
+}
+
 function countTasks(tasks: TaskTreeNode[]): number {
   let n = tasks.length
   for (const t of tasks) n += countTasks(t.children)
   return n
 }
 
+const activeNodes = computed(
+  () => treeData.value?.nodes.filter((n) => hasActiveTasks(n.tasks)) ?? [],
+)
+
 const isEmpty = computed(
-  () => !loading.value && treeData.value && treeData.value.nodes.length === 0 && treeData.value.ungrouped.length === 0,
+  () =>
+    !loading.value &&
+    treeData.value &&
+    activeNodes.value.length === 0 &&
+    treeData.value.ungrouped.length === 0,
 )
 </script>
 

--- a/frontend/src/stores/github.ts
+++ b/frontend/src/stores/github.ts
@@ -90,19 +90,35 @@ export const useGitHubStore = defineStore('github', () => {
     localStorage.setItem('gh_repos', JSON.stringify(repoFullNames))
   }
 
-  async function fetchIssues(repos?: string[], silent = false) {
+  async function fetchAllPages(url: string): Promise<Array<Record<string, unknown>>> {
+    const results: Array<Record<string, unknown>> = []
+    let nextUrl: string | null = url
+    while (nextUrl) {
+      const res = await fetch(nextUrl, { headers: ghHeaders(token.value) })
+      if (!res.ok) break
+      const data: Array<Record<string, unknown>> = await res.json()
+      results.push(...data)
+      const link = res.headers.get('Link') || ''
+      const m = link.match(/<([^>]+)>;\s*rel="next"/)
+      nextUrl = m ? m[1] : null
+    }
+    return results
+  }
+
+  async function fetchIssues(
+    repos?: string[],
+    silent = false,
+    state: 'open' | 'closed' | 'all' = 'all',
+  ) {
     const reposToFetch = repos ?? selectedRepos.value
     if (!token.value || reposToFetch.length === 0) return []
     if (!silent) loading.value = true
     try {
       const allIssues = await Promise.all(
         reposToFetch.map(async (repoName) => {
-          const res = await fetch(
-            `${GH_API}/repos/${repoName}/issues?state=all&per_page=100&sort=created&direction=desc`,
-            { headers: ghHeaders(token.value) },
+          const data = await fetchAllPages(
+            `${GH_API}/repos/${repoName}/issues?state=${state}&per_page=100&sort=created&direction=desc`,
           )
-          if (!res.ok) return [] as GitHubIssue[]
-          const data: Array<Record<string, unknown>> = await res.json()
           return data
             .filter((i) => !i.pull_request)
             .map((i) => ({ ...i, repo: repoName })) as GitHubIssue[]


### PR DESCRIPTION
## Summary

- **IssuesTab**: filter displayed list to open issues only (`state === 'open'`); count badge reflects open issues, not total
- **TaskTree**: filter out issue groups where all tasks are in terminal states (done/failed/cancelled/error) — only groups with at least one active task are shown
- **TaskTree**: resolve issue title and state from `ghStore.issues` when available (uses the frontend's own GitHub token), falling back to backend-provided values; infers `'closed'` when backend returns `'open'` but all tasks are terminal
- **github.ts**: added `fetchAllPages` helper that follows GitHub API `Link` headers, so all issues beyond the 100-per-page cap are fetched
- **github.ts**: `fetchIssues` now accepts a `state` parameter (`'open' | 'closed' | 'all'`, defaulting to `'all'`) instead of hard-coding `state=all`

## Test plan
- [ ] Issues pane only shows open issues; count badge matches
- [ ] Tasks pane hides issue groups whose tasks are all done/failed/cancelled
- [ ] Tasks pane shows real issue titles (not `#<num>`) when GitHub issues are loaded
- [ ] Tasks pane shows `closed` badge for issues that are closed on GitHub
- [ ] Repos with >100 issues have all issues loaded (pagination)

Closes #686