### PR TITLE
Discord integration: Webhook notifier Phase 1 (#708)

### DIFF
--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -1,0 +1,75 @@
+"""Fire-and-forget Discord webhook notifier.
+
+Usage::
+
+    import discord_notifier
+    await discord_notifier.notify("task-complete", "Task done", "t-abc finished")
+
+Set ``DISCORD_WEBHOOK_URL`` in the environment to enable.  When the variable is
+unset every call is a silent no-op.  HTTP failures are logged as warnings and
+never propagate — the caller is never affected.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Colour palette for Discord embed sidebar
+_COLOURS: dict[str, int] = {
+    "task-complete": 0x2ECC71,  # green
+    "task-failed": 0xE74C3C,  # red
+    "task-cancelled": 0xE74C3C,  # red
+    "pr-opened": 0x3498DB,  # blue
+    "pr-merged": 0x9B59B6,  # purple
+    "pr-closed": 0x95A5A6,  # grey
+    "worker-online": 0x1ABC9C,  # teal
+    "worker-offline": 0xE67E22,  # orange
+    "ci-pass": 0x2ECC71,  # green
+    "ci-fail": 0xE74C3C,  # red
+}
+_DEFAULT_COLOUR = 0x7289DA  # blurple
+
+
+def _webhook_url() -> str | None:
+    return os.environ.get("DISCORD_WEBHOOK_URL") or None
+
+
+async def notify(
+    event_type: str,
+    title: str,
+    description: str,
+    url: str | None = None,
+    color: int | None = None,
+) -> None:
+    """Post a Discord embed to the configured webhook.
+
+    Silent no-op when ``DISCORD_WEBHOOK_URL`` is not set.
+    Never raises — HTTP errors are logged at WARNING level.
+    """
+    webhook_url = _webhook_url()
+    if not webhook_url:
+        return
+
+    resolved_color = color if color is not None else _COLOURS.get(event_type, _DEFAULT_COLOUR)
+
+    embed: dict = {
+        "title": title,
+        "description": description,
+        "color": resolved_color,
+    }
+    if url:
+        embed["url"] = url
+
+    payload = {"embeds": [embed]}
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(webhook_url, json=payload)
+            resp.raise_for_status()
+    except Exception:
+        logger.warning("Discord webhook notify failed (event=%s)", event_type, exc_info=True)

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -19,6 +19,18 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+# Module-level singleton; reused across all notify() calls to avoid per-request
+# connection-setup overhead. Closed on application exit (or left to GC).
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(timeout=10)
+    return _client
+
+
 # Colour palette for Discord embed sidebar
 _COLOURS: dict[str, int] = {
     "task-complete": 0x2ECC71,  # green
@@ -36,7 +48,7 @@ _DEFAULT_COLOUR = 0x7289DA  # blurple
 
 
 def _webhook_url() -> str | None:
-    return os.environ.get("DISCORD_WEBHOOK_URL") or None
+    return os.environ.get("DISCORD_WEBHOOK_URL") or None  # treat empty string as unset
 
 
 async def notify(
@@ -68,8 +80,8 @@ async def notify(
     payload = {"embeds": [embed]}
 
     try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.post(webhook_url, json=payload)
-            resp.raise_for_status()
+        client = _get_client()
+        resp = await client.post(webhook_url, json=payload)
+        resp.raise_for_status()
     except Exception:
         logger.warning("Discord webhook notify failed (event=%s)", event_type, exc_info=True)

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -48,7 +48,8 @@ _DEFAULT_COLOUR = 0x7289DA  # blurple
 
 
 def _webhook_url() -> str | None:
-    return os.environ.get("DISCORD_WEBHOOK_URL") or None  # treat empty string as unset
+    url = os.environ.get("DISCORD_WEBHOOK_URL")
+    return url if url else None  # empty string treated as unset
 
 
 async def notify(

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -24,7 +24,6 @@ from datetime import UTC, datetime, timedelta
 
 import discord_notifier
 from database import get_db_dep
-from util.tasks import spawn
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from lock_service import LockService
@@ -35,6 +34,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from util.tasks import spawn
 from ws_types import ChatMsg, GithubEventMsg, TaskFinalizeMsg, TaskUpdateMsg
 
 from foreman import reset_foreman_poll, run_foreman_ai

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -24,6 +24,7 @@ from datetime import UTC, datetime, timedelta
 
 import discord_notifier
 from database import get_db_dep
+from util.tasks import spawn
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from lock_service import LockService
@@ -830,35 +831,38 @@ async def github_webhook(
     if event_type == "pull_request" and action == "opened":
         pr_obj = payload.get("pull_request") or {}
         pr_title = (pr_obj.get("title") or "")[:120]
-        asyncio.ensure_future(
+        spawn(
             discord_notifier.notify(
                 "pr-opened",
                 f"PR opened: {_pr_label}",
                 pr_title or f"New pull request on {_pr_label}",
                 url=pr_url or None,
-            )
+            ),
+            name=f"discord.pr-opened:{_pr_label}",
         )
     elif event_type == "pull_request" and action == "closed":
         pr_obj = payload.get("pull_request") or {}
         if pr_obj.get("merged"):
-            asyncio.ensure_future(
+            spawn(
                 discord_notifier.notify(
                     "pr-merged",
                     f"PR merged: {_pr_label}",
                     f"Pull request `{_pr_label}` was merged."
                     + (f" Task: `{task_id}`." if task_id else ""),
                     url=pr_url or None,
-                )
+                ),
+                name=f"discord.pr-merged:{_pr_label}",
             )
         else:
-            asyncio.ensure_future(
+            spawn(
                 discord_notifier.notify(
                     "pr-closed",
                     f"PR closed: {_pr_label}",
                     f"Pull request `{_pr_label}` was closed without merging."
                     + (f" Task: `{task_id}`." if task_id else ""),
                     url=pr_url or None,
-                )
+                ),
+                name=f"discord.pr-closed:{_pr_label}",
             )
     elif event_type in {"check_run", "check_suite"}:
         node = payload.get(event_type) or {}
@@ -869,24 +873,26 @@ async def github_webhook(
             else "CI"
         )
         if conclusion == "success":
-            asyncio.ensure_future(
+            spawn(
                 discord_notifier.notify(
                     "ci-pass",
                     f"CI passed: {_pr_label}",
                     f"`{check_name}` passed on `{_pr_label}`."
                     + (f" Task: `{task_id}`." if task_id else ""),
                     url=pr_url or None,
-                )
+                ),
+                name=f"discord.ci-pass:{_pr_label}",
             )
         elif conclusion in {"failure", "cancelled", "timed_out", "action_required"}:
-            asyncio.ensure_future(
+            spawn(
                 discord_notifier.notify(
                     "ci-fail",
                     f"CI failed: {_pr_label}",
                     f"`{check_name}` {conclusion} on `{_pr_label}`."
                     + (f" Task: `{task_id}`." if task_id else ""),
                     url=pr_url or None,
-                )
+                ),
+                name=f"discord.ci-fail:{_pr_label}",
             )
 
     await broadcast_msg(

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -22,6 +22,7 @@ import logging
 import os
 from datetime import UTC, datetime, timedelta
 
+import discord_notifier
 from database import get_db_dep
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -823,6 +824,70 @@ async def github_webhook(
         pr_number,
         task_id,
     )
+
+    # Discord notifications for key GitHub events.
+    _pr_label = f"{repo}#{pr_number}" if repo and pr_number else (repo or "")
+    if event_type == "pull_request" and action == "opened":
+        pr_obj = payload.get("pull_request") or {}
+        pr_title = (pr_obj.get("title") or "")[:120]
+        asyncio.ensure_future(
+            discord_notifier.notify(
+                "pr-opened",
+                f"PR opened: {_pr_label}",
+                pr_title or f"New pull request on {_pr_label}",
+                url=pr_url or None,
+            )
+        )
+    elif event_type == "pull_request" and action == "closed":
+        pr_obj = payload.get("pull_request") or {}
+        if pr_obj.get("merged"):
+            asyncio.ensure_future(
+                discord_notifier.notify(
+                    "pr-merged",
+                    f"PR merged: {_pr_label}",
+                    f"Pull request `{_pr_label}` was merged."
+                    + (f" Task: `{task_id}`." if task_id else ""),
+                    url=pr_url or None,
+                )
+            )
+        else:
+            asyncio.ensure_future(
+                discord_notifier.notify(
+                    "pr-closed",
+                    f"PR closed: {_pr_label}",
+                    f"Pull request `{_pr_label}` was closed without merging."
+                    + (f" Task: `{task_id}`." if task_id else ""),
+                    url=pr_url or None,
+                )
+            )
+    elif event_type in {"check_run", "check_suite"}:
+        node = payload.get(event_type) or {}
+        conclusion = node.get("conclusion") if isinstance(node, dict) else None
+        check_name = (
+            (node.get("name") or node.get("app", {}).get("slug") or "CI")
+            if isinstance(node, dict)
+            else "CI"
+        )
+        if conclusion == "success":
+            asyncio.ensure_future(
+                discord_notifier.notify(
+                    "ci-pass",
+                    f"CI passed: {_pr_label}",
+                    f"`{check_name}` passed on `{_pr_label}`."
+                    + (f" Task: `{task_id}`." if task_id else ""),
+                    url=pr_url or None,
+                )
+            )
+        elif conclusion in {"failure", "cancelled", "timed_out", "action_required"}:
+            asyncio.ensure_future(
+                discord_notifier.notify(
+                    "ci-fail",
+                    f"CI failed: {_pr_label}",
+                    f"`{check_name}` {conclusion} on `{_pr_label}`."
+                    + (f" Task: `{task_id}`." if task_id else ""),
+                    url=pr_url or None,
+                )
+            )
 
     await broadcast_msg(
         guild_id,

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -12,8 +12,10 @@ import logging
 from datetime import UTC, datetime
 
 import anyio
+import discord_notifier
 import ws_handlers
 from database import get_db
+from util.tasks import spawn
 from events import (
     agent_owner_lock,
     agent_owners,
@@ -244,6 +246,15 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                         offline_lines,
                         task_name="foreman.worker-offline:disconnect-batch",
                     )
+                    for wid in sorted(abrupt_worker_ids):
+                        spawn(
+                            discord_notifier.notify(
+                                "worker-offline",
+                                f"Worker offline: {wid}",
+                                f"Worker `{wid}` disconnected from guild `{guild_id}` (reason: disconnect).",
+                            ),
+                            name=f"discord.worker-offline:{wid}",
+                        )
             finally:
                 # If a cancellation was delivered inside a handler (e.g.
                 # handle_worker_disconnect) the underlying asyncpg connection

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -15,7 +15,6 @@ import anyio
 import discord_notifier
 import ws_handlers
 from database import get_db
-from util.tasks import spawn
 from events import (
     agent_owner_lock,
     agent_owners,
@@ -29,6 +28,7 @@ from models import Agent, Guild, UserSession, Worker
 from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from util.tasks import spawn
 from ws_types import AgentStateMsg
 
 from foreman import resume_foreman_poll

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -1,17 +1,16 @@
 """Unit tests for discord_notifier.
 
-No real HTTP requests are made — the httpx call is mocked throughout.
+No real HTTP requests are made — the httpx client is mocked throughout.
 """
 
 from __future__ import annotations
 
-import json
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-import respx
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -34,6 +33,25 @@ def reset_client():
     discord_notifier._client = None
 
 
+def _make_mock_client(status_code: int = 204, side_effect=None):
+    """Return a mock httpx.AsyncClient with a stubbed post() coroutine."""
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = status_code
+    if status_code >= 400:
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=mock_response
+        )
+    else:
+        mock_response.raise_for_status.return_value = None
+
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    if side_effect is not None:
+        mock_client.post = AsyncMock(side_effect=side_effect)
+    else:
+        mock_client.post = AsyncMock(return_value=mock_response)
+    return mock_client
+
+
 # ---------------------------------------------------------------------------
 # No-op when env var unset
 # ---------------------------------------------------------------------------
@@ -42,10 +60,10 @@ def reset_client():
 @pytest.mark.asyncio
 async def test_notify_no_op_when_env_unset():
     """notify() must not make any HTTP call when DISCORD_WEBHOOK_URL is unset."""
-    with respx.mock(assert_all_called=False) as mock:
-        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+    mock_client = _make_mock_client()
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify("task-complete", "Done", "All good")
-        assert not route.called
+    mock_client.post.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -57,16 +75,16 @@ async def test_notify_no_op_when_env_unset():
 async def test_notify_posts_correct_embed(monkeypatch):
     """notify() builds the right embed payload and POSTs it to the webhook."""
     monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    mock_client = _make_mock_client()
 
-    with respx.mock() as mock:
-        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify(
             "pr-opened", "PR #42 opened", "New pull request", url="https://example.com/pr/42"
         )
 
-    assert route.called
-    sent = route.calls.last.request
-    body = json.loads(sent.content)
+    mock_client.post.assert_called_once()
+    _, kwargs = mock_client.post.call_args
+    body = kwargs["json"]
     assert body["embeds"][0]["title"] == "PR #42 opened"
     assert body["embeds"][0]["description"] == "New pull request"
     assert body["embeds"][0]["url"] == "https://example.com/pr/42"
@@ -77,13 +95,13 @@ async def test_notify_posts_correct_embed(monkeypatch):
 async def test_notify_no_url_field_when_omitted(monkeypatch):
     """url field must be absent from the embed when url=None."""
     monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    mock_client = _make_mock_client()
 
-    with respx.mock() as mock:
-        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify("worker-online", "Worker connected", "w-abc is online")
 
-    body = json.loads(route.calls.last.request.content)
-    assert "url" not in body["embeds"][0]
+    _, kwargs = mock_client.post.call_args
+    assert "url" not in kwargs["json"]["embeds"][0]
 
 
 # ---------------------------------------------------------------------------
@@ -110,26 +128,26 @@ async def test_notify_no_url_field_when_omitted(monkeypatch):
 )
 async def test_colour_by_event_type(monkeypatch, event_type, expected_color):
     monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    mock_client = _make_mock_client()
 
-    with respx.mock() as mock:
-        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify(event_type, "title", "desc")
 
-    body = json.loads(route.calls.last.request.content)
-    assert body["embeds"][0]["color"] == expected_color
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["json"]["embeds"][0]["color"] == expected_color
 
 
 @pytest.mark.asyncio
 async def test_custom_color_overrides_event_type(monkeypatch):
     """Explicit color= kwarg takes precedence over the event-type colour map."""
     monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    mock_client = _make_mock_client()
 
-    with respx.mock() as mock:
-        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify("task-complete", "t", "d", color=0xABCDEF)
 
-    body = json.loads(route.calls.last.request.content)
-    assert body["embeds"][0]["color"] == 0xABCDEF
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["json"]["embeds"][0]["color"] == 0xABCDEF
 
 
 # ---------------------------------------------------------------------------
@@ -141,9 +159,9 @@ async def test_custom_color_overrides_event_type(monkeypatch):
 async def test_http_error_does_not_raise(monkeypatch):
     """An HTTP error must be swallowed and logged, never propagated."""
     monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    mock_client = _make_mock_client(status_code=500)
 
-    with respx.mock() as mock:
-        mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(500))
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         # Should not raise despite 500 response
         await discord_notifier.notify("task-failed", "Failed", "oh no")
 
@@ -152,7 +170,7 @@ async def test_http_error_does_not_raise(monkeypatch):
 async def test_network_error_does_not_raise(monkeypatch):
     """A network-level exception (connection refused etc.) must be swallowed."""
     monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    mock_client = _make_mock_client(side_effect=httpx.ConnectError("refused"))
 
-    with respx.mock() as mock:
-        mock.post(WEBHOOK_URL).mock(side_effect=httpx.ConnectError("refused"))
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify("task-failed", "Failed", "network down")

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -5,6 +5,7 @@ No real HTTP requests are made — the httpx call is mocked throughout.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 
@@ -23,6 +24,14 @@ WEBHOOK_URL = "https://discord.com/api/webhooks/test/token"
 def reset_env(monkeypatch):
     """Start each test with no webhook URL set."""
     monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    """Reset the module-level httpx singleton so each test gets a fresh client."""
+    discord_notifier._client = None
+    yield
+    discord_notifier._client = None
 
 
 # ---------------------------------------------------------------------------
@@ -57,8 +66,6 @@ async def test_notify_posts_correct_embed(monkeypatch):
 
     assert route.called
     sent = route.calls.last.request
-    import json
-
     body = json.loads(sent.content)
     assert body["embeds"][0]["title"] == "PR #42 opened"
     assert body["embeds"][0]["description"] == "New pull request"
@@ -74,8 +81,6 @@ async def test_notify_no_url_field_when_omitted(monkeypatch):
     with respx.mock() as mock:
         route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
         await discord_notifier.notify("worker-online", "Worker connected", "w-abc is online")
-
-    import json
 
     body = json.loads(route.calls.last.request.content)
     assert "url" not in body["embeds"][0]
@@ -106,8 +111,6 @@ async def test_notify_no_url_field_when_omitted(monkeypatch):
 async def test_colour_by_event_type(monkeypatch, event_type, expected_color):
     monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
 
-    import json
-
     with respx.mock() as mock:
         route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
         await discord_notifier.notify(event_type, "title", "desc")
@@ -120,8 +123,6 @@ async def test_colour_by_event_type(monkeypatch, event_type, expected_color):
 async def test_custom_color_overrides_event_type(monkeypatch):
     """Explicit color= kwarg takes precedence over the event-type colour map."""
     monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
-
-    import json
 
     with respx.mock() as mock:
         route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -1,0 +1,157 @@
+"""Unit tests for discord_notifier.
+
+No real HTTP requests are made — the httpx call is mocked throughout.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import httpx
+import pytest
+import respx
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import discord_notifier
+
+WEBHOOK_URL = "https://discord.com/api/webhooks/test/token"
+
+
+@pytest.fixture(autouse=True)
+def reset_env(monkeypatch):
+    """Start each test with no webhook URL set."""
+    monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# No-op when env var unset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_no_op_when_env_unset():
+    """notify() must not make any HTTP call when DISCORD_WEBHOOK_URL is unset."""
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+        await discord_notifier.notify("task-complete", "Done", "All good")
+        assert not route.called
+
+
+# ---------------------------------------------------------------------------
+# Payload shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_posts_correct_embed(monkeypatch):
+    """notify() builds the right embed payload and POSTs it to the webhook."""
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+
+    with respx.mock() as mock:
+        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+        await discord_notifier.notify(
+            "pr-opened", "PR #42 opened", "New pull request", url="https://example.com/pr/42"
+        )
+
+    assert route.called
+    sent = route.calls.last.request
+    import json
+
+    body = json.loads(sent.content)
+    assert body["embeds"][0]["title"] == "PR #42 opened"
+    assert body["embeds"][0]["description"] == "New pull request"
+    assert body["embeds"][0]["url"] == "https://example.com/pr/42"
+    assert body["embeds"][0]["color"] == 0x3498DB  # blue
+
+
+@pytest.mark.asyncio
+async def test_notify_no_url_field_when_omitted(monkeypatch):
+    """url field must be absent from the embed when url=None."""
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+
+    with respx.mock() as mock:
+        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+        await discord_notifier.notify("worker-online", "Worker connected", "w-abc is online")
+
+    import json
+
+    body = json.loads(route.calls.last.request.content)
+    assert "url" not in body["embeds"][0]
+
+
+# ---------------------------------------------------------------------------
+# Colour map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event_type,expected_color",
+    [
+        ("task-complete", 0x2ECC71),
+        ("task-failed", 0xE74C3C),
+        ("task-cancelled", 0xE74C3C),
+        ("pr-opened", 0x3498DB),
+        ("pr-merged", 0x9B59B6),
+        ("pr-closed", 0x95A5A6),
+        ("worker-online", 0x1ABC9C),
+        ("worker-offline", 0xE67E22),
+        ("ci-pass", 0x2ECC71),
+        ("ci-fail", 0xE74C3C),
+        ("unknown-event", 0x7289DA),  # default blurple
+    ],
+)
+async def test_colour_by_event_type(monkeypatch, event_type, expected_color):
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+
+    import json
+
+    with respx.mock() as mock:
+        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+        await discord_notifier.notify(event_type, "title", "desc")
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["embeds"][0]["color"] == expected_color
+
+
+@pytest.mark.asyncio
+async def test_custom_color_overrides_event_type(monkeypatch):
+    """Explicit color= kwarg takes precedence over the event-type colour map."""
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+
+    import json
+
+    with respx.mock() as mock:
+        route = mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(204))
+        await discord_notifier.notify("task-complete", "t", "d", color=0xABCDEF)
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["embeds"][0]["color"] == 0xABCDEF
+
+
+# ---------------------------------------------------------------------------
+# HTTP failure must not raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_error_does_not_raise(monkeypatch):
+    """An HTTP error must be swallowed and logged, never propagated."""
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+
+    with respx.mock() as mock:
+        mock.post(WEBHOOK_URL).mock(return_value=httpx.Response(500))
+        # Should not raise despite 500 response
+        await discord_notifier.notify("task-failed", "Failed", "oh no")
+
+
+@pytest.mark.asyncio
+async def test_network_error_does_not_raise(monkeypatch):
+    """A network-level exception (connection refused etc.) must be swallowed."""
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+
+    with respx.mock() as mock:
+        mock.post(WEBHOOK_URL).mock(side_effect=httpx.ConnectError("refused"))
+        await discord_notifier.notify("task-failed", "Failed", "network down")

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+import discord_notifier
 from events import (
     agent_owner_lock,
     agent_owners,
@@ -663,6 +664,15 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
         f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}{tools_suffix}{provider_suffix}",
         task_name=f"foreman.worker-online:{worker_id}",
     )
+    spawn(
+        discord_notifier.notify(
+            "worker-online",
+            f"Worker online: {worker_id}",
+            f"Worker `{worker_id}` connected to guild `{ctx.guild_id}`."
+            + (f" Repos: {repos_str}." if repos_str else ""),
+        ),
+        name=f"discord.worker-online:{worker_id}",
+    )
 
 
 async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
@@ -706,6 +716,14 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
                 worker_id,
                 ctx.guild_id,
             )
+        spawn(
+            discord_notifier.notify(
+                "worker-offline",
+                f"Worker offline: {worker_id}",
+                f"Worker `{worker_id}` disconnected from guild `{ctx.guild_id}` (reason: shutdown).",
+            ),
+            name=f"discord.worker-offline:{worker_id}",
+        )
     reset_foreman_poll(ctx.guild_id)
 
 
@@ -814,6 +832,17 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
         spawn(
             maybe_post_plan_comment(ctx.guild_id, task_id, last_text),
             name=f"foreman.plan-comment:{task_id}",
+        )
+        spawn(
+            discord_notifier.notify(
+                "task-complete",
+                f"Task complete: {desc[:80] or task_id}",
+                f"Worker `{worker_id_msg}` finished task `{task_id}`."
+                + (f" Branch: {branch}." if branch else "")
+                + (f" PR: {pr_url}" if pr_url else ""),
+                url=pr_url or None,
+            ),
+            name=f"discord.task-complete:{task_id}",
         )
     if not task_id:
         return


