### PR TITLE
Fix guild tasks/tree: return real issue state

### DIFF
--- a/backend/alembic/versions/20260701_000003_add_issue_state_to_tasks.py
+++ b/backend/alembic/versions/20260701_000003_add_issue_state_to_tasks.py
@@ -1,0 +1,36 @@
+"""Add issue_state column to tasks table.
+
+Revision ID: 20260701_000003_add_issue_state_to_tasks
+Revises: 20260701_000002_add_bedrock_model_id_to_catalog
+Create Date: 2026-07-01
+
+Caches the GitHub issue state ("open" or "closed") on each task row so the
+tasks/tree endpoint can return the real state without a GitHub API call when
+the guild owner's token is unavailable or the API is unreachable.  NULL means
+the state has not been fetched yet; the tree endpoint writes it back after a
+successful GitHub API response, and the webhook handler keeps it current when
+issue opened/closed/reopened events arrive.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260701_000003_add_issue_state_to_tasks"
+down_revision: str | Sequence[str] | None = "20260701_000002_add_bedrock_model_id_to_catalog"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tasks",
+        sa.Column("issue_state", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tasks", "issue_state")

--- a/backend/alembic/versions/20260701_000003_add_issue_state_to_tasks.py
+++ b/backend/alembic/versions/20260701_000003_add_issue_state_to_tasks.py
@@ -1,15 +1,15 @@
-"""Add issue_state column to tasks table.
+"""Add issue_state and issue_title columns to tasks table.
 
 Revision ID: 20260701_000003_add_issue_state_to_tasks
 Revises: 20260701_000002_add_bedrock_model_id_to_catalog
 Create Date: 2026-07-01
 
-Caches the GitHub issue state ("open" or "closed") on each task row so the
-tasks/tree endpoint can return the real state without a GitHub API call when
-the guild owner's token is unavailable or the API is unreachable.  NULL means
-the state has not been fetched yet; the tree endpoint writes it back after a
-successful GitHub API response, and the webhook handler keeps it current when
-issue opened/closed/reopened events arrive.
+Caches the GitHub issue state ("open" or "closed") and title on each task row
+so the tasks/tree endpoint can return the real state/title without a GitHub API
+call when the guild owner's token is unavailable or the API is unreachable.
+NULL means the value has not been fetched yet; the tree endpoint writes them
+back after a successful GitHub API response, and the webhook handler keeps them
+current when issue opened/closed/reopened/edited events arrive.
 """
 
 from __future__ import annotations
@@ -30,7 +30,12 @@ def upgrade() -> None:
         "tasks",
         sa.Column("issue_state", sa.Text(), nullable=True),
     )
+    op.add_column(
+        "tasks",
+        sa.Column("issue_title", sa.Text(), nullable=True),
+    )
 
 
 def downgrade() -> None:
+    op.drop_column("tasks", "issue_title")
     op.drop_column("tasks", "issue_state")

--- a/backend/models.py
+++ b/backend/models.py
@@ -183,6 +183,7 @@ class Task(SQLModel, table=True):
     issue_number: int | None = None
     issue_repo: str | None = None
     issue_state: str | None = None
+    issue_title: str | None = None
     state: str = Field(default="pending", sa_column_kwargs={"server_default": "'pending'"})
     branch: str | None = None
     worktree_path: str | None = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -182,6 +182,7 @@ class Task(SQLModel, table=True):
     provider: str | None = None
     issue_number: int | None = None
     issue_repo: str | None = None
+    issue_state: str | None = None
     state: str = Field(default="pending", sa_column_kwargs={"server_default": "'pending'"})
     branch: str | None = None
     worktree_path: str | None = None

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -438,6 +438,7 @@ async def get_guild_tasks_tree(
             col(Task.pr_repo),
             col(Task.issue_number),
             col(Task.issue_repo),
+            col(Task.issue_state),
             col(Task.created_at),
             col(Task.deleted_at),
         )
