### PR TITLE
Define task-type → model tier mapping (#690)

### DIFF
--- a/backend/tests/test_model_tiers.py
+++ b/backend/tests/test_model_tiers.py
@@ -1,0 +1,240 @@
+"""Tests for the task-type → model tier mapping."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from util.model_tiers import (
+    TIER_CHEAP,
+    TIER_POWERFUL,
+    TIER_STANDARD,
+    get_model_for_tier,
+    select_model_tier,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CATALOG = [
+    {
+        "id": "anthropic",
+        "name": "Anthropic",
+        "models": [
+            {"id": "claude-opus-4-8", "name": "Claude Opus 4.8"},
+            {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"},
+            {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5"},
+        ],
+    },
+    {
+        "id": "bedrock",
+        "name": "Amazon Bedrock",
+        "models": [
+            {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6 (Bedrock)"},
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# select_model_tier — phase-based mapping
+# ---------------------------------------------------------------------------
+
+
+def test_select_plan_phase_is_standard():
+    assert select_model_tier("plan", "claude") == TIER_STANDARD
+
+
+def test_select_execute_phase_is_standard():
+    assert select_model_tier("execute", "claude") == TIER_STANDARD
+
+
+def test_select_review_phase_is_cheap():
+    assert select_model_tier("review", "claude") == TIER_CHEAP
+
+
+def test_select_review_phase_pi_is_cheap():
+    assert select_model_tier("review", "pi") == TIER_CHEAP
+
+
+def test_select_execute_phase_pi_is_standard():
+    assert select_model_tier("execute", "pi") == TIER_STANDARD
+
+
+# ---------------------------------------------------------------------------
+# select_model_tier — tool hard-tier overrides
+# ---------------------------------------------------------------------------
+
+
+def test_select_codex_tool_is_powerful_in_execute():
+    assert select_model_tier("execute", "codex") == TIER_POWERFUL
+
+
+def test_select_codex_tool_is_powerful_in_plan():
+    assert select_model_tier("plan", "codex") == TIER_POWERFUL
+
+
+def test_select_codex_tool_overrides_review_phase():
+    # codex always requires powerful, even in review phase
+    assert select_model_tier("review", "codex") == TIER_POWERFUL
+
+
+# ---------------------------------------------------------------------------
+# select_model_tier — complexity_hint override
+# ---------------------------------------------------------------------------
+
+
+def test_select_complexity_hint_cheap_overrides_codex():
+    assert select_model_tier("execute", "codex", complexity_hint=TIER_CHEAP) == TIER_CHEAP
+
+
+def test_select_complexity_hint_powerful_overrides_review():
+    assert select_model_tier("review", "claude", complexity_hint=TIER_POWERFUL) == TIER_POWERFUL
+
+
+def test_select_complexity_hint_standard():
+    assert select_model_tier("plan", "claude", complexity_hint=TIER_STANDARD) == TIER_STANDARD
+
+
+def test_select_invalid_complexity_hint_is_ignored():
+    # Invalid hint → falls through to normal resolution
+    assert select_model_tier("review", "claude", complexity_hint="ultra") == TIER_CHEAP
+
+
+def test_select_none_complexity_hint_ignored():
+    assert select_model_tier("review", "claude", complexity_hint=None) == TIER_CHEAP
+
+
+# ---------------------------------------------------------------------------
+# select_model_tier — unknown/None inputs
+# ---------------------------------------------------------------------------
+
+
+def test_select_unknown_phase_defaults_to_standard():
+    assert select_model_tier("unknown_phase", "claude") == TIER_STANDARD
+
+
+def test_select_none_phase_defaults_to_standard():
+    assert select_model_tier(None, "claude") == TIER_STANDARD
+
+
+def test_select_unknown_tool_uses_phase_tier():
+    assert select_model_tier("review", "unknown_tool") == TIER_CHEAP
+    assert select_model_tier("execute", "unknown_tool") == TIER_STANDARD
+
+
+def test_select_none_tool_uses_phase_tier():
+    assert select_model_tier("review", None) == TIER_CHEAP
+
+
+# ---------------------------------------------------------------------------
+# get_model_for_tier — known tier + provider combos
+# ---------------------------------------------------------------------------
+
+
+def test_get_anthropic_cheap_returns_haiku():
+    result = get_model_for_tier(TIER_CHEAP, "anthropic", catalog=_SAMPLE_CATALOG)
+    assert result == "claude-haiku-4-5-20251001"
+
+
+def test_get_anthropic_standard_returns_sonnet():
+    result = get_model_for_tier(TIER_STANDARD, "anthropic", catalog=_SAMPLE_CATALOG)
+    assert result == "claude-sonnet-4-6"
+
+
+def test_get_anthropic_powerful_returns_opus():
+    result = get_model_for_tier(TIER_POWERFUL, "anthropic", catalog=_SAMPLE_CATALOG)
+    assert result == "claude-opus-4-8"
+
+
+def test_get_bedrock_standard_returns_sonnet():
+    result = get_model_for_tier(TIER_STANDARD, "bedrock", catalog=_SAMPLE_CATALOG)
+    assert result == "claude-sonnet-4-6"
+
+
+def test_get_bedrock_powerful_returns_sonnet_fallback():
+    result = get_model_for_tier(TIER_POWERFUL, "bedrock", catalog=_SAMPLE_CATALOG)
+    assert result == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# get_model_for_tier — catalog with missing preference (fallback to first pref)
+# ---------------------------------------------------------------------------
+
+
+def test_get_model_falls_back_to_first_pref_when_not_in_catalog():
+    # Catalog only has sonnet; opus (preferred for powerful) is absent.
+    limited_catalog = [
+        {
+            "id": "anthropic",
+            "name": "Anthropic",
+            "models": [{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}],
+        }
+    ]
+    result = get_model_for_tier(TIER_POWERFUL, "anthropic", catalog=limited_catalog)
+    # First preference (opus) is not in catalog so falls to second (sonnet)
+    assert result == "claude-sonnet-4-6"
+
+
+def test_get_model_returns_first_pref_when_catalog_empty():
+    result = get_model_for_tier(TIER_STANDARD, "anthropic", catalog=[])
+    # No catalog → return first preference without validation
+    assert result == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# get_model_for_tier — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_get_unknown_provider_returns_none():
+    result = get_model_for_tier(TIER_STANDARD, "openai", catalog=_SAMPLE_CATALOG)
+    assert result is None
+
+
+def test_get_unknown_provider_empty_catalog_returns_none():
+    result = get_model_for_tier(TIER_STANDARD, "openai", catalog=[])
+    assert result is None
+
+
+def test_get_unknown_tier_returns_none():
+    result = get_model_for_tier("ultra", "anthropic", catalog=_SAMPLE_CATALOG)
+    assert result is None
+
+
+def test_get_model_none_catalog_uses_empty_fallback():
+    # When catalog=None and the in-memory cache is also empty, fall back to
+    # first preference rather than crashing.
+    import util.models_dev as _md
+
+    original = _md._cached_providers
+    try:
+        _md._cached_providers = None
+        result = get_model_for_tier(TIER_STANDARD, "anthropic", catalog=None)
+        assert result == "claude-sonnet-4-6"
+    finally:
+        _md._cached_providers = original
+
+
+def test_get_model_none_catalog_uses_in_memory_cache():
+    # When catalog=None the in-memory cache from models_dev should be consulted.
+    import util.models_dev as _md
+
+    original = _md._cached_providers
+    try:
+        _md._cached_providers = [
+            {
+                "id": "anthropic",
+                "name": "Anthropic",
+                "models": [{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}],
+            }
+        ]
+        result = get_model_for_tier(TIER_STANDARD, "anthropic", catalog=None)
+        assert result == "claude-sonnet-4-6"
+    finally:
+        _md._cached_providers = original

--- a/backend/util/model_tiers.py
+++ b/backend/util/model_tiers.py
@@ -1,0 +1,184 @@
+"""Task-type → model tier mapping.
+
+Defines three tiers (cheap, standard, powerful) and the rules that map a
+task's ``phase`` and ``tool`` fields to the appropriate tier.  A concrete
+model ID can then be resolved from the persisted models.dev catalog via
+``get_model_for_tier()``.
+
+Priority order for ``select_model_tier()``:
+  1. ``complexity_hint`` — explicit caller override, highest priority.
+  2. Tool hard tier — tools like ``codex`` always require a specific tier
+     regardless of phase.
+  3. Phase tier — plan/execute → standard, review → cheap.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+# ---------------------------------------------------------------------------
+# Tier constants
+# ---------------------------------------------------------------------------
+
+TIER_CHEAP: str = "cheap"
+TIER_STANDARD: str = "standard"
+TIER_POWERFUL: str = "powerful"
+
+_VALID_TIERS: frozenset[str] = frozenset({TIER_CHEAP, TIER_STANDARD, TIER_POWERFUL})
+
+# Numeric ordering used for min/max comparisons.
+_TIER_ORDER: dict[str, int] = {TIER_CHEAP: 0, TIER_STANDARD: 1, TIER_POWERFUL: 2}
+
+# ---------------------------------------------------------------------------
+# Phase → tier  (used when the tool has no hard tier requirement)
+# ---------------------------------------------------------------------------
+
+_PHASE_TIERS: dict[str, str] = {
+    "plan": TIER_STANDARD,
+    "execute": TIER_STANDARD,
+    "review": TIER_CHEAP,
+}
+
+# ---------------------------------------------------------------------------
+# Tool tier config
+# ---------------------------------------------------------------------------
+
+# Tools listed here have a hard tier requirement that overrides the phase tier.
+# All other tools fall back to the phase-based tier.
+_TOOL_HARD_TIERS: dict[str, str] = {
+    "codex": TIER_POWERFUL,
+}
+
+# Default tier for tools without a hard requirement (used in documentation /
+# edge-case fallbacks — actual dispatch goes through the phase-tier path).
+_TOOL_DEFAULT_TIERS: dict[str, str] = {
+    "claude": TIER_STANDARD,
+    "pi": TIER_STANDARD,  # configurable; complexity_hint can override
+}
+
+# ---------------------------------------------------------------------------
+# Per-provider model preference lists (most-preferred first) for each tier.
+# ---------------------------------------------------------------------------
+
+_TIER_MODEL_PREFERENCES: dict[str, dict[str, list[str]]] = {
+    "anthropic": {
+        TIER_CHEAP: [
+            "claude-haiku-4-5-20251001",
+            "claude-haiku-4-5",
+            "claude-sonnet-4-6",
+        ],
+        TIER_STANDARD: [
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5-20251001",
+        ],
+        TIER_POWERFUL: [
+            "claude-opus-4-8",
+            "claude-sonnet-4-6",
+        ],
+    },
+    "bedrock": {
+        TIER_CHEAP: [
+            "claude-haiku-4-5-20251001",
+            "claude-sonnet-4-6",
+        ],
+        TIER_STANDARD: [
+            "claude-sonnet-4-6",
+        ],
+        TIER_POWERFUL: [
+            "claude-sonnet-4-6",
+        ],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def select_model_tier(
+    phase: str | None,
+    tool: str | None,
+    complexity_hint: str | None = None,
+) -> str:
+    """Return the appropriate tier string for a task.
+
+    Args:
+        phase: Task phase — ``"plan"``, ``"execute"``, or ``"review"``.
+               Unknown values fall back to ``TIER_STANDARD``.
+        tool: Runner name — ``"claude"``, ``"codex"``, or ``"pi"``.
+              Unknown values fall back to the phase tier.
+        complexity_hint: Explicit tier override supplied by the caller
+                         (``"cheap"``, ``"standard"``, or ``"powerful"``).
+                         Invalid values are silently ignored.
+
+    Returns:
+        One of ``TIER_CHEAP``, ``TIER_STANDARD``, or ``TIER_POWERFUL``.
+    """
+    if complexity_hint in _VALID_TIERS:
+        return complexity_hint
+
+    # Tools with hard tier requirements ignore phase.
+    if tool in _TOOL_HARD_TIERS:
+        return _TOOL_HARD_TIERS[tool]
+
+    # All other tools: let the phase drive the tier.
+    return _PHASE_TIERS.get(phase or "", TIER_STANDARD)
+
+
+def get_model_for_tier(
+    tier: str,
+    provider: str,
+    catalog: list[dict[str, Any]] | None = None,
+) -> str | None:
+    """Return the best available model ID for *tier* + *provider*.
+
+    Walks the per-provider preference list for *tier* and returns the first
+    entry that appears in *catalog*.  Falls back to the first preference when
+    the catalog is absent or the provider is not listed there.
+
+    Args:
+        tier: One of ``TIER_CHEAP``, ``TIER_STANDARD``, ``TIER_POWERFUL``.
+        provider: Normalized provider ID, e.g. ``"anthropic"`` or ``"bedrock"``.
+        catalog: Optional provider list in the same shape returned by
+                 ``fetch_providers()`` / ``get_providers_from_db()``.  When
+                 ``None`` the module-level in-memory cache from
+                 ``util.models_dev`` is used if populated; if neither is
+                 available the first preference is returned without validation.
+
+    Returns:
+        A model ID string, or ``None`` if no preferences are defined for the
+        given *provider* + *tier* combination.
+    """
+    prefs = _TIER_MODEL_PREFERENCES.get(provider, {}).get(tier)
+    if not prefs:
+        return None
+
+    effective_catalog = catalog
+    if effective_catalog is None:
+        try:
+            from util import models_dev as _md
+
+            effective_catalog = _md._cached_providers
+        except Exception:
+            effective_catalog = None
+
+    if not effective_catalog:
+        return prefs[0]
+
+    # Collect model IDs available for this provider in the catalog.
+    available: set[str] = set()
+    for p in effective_catalog:
+        if p.get("id") == provider:
+            available = {m["id"] for m in p.get("models", [])}
+            break
+
+    for model_id in prefs:
+        if model_id in available:
+            return model_id
+
+    # No preference matched catalog — return the top preference as default.
+    return prefs[0]


### PR DESCRIPTION
## Summary

- Adds `backend/util/model_tiers.py` with three tier constants (`cheap`, `standard`, `powerful`) and two public functions:
  - `select_model_tier(phase, tool, complexity_hint=None)` — maps a task's `phase` + `tool` fields to a tier with this priority: `complexity_hint` > tool hard tier (`codex`=powerful) > phase tier (`plan`/`execute`=standard, `review`=cheap).
  - `get_model_for_tier(tier, provider, catalog=None)` — picks the best available model ID from the persisted models.dev catalog (or in-memory cache) for a given tier + provider pair, falling back gracefully when the catalog is absent or the model is not listed.
- Adds 29 unit tests in `backend/tests/test_model_tiers.py` covering all phase/tool combinations, complexity_hint overrides, catalog-based lookups, and edge cases (unknown provider, empty catalog, invalid hint).

## Test plan

```bash
cd backend && python -m pytest tests/test_model_tiers.py -v   # 29 passed
ruff check . && ruff format .                                   # all checks passed
```

Closes #690