### PR TITLE
Persist models.dev catalog to DB (#689)

### DIFF
--- a/backend/alembic/versions/20260701_000000_add_model_catalog.py
+++ b/backend/alembic/versions/20260701_000000_add_model_catalog.py
@@ -1,0 +1,39 @@
+"""Add model_catalog table for persisting the models.dev provider/model catalog.
+
+Revision ID: 20260701_000000_add_model_catalog
+Revises: 20260623_000000_add_task_id_to_messages
+Create Date: 2026-07-01
+
+Stores one row per (provider, model_id) pair fetched from models.dev so the
+catalog survives backend restarts and can be consumed at dispatch time without
+a live network call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260701_000000_add_model_catalog"
+down_revision: str | Sequence[str] | None = "20260623_000000_add_task_id_to_messages"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "model_catalog",
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("model_id", sa.Text(), nullable=False),
+        sa.Column("display_name", sa.Text(), nullable=False),
+        sa.Column("capabilities", sa.JSON(), nullable=True),
+        sa.Column("raw", sa.JSON(), nullable=True),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("provider", "model_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("model_catalog")

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -326,6 +326,14 @@ async def _poll_loop(guild_id: str) -> None:
                     )
                 )
                 active_tasks = [dict(r._mapping) for r in result.all()]
+
+                # Opportunistically refresh the model catalog while we have a DB
+                # session open. The function is a no-op when the catalog is fresh.
+                from util.models_dev import refresh_model_catalog_if_stale as _refresh_catalog
+
+                refreshed = await _refresh_catalog(db)
+                if refreshed:
+                    await db.commit()
             finally:
                 await db.close()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -352,10 +352,17 @@ async def lifespan(app: FastAPI):
         if stale_ids
         else None
     )
-    # Pre-warm the models.dev cache so the first /api/models request is fast.
-    from util.models_dev import fetch_providers as _fetch_providers  # noqa: PLC0415
+    # Refresh the models.dev catalog on startup: persist to DB and warm the
+    # in-memory cache so the first /api/models request is fast.
+    from util.models_dev import refresh_model_catalog_if_stale as _refresh_catalog  # noqa: PLC0415
 
-    asyncio.ensure_future(_fetch_providers())
+    async def _startup_refresh_catalog() -> None:
+        async with AsyncSessionLocal() as db:
+            refreshed = await _refresh_catalog(db)
+            if refreshed:
+                await db.commit()
+
+    asyncio.ensure_future(_startup_refresh_catalog())
     sweeper = spawn(_stale_worker_sweeper(), name="stale-worker-sweeper")
     try:
         yield

--- a/backend/models.py
+++ b/backend/models.py
@@ -511,3 +511,20 @@ class PushToken(SQLModel, table=True):
     )  # ios | (future: android)
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     last_seen_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
+class ModelCatalog(SQLModel, table=True):
+    """Persisted snapshot of models.dev provider/model entries.
+
+    Upserted from the models.dev API on startup and periodically refreshed.
+    Primary key is (provider, model_id) so upserts are idempotent.
+    """
+
+    __tablename__ = "model_catalog"  # type: ignore[assignment]
+
+    provider: str = Field(primary_key=True)
+    model_id: str = Field(primary_key=True)
+    display_name: str
+    capabilities: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    raw: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    fetched_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -1,14 +1,25 @@
-"""Provider/model catalog endpoint backed by models.dev."""
+"""Provider/model catalog endpoint backed by models.dev + DB persistence."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
-from util.models_dev import fetch_providers
+from fastapi import APIRouter, Depends
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from database import get_db_dep
+from util.models_dev import fetch_providers, get_providers_from_db
 
 router = APIRouter()
 
 
 @router.get("/api/models")
-async def list_models():
-    """Return providers and their models sourced from models.dev (cached 1 h)."""
+async def list_models(db: AsyncSession = Depends(get_db_dep)):
+    """Return providers and their models.
+
+    Reads from the persisted ``model_catalog`` table first; falls back to a
+    live fetch from models.dev (with 1-hour in-memory cache) if the table is
+    empty (e.g. on first startup before the catalog has been refreshed).
+    """
+    providers = await get_providers_from_db(db)
+    if providers:
+        return providers
     return await fetch_providers()

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
+from database import get_db_dep
 from fastapi import APIRouter, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
-
-from database import get_db_dep
 from util.models_dev import fetch_providers, get_providers_from_db
 
 router = APIRouter()

--- a/backend/util/models_dev.py
+++ b/backend/util/models_dev.py
@@ -207,9 +207,7 @@ async def get_providers_from_db(db: AsyncSession) -> list[dict[str, Any]]:
     return sorted(providers.values(), key=lambda p: p["name"].lower())
 
 
-async def refresh_model_catalog_if_stale(
-    db: AsyncSession, *, max_age_hours: int = 24
-) -> bool:
+async def refresh_model_catalog_if_stale(db: AsyncSession, *, max_age_hours: int = 24) -> bool:
     """Re-fetch models.dev and upsert into DB if the catalog is empty or stale.
 
     Staleness is determined by the oldest ``fetched_at`` in the table: if it is

--- a/backend/util/models_dev.py
+++ b/backend/util/models_dev.py
@@ -2,15 +2,23 @@
 
 Fetched once at startup (or on first request) and refreshed every TTL seconds.
 Falls back to a minimal static list if the fetch fails.
+
+DB persistence: ``refresh_model_catalog_if_stale`` upserts all supported-provider
+rows into ``model_catalog`` so the catalog survives restarts.  ``get_providers_from_db``
+reads those rows back and reconstructs the provider list used by ``GET /api/models``.
 """
 
 from __future__ import annotations
 
 import logging
 import time
-from typing import Any
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
 
 import httpx
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +31,12 @@ _PROVIDER_ALIASES = {
     "anthropic": "anthropic",
     "amazon-bedrock": "bedrock",
     "bedrock": "bedrock",
+}
+
+# Human-readable display names for the normalized provider IDs.
+_PROVIDER_DISPLAY_NAMES = {
+    "anthropic": "Anthropic",
+    "bedrock": "Amazon Bedrock",
 }
 
 # Minimal fallback so the UI always has something to show.
@@ -109,3 +123,135 @@ async def fetch_providers(*, force: bool = False) -> list[dict[str, Any]]:
         _cached_providers = _FALLBACK_PROVIDERS
 
     return _cached_providers
+
+
+# ---------------------------------------------------------------------------
+# DB persistence helpers
+# ---------------------------------------------------------------------------
+
+
+async def _upsert_catalog(db: AsyncSession, raw_data: dict[str, Any]) -> int:
+    """Upsert supported-provider model rows from a raw models.dev API response.
+
+    Returns the number of rows upserted. Does NOT commit — callers decide when
+    to commit so they can batch with other writes.
+    """
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from models import ModelCatalog
+
+    now = datetime.now(UTC)
+    rows = []
+    for provider_id, entry in raw_data.items():
+        normalized = _PROVIDER_ALIASES.get(provider_id)
+        if normalized is None:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        raw_models = entry.get("models", {})
+        if not isinstance(raw_models, dict):
+            continue
+        for mid, m in raw_models.items():
+            if not isinstance(m, dict):
+                continue
+            capabilities = {k: v for k, v in m.items() if k not in ("id", "name")} or None
+            rows.append(
+                {
+                    "provider": normalized,
+                    "model_id": m.get("id", mid),
+                    "display_name": m.get("name", mid),
+                    "capabilities": capabilities,
+                    "raw": m,
+                    "fetched_at": now,
+                }
+            )
+    if not rows:
+        return 0
+
+    stmt = pg_insert(ModelCatalog).values(rows)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["provider", "model_id"],
+        set_={
+            "display_name": stmt.excluded.display_name,
+            "capabilities": stmt.excluded.capabilities,
+            "raw": stmt.excluded.raw,
+            "fetched_at": stmt.excluded.fetched_at,
+        },
+    )
+    await db.execute(stmt)
+    return len(rows)
+
+
+async def get_providers_from_db(db: AsyncSession) -> list[dict[str, Any]]:
+    """Read the model catalog from DB and return in the same shape as fetch_providers().
+
+    Returns an empty list if the catalog table is empty (caller should fall back
+    to ``fetch_providers()``).
+    """
+    from sqlmodel import col, select
+
+    from models import ModelCatalog
+
+    rows = (await db.exec(select(ModelCatalog).order_by(col(ModelCatalog.provider)))).all()
+    if not rows:
+        return []
+
+    providers: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if row.provider not in providers:
+            providers[row.provider] = {
+                "id": row.provider,
+                "name": _PROVIDER_DISPLAY_NAMES.get(row.provider, row.provider),
+                "models": [],
+            }
+        providers[row.provider]["models"].append({"id": row.model_id, "name": row.display_name})
+
+    return sorted(providers.values(), key=lambda p: p["name"].lower())
+
+
+async def refresh_model_catalog_if_stale(
+    db: AsyncSession, *, max_age_hours: int = 24
+) -> bool:
+    """Re-fetch models.dev and upsert into DB if the catalog is empty or stale.
+
+    Staleness is determined by the oldest ``fetched_at`` in the table: if it is
+    older than ``max_age_hours`` (or if the table is empty) a fresh fetch is
+    performed and all rows are upserted.  The in-memory cache is also updated.
+
+    Does NOT commit on its own — callers are responsible for committing after
+    this returns ``True`` so they can batch with other writes.
+
+    Returns ``True`` if a refresh was performed, ``False`` if the catalog was
+    already fresh.
+    """
+    from sqlmodel import col, select
+
+    from models import ModelCatalog
+
+    cutoff = datetime.now(UTC) - timedelta(hours=max_age_hours)
+
+    oldest_fetched_at = (
+        await db.exec(
+            select(ModelCatalog.fetched_at).order_by(col(ModelCatalog.fetched_at).asc()).limit(1)
+        )
+    ).first()
+
+    if oldest_fetched_at is not None and oldest_fetched_at > cutoff:
+        return False
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(MODELS_DEV_URL)
+            resp.raise_for_status()
+            data = resp.json()
+        count = await _upsert_catalog(db, data)
+        providers = _parse_response(data)
+        if providers:
+            global _cached_providers, _cache_fetched_at
+            _cached_providers = providers
+            _cache_fetched_at = time.monotonic()
+        logger.info("models.dev: refreshed catalog (%d rows upserted)", count)
+        return True
+    except Exception as exc:
+        logger.warning("models.dev: catalog refresh failed (%s) — catalog unchanged", exc)
+        return False

