### PR TITLE
fix(docker-compose): address Discord env var review comments from #721

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ GITHUB_TOKEN=
 # Phase 2: bot token for per-PR/issue thread notifications. Must be set
 # together with DISCORD_CHANNEL_ID. When absent, falls back to
 # DISCORD_WEBHOOK_URL (or no-ops if that is also unset).
+# WARNING: keep this value out of version control
 # DISCORD_BOT_TOKEN=
 
 # Phase 2: ID of the text channel where per-PR/issue threads are created.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,11 +54,11 @@ services:
       AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
       # --- Discord notifications (optional, see docs/discord-bot-setup.md) ---
       # Phase 1: flat-channel webhook notifications.
-      # DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL:-}
+      DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL:-}
       # Phase 2: bot-based per-PR/issue thread notifications. Both required
-      # together; falls back to DISCORD_WEBHOOK_URL if thread creation fails.
-      # DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
-      # DISCORD_CHANNEL_ID: ${DISCORD_CHANNEL_ID:-}
+      # together; used when DISCORD_BOT_TOKEN is absent; falls back to webhook-only mode.
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_CHANNEL_ID: ${DISCORD_CHANNEL_ID:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "cd backend && alembic upgrade head && cd .. && pioneer serve"


### PR DESCRIPTION
## Summary
- Uncomment `DISCORD_WEBHOOK_URL`, `DISCORD_BOT_TOKEN`, `DISCORD_CHANNEL_ID` in `docker-compose.yml` so they're actually injected into the backend container when set in `.env` (previously commented out, so `.env` values were silently ignored)
- Fix the fallback comment in `docker-compose.yml` to say the webhook fallback is used when `DISCORD_BOT_TOKEN` is absent, not only when thread creation fails
- Add a `# WARNING: keep this value out of version control` note above `DISCORD_BOT_TOKEN` in `.env.example`

PR #721 was merged before these review comments (https://github.com/jmelloy/pioneer-square/pull/721#discussion_r3522269721, #discussion_r3522269723, #discussion_r3522269726) landed, so this follow-up branch/PR addresses them directly against `main`.

Refs #711, #721

## Test plan
- [x] `git diff` reviewed — only the three flagged lines/comments changed
- [ ] Manual: run `docker compose config` to confirm the vars resolve with empty defaults when unset