### PR TITLE
Clarify worker vs agent in prompt + tools schema (#713)

### DIFF
--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -19,7 +19,7 @@ abandoned, or it was an ephemeral/automation task).
 - send_followup picks an idle worker automatically: original worker first \
 (worktree usually still cached), otherwise any idle worker in the guild pulls \
 the branch from GitHub. Pass preferred_worker_id to force a specific worker.
-- Message workers mid-task via message_worker for context (reaches the active agent subprocess)
+- Message workers mid-task via message_worker for context (forwarded to the active agent subprocess when one is running)
 - Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
 - Cancel tasks that are going wrong or are no longer needed via cancel_task
 - Shut down a misbehaving or no-longer-needed worker process via shutdown_worker \

--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -2,7 +2,8 @@
 
 FOREMAN_SYSTEM = """\
 You are the Foreman AI in Pioneer Square, a multi-agent coding workshop.
-You coordinate worker agents that autonomously clone repos, write code, and open PRs.
+You coordinate workers — each worker is a host process (w-xxx) that spawns agent subprocesses
+(Claude, Codex, etc.) to autonomously clone repos, write code, and open PRs.
 
 ## Your responsibilities
 - Understand what the human wants and break it into named, tracked tasks
@@ -18,7 +19,7 @@ abandoned, or it was an ephemeral/automation task).
 - send_followup picks an idle worker automatically: original worker first \
 (worktree usually still cached), otherwise any idle worker in the guild pulls \
 the branch from GitHub. Pass preferred_worker_id to force a specific worker.
-- Message workers mid-task via message_worker for context
+- Message workers mid-task via message_worker for context (reaches the active agent subprocess)
 - Redirect running tasks via redirect_task (SIGTERM + resume with full context) to course-correct
 - Cancel tasks that are going wrong or are no longer needed via cancel_task
 - Shut down a misbehaving or no-longer-needed worker process via shutdown_worker \
@@ -32,7 +33,7 @@ For complex work use phases:
    When the worker returns findings, a spec, or an outline, post the result as a
    comment on the linked GitHub issue — do NOT open a PR containing a document.
    A PR should only be opened when there is actual code to merge.
-2. **execute** — assign workers to implement
+2. **execute** — assign workers to implement (each worker spawns an agent subprocess to do the coding)
 3. **review** — dispatch as `create_task(phase="review")` + `assign_task(..., parent_task_id=<foreman_task_id>)`; the worker checks out
    the branch, runs available tests/lint, and posts findings via `gh pr review`. For shallow or
    fallback reviews when no worker is needed, use `review_pr_internal` or `review_pr` instead.

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -36,7 +36,7 @@ FOREMAN_TOOLS = [
     {
         "name": "assign_task",
         "description": (
-            "Queue a coding task — the worker (host process) spawns an agent subprocess to execute it. "
+            "Queue a coding task — the worker host process (w-xxx) spawns an agent subprocess to execute it. "
             "The worker creates a git worktree, runs the chosen coding agent on the description, "
             "and pushes its work. "
             "For execute-phase tasks the worker opens a PR; for plan-phase tasks, the "
@@ -209,7 +209,7 @@ FOREMAN_TOOLS = [
     },
     {
         "name": "message_worker",
-        "description": "Send a message to a worker's terminal — reaches the active agent subprocess mid-task.",
+        "description": "Send a message to a worker's terminal — reaches the active agent subprocess mid-task; has no effect if the worker is idle.",
         "input_schema": {
             "type": "object",
             "properties": {

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -36,8 +36,9 @@ FOREMAN_TOOLS = [
     {
         "name": "assign_task",
         "description": (
-            "Queue a coding task for a worker agent. The worker creates a git worktree, "
-            "runs the chosen coding agent on the description, and pushes its work. "
+            "Queue a coding task — the worker (host process) spawns an agent subprocess to execute it. "
+            "The worker creates a git worktree, runs the chosen coding agent on the description, "
+            "and pushes its work. "
             "For execute-phase tasks the worker opens a PR; for plan-phase tasks, the "
             "Foreman should post findings as a comment on the linked GitHub issue instead "
             "— do NOT open a PR for a document, spec, or outline. "
@@ -54,7 +55,7 @@ FOREMAN_TOOLS = [
             "properties": {
                 "worker_id": {
                     "type": "string",
-                    "description": "Worker agent ID (e.g. w-abc123). Must be idle.",
+                    "description": "Worker host-process ID (e.g. w-abc123). Must be idle.",
                 },
                 "description": {
                     "type": "string",
@@ -208,7 +209,7 @@ FOREMAN_TOOLS = [
     },
     {
         "name": "message_worker",
-        "description": "Send a message to a worker's terminal — for mid-task context injection.",
+        "description": "Send a message to a worker's terminal — reaches the active agent subprocess mid-task.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -258,8 +259,8 @@ FOREMAN_TOOLS = [
     {
         "name": "shutdown_worker",
         "description": (
-            "Send a shutdown signal to a worker agent, causing it to gracefully stop. "
-            "Idle agents exit immediately; busy agents finish their current task and skip "
+            "Send a shutdown signal to a worker host process (w-xxx), causing it to gracefully stop. "
+            "The worker exits immediately if idle; if busy, it finishes the current agent task and skips "
             "the follow-up window. The worker process disconnects and transitions to offline. "
             "Use when a worker is misbehaving, the operator is winding down, or a host needs "
             "to be freed up — prefer cancel_task for stopping a single bad task."
@@ -269,7 +270,7 @@ FOREMAN_TOOLS = [
             "properties": {
                 "worker_id": {
                     "type": "string",
-                    "description": "Worker agent ID (e.g. w-abc123).",
+                    "description": "Worker host-process ID (e.g. w-abc123).",
                 },
                 "reason": {
                     "type": "string",


### PR DESCRIPTION
## Summary

Audits `backend/foreman_core/tools_schema.py` and `backend/foreman_core/prompt.py` to consistently distinguish:

- **Worker** = the `w-xxx` host process (provides environment, credentials, CLI tools)
- **Agent** = the Claude/Codex/pi subprocess the worker spawns to execute a task

Changes:
- `assign_task` description: rewritten to "Queue a coding task — the worker (host process) spawns an agent subprocess to execute it."
- `shutdown_worker` description: changed "worker agent" → "worker host process (w-xxx)"; "Idle agents exit immediately; busy agents finish…" → "The worker exits immediately if idle; if busy, it finishes the current agent task…"
- `shutdown_worker` + `assign_task` `worker_id` field: "Worker agent ID" → "Worker host-process ID"
- `message_worker` description: clarified it "reaches the active agent subprocess mid-task"
- `FOREMAN_SYSTEM` intro: "You coordinate worker agents…" → "You coordinate workers — each worker is a host process (w-xxx) that spawns agent subprocesses (Claude, Codex, etc.)…"
- `FOREMAN_SYSTEM` responsibilities: `message_worker` bullet adds "(reaches the active agent subprocess)"
- `FOREMAN_SYSTEM` multi-step execute phase: adds "(each worker spawns an agent subprocess to do the coding)"

All changes are minimal and surgical — no unrelated copy was touched.

Closes #713