--- a/backend/util/models_dev.py
+++ b/backend/util/models_dev.py
@@ -136,9 +136,8 @@ async def _upsert_catalog(db: AsyncSession, raw_data: dict[str, Any]) -> int:
     Returns the number of rows upserted. Does NOT commit — callers decide when
     to commit so they can batch with other writes.
     """
-    from sqlalchemy.dialects.postgresql import insert as pg_insert
-
     from models import ModelCatalog
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
 
     now = datetime.now(UTC)
     rows = []
@@ -188,9 +187,8 @@ async def get_providers_from_db(db: AsyncSession) -> list[dict[str, Any]]:
     Returns an empty list if the catalog table is empty (caller should fall back
     to ``fetch_providers()``).
     """
-    from sqlmodel import col, select
-
     from models import ModelCatalog
+    from sqlmodel import col, select
 
     rows = (await db.exec(select(ModelCatalog).order_by(col(ModelCatalog.provider)))).all()
     if not rows:
@@ -224,9 +222,8 @@ async def refresh_model_catalog_if_stale(
     Returns ``True`` if a refresh was performed, ``False`` if the catalog was
     already fresh.
     """
-    from sqlmodel import col, select
-
     from models import ModelCatalog
+    from sqlmodel import col, select
 
     cutoff = datetime.now(UTC) - timedelta(hours=max_age_hours)
 


### PR DESCRIPTION
## Summary

- **New `model_catalog` table** (`provider`, `model_id`, `display_name`, `capabilities`, `raw`, `fetched_at`) with a composite PK so upserts are idempotent. Alembic migration: `20260701_000000_add_model_catalog`.
- **`refresh_model_catalog_if_stale(db, max_age_hours=24)`** in `util/models_dev.py`: checks the oldest `fetched_at` in the table; re-fetches from `https://models.dev/api.json` and upserts via PostgreSQL `ON CONFLICT DO UPDATE` only when stale or empty. Also warms the in-memory TTL cache.
- **Called at startup** (`main.py` lifespan) and **in the foreman periodic-check loop** (`foreman/runner.py`), so the catalog is always fresh without blocking.
- **`GET /api/models`** now reads from DB first via `get_providers_from_db(db)`, falling back to the live `fetch_providers()` only when the table is empty (e.g. first startup before the background refresh completes). Response shape is unchanged — the frontend sees no difference.
- The existing 1-hour in-memory cache is retained as a fast path between DB reads.

## Test plan

- [ ] Run `alembic upgrade head` — verify `model_catalog` table is created.
- [ ] Start the backend with a live DB; check logs for `models.dev: refreshed catalog (N rows upserted)` on startup.
- [ ] `GET /api/models` returns providers from DB; restart backend and confirm they survive.
- [ ] Set `fetched_at` to 25h ago in the DB and verify the foreman poll loop re-fetches.
- [ ] Kill the network and verify `GET /api/models` still returns rows from DB.
- [ ] Existing `test_models_dev.py` tests still pass (they mock httpx, no DB required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #689