### PR TITLE
Bedrock model ID format: resolve ARNs (#698)

### DIFF
--- a/backend/alembic/versions/20260701_000002_add_bedrock_model_id_to_catalog.py
+++ b/backend/alembic/versions/20260701_000002_add_bedrock_model_id_to_catalog.py
@@ -1,0 +1,34 @@
+"""Add bedrock_model_id column to model_catalog.
+
+Revision ID: 20260701_000002_add_bedrock_model_id_to_catalog
+Revises: 20260701_000001_add_provider_tool_to_workers
+Create Date: 2026-07-01
+
+Stores the canonical AWS Bedrock model ID or cross-region inference profile
+ARN (e.g. ``us.anthropic.claude-sonnet-4-6-20251001-v1:0``) alongside the
+short models.dev model_id.  NULL until the Bedrock enricher successfully
+resolves the ID (requires AWS credentials at catalog refresh time).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260701_000002_add_bedrock_model_id_to_catalog"
+down_revision: str | Sequence[str] | None = "20260701_000001_add_provider_tool_to_workers"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "model_catalog",
+        sa.Column("bedrock_model_id", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("model_catalog", "bedrock_model_id")

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -981,6 +981,30 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             default_model = catalog_default.one_or_none()
                             if default_model:
                                 model = default_model
+                    # For Bedrock workers, resolve the short model ID to the
+                    # canonical inference-profile ARN stored in the catalog.
+                    # The Claude CLI on Bedrock requires the full ARN; short IDs
+                    # from models.dev are rejected by the InvokeModel API.
+                    if worker_provider == "bedrock" and model and not is_error:
+                        from models import ModelCatalog  # noqa: PLC0415
+
+                        bedrock_id_result = await db.exec(
+                            select(col(ModelCatalog.bedrock_model_id)).where(
+                                col(ModelCatalog.provider) == "bedrock",
+                                col(ModelCatalog.model_id) == model,
+                            )
+                        )
+                        resolved = bedrock_id_result.one_or_none()
+                        if resolved:
+                            model = resolved
+                        else:
+                            logger.warning(
+                                "assign_task: no Bedrock ARN for model %r "
+                                "(catalog may need a refresh with AWS credentials configured) "
+                                "— using short ID as fallback; worker may fail at inference time",
+                                model,
+                            )
+
                     if requested_tool is None:
                         tool = worker_tools[0] if worker_tools else "claude"
                     elif worker_tools and requested_tool not in worker_tools:

--- a/backend/models.py
+++ b/backend/models.py
@@ -534,3 +534,7 @@ class ModelCatalog(SQLModel, table=True):
     capabilities: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     raw: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     fetched_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    # Canonical AWS Bedrock model ID or cross-region inference profile ARN
+    # (e.g. "us.anthropic.claude-sonnet-4-6-20251001-v1:0"). NULL until the
+    # Bedrock enricher resolves it (requires AWS credentials at catalog refresh).
+    bedrock_model_id: str | None = Field(default=None, sa_column=Column(Text, nullable=True))

--- a/backend/tests/test_bedrock_enricher.py
+++ b/backend/tests/test_bedrock_enricher.py
@@ -1,0 +1,174 @@
+"""Tests for the Bedrock model ID enricher."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from util.bedrock_enricher import _extract_short_id, build_bedrock_model_map
+
+# ---------------------------------------------------------------------------
+# _extract_short_id
+# ---------------------------------------------------------------------------
+
+
+def test_extract_short_id_foundation_model():
+    assert _extract_short_id("anthropic.claude-sonnet-4-6-20251001-v1:0") == "claude-sonnet-4-6"
+
+
+def test_extract_short_id_us_inference_profile():
+    assert _extract_short_id("us.anthropic.claude-sonnet-4-6-20251001-v1:0") == "claude-sonnet-4-6"
+
+
+def test_extract_short_id_eu_inference_profile():
+    assert _extract_short_id("eu.anthropic.claude-opus-4-8-20250514-v1:0") == "claude-opus-4-8"
+
+
+def test_extract_short_id_ap_inference_profile():
+    # The date suffix (-20251001) is stripped; the short slug is claude-haiku-4-5
+    assert _extract_short_id("ap.anthropic.claude-haiku-4-5-20251001-v1:0") == "claude-haiku-4-5"
+
+
+def test_extract_short_id_no_match_returns_none():
+    # Unrecognised format — no date+version suffix
+    assert _extract_short_id("not-a-real-id") is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(foundation_models=None, inference_profiles=None):
+    client = MagicMock()
+    client.list_foundation_models.return_value = {"modelSummaries": foundation_models or []}
+    client.list_inference_profiles.return_value = {
+        "inferenceProfileSummaries": inference_profiles or []
+    }
+    return client
+
+
+# ---------------------------------------------------------------------------
+# build_bedrock_model_map — success path
+# ---------------------------------------------------------------------------
+
+
+def test_build_bedrock_model_map_foundation_models_only():
+    client = _make_client(
+        foundation_models=[
+            {"modelId": "anthropic.claude-sonnet-4-6-20251001-v1:0"},
+            {"modelId": "anthropic.claude-opus-4-8-20250514-v1:0"},
+        ]
+    )
+    # boto3 is imported inside the function; patch the cached module attribute.
+    with patch("boto3.client", return_value=client):
+        result = build_bedrock_model_map()
+
+    assert result["claude-sonnet-4-6"] == "anthropic.claude-sonnet-4-6-20251001-v1:0"
+    assert result["claude-opus-4-8"] == "anthropic.claude-opus-4-8-20250514-v1:0"
+
+
+def test_build_bedrock_model_map_inference_profiles_override_foundation():
+    """Cross-region inference profiles (us.*) must override foundation model IDs."""
+    client = _make_client(
+        foundation_models=[
+            {"modelId": "anthropic.claude-sonnet-4-6-20251001-v1:0"},
+        ],
+        inference_profiles=[
+            {"inferenceProfileId": "us.anthropic.claude-sonnet-4-6-20251001-v1:0"},
+        ],
+    )
+    with patch("boto3.client", return_value=client):
+        result = build_bedrock_model_map()
+
+    assert result["claude-sonnet-4-6"] == "us.anthropic.claude-sonnet-4-6-20251001-v1:0"
+
+
+def test_build_bedrock_model_map_non_us_profiles_not_overridden():
+    """eu.* profiles are not indexed; only us.* profiles are stored."""
+    client = _make_client(
+        foundation_models=[
+            {"modelId": "anthropic.claude-sonnet-4-6-20251001-v1:0"},
+        ],
+        inference_profiles=[
+            # eu.* should be ignored; us.* should be indexed
+            {"inferenceProfileId": "eu.anthropic.claude-sonnet-4-6-20251001-v1:0"},
+            {"inferenceProfileId": "us.anthropic.claude-sonnet-4-6-20251001-v1:0"},
+        ],
+    )
+    with patch("boto3.client", return_value=client):
+        result = build_bedrock_model_map()
+
+    assert result["claude-sonnet-4-6"] == "us.anthropic.claude-sonnet-4-6-20251001-v1:0"
+
+
+def test_build_bedrock_model_map_empty_responses():
+    client = _make_client()
+    with patch("boto3.client", return_value=client):
+        result = build_bedrock_model_map()
+
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# build_bedrock_model_map — graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_build_bedrock_model_map_no_credentials():
+    """Missing AWS credentials must return an empty dict without raising."""
+    from botocore.exceptions import NoCredentialsError
+
+    client = MagicMock()
+    client.list_foundation_models.side_effect = NoCredentialsError()
+
+    with patch("boto3.client", return_value=client):
+        result = build_bedrock_model_map()
+
+    assert result == {}
+
+
+def test_build_bedrock_model_map_client_creation_fails():
+    """Failure to create the boto3 client must return an empty dict."""
+    with patch("boto3.client", side_effect=Exception("region not configured")):
+        result = build_bedrock_model_map()
+
+    assert result == {}
+
+
+def test_build_bedrock_model_map_inference_profiles_fail_gracefully():
+    """list_inference_profiles error must not prevent returning foundation model IDs."""
+    client = _make_client(
+        foundation_models=[
+            {"modelId": "anthropic.claude-sonnet-4-6-20251001-v1:0"},
+        ]
+    )
+    client.list_inference_profiles.side_effect = Exception("access denied")
+
+    with patch("boto3.client", return_value=client):
+        result = build_bedrock_model_map()
+
+    # Falls back to foundation model IDs when inference profiles can't be fetched
+    assert result["claude-sonnet-4-6"] == "anthropic.claude-sonnet-4-6-20251001-v1:0"
+
+
+def test_build_bedrock_model_map_boto3_import_error():
+    """ImportError for boto3 must return an empty dict."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "boto3":
+            raise ImportError("No module named 'boto3'")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        result = build_bedrock_model_map()
+
+    assert result == {}

--- a/backend/util/bedrock_enricher.py
+++ b/backend/util/bedrock_enricher.py
@@ -1,0 +1,118 @@
+"""Resolve models.dev short model IDs to AWS Bedrock inference-profile ARNs.
+
+Investigation finding: the Claude CLI on Bedrock does NOT accept the short
+model ID from models.dev (e.g. ``claude-sonnet-4-6``).  AWS Bedrock's
+InvokeModel API requires either:
+  - A foundation model ID:  ``anthropic.claude-sonnet-4-6-20251001-v1:0``
+  - A cross-region inference profile ARN: ``us.anthropic.claude-sonnet-4-6-20251001-v1:0``
+
+Cross-region inference profiles (``us.*`` prefix) are preferred because they
+route to the nearest available region within the geographic area, giving
+higher throughput and availability.
+
+This module fetches both lists from the AWS API and returns a mapping so the
+catalog persistence layer can store the resolved ID alongside the short ID.
+When AWS credentials are absent the module logs a warning and returns an
+empty mapping — startup is never blocked, and workers will see the short ID
+as a fallback (which may fail at inference time).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_short_id(model_id: str) -> str | None:
+    """Extract a models.dev-style short ID from a Bedrock model/profile ID.
+
+    Examples::
+
+        "anthropic.claude-sonnet-4-6-20251001-v1:0"    -> "claude-sonnet-4-6"
+        "us.anthropic.claude-sonnet-4-6-20251001-v1:0" -> "claude-sonnet-4-6"
+        "eu.anthropic.claude-opus-4-8-20250514-v1:0"   -> "claude-opus-4-8"
+    """
+    stripped = model_id
+    # Strip geographic prefix (us., eu., ap.)
+    stripped = re.sub(r"^(?:us|eu|ap)\.", "", stripped)
+    # Strip provider prefix (e.g. "anthropic.")
+    stripped = re.sub(r"^[a-z]+\.", "", stripped)
+    # Match <model-slug>-YYYYMMDD-vN:M and extract just the slug.
+    m = re.match(r"^(claude[-\w]+?)-\d{8}-v\d+:\d+$", stripped)
+    if m:
+        return m.group(1)
+    return None
+
+
+def build_bedrock_model_map() -> dict[str, str]:
+    """Return ``{short_id: bedrock_arn}`` using live AWS Bedrock API calls.
+
+    Calls ``list_foundation_models`` and ``list_inference_profiles``
+    synchronously (boto3 is a sync library).  Cross-region inference profiles
+    (``us.*`` prefix) override plain foundation model IDs when both exist for
+    the same short ID.
+
+    Returns an empty dict when:
+    - boto3 is not installed (should not happen — it's a declared dependency)
+    - AWS credentials are absent or insufficient
+    - any unexpected error occurs
+
+    All failures are logged as warnings rather than raised.
+    """
+    try:
+        import boto3
+        from botocore.exceptions import NoCredentialsError
+    except ImportError:
+        logger.warning(
+            "bedrock_enricher: boto3 not installed — Bedrock model IDs will not be resolved"
+        )
+        return {}
+
+    try:
+        client = boto3.client("bedrock")
+    except Exception as exc:
+        logger.warning("bedrock_enricher: failed to create Bedrock client (%s) — skipping", exc)
+        return {}
+
+    mapping: dict[str, str] = {}
+
+    # Step 1: foundation model IDs (e.g. "anthropic.claude-sonnet-4-6-20251001-v1:0").
+    try:
+        response = client.list_foundation_models(byProvider="Anthropic")
+        for entry in response.get("modelSummaries", []):
+            mid = entry.get("modelId", "")
+            short = _extract_short_id(mid)
+            if short:
+                mapping[short] = mid
+    except NoCredentialsError:
+        logger.warning(
+            "bedrock_enricher: no AWS credentials configured — "
+            "Bedrock model IDs will not be resolved; workers using the bedrock "
+            "provider will fall back to the short model ID and may fail at runtime"
+        )
+        return {}
+    except Exception as exc:
+        logger.warning("bedrock_enricher: list_foundation_models failed (%s) — skipping", exc)
+        return {}
+
+    # Step 2: cross-region inference profiles override foundation model IDs.
+    # These are preferred because they route across regions for higher availability.
+    try:
+        response = client.list_inference_profiles()
+        for profile in response.get("inferenceProfileSummaries", []):
+            pid = profile.get("inferenceProfileId", "")
+            if pid.startswith("us."):
+                short = _extract_short_id(pid)
+                if short:
+                    mapping[short] = pid
+    except Exception as exc:
+        logger.warning(
+            "bedrock_enricher: list_inference_profiles failed (%s) — "
+            "falling back to foundation model IDs",
+            exc,
+        )
+
+    logger.info("bedrock_enricher: resolved %d model ID(s)", len(mapping))
+    return mapping

--- a/backend/util/models_dev.py
+++ b/backend/util/models_dev.py
@@ -10,6 +10,7 @@ reads those rows back and reconstructs the provider list used by ``GET /api/mode
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import UTC, datetime, timedelta
@@ -130,8 +131,16 @@ async def fetch_providers(*, force: bool = False) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-async def _upsert_catalog(db: AsyncSession, raw_data: dict[str, Any]) -> int:
+async def _upsert_catalog(
+    db: AsyncSession,
+    raw_data: dict[str, Any],
+    bedrock_model_map: dict[str, str] | None = None,
+) -> int:
     """Upsert supported-provider model rows from a raw models.dev API response.
+
+    *bedrock_model_map* is an optional ``{short_id: bedrock_arn}`` mapping
+    produced by the Bedrock enricher.  When provided, Bedrock rows are
+    enriched with the canonical AWS model ID or inference-profile ARN.
 
     Returns the number of rows upserted. Does NOT commit — callers decide when
     to commit so they can batch with other writes.
@@ -154,14 +163,19 @@ async def _upsert_catalog(db: AsyncSession, raw_data: dict[str, Any]) -> int:
             if not isinstance(m, dict):
                 continue
             capabilities = {k: v for k, v in m.items() if k not in ("id", "name")} or None
+            short_id = m.get("id", mid)
+            bedrock_model_id: str | None = None
+            if normalized == "bedrock" and bedrock_model_map:
+                bedrock_model_id = bedrock_model_map.get(short_id)
             rows.append(
                 {
                     "provider": normalized,
-                    "model_id": m.get("id", mid),
+                    "model_id": short_id,
                     "display_name": m.get("name", mid),
                     "capabilities": capabilities,
                     "raw": m,
                     "fetched_at": now,
+                    "bedrock_model_id": bedrock_model_id,
                 }
             )
     if not rows:
@@ -175,6 +189,7 @@ async def _upsert_catalog(db: AsyncSession, raw_data: dict[str, Any]) -> int:
             "capabilities": stmt.excluded.capabilities,
             "raw": stmt.excluded.raw,
             "fetched_at": stmt.excluded.fetched_at,
+            "bedrock_model_id": stmt.excluded.bedrock_model_id,
         },
     )
     await db.execute(stmt)
@@ -239,7 +254,24 @@ async def refresh_model_catalog_if_stale(db: AsyncSession, *, max_age_hours: int
             resp = await client.get(MODELS_DEV_URL)
             resp.raise_for_status()
             data = resp.json()
-        count = await _upsert_catalog(db, data)
+
+        # Enrich Bedrock rows with canonical model IDs / inference-profile ARNs
+        # when AWS credentials are available.  Failures are non-fatal.
+        bedrock_map: dict[str, str] = {}
+        has_bedrock = any(
+            _PROVIDER_ALIASES.get(pid) == "bedrock"
+            for pid, entry in data.items()
+            if isinstance(entry, dict) and entry.get("models")
+        )
+        if has_bedrock:
+            from util.bedrock_enricher import build_bedrock_model_map
+
+            try:
+                bedrock_map = await asyncio.to_thread(build_bedrock_model_map)
+            except Exception as exc:
+                logger.warning("models.dev: Bedrock enrichment failed (%s) — skipping", exc)
+
+        count = await _upsert_catalog(db, data, bedrock_model_map=bedrock_map or None)
         providers = _parse_response(data)
         if providers:
             global _cached_providers, _cache_fetched_at


### PR DESCRIPTION
## Summary

- **Investigation**: The Claude CLI on Bedrock rejects the short model IDs from models.dev (e.g. `claude-sonnet-4-6`). AWS Bedrock's InvokeModel API requires either a foundation model ID (`anthropic.claude-sonnet-4-6-20251001-v1:0`) or a cross-region inference profile ARN (`us.anthropic.claude-sonnet-4-6-20251001-v1:0`). This finding is documented in a module-level comment in `bedrock_enricher.py`.

- **Bedrock enrichment service** (`backend/util/bedrock_enricher.py`): calls `list_foundation_models` and `list_inference_profiles` via boto3 (sync, blocking). Cross-region inference profiles (`us.*`) are preferred over plain foundation model IDs for better availability. Returns `{short_id: arn}`.

- **Catalog integration** (`ModelCatalog.bedrock_model_id`): new migration (`20260701_000002`) adds a nullable `bedrock_model_id` column; `refresh_model_catalog_if_stale` runs the enricher in a thread and stores the resolved ARN when refreshing the catalog.

- **`assign_task` plumbing** (`backend/foreman/tools.py`): when the selected worker uses the `bedrock` provider, the resolved `bedrock_model_id` is substituted for the short model ID before the task is written and the `task-assigned` message is broadcast. Falls back to the short ID with a warning when no resolved ID is found.

- **Graceful degradation**: if AWS credentials are absent, `build_bedrock_model_map` logs a warning and returns `{}`. No errors are raised; the system starts cleanly.

## Test plan

- [x] `backend/tests/test_bedrock_enricher.py` — 13 tests: `_extract_short_id` for foundation models and all region prefixes; `build_bedrock_model_map` success path (foundation models only; inference profiles override foundation IDs; non-`us.*` profiles are not indexed); graceful degradation (no credentials, client creation failure, inference-profile list failure, boto3 not installed)
- [x] All existing `test_models_dev.py` and `test_model_tiers.py` tests pass
- [x] `ruff check . --fix && ruff format .` applied

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)