### PR TITLE
Workers advertise provider+tool; Foreman model selection (#691)

### DIFF
--- a/backend/alembic/versions/20260701_000001_add_provider_tool_to_workers.py
+++ b/backend/alembic/versions/20260701_000001_add_provider_tool_to_workers.py
@@ -1,0 +1,37 @@
+"""Add provider and tool columns to workers table.
+
+Revision ID: 20260701_000001_add_provider_tool_to_workers
+Revises: 20260701_000000_add_model_catalog
+Create Date: 2026-07-01
+
+provider: the AI provider this worker communicates with (e.g. 'anthropic', 'bedrock', 'openai').
+tool: the primary tool runner this worker is configured for (e.g. 'claude', 'pi', 'codex').
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260701_000001_add_provider_tool_to_workers"
+down_revision: str | Sequence[str] | None = "20260701_000000_add_model_catalog"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workers",
+        sa.Column("provider", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "workers",
+        sa.Column("tool", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "tool")
+    op.drop_column("workers", "provider")

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -940,7 +940,11 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 repos: list[str] = inp.get("repos") or ([primary_repo] if primary_repo else [])
                 worker_result = await db.exec(
                     select(
-                        col(Worker.id), col(Worker.repos), col(Worker.org), col(Worker.tools)
+                        col(Worker.id),
+                        col(Worker.repos),
+                        col(Worker.org),
+                        col(Worker.tools),
+                        col(Worker.provider),
                     ).where(col(Worker.id) == wid, col(Worker.guild_id) == guild_pk)
                 )
                 worker_row = worker_result.one_or_none()
@@ -949,6 +953,34 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     is_error = True
                 else:
                     worker_tools: list[str] = json.loads(worker_row.tools or "[]")
+                    worker_provider: str | None = worker_row.provider
+                    # Filter model selection to only provider-compatible models.
+                    if worker_provider and not is_error:
+                        from models import ModelCatalog  # noqa: PLC0415
+
+                        if model:
+                            catalog_check = await db.exec(
+                                select(col(ModelCatalog.model_id)).where(
+                                    col(ModelCatalog.provider) == worker_provider,
+                                    col(ModelCatalog.model_id) == model,
+                                )
+                            )
+                            if catalog_check.one_or_none() is None:
+                                result_text = (
+                                    f"Model {model!r} is not available for provider "
+                                    f"{worker_provider!r}. Use GET /api/models to see "
+                                    "available models for each provider."
+                                )
+                                is_error = True
+                        else:
+                            catalog_default = await db.exec(
+                                select(col(ModelCatalog.model_id))
+                                .where(col(ModelCatalog.provider) == worker_provider)
+                                .limit(1)
+                            )
+                            default_model = catalog_default.one_or_none()
+                            if default_model:
+                                model = default_model
                     if requested_tool is None:
                         tool = worker_tools[0] if worker_tools else "claude"
                     elif worker_tools and requested_tool not in worker_tools:

--- a/backend/models.py
+++ b/backend/models.py
@@ -155,6 +155,12 @@ class Worker(SQLModel, table=True):
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default=text("false")),
     )
+    # AI provider this worker communicates with (e.g. 'anthropic', 'bedrock', 'openai').
+    # NULL on legacy rows that predate this column; set during worker-register.
+    provider: str | None = None
+    # Primary tool runner this worker is configured for (e.g. 'claude', 'pi', 'codex').
+    # NULL on legacy rows; set during worker-register.
+    tool: str | None = None
 
 
 class Task(SQLModel, table=True):

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -615,15 +615,16 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
     user_ident = data.get("user")
     provider = data.get("provider") or None
     tool = data.get("tool") or None
-    update_vals: dict = {"repos": json.dumps(repos), "tools": json.dumps(tools)}
+    update_vals: dict = {
+        "repos": json.dumps(repos),
+        "tools": json.dumps(tools),
+        "provider": provider,
+        "tool": tool,
+    }
     if user_ident:
         resolved = await _resolve_user_identifier(ctx.db, user_ident)
         if resolved:
             update_vals["user_id"] = resolved
-    if provider:
-        update_vals["provider"] = provider
-    if tool:
-        update_vals["tool"] = tool
     await ctx.db.exec(
         update(Worker)
         .where(col(Worker.id) == worker_id, col(Worker.guild_id) == ctx.guild_pk)

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -613,11 +613,17 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
     repos = data.get("repos") or []
     tools = data.get("tools") or []
     user_ident = data.get("user")
+    provider = data.get("provider") or None
+    tool = data.get("tool") or None
     update_vals: dict = {"repos": json.dumps(repos), "tools": json.dumps(tools)}
     if user_ident:
         resolved = await _resolve_user_identifier(ctx.db, user_ident)
         if resolved:
             update_vals["user_id"] = resolved
+    if provider:
+        update_vals["provider"] = provider
+    if tool:
+        update_vals["tool"] = tool
     await ctx.db.exec(
         update(Worker)
         .where(col(Worker.id) == worker_id, col(Worker.guild_id) == ctx.guild_pk)
@@ -638,10 +644,11 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
     )
     agent_count = count_res.one()
     tools_suffix = f" tools={tools_str}" if tools_str else ""
+    provider_suffix = f" provider={provider}" if provider else ""
     await _trigger_foreman(
         ctx.guild_id,
         "worker-online",
-        f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}{tools_suffix}",
+        f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}{tools_suffix}{provider_suffix}",
         task_name=f"foreman.worker-online:{worker_id}",
     )
 

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -288,6 +288,7 @@ async def run_claude_auto(
     on_usage: UsageFn | None = None,
     claude_path: str = "claude",
     resume_session_id: str | None = None,
+    model: str | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Run claude on *description* in *cwd*. Returns (success, stop_reason, last_assistant_text, session_id).
 
@@ -297,6 +298,8 @@ async def run_claude_auto(
 
     If *resume_session_id* is given, passes ``--resume <id>`` so Claude continues
     the previous session with full context (used after a redirect/SIGTERM).
+
+    If *model* is given, passes ``--model <model>`` to select a specific model.
     """
     cmd = [
         claude_path,
@@ -307,6 +310,8 @@ async def run_claude_auto(
         str(max_turns),
         "--dangerously-skip-permissions",
     ]
+    if model:
+        cmd += ["--model", model]
     if resume_session_id:
         cmd += ["--resume", resume_session_id, "-p", description]
     else:

--- a/worker/pioneer_worker/codex_runner.py
+++ b/worker/pioneer_worker/codex_runner.py
@@ -67,7 +67,7 @@ async def run_codex_auto(
         cwd,
         "--output-last-message",
         last_message_path,
-        *(["--model", model] if model else []),
+        *(["--model", model] if model and "--model" not in (codex_args or []) else []),
         *(codex_args or []),
         description,
     ]

--- a/worker/pioneer_worker/codex_runner.py
+++ b/worker/pioneer_worker/codex_runner.py
@@ -43,6 +43,7 @@ async def run_codex_auto(
     codex_path: str = "codex",
     codex_args: list[str] | None = None,
     openai_api_key: str | None = None,
+    model: str | None = None,
 ) -> tuple[bool, str, str]:
     """Run codex on *description* in *cwd*. Returns (success, stop_reason, last_text).
 
@@ -50,6 +51,8 @@ async def run_codex_auto(
     when provided, overriding whatever is in the current process env. This lets
     the worker forward the key without requiring it to be set globally before
     import time.
+
+    If *model* is given, passes ``--model <model>`` to select a specific model.
     """
     last_message_file = tempfile.NamedTemporaryFile(
         prefix="pioneer-codex-last-", suffix=".txt", delete=False
@@ -64,6 +67,7 @@ async def run_codex_auto(
         cwd,
         "--output-last-message",
         last_message_path,
+        *(["--model", model] if model else []),
         *(codex_args or []),
         description,
     ]

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -51,6 +51,14 @@ class Config:
     # startup; set here to avoid exposing the secret in the process environment
     # before the worker has a chance to forward it.
     openai_api_key: str | None = None
+    # AI provider this worker communicates with. Used to advertise to the backend
+    # so the foreman can filter the model catalog to only provider-compatible models.
+    # e.g. 'anthropic', 'bedrock', 'openai'. NULL = not configured (falls back to
+    # per-runner defaults: pi_provider for pi, 'anthropic' for claude, 'openai' for codex).
+    provider: str | None = None
+    # Primary tool runner this worker is intended for. Auto-derived from the first
+    # detected tool if not explicitly set. e.g. 'claude', 'pi', 'codex'.
+    tool: str | None = None
     pi_path: str = "pi"
     pi_model: str | None = None
     pi_provider: str | None = None
@@ -267,6 +275,11 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
     return Config(
         backend_url=backend_url.rstrip("/"),
         guild_id=guild_id,
+        provider=overrides.get("provider")
+        or raw.get("provider")
+        or os.environ.get("PIONEER_PROVIDER")
+        or None,
+        tool=overrides.get("tool") or raw.get("tool") or os.environ.get("PIONEER_TOOL") or None,
         repos=list(
             overrides.get("repos")
             or github_block.get("repos")

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1010,15 +1010,23 @@ class Worker:
                     "workerId": self.cfg.worker_id,
                 }
             )
-        await self._send(
-            {
-                "type": "worker-register",
-                "workerId": self.cfg.worker_id,
-                "repos": self._broadcast_repos,
-                "tools": self._available_tools,
-                **({"user": self.cfg.user} if self.cfg.user else {}),
-            }
+        # Derive primary tool from config or first detected tool.
+        primary_tool = self.cfg.tool or (
+            self._available_tools[0] if self._available_tools else None
         )
+        msg: dict = {
+            "type": "worker-register",
+            "workerId": self.cfg.worker_id,
+            "repos": self._broadcast_repos,
+            "tools": self._available_tools,
+        }
+        if self.cfg.user:
+            msg["user"] = self.cfg.user
+        if self.cfg.provider:
+            msg["provider"] = self.cfg.provider
+        if primary_tool:
+            msg["tool"] = primary_tool
+        await self._send(msg)
 
     async def _on_ws_reconnect(self) -> None:
         """Re-announce ourselves after the WebSocket reconnects.
@@ -1601,15 +1609,22 @@ class Worker:
         self._broadcast_repos = merged
         logger.info("GitHub repos refreshed: %d total (was %d)", len(merged), prev_count)
         if self.cfg.worker_id:
-            await self._send(
-                {
-                    "type": "worker-register",
-                    "workerId": self.cfg.worker_id,
-                    "repos": self._broadcast_repos,
-                    "tools": self._available_tools,
-                    **({"user": self.cfg.user} if self.cfg.user else {}),
-                }
+            primary_tool = self.cfg.tool or (
+                self._available_tools[0] if self._available_tools else None
             )
+            refresh_msg: dict = {
+                "type": "worker-register",
+                "workerId": self.cfg.worker_id,
+                "repos": self._broadcast_repos,
+                "tools": self._available_tools,
+            }
+            if self.cfg.user:
+                refresh_msg["user"] = self.cfg.user
+            if self.cfg.provider:
+                refresh_msg["provider"] = self.cfg.provider
+            if primary_tool:
+                refresh_msg["tool"] = primary_tool
+            await self._send(refresh_msg)
 
     def _known_repos(self) -> list[str]:
         """All repos this worker may have cloned: static list + org repos already on disk."""
@@ -2070,7 +2085,13 @@ class Worker:
 
             while True:
                 if tool == "codex":
-                    logger.info("Task %s: launching codex in %s", task_id, primary_wt)
+                    _codex_model = task.get("model") or None
+                    logger.info(
+                        "Task %s: launching codex in %s (model=%s)",
+                        task_id,
+                        primary_wt,
+                        _codex_model,
+                    )
                     success, stop_reason, last_msg = await codex_runner.run_codex_auto(
                         current_desc,
                         primary_wt,
@@ -2078,6 +2099,7 @@ class Worker:
                         codex_path=self.cfg.codex_path,
                         codex_args=self.cfg.codex_args,
                         openai_api_key=self.cfg.openai_api_key,
+                        model=_codex_model,
                     )
                 elif tool == "pi":
                     _pi_model = task.get("model") or self.cfg.pi_model
@@ -2100,12 +2122,14 @@ class Worker:
                     )
                     resume_session_id = _pi_session_id
                 else:
+                    _claude_model = task.get("model") or None
                     logger.info(
-                        "Task %s: launching claude in %s (max_turns=%d, resume=%s)",
+                        "Task %s: launching claude in %s (max_turns=%d, resume=%s, model=%s)",
                         task_id,
                         primary_wt,
                         self.cfg.claude_max_turns,
                         resume_session_id,
+                        _claude_model,
                     )
                     (
                         success,
@@ -2121,6 +2145,7 @@ class Worker:
                         on_usage=_collect_usage,
                         claude_path=self.cfg.claude_path,
                         resume_session_id=resume_session_id,
+                        model=_claude_model,
                     )
 
                     _capture_session_and_clear()


### PR DESCRIPTION
## Summary

- **DB schema**: Added `provider` and `tool` columns to the `workers` table via Alembic migration `20260701_000001_add_provider_tool_to_workers`
- **Worker config**: New `provider` and `tool` fields in `Config`, readable from TOML or `PIONEER_PROVIDER`/`PIONEER_TOOL` env vars
- **Worker registration**: `worker-register` WS message now includes `provider` (e.g. `anthropic`, `bedrock`, `openai`) and `tool` (e.g. `claude`, `pi`, `codex`); `tool` is auto-derived from the first detected runner if not explicitly configured
- **Backend persistence**: `handle_worker_register` persists `provider` and `tool` to the DB on every registration
- **API**: `GET /api/workers` returns `provider` and `tool` fields automatically via the existing `row_to_dict` serializer
- **Foreman model selection**: `assign_task` looks up the target worker's `provider` from the DB and filters the model catalog:
  - If a model is explicitly specified, validates it exists in the catalog for that provider (returns error if incompatible)
  - If no model is specified and the worker has a provider, auto-selects the first available model from the catalog for that provider
- **Runner propagation**: `run_claude_auto` and `run_codex_auto` now accept a `model=` parameter and pass `--model <name>` to their respective subprocesses; `_execute_task` passes `task.get("model")` through

## Test plan

- [ ] `ruff check . && ruff format .` — clean (verified locally)
- [ ] Worker tests: 238 pass, 1 pre-existing failure in `test_no_tools_flag_gives_none` (confirmed pre-existing before this change)
- [ ] Acceptance criteria:
  - [ ] `GET /api/workers` returns `provider` field for a worker that registers with one
  - [ ] `assign_task` with `provider=bedrock` worker rejects models not in the Bedrock catalog
  - [ ] `claude` runner passes `--model <name>` when model is set on the task
  - [ ] `codex` runner passes `--model <name>` when model is set on the task

Closes #691