### PR DESCRIPTION
## Summary

- Adds `backend/discord_notifier.py` — a thin, fire-and-forget async notifier that POSTs Discord embed payloads to an incoming webhook URL
- Wired into `ws_handlers.py`: fires on `task-complete`, `worker-online`, and `worker-offline` WebSocket events
- Wired into `routes/webhooks.py`: fires on GitHub PR opened/merged/closed and CI check_run pass/fail events
- 17 unit tests in `backend/tests/test_discord_notifier.py` covering payload shape, colour map, no-op when env unset, and error resilience (no real HTTP)

## Behaviour

| Env var | Result |
|---------|--------|
| `DISCORD_WEBHOOK_URL` set | Notifications posted as Discord embeds |
| `DISCORD_WEBHOOK_URL` unset | All calls are silent no-ops |

HTTP errors are caught and logged at WARNING level — they never affect the caller.

## Event coverage

| Event | Colour |
|-------|--------|
| `task-complete` | green |
| `task-failed` / `task-cancelled` | red |
| `pr-opened` | blue |
| `pr-merged` | purple |
| `pr-closed` | grey |
| `worker-online` | teal |
| `worker-offline` | orange |
| `ci-pass` | green |
| `ci-fail` | red |

## Test plan

- [ ] `cd backend && python -m pytest tests/test_discord_notifier.py -v` → 17 passed
- [ ] `ruff check backend/discord_notifier.py backend/tests/test_discord_notifier.py backend/ws_handlers.py backend/routes/webhooks.py` → no errors
- [ ] Set `DISCORD_WEBHOOK_URL` to a real webhook and trigger a task-complete event to confirm a notification appears in the channel

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)