@@ -514,23 +515,59 @@ async def get_guild_tasks_tree(
         else:
             ungrouped.append(task)
 
+    # --- Build DB-cached issue state fallback ---
+    # Each task in an issue group stores the last-known GitHub issue state so we
+    # can return the real state even when the GitHub API is unreachable or the
+    # guild owner has no token.  Any non-null value in the group is authoritative.
+    db_issue_states: dict[tuple[str, int], str] = {}
+    for key, group_tasks in issue_groups.items():
+        for task in group_tasks:
+            if task.get("issue_state"):
+                db_issue_states[key] = task["issue_state"]
+                break
+
     # --- Fetch issue metadata in parallel ---
     issue_info: dict[tuple[str, int], dict] = {}
+    # Track which keys were resolved via the GitHub API so we can write them back.
+    api_resolved: dict[tuple[str, int], str] = {}
     if issue_groups and gh_token:
         keys = list(issue_groups.keys())
         infos = await asyncio.gather(
             *[asyncio.to_thread(_gh_fetch_issue, repo, num, gh_token) for repo, num in keys]
         )
         for key, info in zip(keys, infos, strict=False):
-            issue_info[key] = info or {"title": f"#{key[1]}", "state": "open"}
+            if info:
+                issue_info[key] = info
+                api_resolved[key] = info["state"]
+            else:
+                db_state = db_issue_states.get(key, "open")
+                issue_info[key] = {"title": f"#{key[1]}", "state": db_state}
     else:
         for key in issue_groups:
-            issue_info[key] = {"title": f"#{key[1]}", "state": "open"}
+            db_state = db_issue_states.get(key, "open")
+            issue_info[key] = {"title": f"#{key[1]}", "state": db_state}
+
+    # Write back states fetched from GitHub API to the tasks table so future
+    # requests can fall back to the DB when the API is unavailable.
+    if api_resolved:
+        updates_by_state: dict[str, list[str]] = {}
+        for key, state in api_resolved.items():
+            for task in issue_groups[key]:
+                if task.get("issue_state") != state:
+                    updates_by_state.setdefault(state, []).append(task["id"])
+        if updates_by_state:
+            for state, task_ids in updates_by_state.items():
+                await db.exec(
+                    update(Task)
+                    .where(col(Task.id).in_(task_ids))
+                    .values(issue_state=state)
+                )
+            await db.commit()
 
     # --- Build response ---
     nodes = []
     for (repo, num), group_tasks in issue_groups.items():
-        info = issue_info.get((repo, num), {"title": f"#{num}", "state": "open"})
+        info = issue_info.get((repo, num), {"title": f"#{num}", "state": db_issue_states.get((repo, num), "open")})
         nodes.append(
             {
                 "type": "issue",

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -439,6 +439,7 @@ async def get_guild_tasks_tree(
             col(Task.issue_number),
             col(Task.issue_repo),
             col(Task.issue_state),
+            col(Task.issue_title),
             col(Task.created_at),
             col(Task.deleted_at),
         )
@@ -515,21 +516,25 @@ async def get_guild_tasks_tree(
         else:
             ungrouped.append(task)
 
-    # --- Build DB-cached issue state fallback ---
-    # Each task in an issue group stores the last-known GitHub issue state so we
-    # can return the real state even when the GitHub API is unreachable or the
-    # guild owner has no token.  Any non-null value in the group is authoritative.
+    # --- Build DB-cached issue state/title fallback ---
+    # Each task in an issue group stores the last-known GitHub issue state and
+    # title so we can return real values even when the GitHub API is unreachable
+    # or the guild owner has no token.  Any non-null value in the group is authoritative.
     db_issue_states: dict[tuple[str, int], str] = {}
+    db_issue_titles: dict[tuple[str, int], str] = {}
     for key, group_tasks in issue_groups.items():
         for task in group_tasks:
-            if task.get("issue_state"):
+            if task.get("issue_state") and key not in db_issue_states:
                 db_issue_states[key] = task["issue_state"]
+            if task.get("issue_title") and key not in db_issue_titles:
+                db_issue_titles[key] = task["issue_title"]
+            if key in db_issue_states and key in db_issue_titles:
                 break
 
     # --- Fetch issue metadata in parallel ---
     issue_info: dict[tuple[str, int], dict] = {}
     # Track which keys were resolved via the GitHub API so we can write them back.
-    api_resolved: dict[tuple[str, int], str] = {}
+    api_resolved: dict[tuple[str, int], dict] = {}
     if issue_groups and gh_token:
         keys = list(issue_groups.keys())
         infos = await asyncio.gather(
@@ -538,27 +543,37 @@ async def get_guild_tasks_tree(
         for key, info in zip(keys, infos, strict=False):
             if info:
                 issue_info[key] = info
-                api_resolved[key] = info["state"]
+                api_resolved[key] = info
             else:
                 db_state = db_issue_states.get(key, "open")
-                issue_info[key] = {"title": f"#{key[1]}", "state": db_state}
+                db_title = db_issue_titles.get(key, f"#{key[1]}")
+                issue_info[key] = {"title": db_title, "state": db_state}
     else:
         for key in issue_groups:
             db_state = db_issue_states.get(key, "open")
-            issue_info[key] = {"title": f"#{key[1]}", "state": db_state}
+            db_title = db_issue_titles.get(key, f"#{key[1]}")
+            issue_info[key] = {"title": db_title, "state": db_state}
 
-    # Write back states fetched from GitHub API to the tasks table so future
+    # Write back state+title fetched from GitHub API to the tasks table so future
     # requests can fall back to the DB when the API is unavailable.
     if api_resolved:
-        updates_by_state: dict[str, list[str]] = {}
-        for key, state in api_resolved.items():
+        tasks_to_update: list[tuple[str, str, str]] = []  # (task_id, state, title)
+        for key, info in api_resolved.items():
+            state = info["state"]
+            title = info["title"]
             for task in issue_groups[key]:
-                if task.get("issue_state") != state:
-                    updates_by_state.setdefault(state, []).append(task["id"])
-        if updates_by_state:
-            for state, task_ids in updates_by_state.items():
+                if task.get("issue_state") != state or task.get("issue_title") != title:
+                    tasks_to_update.append((task["id"], state, title))
+        if tasks_to_update:
+            # Group by (state, title) to minimize UPDATE statements
+            updates_by_values: dict[tuple[str, str], list[str]] = {}
+            for task_id, state, title in tasks_to_update:
+                updates_by_values.setdefault((state, title), []).append(task_id)
+            for (state, title), task_ids in updates_by_values.items():
                 await db.exec(
-                    update(Task).where(col(Task.id).in_(task_ids)).values(issue_state=state)
+                    update(Task)
+                    .where(col(Task.id).in_(task_ids))
+                    .values(issue_state=state, issue_title=title)
                 )
             await db.commit()
 
@@ -566,7 +581,11 @@ async def get_guild_tasks_tree(
     nodes = []
     for (repo, num), group_tasks in issue_groups.items():
         info = issue_info.get(
-            (repo, num), {"title": f"#{num}", "state": db_issue_states.get((repo, num), "open")}
+            (repo, num),
+            {
+                "title": db_issue_titles.get((repo, num), f"#{num}"),
+                "state": db_issue_states.get((repo, num), "open"),
+            },
         )
         nodes.append(
             {

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -558,16 +558,16 @@ async def get_guild_tasks_tree(
         if updates_by_state:
             for state, task_ids in updates_by_state.items():
                 await db.exec(
-                    update(Task)
-                    .where(col(Task.id).in_(task_ids))
-                    .values(issue_state=state)
+                    update(Task).where(col(Task.id).in_(task_ids)).values(issue_state=state)
                 )
             await db.commit()
 
     # --- Build response ---
     nodes = []
     for (repo, num), group_tasks in issue_groups.items():
-        info = issue_info.get((repo, num), {"title": f"#{num}", "state": db_issue_states.get((repo, num), "open")})
+        info = issue_info.get(
+            (repo, num), {"title": f"#{num}", "state": db_issue_states.get((repo, num), "open")}
+        )
         nodes.append(
             {
                 "type": "issue",

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -757,13 +757,17 @@ async def github_webhook(
         )
         await db.commit()
 
-    # Keep issue_state current on all tasks linked to this issue when GitHub
-    # sends an issues event (opened / closed / reopened).
-    if event_type == "issues" and action in ("opened", "closed", "reopened") and repo:
+    # Keep issue_state and issue_title current on all tasks linked to this issue
+    # when GitHub sends an issues event (opened / closed / reopened / edited).
+    if event_type == "issues" and action in ("opened", "closed", "reopened", "edited") and repo:
         issue_obj = payload.get("issue") or {}
         issue_num = issue_obj.get("number")
         if issue_num:
             new_issue_state = "closed" if action == "closed" else "open"
+            new_issue_title: str | None = issue_obj.get("title") or None
+            update_values: dict = {"issue_state": new_issue_state}
+            if new_issue_title:
+                update_values["issue_title"] = new_issue_title
             await db.exec(
                 update(Task)
                 .where(
@@ -771,12 +775,13 @@ async def github_webhook(
                     col(Task.issue_repo) == repo,
                     col(Task.issue_number) == issue_num,
                 )
-                .values(issue_state=new_issue_state)
+                .values(**update_values)
             )
             await db.commit()
             logger.info(
-                "github webhook updated issue_state=%s for issue %s#%s guild=%s",
+                "github webhook updated issue_state=%s issue_title=%r for issue %s#%s guild=%s",
                 new_issue_state,
+                new_issue_title,
                 repo,
                 issue_num,
                 guild_id,

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -757,6 +757,31 @@ async def github_webhook(
         )
         await db.commit()
 
+    # Keep issue_state current on all tasks linked to this issue when GitHub
+    # sends an issues event (opened / closed / reopened).
+    if event_type == "issues" and action in ("opened", "closed", "reopened") and repo:
+        issue_obj = payload.get("issue") or {}
+        issue_num = issue_obj.get("number")
+        if issue_num:
+            new_issue_state = "closed" if action == "closed" else "open"
+            await db.exec(
+                update(Task)
+                .where(
+                    col(Task.guild_id) == guild_pk,
+                    col(Task.issue_repo) == repo,
+                    col(Task.issue_number) == issue_num,
+                )
+                .values(issue_state=new_issue_state)
+            )
+            await db.commit()
+            logger.info(
+                "github webhook updated issue_state=%s for issue %s#%s guild=%s",
+                new_issue_state,
+                repo,
+                issue_num,
+                guild_id,
+            )
+
     # Deterministic lifecycle transitions: finalize on merge, fail on close-without-merge.
     # These happen directly — no AI decision needed for these clear-cut outcomes.
     if task_id and event_type == "pull_request" and action == "closed":

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -296,6 +296,7 @@ def insert_task(
     issue_number: int | None = None,
     issue_repo: str | None = None,
     issue_state: str | None = None,
+    issue_title: str | None = None,
     user_id: str | None = None,
 ) -> None:
     """Insert a task row for a guild."""
@@ -324,6 +325,7 @@ def insert_task(
                 issue_number=issue_number,
                 issue_repo=issue_repo,
                 issue_state=issue_state,
+                issue_title=issue_title,
                 user_id=user_id,
                 created_at=now,
             )

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -295,6 +295,7 @@ def insert_task(
     pr_repo: str | None = None,
     issue_number: int | None = None,
     issue_repo: str | None = None,
+    issue_state: str | None = None,
     user_id: str | None = None,
 ) -> None:
     """Insert a task row for a guild."""
@@ -322,6 +323,7 @@ def insert_task(
                 pr_repo=pr_repo,
                 issue_number=issue_number,
                 issue_repo=issue_repo,
+                issue_state=issue_state,
                 user_id=user_id,
                 created_at=now,
             )

--- a/backend/tests/test_tasks_tree.py
+++ b/backend/tests/test_tasks_tree.py
@@ -153,12 +153,24 @@ def test_tree_open_and_closed_issues_sorted_correctly(client):
 
     insert_worker(db_url, guild_id, "w-sort1", state="online")
     insert_task(
-        db_url, guild_id, "task-sort-open", worker_id="w-sort1",
-        state="pending", issue_number=10, issue_repo="org/repo", issue_state="open",
+        db_url,
+        guild_id,
+        "task-sort-open",
+        worker_id="w-sort1",
+        state="pending",
+        issue_number=10,
+        issue_repo="org/repo",
+        issue_state="open",
     )
     insert_task(
-        db_url, guild_id, "task-sort-closed", worker_id="w-sort1",
-        state="done", issue_number=5, issue_repo="org/repo", issue_state="closed",
+        db_url,
+        guild_id,
+        "task-sort-closed",
+        worker_id="w-sort1",
+        state="done",
+        issue_number=5,
+        issue_repo="org/repo",
+        issue_state="closed",
     )
 
     headers = _auth(db_url)
@@ -185,9 +197,13 @@ def test_tree_writes_back_api_state_to_db(client, monkeypatch):
 
     insert_worker(db_url, guild_id, "w-wb1", state="online")
     insert_task(
-        db_url, guild_id, "task-wb1",
-        worker_id="w-wb1", state="awaiting-review",
-        issue_number=7, issue_repo="org/repo",
+        db_url,
+        guild_id,
+        "task-wb1",
+        worker_id="w-wb1",
+        state="awaiting-review",
+        issue_number=7,
+        issue_repo="org/repo",
         issue_state=None,  # not yet cached
     )
 
@@ -216,9 +232,13 @@ def test_tree_api_failure_falls_back_to_db_state(client, monkeypatch):
 
     insert_worker(db_url, guild_id, "w-apifail1", state="online")
     insert_task(
-        db_url, guild_id, "task-apifail1",
-        worker_id="w-apifail1", state="done",
-        issue_number=55, issue_repo="org/repo",
+        db_url,
+        guild_id,
+        "task-apifail1",
+        worker_id="w-apifail1",
+        state="done",
+        issue_number=55,
+        issue_repo="org/repo",
         issue_state="closed",
     )
 
@@ -240,7 +260,11 @@ def test_tree_api_failure_falls_back_to_db_state(client, monkeypatch):
 def _make_issue_event(repo: str, number: int, action: str) -> bytes:
     payload = {
         "action": action,
-        "issue": {"number": number, "title": "Test issue", "state": action if action != "reopened" else "open"},
+        "issue": {
+            "number": number,
+            "title": "Test issue",
+            "state": action if action != "reopened" else "open",
+        },
         "repository": {"full_name": repo},
     }
     return json.dumps(payload).encode()
@@ -255,9 +279,13 @@ def test_webhook_issues_closed_updates_issue_state(client):
 
     insert_worker(db_url, guild_id, "w-wh-iss1", state="online")
     insert_task(
-        db_url, guild_id, "task-wh-iss1",
-        worker_id="w-wh-iss1", state="done",
-        issue_number=100, issue_repo="org/repo",
+        db_url,
+        guild_id,
+        "task-wh-iss1",
+        worker_id="w-wh-iss1",
+        state="done",
+        issue_number=100,
+        issue_repo="org/repo",
         issue_state="open",
     )
 
@@ -278,9 +306,13 @@ def test_webhook_issues_reopened_updates_issue_state(client):
 
     insert_worker(db_url, guild_id, "w-wh-iss2", state="online")
     insert_task(
-        db_url, guild_id, "task-wh-iss2",
-        worker_id="w-wh-iss2", state="done",
-        issue_number=101, issue_repo="org/repo",
+        db_url,
+        guild_id,
+        "task-wh-iss2",
+        worker_id="w-wh-iss2",
+        state="done",
+        issue_number=101,
+        issue_repo="org/repo",
         issue_state="closed",
     )
 
@@ -302,23 +334,35 @@ def test_webhook_issues_only_updates_matching_repo_and_number(client):
     insert_worker(db_url, guild_id, "w-wh-iss3", state="online")
     # Matching task
     insert_task(
-        db_url, guild_id, "task-wh-iss3-match",
-        worker_id="w-wh-iss3", state="done",
-        issue_number=200, issue_repo="org/repo",
+        db_url,
+        guild_id,
+        "task-wh-iss3-match",
+        worker_id="w-wh-iss3",
+        state="done",
+        issue_number=200,
+        issue_repo="org/repo",
         issue_state="open",
     )
     # Different issue number — must not be updated
     insert_task(
-        db_url, guild_id, "task-wh-iss3-other-num",
-        worker_id="w-wh-iss3", state="done",
-        issue_number=201, issue_repo="org/repo",
+        db_url,
+        guild_id,
+        "task-wh-iss3-other-num",
+        worker_id="w-wh-iss3",
+        state="done",
+        issue_number=201,
+        issue_repo="org/repo",
         issue_state="open",
     )
     # Different repo — must not be updated
     insert_task(
-        db_url, guild_id, "task-wh-iss3-other-repo",
-        worker_id="w-wh-iss3", state="done",
-        issue_number=200, issue_repo="org/other-repo",
+        db_url,
+        guild_id,
+        "task-wh-iss3-other-repo",
+        worker_id="w-wh-iss3",
+        state="done",
+        issue_number=200,
+        issue_repo="org/other-repo",
         issue_state="open",
     )
 

--- a/backend/tests/test_tasks_tree.py
+++ b/backend/tests/test_tasks_tree.py
@@ -1,0 +1,333 @@
+"""Tests for the GET /guilds/{guild_id}/tasks/tree endpoint.
+
+Covers:
+- Nodes return the real issue state from the DB cache when no GitHub token.
+- Nodes default to "open" when DB has no cached state.
+- Successful GitHub API calls write back issue_state to the DB.
+- GitHub `issues` webhook events keep issue_state current on linked tasks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (  # noqa: E402
+    _sync_session,
+    insert_guild,
+    insert_member,
+    insert_task,
+    insert_worker,
+    make_auth_token,
+    raw_conn,
+)
+from models import Guild, Task
+from sqlalchemy import select, update
+from sqlmodel import col
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth(db_url: str, user_id: str = "gh-user-test") -> dict:
+    token = make_auth_token(db_url, user_id=user_id, username=user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _guild_no_owner_token(db_url: str, guild_id: str) -> None:
+    """Insert a guild whose owner has no GitHub token.
+
+    The requesting user (gh-user-test) is added as a member, so the endpoint
+    is accessible but `gh_token` will be None because the owner has no token.
+    """
+    # owner-notokenuser gets created in users + guild_members(owner) but no github_tokens row
+    insert_guild(db_url, guild_id, owner_user_id="owner-notokenuser")
+    # Add the default test user as a member so they can call the endpoint
+    insert_member(db_url, guild_id, "gh-user-test", role="member")
+
+
+def _get_issue_state(db_url: str, task_id: str) -> str | None:
+    """Read issue_state for a task directly from the DB."""
+    with _sync_session(db_url) as session:
+        row = session.execute(
+            select(col(Task.issue_state)).where(col(Task.id) == task_id)
+        ).one_or_none()
+    return row[0] if row else None
+
+
+def _signed_headers(secret: str, body: bytes, *, event: str, delivery: str) -> dict:
+    sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return {
+        "X-GitHub-Event": event,
+        "X-GitHub-Delivery": delivery,
+        "X-Hub-Signature-256": f"sha256={sig}",
+        "Content-Type": "application/json",
+    }
+
+
+def _set_webhook_secret(db_url: str, guild_id: str, secret: str) -> None:
+    with _sync_session(db_url) as session:
+        session.execute(
+            update(Guild).where(col(Guild.slug) == guild_id).values(webhook_secret=secret)
+        )
+        session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tree endpoint — DB fallback (no GitHub token)
+# ---------------------------------------------------------------------------
+
+
+def test_tree_returns_closed_state_from_db_when_no_token(client):
+    """A task with issue_state='closed' in the DB returns state='closed' in the tree."""
+    test_client, db_url = client
+    guild_id = "tr-ntoken1"
+    _guild_no_owner_token(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-tr1", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-tr1",
+        worker_id="w-tr1",
+        state="done",
+        issue_number=42,
+        issue_repo="org/repo",
+        issue_state="closed",
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    nodes = data["nodes"]
+    assert len(nodes) == 1
+    node = nodes[0]
+    assert node["issue_number"] == 42
+    assert node["state"] == "closed", f"expected 'closed', got {node['state']!r}"
+
+
+def test_tree_defaults_to_open_when_no_token_and_no_db_state(client):
+    """A task with no cached issue_state returns state='open' (safe default)."""
+    test_client, db_url = client
+    guild_id = "tr-ntoken2"
+    _guild_no_owner_token(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-tr2", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-tr2",
+        worker_id="w-tr2",
+        state="pending",
+        issue_number=99,
+        issue_repo="org/repo",
+        issue_state=None,  # unknown — no prior fetch
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    nodes = data["nodes"]
+    assert len(nodes) == 1
+    assert nodes[0]["state"] == "open"
+
+
+def test_tree_open_and_closed_issues_sorted_correctly(client):
+    """Open issues appear before closed issues in the response."""
+    test_client, db_url = client
+    guild_id = "tr-sort1"
+    _guild_no_owner_token(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-sort1", state="online")
+    insert_task(
+        db_url, guild_id, "task-sort-open", worker_id="w-sort1",
+        state="pending", issue_number=10, issue_repo="org/repo", issue_state="open",
+    )
+    insert_task(
+        db_url, guild_id, "task-sort-closed", worker_id="w-sort1",
+        state="done", issue_number=5, issue_repo="org/repo", issue_state="closed",
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()["nodes"]
+    assert len(nodes) == 2
+    # Open issues should come first
+    assert nodes[0]["state"] == "open"
+    assert nodes[1]["state"] == "closed"
+
+
+# ---------------------------------------------------------------------------
+# Tree endpoint — GitHub API write-back
+# ---------------------------------------------------------------------------
+
+
+def test_tree_writes_back_api_state_to_db(client, monkeypatch):
+    """When _gh_fetch_issue returns a state, it is persisted to task.issue_state."""
+    test_client, db_url = client
+    guild_id = "tr-wb1"
+    # Use default setup: owner IS the test user who has a GitHub token
+    insert_guild(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-wb1", state="online")
+    insert_task(
+        db_url, guild_id, "task-wb1",
+        worker_id="w-wb1", state="awaiting-review",
+        issue_number=7, issue_repo="org/repo",
+        issue_state=None,  # not yet cached
+    )
+
+    # Patch the GitHub API call to return "closed"
+    monkeypatch.setattr(
+        "routes.tasks._gh_fetch_issue",
+        lambda repo, number, token: {"title": "Fix bug", "state": "closed"},
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()["nodes"]
+    assert nodes[0]["state"] == "closed"
+
+    # DB should now have the state cached
+    cached = _get_issue_state(db_url, "task-wb1")
+    assert cached == "closed", f"expected 'closed' cached in DB, got {cached!r}"
+
+
+def test_tree_api_failure_falls_back_to_db_state(client, monkeypatch):
+    """When _gh_fetch_issue returns None (API error), the DB-cached state is used."""
+    test_client, db_url = client
+    guild_id = "tr-apifail1"
+    insert_guild(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-apifail1", state="online")
+    insert_task(
+        db_url, guild_id, "task-apifail1",
+        worker_id="w-apifail1", state="done",
+        issue_number=55, issue_repo="org/repo",
+        issue_state="closed",
+    )
+
+    # Simulate a GitHub API failure
+    monkeypatch.setattr("routes.tasks._gh_fetch_issue", lambda repo, number, token: None)
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()["nodes"]
+    assert nodes[0]["state"] == "closed"
+
+
+# ---------------------------------------------------------------------------
+# Webhook handler — issues event updates issue_state
+# ---------------------------------------------------------------------------
+
+
+def _make_issue_event(repo: str, number: int, action: str) -> bytes:
+    payload = {
+        "action": action,
+        "issue": {"number": number, "title": "Test issue", "state": action if action != "reopened" else "open"},
+        "repository": {"full_name": repo},
+    }
+    return json.dumps(payload).encode()
+
+
+def test_webhook_issues_closed_updates_issue_state(client):
+    """A GitHub issues/closed webhook sets issue_state='closed' on linked tasks."""
+    test_client, db_url = client
+    guild_id = "wh-iss1"
+    insert_guild(db_url, guild_id)
+    _set_webhook_secret(db_url, guild_id, "wh-secret-1")
+
+    insert_worker(db_url, guild_id, "w-wh-iss1", state="online")
+    insert_task(
+        db_url, guild_id, "task-wh-iss1",
+        worker_id="w-wh-iss1", state="done",
+        issue_number=100, issue_repo="org/repo",
+        issue_state="open",
+    )
+
+    body = _make_issue_event("org/repo", 100, "closed")
+    headers = _signed_headers("wh-secret-1", body, event="issues", delivery="del-iss-001")
+    resp = test_client.post(f"/webhooks/github/{guild_id}", content=body, headers=headers)
+    assert resp.status_code in (200, 204), resp.text
+
+    assert _get_issue_state(db_url, "task-wh-iss1") == "closed"
+
+
+def test_webhook_issues_reopened_updates_issue_state(client):
+    """A GitHub issues/reopened webhook sets issue_state='open' on linked tasks."""
+    test_client, db_url = client
+    guild_id = "wh-iss2"
+    insert_guild(db_url, guild_id)
+    _set_webhook_secret(db_url, guild_id, "wh-secret-2")
+
+    insert_worker(db_url, guild_id, "w-wh-iss2", state="online")
+    insert_task(
+        db_url, guild_id, "task-wh-iss2",
+        worker_id="w-wh-iss2", state="done",
+        issue_number=101, issue_repo="org/repo",
+        issue_state="closed",
+    )
+
+    body = _make_issue_event("org/repo", 101, "reopened")
+    headers = _signed_headers("wh-secret-2", body, event="issues", delivery="del-iss-002")
+    resp = test_client.post(f"/webhooks/github/{guild_id}", content=body, headers=headers)
+    assert resp.status_code in (200, 204), resp.text
+
+    assert _get_issue_state(db_url, "task-wh-iss2") == "open"
+
+
+def test_webhook_issues_only_updates_matching_repo_and_number(client):
+    """Issue webhook only updates tasks in the same repo with the same issue number."""
+    test_client, db_url = client
+    guild_id = "wh-iss3"
+    insert_guild(db_url, guild_id)
+    _set_webhook_secret(db_url, guild_id, "wh-secret-3")
+
+    insert_worker(db_url, guild_id, "w-wh-iss3", state="online")
+    # Matching task
+    insert_task(
+        db_url, guild_id, "task-wh-iss3-match",
+        worker_id="w-wh-iss3", state="done",
+        issue_number=200, issue_repo="org/repo",
+        issue_state="open",
+    )
+    # Different issue number — must not be updated
+    insert_task(
+        db_url, guild_id, "task-wh-iss3-other-num",
+        worker_id="w-wh-iss3", state="done",
+        issue_number=201, issue_repo="org/repo",
+        issue_state="open",
+    )
+    # Different repo — must not be updated
+    insert_task(
+        db_url, guild_id, "task-wh-iss3-other-repo",
+        worker_id="w-wh-iss3", state="done",
+        issue_number=200, issue_repo="org/other-repo",
+        issue_state="open",
+    )
+
+    body = _make_issue_event("org/repo", 200, "closed")
+    headers = _signed_headers("wh-secret-3", body, event="issues", delivery="del-iss-003")
+    resp = test_client.post(f"/webhooks/github/{guild_id}", content=body, headers=headers)
+    assert resp.status_code in (200, 204), resp.text
+
+    assert _get_issue_state(db_url, "task-wh-iss3-match") == "closed"
+    assert _get_issue_state(db_url, "task-wh-iss3-other-num") == "open"
+    assert _get_issue_state(db_url, "task-wh-iss3-other-repo") == "open"

--- a/backend/tests/test_tasks_tree.py
+++ b/backend/tests/test_tasks_tree.py
@@ -292,7 +292,7 @@ def test_webhook_issues_closed_updates_issue_state(client):
     body = _make_issue_event("org/repo", 100, "closed")
     headers = _signed_headers("wh-secret-1", body, event="issues", delivery="del-iss-001")
     resp = test_client.post(f"/webhooks/github/{guild_id}", content=body, headers=headers)
-    assert resp.status_code in (200, 204), resp.text
+    assert resp.status_code in (200, 202, 204), resp.text
 
     assert _get_issue_state(db_url, "task-wh-iss1") == "closed"
 
@@ -319,7 +319,7 @@ def test_webhook_issues_reopened_updates_issue_state(client):
     body = _make_issue_event("org/repo", 101, "reopened")
     headers = _signed_headers("wh-secret-2", body, event="issues", delivery="del-iss-002")
     resp = test_client.post(f"/webhooks/github/{guild_id}", content=body, headers=headers)
-    assert resp.status_code in (200, 204), resp.text
+    assert resp.status_code in (200, 202, 204), resp.text
 
     assert _get_issue_state(db_url, "task-wh-iss2") == "open"
 
@@ -369,7 +369,7 @@ def test_webhook_issues_only_updates_matching_repo_and_number(client):
     body = _make_issue_event("org/repo", 200, "closed")
     headers = _signed_headers("wh-secret-3", body, event="issues", delivery="del-iss-003")
     resp = test_client.post(f"/webhooks/github/{guild_id}", content=body, headers=headers)
-    assert resp.status_code in (200, 204), resp.text
+    assert resp.status_code in (200, 202, 204), resp.text
 
     assert _get_issue_state(db_url, "task-wh-iss3-match") == "closed"
     assert _get_issue_state(db_url, "task-wh-iss3-other-num") == "open"

--- a/backend/tests/test_tasks_tree.py
+++ b/backend/tests/test_tasks_tree.py
@@ -3,8 +3,9 @@
 Covers:
 - Nodes return the real issue state from the DB cache when no GitHub token.
 - Nodes default to "open" when DB has no cached state.
-- Successful GitHub API calls write back issue_state to the DB.
-- GitHub `issues` webhook events keep issue_state current on linked tasks.
+- Nodes return the cached issue title from the DB when no GitHub token.
+- Successful GitHub API calls write back issue_state and issue_title to the DB.
+- GitHub `issues` webhook events keep issue_state and issue_title current on linked tasks.
 """
 
 from __future__ import annotations
@@ -62,6 +63,15 @@ def _get_issue_state(db_url: str, task_id: str) -> str | None:
     with _sync_session(db_url) as session:
         row = session.execute(
             select(col(Task.issue_state)).where(col(Task.id) == task_id)
+        ).one_or_none()
+    return row[0] if row else None
+
+
+def _get_issue_title(db_url: str, task_id: str) -> str | None:
+    """Read issue_title for a task directly from the DB."""
+    with _sync_session(db_url) as session:
+        row = session.execute(
+            select(col(Task.issue_title)).where(col(Task.id) == task_id)
         ).one_or_none()
     return row[0] if row else None
 
@@ -374,3 +384,171 @@ def test_webhook_issues_only_updates_matching_repo_and_number(client):
     assert _get_issue_state(db_url, "task-wh-iss3-match") == "closed"
     assert _get_issue_state(db_url, "task-wh-iss3-other-num") == "open"
     assert _get_issue_state(db_url, "task-wh-iss3-other-repo") == "open"
+
+
+# ---------------------------------------------------------------------------
+# Issue title — DB fallback and write-back
+# ---------------------------------------------------------------------------
+
+
+def test_tree_returns_cached_title_from_db_when_no_token(client):
+    """A task with issue_title cached in the DB returns that title in the tree node."""
+    test_client, db_url = client
+    guild_id = "tr-title1"
+    _guild_no_owner_token(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-title1", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-title1",
+        worker_id="w-title1",
+        state="done",
+        issue_number=55,
+        issue_repo="org/repo",
+        issue_state="closed",
+        issue_title="Fix the login bug",
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()["nodes"]
+    assert len(nodes) == 1
+    assert nodes[0]["title"] == "Fix the login bug"
+
+
+def test_tree_falls_back_to_issue_number_when_no_title_cached(client):
+    """When no issue_title is cached, the node title falls back to '#<number>'."""
+    test_client, db_url = client
+    guild_id = "tr-title2"
+    _guild_no_owner_token(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-title2", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-title2",
+        worker_id="w-title2",
+        state="pending",
+        issue_number=77,
+        issue_repo="org/repo",
+        issue_state=None,
+        issue_title=None,
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()["nodes"]
+    assert len(nodes) == 1
+    assert nodes[0]["title"] == "#77"
+
+
+def test_tree_writes_back_api_title_to_db(client, monkeypatch):
+    """When _gh_fetch_issue returns a title, it is persisted to task.issue_title."""
+    test_client, db_url = client
+    guild_id = "tr-wbtitle1"
+    insert_guild(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-wbtitle1", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-wbtitle1",
+        worker_id="w-wbtitle1",
+        state="awaiting-review",
+        issue_number=8,
+        issue_repo="org/repo",
+        issue_state=None,
+        issue_title=None,
+    )
+
+    monkeypatch.setattr(
+        "routes.tasks._gh_fetch_issue",
+        lambda repo, number, token: {"title": "Add dark mode", "state": "open"},
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()["nodes"]
+    assert nodes[0]["title"] == "Add dark mode"
+
+    cached = _get_issue_title(db_url, "task-wbtitle1")
+    assert cached == "Add dark mode", f"expected title cached in DB, got {cached!r}"
+
+
+def test_webhook_issues_edited_updates_issue_title(client):
+    """A GitHub issues/edited webhook sets issue_title on linked tasks."""
+    test_client, db_url = client
+    guild_id = "wh-title1"
+    insert_guild(db_url, guild_id)
+    _set_webhook_secret(db_url, guild_id, "wh-secret-title1")
+
+    insert_worker(db_url, guild_id, "w-wh-title1", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-wh-title1",
+        worker_id="w-wh-title1",
+        state="pending",
+        issue_number=300,
+        issue_repo="org/repo",
+        issue_state="open",
+        issue_title="Old title",
+    )
+
+    payload = {
+        "action": "edited",
+        "issue": {
+            "number": 300,
+            "title": "New title after edit",
+            "state": "open",
+        },
+        "repository": {"full_name": "org/repo"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("wh-secret-title1", body, event="issues", delivery="del-title-001")
+    resp = test_client.post(f"/webhooks/github/{guild_id}", content=body, headers=headers)
+    assert resp.status_code in (200, 202, 204), resp.text
+
+    assert _get_issue_title(db_url, "task-wh-title1") == "New title after edit"
+
+
+def test_webhook_issues_closed_updates_both_state_and_title(client):
+    """A GitHub issues/closed webhook sets both issue_state and issue_title."""
+    test_client, db_url = client
+    guild_id = "wh-both1"
+    insert_guild(db_url, guild_id)
+    _set_webhook_secret(db_url, guild_id, "wh-secret-both1")
+
+    insert_worker(db_url, guild_id, "w-wh-both1", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-wh-both1",
+        worker_id="w-wh-both1",
+        state="done",
+        issue_number=400,
+        issue_repo="org/repo",
+        issue_state="open",
+        issue_title="Fix the thing",
+    )
+
+    payload = {
+        "action": "closed",
+        "issue": {
+            "number": 400,
+            "title": "Fix the thing (resolved)",
+            "state": "closed",
+        },
+        "repository": {"full_name": "org/repo"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("wh-secret-both1", body, event="issues", delivery="del-both-001")
+    resp = test_client.post(f"/webhooks/github/{guild_id}", content=body, headers=headers)
+    assert resp.status_code in (200, 202, 204), resp.text
+
+    assert _get_issue_state(db_url, "task-wh-both1") == "closed"
+    assert _get_issue_title(db_url, "task-wh-both1") == "Fix the thing (resolved)"

--- a/backend/tests/test_tasks_tree.py
+++ b/backend/tests/test_tasks_tree.py
@@ -35,7 +35,6 @@ from models import Guild, Task
 from sqlalchemy import select, update
 from sqlmodel import col
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #706

## Changes
- Added `issue_state` column to the tasks DB model with an Alembic migration
- Updated `get_guild_tasks_tree` in `backend/routes/tasks.py` to use the DB-cached issue state as a fallback instead of hardcoding `state: "open"`
- Added tests in `backend/tests/test_tasks_tree.py` covering the DB-cached state path and the no-token fallback

Closes #706