### PR TITLE
Foreman assign_task: auto-select model from tier (#692)

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -973,14 +973,16 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 )
                                 is_error = True
                         else:
-                            catalog_default = await db.exec(
-                                select(col(ModelCatalog.model_id))
-                                .where(col(ModelCatalog.provider) == worker_provider)
-                                .limit(1)
+                            # Auto-select: phase+tool → tier → best model from catalog.
+                            from util.model_tiers import (  # noqa: PLC0415
+                                get_model_for_tier,
+                                select_model_tier,
                             )
-                            default_model = catalog_default.one_or_none()
-                            if default_model:
-                                model = default_model
+                            from util.models_dev import get_providers_from_db  # noqa: PLC0415
+
+                            tier = select_model_tier(phase, tool)
+                            catalog = await get_providers_from_db(db)
+                            model = get_model_for_tier(tier, worker_provider, catalog)
                     # For Bedrock workers, resolve the short model ID to the
                     # canonical inference-profile ARN stored in the catalog.
                     # The Claude CLI on Bedrock requires the full ARN; short IDs

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -76,7 +76,12 @@ FOREMAN_TOOLS = [
                 },
                 "model": {
                     "type": "string",
-                    "description": "Model override for the chosen tool (e.g. 'claude-opus-4-8', 'o4-mini', 'gpt-4o'). Omit to use the worker's configured default.",
+                    "description": (
+                        "Model override for the chosen tool (e.g. 'claude-opus-4-8', 'o4-mini', 'gpt-4o'). "
+                        "Omit to auto-select: the foreman maps the task phase and tool to a tier "
+                        "(cheap/standard/powerful) and picks the best available model from the "
+                        "worker's provider catalog. Explicit values are validated against the catalog."
+                    ),
                 },
                 "provider": {
                     "type": "string",

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -214,6 +214,7 @@ def insert_worker(
     org: str | None = None,
     tools: str = "[]",
     disabled: bool = False,
+    provider: str | None = None,
 ) -> None:
     """Insert a worker row for a guild."""
     now = datetime.now(UTC)
@@ -234,6 +235,7 @@ def insert_worker(
                 state=state,
                 org=org,
                 disabled=disabled,
+                provider=provider,
                 created_at=now,
             )
             .on_conflict_do_nothing(index_elements=["id"])

--- a/backend/tests/test_assign_task_auto_model.py
+++ b/backend/tests/test_assign_task_auto_model.py
@@ -1,0 +1,224 @@
+"""Integration tests: assign_task auto-selects model from tier+catalog (#692).
+
+When the foreman calls assign_task without an explicit ``model`` argument the
+handler maps phase+tool → tier → best model in the worker's provider catalog
+and persists the resolved value on the task row.  Explicit overrides bypass
+auto-selection entirely.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module
+from _test_config import TEST_DATABASE_URL
+from foreman.tools import exec_tools
+from helpers import create_db, insert_guild, insert_worker, truncate_all
+from models import ModelCatalog, Task
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session(monkeypatch):
+    """Provide the PostgreSQL test database, isolated per test."""
+    create_db(TEST_DATABASE_URL)
+    truncate_all(TEST_DATABASE_URL)
+
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False, poolclass=NullPool)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    monkeypatch.setattr(database_module, "AsyncSessionLocal", session_factory)
+
+    yield TEST_DATABASE_URL
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool(name: str, inputs: dict, tool_id: str = "tool-abc") -> SimpleNamespace:
+    return SimpleNamespace(name=name, input=inputs, id=tool_id)
+
+
+async def _seed_catalog(db_url: str, provider: str, model_ids: list[str]) -> None:
+    """Insert model catalog rows directly via the async session."""
+    now = datetime.now(UTC)
+    async with database_module.AsyncSessionLocal() as db:
+        for mid in model_ids:
+            db.add(
+                ModelCatalog(
+                    provider=provider,
+                    model_id=mid,
+                    display_name=mid,
+                    fetched_at=now,
+                )
+            )
+        await db.commit()
+
+
+async def _get_task(worker_id: str) -> Task | None:
+    async with database_module.AsyncSessionLocal() as db:
+        return (await db.exec(select(Task).where(col(Task.worker_id) == worker_id))).one_or_none()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAssignTaskAutoModelSelection:
+    @pytest.mark.asyncio
+    async def test_execute_phase_auto_selects_standard_tier_model(self, db_session):
+        """assign_task without model= and phase=execute picks a standard-tier model."""
+        guild_id = "g-am001"
+        worker_id = "w-am001"
+        insert_guild(db_session, guild_id)
+        insert_worker(
+            db_session, guild_id, worker_id, state="idle", tools='["claude"]', provider="anthropic"
+        )
+        await _seed_catalog(
+            db_session,
+            "anthropic",
+            ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-8"],
+        )
+
+        tu = _tool(
+            "assign_task",
+            {"worker_id": worker_id, "description": "Implement the feature", "phase": "execute"},
+            "tool-001",
+        )
+        with (
+            patch("foreman.tools.broadcast", new=AsyncMock()),
+            patch("foreman.tools.emit_terminal_line", new=AsyncMock()),
+        ):
+            results = await exec_tools(guild_id, [tu])
+
+        r = results[0]
+        assert not r.get("is_error"), f"Expected success but got error: {r['content']}"
+
+        task = await _get_task(worker_id)
+        assert task is not None, "Task row not created"
+        assert task.model is not None, "model should be auto-selected, not null"
+        # execute → standard tier → claude-sonnet-4-6 is first preference for anthropic
+        assert task.model == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_review_phase_auto_selects_cheap_tier_model(self, db_session):
+        """review phase maps to cheap tier — cheapest model in preference list is chosen."""
+        guild_id = "g-am002"
+        worker_id = "w-am002"
+        insert_guild(db_session, guild_id)
+        insert_worker(
+            db_session, guild_id, worker_id, state="idle", tools='["claude"]', provider="anthropic"
+        )
+        await _seed_catalog(
+            db_session,
+            "anthropic",
+            ["claude-haiku-4-5-20251001", "claude-sonnet-4-6"],
+        )
+
+        tu = _tool(
+            "assign_task",
+            {"worker_id": worker_id, "description": "Review the PR", "phase": "review"},
+            "tool-002",
+        )
+        with (
+            patch("foreman.tools.broadcast", new=AsyncMock()),
+            patch("foreman.tools.emit_terminal_line", new=AsyncMock()),
+        ):
+            results = await exec_tools(guild_id, [tu])
+
+        r = results[0]
+        assert not r.get("is_error"), f"Expected success but got error: {r['content']}"
+
+        task = await _get_task(worker_id)
+        assert task is not None
+        assert task.model is not None
+        # review → cheap tier → haiku is first preference for anthropic/cheap
+        assert task.model == "claude-haiku-4-5-20251001"
+
+    @pytest.mark.asyncio
+    async def test_explicit_model_override_is_respected(self, db_session):
+        """When model= is explicitly passed, auto-selection is skipped."""
+        guild_id = "g-am003"
+        worker_id = "w-am003"
+        insert_guild(db_session, guild_id)
+        insert_worker(
+            db_session, guild_id, worker_id, state="idle", tools='["claude"]', provider="anthropic"
+        )
+        await _seed_catalog(
+            db_session,
+            "anthropic",
+            ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-8"],
+        )
+
+        tu = _tool(
+            "assign_task",
+            {
+                "worker_id": worker_id,
+                "description": "Big complex task",
+                "phase": "execute",
+                "model": "claude-opus-4-8",
+            },
+            "tool-003",
+        )
+        with (
+            patch("foreman.tools.broadcast", new=AsyncMock()),
+            patch("foreman.tools.emit_terminal_line", new=AsyncMock()),
+        ):
+            results = await exec_tools(guild_id, [tu])
+
+        r = results[0]
+        assert not r.get("is_error"), f"Expected success but got error: {r['content']}"
+
+        task = await _get_task(worker_id)
+        assert task is not None
+        assert task.model == "claude-opus-4-8", "Explicit model override must be preserved"
+
+    @pytest.mark.asyncio
+    async def test_auto_selected_model_persisted_on_task_row(self, db_session):
+        """The resolved model is visible on the task record after assignment."""
+        guild_id = "g-am004"
+        worker_id = "w-am004"
+        insert_guild(db_session, guild_id)
+        insert_worker(
+            db_session, guild_id, worker_id, state="idle", tools='["claude"]', provider="anthropic"
+        )
+        await _seed_catalog(db_session, "anthropic", ["claude-sonnet-4-6"])
+
+        tu = _tool(
+            "assign_task",
+            {"worker_id": worker_id, "description": "Write tests"},
+            "tool-004",
+        )
+        with (
+            patch("foreman.tools.broadcast", new=AsyncMock()),
+            patch("foreman.tools.emit_terminal_line", new=AsyncMock()),
+        ):
+            results = await exec_tools(guild_id, [tu])
+
+        assert not results[0].get("is_error")
+
+        task = await _get_task(worker_id)
+        assert task is not None
+        # model must be persisted (non-null) on the DB row
+        assert task.model is not None
+        assert len(task.model) > 0


### PR DESCRIPTION
## Summary

- **Auto-selection in `assign_task`**: When `model` is omitted, the handler now calls `select_model_tier(phase, tool)` to get the appropriate tier (cheap/standard/powerful), then `get_providers_from_db(db)` to load the worker's provider catalog, then `get_model_for_tier(tier, provider, catalog)` to pick the best available model. Previously it just picked the first catalog entry for the provider with no tier awareness.
- **Explicit override preserved**: If `model` is supplied by the caller it skips auto-selection and validates the model exists in the catalog (existing behavior, unchanged).
- **Model persisted on task row**: The resolved model is stored in the existing `tasks.model` column (added in migration `20260601_000000_add_model_provider_to_tasks.py` — no new migration needed).
- **Tool schema updated**: The `assign_task` tool's `model` field description now documents that omitting it triggers auto-selection based on phase/tool tier.
- **Test helper**: Added `provider` parameter to `insert_worker` in `tests/helpers.py` to support seeding workers with a declared provider.
- **Integration tests** (`test_assign_task_auto_model.py`): Four tests covering execute-phase auto-selection (standard tier → sonnet), review-phase auto-selection (cheap tier → haiku), explicit override preservation, and DB row persistence.

## Test plan

- [x] `cd backend && python -m pytest tests/test_model_tiers.py tests/test_foreman_runner.py -v` — 38 tests pass
- [x] `ruff check . && ruff format --check .` — clean
- [ ] `cd backend && python -m pytest tests/test_assign_task_auto_model.py` — requires `docker compose up -d postgres-test`

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)