### PR TITLE
Fix CI: backend test on PR #699 (auto-select model) v6

### DIFF
--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -740,6 +740,7 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
             event_ids = [r[0] for r in rows]
             queued_payloads = [json.loads(r[1]) for r in rows]
             await ctx.db.exec(delete(TaskEvent).where(TaskEvent.id.in_(event_ids)))
+            await ctx.db.commit()
         worker_id_upd = data.get("workerId", "a worker")
         task_uid = await _task_user_id(ctx.db, task_id)
         if queued_payloads:


### PR DESCRIPTION
## Summary

- Adds missing `await ctx.db.commit()` after the `DELETE` of `pending-followup` `TaskEvent` rows when a task transitions to `error` state in `backend/ws_handlers.py`
- Without the commit, the DELETE is not persisted, so `test_error_state_releases_lock_and_drains_followups` correctly detects the events remain after the transition

## Root cause

In `ws_handlers.py` `handle_task_update()`, the drain block at ~line 742 executes `ctx.db.exec(delete(...))` but never called `ctx.db.commit()` to flush the transaction. The task state commit happens earlier (line ~725), but the subsequent DELETE was left uncommitted.

## Test plan

- [ ] CI runs `test_error_state_releases_lock_and_drains_followups` and passes
- [ ] No other tests regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)