### PR TITLE
docker-compose: add Discord webhook/bot env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,22 @@ CLAUDE_CODE_OAUTH_TOKEN=
 # Optional — if empty, worker fetches the OAuth token from the backend DB.
 GITHUB_TOKEN=
 
+# --- Discord notifications (optional, backend-only) ---
+# See docs/discord-bot-setup.md for full setup instructions.
+
+# Phase 1: incoming webhook URL for flat-channel embed notifications.
+# Used as a fallback when DISCORD_BOT_TOKEN is not set.
+# DISCORD_WEBHOOK_URL=
+
+# Phase 2: bot token for per-PR/issue thread notifications. Must be set
+# together with DISCORD_CHANNEL_ID. When absent, falls back to
+# DISCORD_WEBHOOK_URL (or no-ops if that is also unset).
+# DISCORD_BOT_TOKEN=
+
+# Phase 2: ID of the text channel where per-PR/issue threads are created.
+# Right-click the channel in Discord (Developer Mode) → Copy Channel ID.
+# DISCORD_CHANNEL_ID=
+
 # Build-only: GitHub token used by backend/Dockerfile to clone private dnsid-go.
 BUILD_GITHUB_TOKEN=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,13 @@ services:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+      # --- Discord notifications (optional, see docs/discord-bot-setup.md) ---
+      # Phase 1: flat-channel webhook notifications.
+      # DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL:-}
+      # Phase 2: bot-based per-PR/issue thread notifications. Both required
+      # together; falls back to DISCORD_WEBHOOK_URL if thread creation fails.
+      # DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      # DISCORD_CHANNEL_ID: ${DISCORD_CHANNEL_ID:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "cd backend && alembic upgrade head && cd .. && pioneer serve"


### PR DESCRIPTION
## Summary
- Add `DISCORD_WEBHOOK_URL`, `DISCORD_BOT_TOKEN`, and `DISCORD_CHANNEL_ID` (commented out) to the `backend` service in `docker-compose.yml`, since all Discord notifier call sites (`webhooks.py`, `ws_handlers.py`, `websocket.py`) live in the backend process.
- Document the same three vars in `.env.example`, cross-referencing `docs/discord-bot-setup.md` for full setup instructions.

## Note on scope
Issue #711 also lists `DISCORD_GUILD_ID`, `DISCORD_NOTIFICATION_CHANNEL_ID`, `DISCORD_ALLOWED_ROLE_IDS`, and an interaction/public-key URL for slash-command support. I checked the merged Phase 1 (#708) and Phase 2 (#709/#718) code and none of those are actually read anywhere — only `DISCORD_WEBHOOK_URL`, `DISCORD_BOT_TOKEN`, and `DISCORD_CHANNEL_ID` exist in `backend/discord_notifier.py` today. The other vars belong to an unimplemented future phase (Discord slash commands/interactions), so I left them out to avoid documenting config that does nothing. Happy to add placeholders back in if you'd like the `.env.example` to serve as forward-looking documentation ahead of that phase landing.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"` — YAML parses cleanly
- [x] Confirmed via `grep` that `discord_notifier.py` only reads `DISCORD_WEBHOOK_URL`, `DISCORD_BOT_TOKEN`, `DISCORD_CHANNEL_ID`

Closes #711