### PR TITLE
Discord: Slash commands & bidirectional control (#710)

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -168,7 +168,9 @@ async def _load_history(guild_id: str, user_id: str, task_id: str | None = None)
         # Fetch only the most recent rows at the SQL level so query cost doesn't
         # scale with the table's total lifetime turn count; the Python-side
         # windowing below then trims this small set down further.
-        result = await db.exec(stmt.order_by(col(ForemanTurn.id).desc()).limit(_HISTORY_FETCH_LIMIT))
+        result = await db.exec(
+            stmt.order_by(col(ForemanTurn.id).desc()).limit(_HISTORY_FETCH_LIMIT)
+        )
         turns = list(reversed(result.all()))
     finally:
         await db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -426,6 +426,7 @@ from routes import agents as _agents_routes  # noqa: E402
 from routes import auth as _auth_routes  # noqa: E402
 from routes import cost as _cost_routes  # noqa: E402
 from routes import debug as _debug_routes  # noqa: E402
+from routes import discord as _discord_routes  # noqa: E402
 from routes import foreman as _foreman_routes  # noqa: E402
 from routes import guilds as _guilds_routes  # noqa: E402
 from routes import issues as _issues_routes  # noqa: E402
@@ -454,6 +455,7 @@ app.include_router(_debug_routes.router)
 app.include_router(_models_routes.router)
 app.include_router(_issues_routes.router)
 app.include_router(_cost_routes.router)
+app.include_router(_discord_routes.router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -1,0 +1,624 @@
+"""Discord slash command interaction handler (Phase 3).
+
+POST /discord/interactions — receives and validates Discord interaction payloads.
+
+Required env vars:
+    DISCORD_PUBLIC_KEY          Ed25519 public key (hex) from Discord developer portal
+    DISCORD_APPLICATION_ID      Discord application/bot ID (used for followup URLs)
+    DISCORD_BOT_TOKEN           Discord bot token (reuses Phase 2 var)
+    DISCORD_PIONEER_GUILD_SLUG  Pioneer Square guild slug to target for all commands
+
+Optional env vars:
+    DISCORD_ALLOWED_ROLE_IDS    Comma-separated Discord role IDs; empty = allow all
+
+Registered slash commands (see scripts/register_discord_commands.py):
+    /ps status              — formatted embed with worker states and active task counts
+    /ps workers             — list all workers with state, repos, and agent count
+    /ps pickup <issue-url>  — claim an issue and assign to an idle worker
+    /ps review <pr-url>     — trigger a PR review task
+    /ps cancel <task-id>    — cancel a running task
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import random
+import re
+import string
+from datetime import UTC, datetime, timedelta
+
+import httpx
+from database import AsyncSessionLocal
+from events import broadcast_msg
+from fastapi import APIRouter, Request, Response
+from models import Agent, Guild, Task, Worker, live_tasks_filter
+from sqlalchemy import func, update
+from sqlmodel import col, select
+from ws_types import TaskCancelMsg, TaskCreatedMsg, TaskUpdateMsg
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_DISCORD_API_BASE = "https://discord.com/api/v10"
+
+# Discord interaction types
+_PING = 1
+_APPLICATION_COMMAND = 2
+
+# Discord response types
+_PONG = 1
+_CHANNEL_MESSAGE = 4
+_DEFERRED_CHANNEL_MESSAGE = 5
+
+# Ephemeral message flag
+_EPHEMERAL = 64
+
+# Default soft-delete window for cancelled tasks
+_CANCEL_TTL = timedelta(days=3)
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+
+def _public_key() -> str | None:
+    return os.environ.get("DISCORD_PUBLIC_KEY") or None
+
+
+def _application_id() -> str | None:
+    return os.environ.get("DISCORD_APPLICATION_ID") or None
+
+
+def _bot_token() -> str | None:
+    return os.environ.get("DISCORD_BOT_TOKEN") or None
+
+
+def _pioneer_guild_slug() -> str | None:
+    return os.environ.get("DISCORD_PIONEER_GUILD_SLUG") or None
+
+
+def _allowed_role_ids() -> set[str]:
+    raw = os.environ.get("DISCORD_ALLOWED_ROLE_IDS", "")
+    return {r.strip() for r in raw.split(",") if r.strip()}
+
+
+# ---------------------------------------------------------------------------
+# Ed25519 signature verification
+# ---------------------------------------------------------------------------
+
+
+def _verify_signature(public_key_hex: str, signature_hex: str, timestamp: str, body: bytes) -> bool:
+    """Verify a Discord Ed25519 request signature. Returns False on any error."""
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # noqa: PLC0415
+            Ed25519PublicKey,
+        )
+
+        pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key_hex))
+        pub.verify(bytes.fromhex(signature_hex), timestamp.encode() + body)
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Authorization
+# ---------------------------------------------------------------------------
+
+
+def _is_authorized(interaction: dict) -> bool:
+    """Return True if the interaction's author has an allowed role (or all roles allowed)."""
+    allowed = _allowed_role_ids()
+    if not allowed:
+        return True  # no restriction configured — allow everyone
+    member = interaction.get("member")
+    if not member:
+        # DM interaction — no role info available; deny by default
+        return False
+    user_roles: list[str] = member.get("roles", [])
+    return bool(set(user_roles) & allowed)
+
+
+# ---------------------------------------------------------------------------
+# Discord API helper
+# ---------------------------------------------------------------------------
+
+
+async def _discord_patch(path: str, payload: dict) -> None:
+    """PATCH a Discord REST endpoint. Errors are logged and swallowed."""
+    token = _bot_token()
+    if not token:
+        return
+    headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.patch(f"{_DISCORD_API_BASE}{path}", json=payload, headers=headers)
+            resp.raise_for_status()
+    except Exception:
+        logger.warning("discord: PATCH %s failed", path, exc_info=True)
+
+
+async def _send_followup(
+    interaction_token: str, content: str | None = None, embeds: list | None = None
+) -> None:
+    """Edit the deferred reply for an interaction."""
+    app_id = _application_id()
+    if not app_id:
+        return
+    payload: dict = {}
+    if content is not None:
+        payload["content"] = content
+    if embeds is not None:
+        payload["embeds"] = embeds
+    await _discord_patch(f"/webhooks/{app_id}/{interaction_token}/messages/@original", payload)
+
+
+# ---------------------------------------------------------------------------
+# GitHub URL parsers
+# ---------------------------------------------------------------------------
+
+_GH_ISSUE_RE = re.compile(r"https://github\.com/([^/\s]+/[^/\s]+)/issues/(\d+)", re.IGNORECASE)
+_GH_PR_RE = re.compile(r"https://github\.com/([^/\s]+/[^/\s]+)/pull/(\d+)", re.IGNORECASE)
+
+
+def _parse_issue_url(url: str) -> tuple[str, int] | None:
+    m = _GH_ISSUE_RE.search(url)
+    if not m:
+        return None
+    return m.group(1), int(m.group(2))
+
+
+def _parse_pr_url(url: str) -> tuple[str, int] | None:
+    m = _GH_PR_RE.search(url)
+    if not m:
+        return None
+    return m.group(1), int(m.group(2))
+
+
+def _new_task_id() -> str:
+    return "t-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+
+
+# ---------------------------------------------------------------------------
+# Command implementations (run in background after deferred ack)
+# ---------------------------------------------------------------------------
+
+
+async def _cmd_status(interaction_token: str, guild_slug: str) -> None:
+    """Reply with a summary of workers and active tasks."""
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(select(Guild).where(col(Guild.slug) == guild_slug))
+            guild = result.one_or_none()
+            if not guild:
+                await _send_followup(
+                    interaction_token, content=f"Pioneer guild `{guild_slug}` not found."
+                )
+                return
+            guild_pk = guild.id
+
+            worker_rows = (
+                await db.exec(select(Worker).where(col(Worker.guild_id) == guild_pk))
+            ).all()
+
+            task_rows = (
+                await db.exec(
+                    select(Task).where(
+                        col(Task.guild_id) == guild_pk,
+                        col(Task.state).in_(["pending", "working", "awaiting-review"]),
+                        live_tasks_filter(),
+                    )
+                )
+            ).all()
+
+        total = len(worker_rows)
+        online = sum(1 for w in worker_rows if w.state == "online")
+        idle = sum(1 for w in worker_rows if w.state == "idle")
+        offline = total - online - idle
+
+        state_counts: dict[str, int] = {}
+        for t in task_rows:
+            state_counts[t.state] = state_counts.get(t.state, 0) + 1
+
+        task_lines = (
+            "\n".join(f"• **{s}**: {c}" for s, c in sorted(state_counts.items()))
+            or "No active tasks"
+        )
+
+        embeds = [
+            {
+                "title": "Pioneer Square Status",
+                "color": 0x3498DB,
+                "fields": [
+                    {
+                        "name": "Workers",
+                        "value": f"Total: {total} | Online: {online} | Idle: {idle} | Offline: {offline}",
+                        "inline": False,
+                    },
+                    {
+                        "name": "Active Tasks",
+                        "value": task_lines,
+                        "inline": False,
+                    },
+                ],
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        ]
+        await _send_followup(interaction_token, embeds=embeds)
+    except Exception:
+        logger.exception("discord: /ps status failed")
+        await _send_followup(interaction_token, content="Failed to fetch status.")
+
+
+async def _cmd_workers(interaction_token: str, guild_slug: str) -> None:
+    """Reply with a list of all workers and their state."""
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(select(Guild).where(col(Guild.slug) == guild_slug))
+            guild = result.one_or_none()
+            if not guild:
+                await _send_followup(
+                    interaction_token, content=f"Pioneer guild `{guild_slug}` not found."
+                )
+                return
+            guild_pk = guild.id
+
+            worker_rows = (
+                await db.exec(
+                    select(
+                        col(Worker.id),
+                        col(Worker.state),
+                        col(Worker.repos),
+                        col(Worker.name),
+                        col(Worker.org),
+                        func.count(col(Agent.id)).label("agent_count"),
+                    )
+                    .outerjoin(
+                        Agent,
+                        (col(Agent.worker_id) == col(Worker.id)) & (col(Agent.state) != "offline"),
+                    )
+                    .where(col(Worker.guild_id) == guild_pk)
+                    .group_by(col(Worker.id))
+                )
+            ).all()
+
+        if not worker_rows:
+            await _send_followup(interaction_token, content="No workers registered.")
+            return
+
+        _STATE_EMOJI = {"online": "🟢", "idle": "🟡", "offline": "⚫"}
+        lines = []
+        for row in worker_rows:
+            label = row.name or row.id
+            emoji = _STATE_EMOJI.get(row.state, "❓")
+            repos_raw = row.repos or "[]"
+            try:
+                repos = json.loads(repos_raw)
+            except Exception:
+                repos = []
+            if row.org and not repos:
+                repos_str = f"{row.org}/*"
+            elif repos:
+                repos_str = ", ".join(repos[:3]) + ("..." if len(repos) > 3 else "")
+            else:
+                repos_str = "—"
+            lines.append(
+                f"{emoji} **{label}** ({row.state}) — agents: {row.agent_count} — repos: {repos_str}"
+            )
+
+        embeds = [
+            {
+                "title": "Pioneer Square Workers",
+                "description": "\n".join(lines),
+                "color": 0x1ABC9C,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        ]
+        await _send_followup(interaction_token, embeds=embeds)
+    except Exception:
+        logger.exception("discord: /ps workers failed")
+        await _send_followup(interaction_token, content="Failed to fetch workers.")
+
+
+async def _cmd_pickup(interaction_token: str, guild_slug: str, issue_url: str) -> None:
+    """Create a task to pick up a GitHub issue and assign it to an idle worker."""
+    parsed = _parse_issue_url(issue_url)
+    if not parsed:
+        await _send_followup(
+            interaction_token,
+            content=f"Invalid issue URL: `{issue_url}`\nExpected: `https://github.com/owner/repo/issues/N`",
+        )
+        return
+
+    issue_repo, issue_number = parsed
+
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(select(Guild).where(col(Guild.slug) == guild_slug))
+            guild = result.one_or_none()
+            if not guild:
+                await _send_followup(
+                    interaction_token, content=f"Pioneer guild `{guild_slug}` not found."
+                )
+                return
+            guild_pk = guild.id
+
+            task_id = _new_task_id()
+            task_name = f"{issue_repo}#{issue_number}"
+            desc = f"Implement GitHub issue {issue_repo}#{issue_number}: {issue_url}"
+            created_at = datetime.now(UTC)
+            task = Task(
+                id=task_id,
+                worker_id=None,
+                guild_id=guild_pk,
+                name=task_name,
+                description=desc,
+                tool="claude",
+                state="pending",
+                phase="execute",
+                issue_repo=issue_repo,
+                issue_number=issue_number,
+                created_at=created_at,
+            )
+            db.add(task)
+            await db.commit()
+
+        await broadcast_msg(
+            guild_slug,
+            TaskCreatedMsg(
+                taskId=task_id,
+                name=task_name,
+                description=desc,
+                phase="execute",
+                state="pending",
+                createdAt=created_at.isoformat(),
+            ),
+        )
+
+        embeds = [
+            {
+                "title": f"Issue Claimed: {issue_repo}#{issue_number}",
+                "description": f"Task `{task_id}` created and queued for an idle worker.\n[View issue]({issue_url})",
+                "color": 0x2ECC71,
+                "timestamp": created_at.isoformat(),
+            }
+        ]
+        await _send_followup(interaction_token, embeds=embeds)
+    except Exception:
+        logger.exception("discord: /ps pickup failed for %s", issue_url)
+        await _send_followup(interaction_token, content="Failed to create task.")
+
+
+async def _cmd_review(interaction_token: str, guild_slug: str, pr_url: str) -> None:
+    """Create a PR review task."""
+    parsed = _parse_pr_url(pr_url)
+    if not parsed:
+        await _send_followup(
+            interaction_token,
+            content=f"Invalid PR URL: `{pr_url}`\nExpected: `https://github.com/owner/repo/pull/N`",
+        )
+        return
+
+    pr_repo, pr_number = parsed
+
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(select(Guild).where(col(Guild.slug) == guild_slug))
+            guild = result.one_or_none()
+            if not guild:
+                await _send_followup(
+                    interaction_token, content=f"Pioneer guild `{guild_slug}` not found."
+                )
+                return
+            guild_pk = guild.id
+
+            task_id = _new_task_id()
+            desc = f"Review pull request {pr_repo}#{pr_number}: {pr_url}"
+            created_at = datetime.now(UTC)
+            task = Task(
+                id=task_id,
+                worker_id=None,
+                guild_id=guild_pk,
+                description=desc,
+                tool="claude",
+                state="pending",
+                phase="review",
+                issue_repo=pr_repo,
+                issue_number=pr_number,
+                pr_url=pr_url,
+                pr_number=pr_number,
+                pr_repo=pr_repo,
+                created_at=created_at,
+            )
+            db.add(task)
+            await db.commit()
+
+        pr_name = f"{pr_repo}#{pr_number}"
+        await broadcast_msg(
+            guild_slug,
+            TaskCreatedMsg(
+                taskId=task_id,
+                name=pr_name,
+                description=desc,
+                phase="review",
+                state="pending",
+                createdAt=created_at.isoformat(),
+            ),
+        )
+
+        embeds = [
+            {
+                "title": f"PR Review Queued: {pr_repo}#{pr_number}",
+                "description": f"Review task `{task_id}` created and queued.\n[View PR]({pr_url})",
+                "color": 0x9B59B6,
+                "timestamp": created_at.isoformat(),
+            }
+        ]
+        await _send_followup(interaction_token, embeds=embeds)
+    except Exception:
+        logger.exception("discord: /ps review failed for %s", pr_url)
+        await _send_followup(interaction_token, content="Failed to create review task.")
+
+
+async def _cmd_cancel(interaction_token: str, guild_slug: str, task_id: str) -> None:
+    """Cancel a running task."""
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(select(Guild).where(col(Guild.slug) == guild_slug))
+            guild = result.one_or_none()
+            if not guild:
+                await _send_followup(
+                    interaction_token, content=f"Pioneer guild `{guild_slug}` not found."
+                )
+                return
+            guild_pk = guild.id
+
+            task_result = await db.exec(
+                select(col(Task.worker_id), col(Task.state)).where(
+                    col(Task.id) == task_id, col(Task.guild_id) == guild_pk
+                )
+            )
+            row = task_result.one_or_none()
+            if not row:
+                await _send_followup(interaction_token, content=f"Task `{task_id}` not found.")
+                return
+
+            worker_id, state = row
+            if state in ("done", "failed", "cancelled"):
+                await _send_followup(
+                    interaction_token, content=f"Task `{task_id}` is already `{state}`."
+                )
+                return
+
+            deleted_at = datetime.now(UTC) + _CANCEL_TTL
+            await db.exec(
+                update(Task)
+                .where(col(Task.id) == task_id)
+                .values(state="cancelled", deleted_at=deleted_at)
+            )
+            await db.commit()
+
+        await broadcast_msg(guild_slug, TaskCancelMsg(workerId=worker_id, taskId=task_id))
+        await broadcast_msg(
+            guild_slug,
+            TaskUpdateMsg(taskId=task_id, state="cancelled", deletedAt=deleted_at.isoformat()),
+        )
+
+        embeds = [
+            {
+                "title": f"Task Cancelled: {task_id}",
+                "description": f"Task `{task_id}` has been cancelled.",
+                "color": 0xE74C3C,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        ]
+        await _send_followup(interaction_token, embeds=embeds)
+    except Exception:
+        logger.exception("discord: /ps cancel failed for task %s", task_id)
+        await _send_followup(interaction_token, content="Failed to cancel task.")
+
+
+# ---------------------------------------------------------------------------
+# Command dispatcher
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch_command(interaction: dict) -> None:
+    """Parse the interaction data and dispatch to the appropriate command handler."""
+    token = interaction.get("token", "")
+    data = interaction.get("data", {})
+    guild_slug = _pioneer_guild_slug() or ""
+
+    options: list[dict] = data.get("options", [])
+    if not options:
+        await _send_followup(token, content="Unknown subcommand.")
+        return
+
+    sub = options[0]
+    sub_name = sub.get("name", "")
+    sub_opts = {o["name"]: o["value"] for o in sub.get("options", [])}
+
+    if sub_name == "status":
+        await _cmd_status(token, guild_slug)
+    elif sub_name == "workers":
+        await _cmd_workers(token, guild_slug)
+    elif sub_name == "pickup":
+        issue_url = sub_opts.get("issue-url", "")
+        await _cmd_pickup(token, guild_slug, issue_url)
+    elif sub_name == "review":
+        pr_url = sub_opts.get("pr-url", "")
+        await _cmd_review(token, guild_slug, pr_url)
+    elif sub_name == "cancel":
+        task_id_val = sub_opts.get("task-id", "")
+        await _cmd_cancel(token, guild_slug, task_id_val)
+    else:
+        await _send_followup(token, content=f"Unknown subcommand: `{sub_name}`")
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/discord/interactions")
+async def discord_interactions(request: Request) -> Response:
+    """Receive and handle Discord interaction payloads.
+
+    Signature verification is always performed first. PING responses are
+    immediate. Slash commands return a deferred ephemeral acknowledgement
+    within the 3-second Discord window and then resolve the response in a
+    background task.
+    """
+    pub_key = _public_key()
+    body = await request.body()
+
+    # Always verify signature if a public key is configured
+    if pub_key:
+        sig = request.headers.get("x-signature-ed25519", "")
+        ts = request.headers.get("x-signature-timestamp", "")
+        if not sig or not ts or not _verify_signature(pub_key, sig, ts, body):
+            return Response(content="Invalid signature", status_code=401)
+
+    try:
+        interaction = json.loads(body)
+    except Exception:
+        return Response(content="Bad JSON", status_code=400)
+
+    itype = interaction.get("type")
+
+    # Discord PING health check — must respond with PONG immediately
+    if itype == _PING:
+        return Response(
+            content=json.dumps({"type": _PONG}),
+            media_type="application/json",
+        )
+
+    if itype == _APPLICATION_COMMAND:
+        # Authorization check — return an immediate non-deferred ephemeral error
+        if not _is_authorized(interaction):
+            payload = {
+                "type": _CHANNEL_MESSAGE,
+                "data": {
+                    "content": "You are not authorized to use Pioneer Square commands.",
+                    "flags": _EPHEMERAL,
+                },
+            }
+            return Response(content=json.dumps(payload), media_type="application/json")
+
+        # Acknowledge immediately with a deferred ephemeral response
+        ack = {
+            "type": _DEFERRED_CHANNEL_MESSAGE,
+            "data": {"flags": _EPHEMERAL},
+        }
+
+        # Schedule command execution in the background
+        asyncio.ensure_future(_dispatch_command(interaction))
+
+        return Response(content=json.dumps(ack), media_type="application/json")
+
+    return Response(content=json.dumps({"error": "unhandled interaction type"}), status_code=400)

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -578,8 +578,8 @@ async def discord_interactions(request: Request, background_tasks: BackgroundTas
     """
     pub_key = _public_key()
     if not pub_key:
-        logger.error("discord: DISCORD_PUBLIC_KEY is not configured; refusing request")
-        return Response(content="Server misconfiguration: DISCORD_PUBLIC_KEY not set", status_code=500)
+        logger.error("discord: DISCORD_PUBLIC_KEY is not configured; refusing all requests")
+        return Response(content="Invalid signature", status_code=401)
 
     body = await request.body()
     sig = request.headers.get("x-signature-ed25519", "")

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -21,7 +21,6 @@ Registered slash commands (see scripts/register_discord_commands.py):
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -33,7 +32,7 @@ from datetime import UTC, datetime, timedelta
 import httpx
 from database import AsyncSessionLocal
 from events import broadcast_msg
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Request, Response
 from models import Agent, Guild, Task, Worker, live_tasks_filter
 from sqlalchemy import func, update
 from sqlmodel import col, select
@@ -418,12 +417,14 @@ async def _cmd_review(interaction_token: str, guild_slug: str, pr_url: str) -> N
             guild_pk = guild.id
 
             task_id = _new_task_id()
+            task_name = f"Review PR {pr_url}"
             desc = f"Review pull request {pr_repo}#{pr_number}: {pr_url}"
             created_at = datetime.now(UTC)
             task = Task(
                 id=task_id,
                 worker_id=None,
                 guild_id=guild_pk,
+                name=task_name,
                 description=desc,
                 tool="claude",
                 state="pending",
@@ -503,7 +504,8 @@ async def _cmd_cancel(interaction_token: str, guild_slug: str, task_id: str) -> 
             )
             await db.commit()
 
-        await broadcast_msg(guild_slug, TaskCancelMsg(workerId=worker_id, taskId=task_id))
+        if worker_id:
+            await broadcast_msg(guild_slug, TaskCancelMsg(workerId=worker_id, taskId=task_id))
         await broadcast_msg(
             guild_slug,
             TaskUpdateMsg(taskId=task_id, state="cancelled", deletedAt=deleted_at.isoformat()),
@@ -566,7 +568,7 @@ async def _dispatch_command(interaction: dict) -> None:
 
 
 @router.post("/discord/interactions")
-async def discord_interactions(request: Request) -> Response:
+async def discord_interactions(request: Request, background_tasks: BackgroundTasks) -> Response:
     """Receive and handle Discord interaction payloads.
 
     Signature verification is always performed first. PING responses are
@@ -575,14 +577,15 @@ async def discord_interactions(request: Request) -> Response:
     background task.
     """
     pub_key = _public_key()
-    body = await request.body()
+    if not pub_key:
+        logger.error("discord: DISCORD_PUBLIC_KEY is not configured; refusing request")
+        return Response(content="Server misconfiguration: DISCORD_PUBLIC_KEY not set", status_code=500)
 
-    # Always verify signature if a public key is configured
-    if pub_key:
-        sig = request.headers.get("x-signature-ed25519", "")
-        ts = request.headers.get("x-signature-timestamp", "")
-        if not sig or not ts or not _verify_signature(pub_key, sig, ts, body):
-            return Response(content="Invalid signature", status_code=401)
+    body = await request.body()
+    sig = request.headers.get("x-signature-ed25519", "")
+    ts = request.headers.get("x-signature-timestamp", "")
+    if not sig or not ts or not _verify_signature(pub_key, sig, ts, body):
+        return Response(content="Invalid signature", status_code=401)
 
     try:
         interaction = json.loads(body)
@@ -617,7 +620,7 @@ async def discord_interactions(request: Request) -> Response:
         }
 
         # Schedule command execution in the background
-        asyncio.ensure_future(_dispatch_command(interaction))
+        background_tasks.add_task(_dispatch_command, interaction)
 
         return Response(content=json.dumps(ack), media_type="application/json")
 

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -202,16 +202,15 @@ def test_valid_ping_returns_pong(client, keypair, monkeypatch):
     assert resp.json() == {"type": 1}
 
 
-def test_no_public_key_skips_verification(client, monkeypatch):
-    """When DISCORD_PUBLIC_KEY is absent, PING passes without verification."""
+def test_no_public_key_returns_401(client, monkeypatch):
+    """When DISCORD_PUBLIC_KEY is absent, all requests are rejected with 401."""
     c, _ = client
     monkeypatch.delenv("DISCORD_PUBLIC_KEY", raising=False)
     body = json.dumps({"type": 1}).encode()
     resp = c.post(
         "/discord/interactions", content=body, headers={"Content-Type": "application/json"}
     )
-    assert resp.status_code == 200
-    assert resp.json() == {"type": 1}
+    assert resp.status_code == 401
 
 
 def test_unauthorized_user_gets_ephemeral_denied(client, keypair, monkeypatch):

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -1,0 +1,558 @@
+"""Integration tests for the Discord slash command interaction endpoint.
+
+Tests use mocked Ed25519 keys — no real Discord credentials are needed.
+HTTP endpoint tests rely on the conftest ``client`` fixture (postgres-test DB).
+Pure-unit tests run without any DB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_keypair():
+    """Return (private_key, public_key_hex)."""
+    priv = Ed25519PrivateKey.generate()
+    pub_bytes = priv.public_key().public_bytes_raw()
+    return priv, pub_bytes.hex()
+
+
+def _sign(private_key, timestamp: str, body: bytes) -> str:
+    """Hex Ed25519 signature of timestamp||body."""
+    return private_key.sign(timestamp.encode() + body).hex()
+
+
+@pytest.fixture()
+def keypair():
+    return _generate_keypair()
+
+
+def _post_signed(c, priv, body: dict, timestamp: str = "1234567890"):
+    raw = json.dumps(body).encode()
+    sig = _sign(priv, timestamp, raw)
+    return c.post(
+        "/discord/interactions",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Signature-Ed25519": sig,
+            "X-Signature-Timestamp": timestamp,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signature verification (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_signature_correct():
+    from routes.discord import _verify_signature
+
+    priv, pub_hex = _generate_keypair()
+    body = b'{"type":1}'
+    ts = "1700000000"
+    sig = _sign(priv, ts, body)
+    assert _verify_signature(pub_hex, sig, ts, body) is True
+
+
+def test_verify_signature_tampered_body():
+    from routes.discord import _verify_signature
+
+    priv, pub_hex = _generate_keypair()
+    body = b'{"type":1}'
+    ts = "1700000000"
+    sig = _sign(priv, ts, body)
+    assert _verify_signature(pub_hex, sig, ts, b'{"type":2}') is False
+
+
+def test_verify_signature_wrong_key():
+    from routes.discord import _verify_signature
+
+    priv, _ = _generate_keypair()
+    _, other_pub = _generate_keypair()
+    body = b'{"type":1}'
+    ts = "1700000000"
+    sig = _sign(priv, ts, body)
+    assert _verify_signature(other_pub, sig, ts, body) is False
+
+
+# ---------------------------------------------------------------------------
+# URL parsers (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_issue_url_valid():
+    from routes.discord import _parse_issue_url
+
+    assert _parse_issue_url("https://github.com/my-org/my-repo/issues/42") == (
+        "my-org/my-repo",
+        42,
+    )
+
+
+def test_parse_issue_url_invalid():
+    from routes.discord import _parse_issue_url
+
+    assert _parse_issue_url("https://github.com/org/repo/pull/1") is None
+    assert _parse_issue_url("not-a-url") is None
+
+
+def test_parse_pr_url_valid():
+    from routes.discord import _parse_pr_url
+
+    assert _parse_pr_url("https://github.com/org/repo/pull/99") == ("org/repo", 99)
+
+
+def test_parse_pr_url_invalid():
+    from routes.discord import _parse_pr_url
+
+    assert _parse_pr_url("https://github.com/org/repo/issues/1") is None
+
+
+# ---------------------------------------------------------------------------
+# Authorization (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def test_is_authorized_no_restriction():
+    """Empty DISCORD_ALLOWED_ROLE_IDS → allow all."""
+    from routes.discord import _is_authorized
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("DISCORD_ALLOWED_ROLE_IDS", None)
+        assert _is_authorized({"member": {"roles": []}}) is True
+        assert _is_authorized({}) is True
+
+
+def test_is_authorized_matching_role(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_ROLE_IDS", "role-a,role-b")
+    from routes.discord import _is_authorized
+
+    assert _is_authorized({"member": {"roles": ["role-b", "role-c"]}}) is True
+
+
+def test_is_authorized_no_matching_role(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_ROLE_IDS", "role-a,role-b")
+    from routes.discord import _is_authorized
+
+    assert _is_authorized({"member": {"roles": ["role-x"]}}) is False
+
+
+def test_is_authorized_dm_denied_when_roles_required(monkeypatch):
+    """DM interaction (no member) is denied when role restrictions are set."""
+    monkeypatch.setenv("DISCORD_ALLOWED_ROLE_IDS", "some-role")
+    from routes.discord import _is_authorized
+
+    assert _is_authorized({}) is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests (use conftest client with real DB)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_signature_returns_401(client, keypair, monkeypatch):
+    """A wrong signature must return HTTP 401."""
+    c, _ = client
+    priv, pub_hex = keypair
+    monkeypatch.setenv("DISCORD_PUBLIC_KEY", pub_hex)
+    body = json.dumps({"type": 1}).encode()
+    resp = c.post(
+        "/discord/interactions",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Signature-Ed25519": "deadbeef" * 8,
+            "X-Signature-Timestamp": "1234567890",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_missing_signature_headers_returns_401(client, keypair, monkeypatch):
+    """Missing signature headers → HTTP 401."""
+    c, _ = client
+    _, pub_hex = keypair
+    monkeypatch.setenv("DISCORD_PUBLIC_KEY", pub_hex)
+    body = json.dumps({"type": 1}).encode()
+    resp = c.post("/discord/interactions", content=body)
+    assert resp.status_code == 401
+
+
+def test_valid_ping_returns_pong(client, keypair, monkeypatch):
+    """Type-1 PING with a valid signature → type-1 PONG."""
+    c, _ = client
+    priv, pub_hex = keypair
+    monkeypatch.setenv("DISCORD_PUBLIC_KEY", pub_hex)
+    resp = _post_signed(c, priv, {"type": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"type": 1}
+
+
+def test_no_public_key_skips_verification(client, monkeypatch):
+    """When DISCORD_PUBLIC_KEY is absent, PING passes without verification."""
+    c, _ = client
+    monkeypatch.delenv("DISCORD_PUBLIC_KEY", raising=False)
+    body = json.dumps({"type": 1}).encode()
+    resp = c.post(
+        "/discord/interactions", content=body, headers={"Content-Type": "application/json"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"type": 1}
+
+
+def test_unauthorized_user_gets_ephemeral_denied(client, keypair, monkeypatch):
+    """User without an allowed role receives ephemeral 'not authorized' message."""
+    c, _ = client
+    priv, pub_hex = keypair
+    monkeypatch.setenv("DISCORD_PUBLIC_KEY", pub_hex)
+    monkeypatch.setenv("DISCORD_ALLOWED_ROLE_IDS", "allowed-role-1,allowed-role-2")
+    interaction = {
+        "type": 2,
+        "token": "tok",
+        "data": {
+            "name": "ps",
+            "type": 1,
+            "options": [{"name": "status", "type": 1, "options": []}],
+        },
+        "member": {"roles": ["some-other-role"]},
+    }
+    resp = _post_signed(c, priv, interaction)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["type"] == 4
+    assert data["data"]["flags"] == 64
+    assert "not authorized" in data["data"]["content"].lower()
+
+
+def test_authorized_user_gets_deferred_ack(client, keypair, monkeypatch):
+    """User with an allowed role gets a deferred ephemeral ack (type 5)."""
+    c, _ = client
+    priv, pub_hex = keypair
+    monkeypatch.setenv("DISCORD_PUBLIC_KEY", pub_hex)
+    monkeypatch.setenv("DISCORD_ALLOWED_ROLE_IDS", "allowed-role")
+    interaction = {
+        "type": 2,
+        "token": "tok",
+        "data": {
+            "name": "ps",
+            "type": 1,
+            "options": [{"name": "status", "type": 1, "options": []}],
+        },
+        "member": {"roles": ["allowed-role"]},
+    }
+    with patch("routes.discord._dispatch_command", new=AsyncMock()):
+        resp = _post_signed(c, priv, interaction)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["type"] == 5
+    assert data["data"]["flags"] == 64
+
+
+def test_no_roles_configured_allows_everyone(client, keypair, monkeypatch):
+    """No DISCORD_ALLOWED_ROLE_IDS → anyone is allowed (deferred ack)."""
+    c, _ = client
+    priv, pub_hex = keypair
+    monkeypatch.setenv("DISCORD_PUBLIC_KEY", pub_hex)
+    monkeypatch.delenv("DISCORD_ALLOWED_ROLE_IDS", raising=False)
+    interaction = {
+        "type": 2,
+        "token": "tok",
+        "data": {
+            "name": "ps",
+            "type": 1,
+            "options": [{"name": "status", "type": 1, "options": []}],
+        },
+        "member": {"roles": []},
+    }
+    with patch("routes.discord._dispatch_command", new=AsyncMock()):
+        resp = _post_signed(c, priv, interaction)
+    assert resp.status_code == 200
+    assert resp.json()["type"] == 5
+
+
+# ---------------------------------------------------------------------------
+# _cmd_* unit tests — all DB calls mocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cmd_status_sends_embed(monkeypatch):
+    """_cmd_status sends an embed with worker and task summary."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    guild = MagicMock()
+    guild.id = 1
+
+    w_online = MagicMock()
+    w_online.state = "online"
+    w_idle = MagicMock()
+    w_idle.state = "idle"
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value=guild)),
+            MagicMock(all=MagicMock(return_value=[w_online, w_idle])),
+            MagicMock(all=MagicMock(return_value=[])),
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_status
+
+        await _cmd_status("tok-123", "test-guild")
+
+    assert sent
+    assert sent[0]["embeds"][0]["title"] == "Pioneer Square Status"
+
+
+@pytest.mark.asyncio
+async def test_cmd_workers_sends_embed(monkeypatch):
+    """_cmd_workers lists all workers in an embed."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    guild = MagicMock()
+    guild.id = 2
+
+    row = MagicMock()
+    row.id = "w-abc123"
+    row.state = "online"
+    row.repos = '["org/repo"]'
+    row.name = "my-worker"
+    row.org = None
+    row.agent_count = 2
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value=guild)),
+            MagicMock(all=MagicMock(return_value=[row])),
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_workers
+
+        await _cmd_workers("tok-w", "test-guild")
+
+    assert sent
+    assert "Workers" in sent[0]["embeds"][0]["title"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_pickup_creates_task_and_broadcasts(monkeypatch):
+    """_cmd_pickup creates a Task row and broadcasts TaskCreatedMsg."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    guild = MagicMock()
+    guild.id = 7
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=guild)))
+    mock_db.add = MagicMock()
+    mock_db.commit = AsyncMock()
+
+    sent = []
+    broadcast_calls = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    async def fake_broadcast(guild_slug, msg):
+        broadcast_calls.append((guild_slug, msg))
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("routes.discord.broadcast_msg", new=fake_broadcast),
+    ):
+        from routes.discord import _cmd_pickup
+
+        await _cmd_pickup("tok-p", "test-guild", "https://github.com/org/repo/issues/10")
+
+    assert mock_db.add.called
+    assert mock_db.commit.called
+    assert broadcast_calls
+    assert sent
+    assert "10" in sent[0]["embeds"][0]["title"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_pickup_invalid_url_sends_error(monkeypatch):
+    """_cmd_pickup rejects invalid issue URLs without touching the DB."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    with patch("routes.discord._discord_patch", new=fake_patch):
+        from routes.discord import _cmd_pickup
+
+        await _cmd_pickup("tok-bad", "test-guild", "not-a-url")
+
+    assert sent
+    assert "Invalid" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_review_creates_task(monkeypatch):
+    """_cmd_review creates a review-phase Task row."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    guild = MagicMock()
+    guild.id = 5
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=guild)))
+    mock_db.add = MagicMock()
+    mock_db.commit = AsyncMock()
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    async def fake_broadcast(guild_slug, msg):
+        pass
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("routes.discord.broadcast_msg", new=fake_broadcast),
+    ):
+        from routes.discord import _cmd_review
+
+        await _cmd_review("tok-r", "test-guild", "https://github.com/org/repo/pull/99")
+
+    assert mock_db.add.called
+    added_task = mock_db.add.call_args[0][0]
+    assert added_task.phase == "review"
+    assert added_task.pr_number == 99
+    assert sent
+    assert "99" in sent[0]["embeds"][0]["title"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_cancel_cancels_task(monkeypatch):
+    """_cmd_cancel sets task state to cancelled and broadcasts."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    guild = MagicMock()
+    guild.id = 3
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value=guild)),
+            MagicMock(one_or_none=MagicMock(return_value=("w-worker1", "working"))),
+            MagicMock(),
+        ]
+    )
+    mock_db.commit = AsyncMock()
+
+    sent = []
+    broadcast_calls = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    async def fake_broadcast(guild_slug, msg):
+        broadcast_calls.append((guild_slug, msg))
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("routes.discord.broadcast_msg", new=fake_broadcast),
+    ):
+        from routes.discord import _cmd_cancel
+
+        await _cmd_cancel("tok-c", "test-guild", "t-abc123")
+
+    assert mock_db.commit.called
+    assert len(broadcast_calls) == 2
+    assert sent
+    assert "t-abc123" in sent[0]["embeds"][0]["title"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_cancel_already_done(monkeypatch):
+    """_cmd_cancel returns informational message when task is already done."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    guild = MagicMock()
+    guild.id = 3
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value=guild)),
+            MagicMock(one_or_none=MagicMock(return_value=("w-w1", "done"))),
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_cancel
+
+        await _cmd_cancel("tok-done", "test-guild", "t-done1")
+
+    assert sent
+    assert "already" in sent[0]["content"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,11 @@ services:
       # together; falls back to DISCORD_WEBHOOK_URL if thread creation fails.
       # DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
       # DISCORD_CHANNEL_ID: ${DISCORD_CHANNEL_ID:-}
+      # Phase 3: slash commands & bidirectional control.
+      # DISCORD_APPLICATION_ID: ${DISCORD_APPLICATION_ID:-}
+      # DISCORD_PUBLIC_KEY: ${DISCORD_PUBLIC_KEY:-}
+      # DISCORD_ALLOWED_ROLE_IDS: ${DISCORD_ALLOWED_ROLE_IDS:-}
+      # DISCORD_PIONEER_GUILD_SLUG: ${DISCORD_PIONEER_GUILD_SLUG:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "cd backend && alembic upgrade head && cd .. && pioneer serve"

--- a/scripts/register_discord_commands.py
+++ b/scripts/register_discord_commands.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Register (or update) Pioneer Square slash commands with Discord.
+
+Run once after adding or changing commands:
+
+    DISCORD_APPLICATION_ID=<id> DISCORD_BOT_TOKEN=<token> python scripts/register_discord_commands.py
+
+To register commands for a specific Discord guild only (faster for dev):
+
+    DISCORD_APPLICATION_ID=<id> DISCORD_BOT_TOKEN=<token> \
+        DISCORD_DEV_GUILD_ID=<guild_id> python scripts/register_discord_commands.py
+
+Without DISCORD_DEV_GUILD_ID the commands are registered globally (takes up to 1 hour to propagate).
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+APPLICATION_ID = os.environ.get("DISCORD_APPLICATION_ID", "")
+BOT_TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
+DEV_GUILD_ID = os.environ.get("DISCORD_DEV_GUILD_ID", "")
+
+if not APPLICATION_ID or not BOT_TOKEN:
+    print("Error: DISCORD_APPLICATION_ID and DISCORD_BOT_TOKEN must be set.", file=sys.stderr)
+    sys.exit(1)
+
+# /ps command with five subcommands
+COMMANDS = [
+    {
+        "name": "ps",
+        "description": "Pioneer Square control commands",
+        "options": [
+            {
+                "name": "status",
+                "description": "Show current workers and active task counts",
+                "type": 1,  # SUB_COMMAND
+            },
+            {
+                "name": "workers",
+                "description": "List all workers with their state, repos, and agent count",
+                "type": 1,  # SUB_COMMAND
+            },
+            {
+                "name": "pickup",
+                "description": "Claim a GitHub issue and assign it to an idle worker",
+                "type": 1,  # SUB_COMMAND
+                "options": [
+                    {
+                        "name": "issue-url",
+                        "description": "Full GitHub issue URL (e.g. https://github.com/owner/repo/issues/123)",
+                        "type": 3,  # STRING
+                        "required": True,
+                    }
+                ],
+            },
+            {
+                "name": "review",
+                "description": "Trigger a PR review task",
+                "type": 1,  # SUB_COMMAND
+                "options": [
+                    {
+                        "name": "pr-url",
+                        "description": "Full GitHub PR URL (e.g. https://github.com/owner/repo/pull/456)",
+                        "type": 3,  # STRING
+                        "required": True,
+                    }
+                ],
+            },
+            {
+                "name": "cancel",
+                "description": "Cancel a running task",
+                "type": 1,  # SUB_COMMAND
+                "options": [
+                    {
+                        "name": "task-id",
+                        "description": "Task ID to cancel (e.g. t-abc123)",
+                        "type": 3,  # STRING
+                        "required": True,
+                    }
+                ],
+            },
+        ],
+    }
+]
+
+DISCORD_API = "https://discord.com/api/v10"
+
+if DEV_GUILD_ID:
+    url = f"{DISCORD_API}/applications/{APPLICATION_ID}/guilds/{DEV_GUILD_ID}/commands"
+    scope = f"guild {DEV_GUILD_ID}"
+else:
+    url = f"{DISCORD_API}/applications/{APPLICATION_ID}/commands"
+    scope = "global"
+
+print(f"Registering commands ({scope}) …")
+
+data = json.dumps(COMMANDS).encode()
+req = urllib.request.Request(
+    url,
+    data=data,
+    method="PUT",
+    headers={
+        "Authorization": f"Bot {BOT_TOKEN}",
+        "Content-Type": "application/json",
+    },
+)
+
+try:
+    with urllib.request.urlopen(req) as resp:
+        body = json.loads(resp.read())
+    print(f"Registered {len(body)} command(s):")
+    for cmd in body:
+        print(f"  /{cmd['name']} — {cmd['description']}")
+    print("Done.")
+except urllib.error.HTTPError as exc:
+    detail = exc.read().decode(errors="replace")
+    print(f"HTTP {exc.code}: {detail}", file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
## Summary

Implements Phase 3 Discord slash commands, building on Phase 1 (webhook) and Phase 2 (per-PR threads).

**New endpoint:** `POST /discord/interactions`

- Ed25519 signature verification using `X-Signature-Ed25519` / `X-Signature-Timestamp` headers — tampered requests get HTTP 401
- Role-based authorization via `DISCORD_ALLOWED_ROLE_IDS` (comma-separated); unauthorized users get an ephemeral "not authorized" message; empty = allow all
- Immediate deferred-ephemeral acknowledgement (Discord type 5) within the 3-second timeout window; actual response sent via background task through `PATCH /webhooks/{app_id}/{token}/messages/@original`

**Five `/ps` subcommands:**

| Command | Action |
|---|---|
| `/ps status` | Formatted embed: worker states + active task counts |
| `/ps workers` | Lists all workers with state, repos, and agent count |
| `/ps pickup <issue-url>` | Parses GitHub issue URL, creates a `pending/execute` task, broadcasts `task-created` |
| `/ps review <pr-url>` | Parses GitHub PR URL, creates a `pending/review` task, broadcasts `task-created` |
| `/ps cancel <task-id>` | Cancels task, broadcasts `TaskCancelMsg` + `TaskUpdateMsg` |

**New script:** `scripts/register_discord_commands.py` — one-shot command registration using Discord application commands REST API (supports both global and dev-guild registration via `DISCORD_DEV_GUILD_ID`).

**New env vars** (all optional, documented in docker-compose.yml):
- `DISCORD_APPLICATION_ID` — required for followup responses and command registration
- `DISCORD_PUBLIC_KEY` — hex Ed25519 key from Discord dev portal; skip verification when absent (dev mode)
- `DISCORD_ALLOWED_ROLE_IDS` — comma-separated role IDs; empty = allow all
- `DISCORD_PIONEER_GUILD_SLUG` — which Pioneer Square guild to target

## Test plan

- [x] 18 unit/integration tests added (`backend/tests/test_discord_interactions.py`)
  - Ed25519 signature verification (correct, tampered body, wrong key)
  - URL parsers for issue and PR URLs
  - Authorization logic (role match, no match, DM denial, empty = allow all)
  - All five command implementations with mocked DB and Discord API
  - HTTP endpoint tests via conftest client (invalid sig → 401, valid PING → PONG, auth denial, deferred ack)
- [x] `ruff check . --fix && ruff format .` passes clean
- Run `python scripts/register_discord_commands.py` with real credentials to register commands

Closes #710