### PR TITLE
Tasks pane: keep done tasks with open PRs (#702)

### DIFF
--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -230,6 +230,82 @@ describe('useTasksStore', () => {
       expect(ids).not.toContain('t-past')
     })
 
+    it('done task with no pr_url is removed when timer fires', () => {
+      const store = useTasksStore()
+      store.tasks.push({ id: 't-1', state: 'done' })
+
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        deletedAt: new Date(Date.now() + 1_000).toISOString(),
+      })
+
+      vi.advanceTimersByTime(2_000)
+      expect(store.tasks).toHaveLength(0)
+    })
+
+    it('done task with pr_url is NOT removed when timer would fire', () => {
+      const store = useTasksStore()
+      store.tasks.push({ id: 't-1', state: 'done', pr_url: 'https://github.com/x/y/pull/1' })
+
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        deletedAt: new Date(Date.now() + 1_000).toISOString(),
+      })
+
+      vi.advanceTimersByTime(2_000)
+      expect(store.tasks).toHaveLength(1)
+    })
+
+    it('cancelled task with pr_url is NOT removed when timer would fire', () => {
+      const store = useTasksStore()
+      store.tasks.push({ id: 't-1', state: 'cancelled', pr_url: 'https://github.com/x/y/pull/2' })
+
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        deletedAt: new Date(Date.now() + 1_000).toISOString(),
+      })
+
+      vi.advanceTimersByTime(2_000)
+      expect(store.tasks).toHaveLength(1)
+    })
+
+    it('liveTasks keeps tasks with pr_url even when deleted_at has passed', () => {
+      const store = useTasksStore()
+      const past = new Date(Date.now() - 5_000).toISOString()
+      store.tasks.push({ id: 't-with-pr', state: 'done', deleted_at: past, pr_url: 'https://github.com/x/y/pull/3' })
+      store.tasks.push({ id: 't-no-pr', state: 'done', deleted_at: past })
+
+      const ids = store.liveTasks.map((t) => t.id)
+      expect(ids).toContain('t-with-pr')
+      expect(ids).not.toContain('t-no-pr')
+    })
+
+    it('receiving prUrl on task-update cancels any pending expiry timer', () => {
+      const store = useTasksStore()
+      store.tasks.push({ id: 't-1', state: 'done' })
+
+      // First, schedule expiry
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        deletedAt: new Date(Date.now() + 5_000).toISOString(),
+      })
+      expect(store.tasks).toHaveLength(1)
+
+      // Then, PR is opened — should cancel the expiry timer
+      store.handleWebSocketMessage({
+        type: 'task-update',
+        taskId: 't-1',
+        prUrl: 'https://github.com/x/y/pull/4',
+      })
+
+      vi.advanceTimersByTime(10_000)
+      expect(store.tasks).toHaveLength(1)
+    })
+
     it('clearTasks cancels pending expiry timers', () => {
       const store = useTasksStore()
       store.tasks.push({ id: 't-1', state: 'done' })

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -46,7 +46,11 @@ export const useTasksStore = defineStore('tasks', () => {
 
   function _removeTask(taskId: string) {
     const idx = tasks.value.findIndex((t) => t.id === taskId)
-    if (idx >= 0) tasks.value.splice(idx, 1)
+    if (idx >= 0) {
+      // Keep tasks with an open PR visible even after their soft-delete window elapses.
+      if (tasks.value[idx].pr_url) return
+      tasks.value.splice(idx, 1)
+    }
     delete taskLogs.value[taskId]
     closeTask(taskId)
     const timer = _expiryTimers.get(taskId)
@@ -63,6 +67,9 @@ export const useTasksStore = defineStore('tasks', () => {
       _expiryTimers.delete(taskId)
     }
     if (!deletedAt) return
+    // Tasks with an open PR stay visible regardless of their soft-delete window.
+    const task = tasks.value.find((t) => t.id === taskId)
+    if (task?.pr_url) return
     const delay = new Date(deletedAt).getTime() - Date.now()
     if (Number.isNaN(delay)) return
     if (delay <= 0) {
@@ -179,7 +186,15 @@ export const useTasksStore = defineStore('tasks', () => {
       if (task) {
         if (data.state) task.state = data.state
         if (data.branch) task.branch = data.branch
-        if (data.prUrl) task.pr_url = data.prUrl
+        if (data.prUrl) {
+          task.pr_url = data.prUrl
+          // Cancel any pending expiry — this task now has an open PR and must stay visible.
+          const existing = _expiryTimers.get(task.id)
+          if (existing) {
+            clearTimeout(existing)
+            _expiryTimers.delete(task.id)
+          }
+        }
         if (data.worktreePath) task.worktree_path = data.worktreePath
         if (data.deletedAt !== undefined) {
           task.deleted_at = data.deletedAt
@@ -238,6 +253,7 @@ export const useTasksStore = defineStore('tasks', () => {
   const liveTasks = computed(() => {
     const now = Date.now()
     return tasks.value.filter((t) => {
+      if (t.pr_url) return true
       if (!t.deleted_at) return true
       const ts = new Date(t.deleted_at).getTime()
       return Number.isNaN(ts) || ts > now


### PR DESCRIPTION
## Summary

- Tasks in terminal states (`done`, `cancelled`, `failed`) are now kept visible in the tasks pane when they have a `pr_url` set, so engineers can still review and merge them.
- Tasks with no PR and a terminal state continue to expire and disappear as before.

## Changes

**`frontend/src/stores/tasks.ts`**
- `_scheduleExpiry`: skips scheduling if the task already has a `pr_url`
- `handleWebSocketMessage` (task-update): cancels any pending expiry timer when `prUrl` is received
- `_removeTask`: safety-net guard — returns early if the task has `pr_url` (covers the race where a timer was queued before the PR was set)
- `liveTasks`: adds `|| t.pr_url` so tasks with an open PR are never filtered out by the computed

**`frontend/src/stores/__tests__/tasks.spec.ts`**
- `done` + no `pr_url` → removed when timer fires ✓
- `done` + `pr_url` → NOT removed when timer fires ✓
- `cancelled` + `pr_url` → NOT removed when timer fires ✓
- `liveTasks` keeps tasks with `pr_url` even after `deleted_at` passes ✓
- Receiving `prUrl` on `task-update` cancels a pending expiry timer ✓

## Test plan

- [x] Frontend unit tests: 108 passed (5 new tests added)
- [ ] Backend tests: covered by CI

Closes #702