### PR TITLE
Issues tab: open-only count + remove duplicate (#704)

### DIFF
--- a/frontend/src/components/GuildSidebar.vue
+++ b/frontend/src/components/GuildSidebar.vue
@@ -23,7 +23,7 @@
         @click="activeTab = 'issues'"
       >
         <span class="tab-label">Issues</span>
-        <span v-if="ghStore.issues.length" class="tab-count">{{ ghStore.issues.length }}</span>
+        <span v-if="openIssueCount" class="tab-count">{{ openIssueCount }}</span>
       </button>
     </div>
 
@@ -65,6 +65,7 @@ const switchMobileTab = inject<(tab: string) => void>('switchMobileTab', () => {
 
 const isConnected = computed(() => guildStore.isConnected)
 const workerCount = computed(() => agentsStore.workers.filter((w) => w.state !== 'offline').length)
+const openIssueCount = computed(() => ghStore.issues.filter((i) => i.state === 'open').length)
 const activeTab = ref<'tasks' | 'workers' | 'issues'>('tasks')
 
 onMounted(async () => {

--- a/frontend/src/components/chat-pane/IssuesTab.vue
+++ b/frontend/src/components/chat-pane/IssuesTab.vue
@@ -7,7 +7,6 @@
     >
       {{ ghStore.loading ? '...' : '↻' }}
     </button>
-    <span class="issues-count">{{ openIssues.length }} issue{{ openIssues.length !== 1 ? 's' : '' }}</span>
     <span class="issues-repos">{{
       guildStore.currentGuild?.primary_repo ??
       ghStore.selectedRepos.length + ' repo' + (ghStore.selectedRepos.length !== 1 ? 's' : '')
@@ -113,11 +112,6 @@ onUnmounted(() => {
 .refresh-btn:disabled {
   opacity: 0.4;
   pointer-events: none;
-}
-
-.issues-count {
-  font-size: 11px;
-  color: var(--color-text-dim);
 }
 
 .issues-repos {


### PR DESCRIPTION
## Summary

- **Wrong count fixed**: The Issues tab badge in the sidebar (`GuildSidebar.vue`) was using `ghStore.issues.length`, which counted all issues including closed ones. It now uses a computed `openIssueCount` that filters for `state === 'open'`.
- **Duplicate count removed**: `IssuesTab.vue` had an `"N issues"` span in the toolbar that duplicated the number already shown on the tab badge. This span (and its CSS rule) has been removed. The toolbar still shows the refresh button and the repo name on the right.

## Test plan

- [ ] Open a guild with a configured GitHub token; verify the Issues tab badge shows only the count of open issues
- [ ] Click the Issues tab and confirm the toolbar no longer shows a redundant "N issues" label
- [ ] All 103 frontend unit tests pass (`npm test`)
- [ ] TypeScript type-check passes (`npm run type-check`)

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)