### PR TITLE
Discord: Foreman chat as thread + user identity (#717)

### DIFF
--- a/backend/alembic/versions/20260704_000001_add_discord_users.py
+++ b/backend/alembic/versions/20260704_000001_add_discord_users.py
@@ -1,0 +1,37 @@
+"""Add discord_users table mapping GitHub logins to Discord user IDs.
+
+Revision ID: 20260704_000001_add_discord_users
+Revises: 20260704_000000_merge_discord_threads_and_model_tier
+Create Date: 2026-07-04
+
+Lets the notifier turn a plain ``@login`` reference into a real Discord
+``<@id>`` mention when a human has linked the two accounts via the
+``/api/discord-users`` REST endpoints.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260704_000001_add_discord_users"
+down_revision: str | Sequence[str] | None = "20260704_000000_merge_discord_threads_and_model_tier"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "discord_users",
+        sa.Column("github_login", sa.Text(), nullable=False),
+        sa.Column("discord_user_id", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("github_login"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("discord_users")

--- a/backend/alembic/versions/20260704_000002_add_discord_foreman_threads.py
+++ b/backend/alembic/versions/20260704_000002_add_discord_foreman_threads.py
@@ -1,0 +1,48 @@
+"""Add discord_foreman_threads table for per-session Foreman chat threads.
+
+Revision ID: 20260704_000002_add_discord_foreman_threads
+Revises: 20260704_000001_add_discord_users
+Create Date: 2026-07-04
+
+Maps a (guild_id, session_key) pair — one calendar day of Foreman chat, per
+guild — to a Discord thread channel ID so Foreman<->user narration can be
+mirrored into the notification channel without re-creating the thread on
+every turn or every restart.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260704_000002_add_discord_foreman_threads"
+down_revision: str | Sequence[str] | None = "20260704_000001_add_discord_users"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "discord_foreman_threads",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("guild_id", sa.Text(), nullable=False),
+        sa.Column("session_key", sa.Text(), nullable=False),
+        sa.Column("thread_id", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_discord_foreman_threads_guild_session",
+        "discord_foreman_threads",
+        ["guild_id", "session_key"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_discord_foreman_threads_guild_session", table_name="discord_foreman_threads"
+    )
+    op.drop_table("discord_foreman_threads")

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -1,4 +1,5 @@
-"""Discord notification helpers: flat webhook (Phase 1) and per-PR/issue threads (Phase 2).
+"""Discord notification helpers: flat webhook (Phase 1), per-PR/issue threads (Phase 2),
+and Foreman chat threads + user mentions (Phase 3).
 
 Phase 1 — flat webhook
     Set ``DISCORD_WEBHOOK_URL`` in the environment to post embeds to a single channel.
@@ -13,7 +14,17 @@ Phase 2 — per-PR/issue threads
     Both tokens absent → silent no-op.  HTTP and DB failures are always logged
     at WARNING level and never propagate.
 
-Required bot permissions for Phase 2: ``SEND_MESSAGES``, ``CREATE_PUBLIC_THREADS``, ``MANAGE_THREADS``.
+Phase 3 — Foreman chat threads + user mentions
+    ``notify_foreman_chat`` mirrors Foreman → user chat narration into one
+    Discord thread per guild per UTC day (mapping persisted in
+    ``discord_foreman_threads``), reusing the same bot token/channel as Phase 2.
+
+    ``mention_or_login`` resolves a GitHub login to a real ``<@id>`` Discord
+    mention via the ``discord_users`` table (populated through the
+    ``/api/discord-users`` REST endpoints). Falls back to a plain ``@login``
+    string when no mapping exists — never raises, never blocks a notification.
+
+Required bot permissions for Phase 2/3: ``SEND_MESSAGES``, ``CREATE_PUBLIC_THREADS``, ``MANAGE_THREADS``.
 
 Usage::
 
@@ -31,6 +42,12 @@ Usage::
         thread_name="#42: Fix the bug",
         header_fields={"Assignee": "@alice", "Labels": "bug"},
     )
+
+    # Foreman chat mirrored into a per-day thread:
+    await discord_notifier.notify_foreman_chat(guild_id, "Spun up worker w-abc for t-123.")
+
+    # Resolve a GitHub login to a Discord mention (or a plain @login fallback):
+    mention = await discord_notifier.mention_or_login("alice")
 """
 
 from __future__ import annotations
@@ -221,12 +238,44 @@ async def _save_thread(issue_repo: str, issue_number: int, thread_id: str) -> No
         )
 
 
-async def _ensure_thread(issue_repo: str, issue_number: int, thread_name: str) -> str | None:
-    """Return the Discord thread_id for a PR/issue, creating it if necessary.
+async def _create_thread_in_channel(channel: str, thread_name: str) -> str | None:
+    """Create a new thread in *channel*, anchored by a starter message.
 
     For standard text channels, thread creation requires a starter message first:
     POST /channels/{channel}/messages → get message_id
     POST /channels/{channel}/messages/{message_id}/threads → get thread_id
+
+    Returns the new thread_id, or None on API error.
+    """
+    starter = await _bot_request(
+        "post",
+        f"/channels/{channel}/messages",
+        {"content": thread_name[:100]},
+    )
+    if not starter:
+        return None
+    message_id = starter.get("id")
+    if not message_id:
+        logger.warning("discord: starter message returned no id for channel=%s", channel)
+        return None
+
+    data = await _bot_request(
+        "post",
+        f"/channels/{channel}/messages/{message_id}/threads",
+        {"name": thread_name[:100]},
+    )
+    if not data:
+        return None
+
+    new_thread_id = data.get("id")
+    if not new_thread_id:
+        logger.warning("discord: thread creation returned no id for channel=%s", channel)
+        return None
+    return new_thread_id
+
+
+async def _ensure_thread(issue_repo: str, issue_number: int, thread_name: str) -> str | None:
+    """Return the Discord thread_id for a PR/issue, creating it if necessary.
 
     Returns None when bot token or channel ID are not configured, or on API error.
     """
@@ -238,35 +287,8 @@ async def _ensure_thread(issue_repo: str, issue_number: int, thread_name: str) -
     if not channel:
         return None
 
-    # Step 1: post a starter message to anchor the thread
-    starter = await _bot_request(
-        "post",
-        f"/channels/{channel}/messages",
-        {"content": thread_name[:100]},
-    )
-    if not starter:
-        return None
-    message_id = starter.get("id")
-    if not message_id:
-        logger.warning(
-            "discord: starter message returned no id for repo=%s #%s", issue_repo, issue_number
-        )
-        return None
-
-    # Step 2: create the thread from that starter message
-    data = await _bot_request(
-        "post",
-        f"/channels/{channel}/messages/{message_id}/threads",
-        {"name": thread_name[:100]},
-    )
-    if not data:
-        return None
-
-    new_thread_id = data.get("id")
+    new_thread_id = await _create_thread_in_channel(channel, thread_name)
     if not new_thread_id:
-        logger.warning(
-            "discord: thread creation returned no id for repo=%s #%s", issue_repo, issue_number
-        )
         return None
 
     await _save_thread(issue_repo, issue_number, new_thread_id)
@@ -297,6 +319,148 @@ async def _post_to_thread(
 async def archive_thread(thread_id: str) -> None:
     """Archive a Discord thread. Never raises."""
     await _bot_request("patch", f"/channels/{thread_id}", {"archived": True})
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Foreman chat threads
+# ---------------------------------------------------------------------------
+
+
+async def _lookup_foreman_thread(guild_id: str, session_key: str) -> str | None:
+    """Return the persisted Discord thread_id for a Foreman chat session, or None."""
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415
+        from models import DiscordForemanThread  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(
+                select(DiscordForemanThread).where(
+                    col(DiscordForemanThread.guild_id) == guild_id,
+                    col(DiscordForemanThread.session_key) == session_key,
+                )
+            )
+            row = result.one_or_none()
+            return row.thread_id if row else None
+    except Exception:
+        logger.warning(
+            "discord: foreman thread DB lookup failed guild=%s session=%s",
+            guild_id,
+            session_key,
+            exc_info=True,
+        )
+        return None
+
+
+async def _save_foreman_thread(guild_id: str, session_key: str, thread_id: str) -> None:
+    """Persist a new Foreman thread mapping using an atomic upsert (ignore duplicates)."""
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415
+        from models import DiscordForemanThread  # noqa: PLC0415
+        from sqlalchemy.dialects.postgresql import insert  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            stmt = (
+                insert(DiscordForemanThread)
+                .values(
+                    guild_id=guild_id,
+                    session_key=session_key,
+                    thread_id=thread_id,
+                    created_at=datetime.now(UTC),
+                )
+                .on_conflict_do_nothing()
+            )
+            await db.execute(stmt)
+            await db.commit()
+    except Exception:
+        logger.warning(
+            "discord: foreman thread DB save failed guild=%s session=%s thread=%s",
+            guild_id,
+            session_key,
+            thread_id,
+            exc_info=True,
+        )
+
+
+async def _ensure_foreman_thread(guild_id: str, session_key: str, thread_name: str) -> str | None:
+    """Return the Discord thread_id for a Foreman chat session, creating it if necessary.
+
+    Returns None when bot token or channel ID are not configured, or on API error.
+    """
+    existing = await _lookup_foreman_thread(guild_id, session_key)
+    if existing:
+        return existing
+
+    channel = _channel_id()
+    if not channel:
+        return None
+
+    new_thread_id = await _create_thread_in_channel(channel, thread_name)
+    if not new_thread_id:
+        return None
+
+    await _save_foreman_thread(guild_id, session_key, new_thread_id)
+    return await _lookup_foreman_thread(guild_id, session_key) or new_thread_id
+
+
+async def notify_foreman_chat(guild_id: str, content: str, session_key: str | None = None) -> None:
+    """Mirror a Foreman → user chat line into a per-guild, per-day Discord thread.
+
+    One thread is created per ``(guild_id, session_key)`` pair — *session_key*
+    defaults to the current UTC date, so a whole day's conversation lands in
+    the same thread. Silent no-op when the bot token or channel are not
+    configured, or when *content* is blank. Never raises.
+    """
+    if not content or not content.strip():
+        return
+    if not (_bot_token() and _channel_id()):
+        return
+
+    key = session_key or datetime.now(UTC).strftime("%Y-%m-%d")
+    thread_name = f"Foreman session {key} ({guild_id})"[:100]
+    thread_id = await _ensure_foreman_thread(guild_id, key, thread_name)
+    if not thread_id:
+        return
+    await _bot_request("post", f"/channels/{thread_id}/messages", {"content": content[:2000]})
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: GitHub login -> Discord user mentions
+# ---------------------------------------------------------------------------
+
+
+async def _lookup_discord_user(github_login: str) -> str | None:
+    """Return the Discord user ID mapped to *github_login*, or None."""
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415
+        from models import DiscordUser  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(
+                select(DiscordUser.discord_user_id).where(
+                    col(DiscordUser.github_login) == github_login.lower()
+                )
+            )
+            return result.one_or_none()
+    except Exception:
+        logger.warning(
+            "discord: user mapping lookup failed login=%s", github_login, exc_info=True
+        )
+        return None
+
+
+async def mention_or_login(github_login: str | None) -> str:
+    """Return a Discord @-mention for *github_login* when a mapping exists.
+
+    Falls back to a plain ``@login`` string when no mapping is found, and to
+    ``""`` when *github_login* is empty — callers never need to special-case
+    a missing mapping. Never raises.
+    """
+    if not github_login:
+        return ""
+    discord_id = await _lookup_discord_user(github_login)
+    return f"<@{discord_id}>" if discord_id else f"@{github_login}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -444,9 +444,7 @@ async def _lookup_discord_user(github_login: str) -> str | None:
             )
             return result.one_or_none()
     except Exception:
-        logger.warning(
-            "discord: user mapping lookup failed login=%s", github_login, exc_info=True
-        )
+        logger.warning("discord: user mapping lookup failed login=%s", github_login, exc_info=True)
         return None
 
 

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -352,26 +352,52 @@ async def _lookup_foreman_thread(guild_id: str, session_key: str) -> str | None:
         return None
 
 
-async def _save_foreman_thread(guild_id: str, session_key: str, thread_id: str) -> None:
-    """Persist a new Foreman thread mapping using an atomic upsert (ignore duplicates)."""
+async def _save_foreman_thread(guild_id: str, session_key: str, thread_id: str) -> str | None:
+    """Persist a new Foreman thread mapping if one doesn't already exist.
+
+    Dialect-agnostic SELECT-then-INSERT (works on SQLite and Postgres alike).
+    Returns the thread_id that should be used going forward: *thread_id* on a
+    fresh insert, or the winning row's thread_id if a concurrent caller raced
+    us and inserted first. Returns None on error.
+    """
     try:
         from database import AsyncSessionLocal  # noqa: PLC0415
         from models import DiscordForemanThread  # noqa: PLC0415
-        from sqlalchemy.dialects.postgresql import insert  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
 
         async with AsyncSessionLocal() as db:
-            stmt = (
-                insert(DiscordForemanThread)
-                .values(
+            result = await db.exec(
+                select(DiscordForemanThread).where(
+                    col(DiscordForemanThread.guild_id) == guild_id,
+                    col(DiscordForemanThread.session_key) == session_key,
+                )
+            )
+            existing = result.one_or_none()
+            if existing:
+                return existing.thread_id
+
+            db.add(
+                DiscordForemanThread(
                     guild_id=guild_id,
                     session_key=session_key,
                     thread_id=thread_id,
                     created_at=datetime.now(UTC),
                 )
-                .on_conflict_do_nothing()
             )
-            await db.execute(stmt)
-            await db.commit()
+            try:
+                await db.commit()
+            except Exception:
+                # Unique-index race: a concurrent caller inserted first. Use its row.
+                await db.rollback()
+                result = await db.exec(
+                    select(DiscordForemanThread).where(
+                        col(DiscordForemanThread.guild_id) == guild_id,
+                        col(DiscordForemanThread.session_key) == session_key,
+                    )
+                )
+                existing = result.one_or_none()
+                return existing.thread_id if existing else thread_id
+            return thread_id
     except Exception:
         logger.warning(
             "discord: foreman thread DB save failed guild=%s session=%s thread=%s",
@@ -380,6 +406,7 @@ async def _save_foreman_thread(guild_id: str, session_key: str, thread_id: str) 
             thread_id,
             exc_info=True,
         )
+        return None
 
 
 async def _ensure_foreman_thread(guild_id: str, session_key: str, thread_name: str) -> str | None:
@@ -399,8 +426,7 @@ async def _ensure_foreman_thread(guild_id: str, session_key: str, thread_name: s
     if not new_thread_id:
         return None
 
-    await _save_foreman_thread(guild_id, session_key, new_thread_id)
-    return await _lookup_foreman_thread(guild_id, session_key) or new_thread_id
+    return await _save_foreman_thread(guild_id, session_key, new_thread_id) or new_thread_id
 
 
 async def notify_foreman_chat(guild_id: str, content: str, session_key: str | None = None) -> None:

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -474,6 +474,23 @@ async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
     return [dict(r._mapping) for r in result.all()]
 
 
+async def _emit_foreman_chat(guild_id: str, content: str, created_at: str) -> None:
+    """Broadcast a Foreman -> user narration line and mirror it into Discord.
+
+    Every plain-text line the Foreman sends to the user (not tool_use/tool_result
+    traces) goes through here so the Discord thread mirror in discord_notifier
+    stays in sync with the WS chat stream.
+    """
+    await broadcast_msg(
+        guild_id,
+        ChatMsg(from_="foreman", to="user", content=content, createdAt=created_at),
+    )
+    spawn(
+        discord_notifier.notify_foreman_chat(guild_id, content),
+        name=f"discord.foreman-chat:{guild_id}",
+    )
+
+
 async def run_foreman_ai(
     guild_id: str,
     human_message: str,

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -7,6 +7,7 @@ import os
 import time
 from datetime import UTC, datetime
 
+import discord_notifier
 from auth_deps import get_guild_pk
 from database import AsyncSessionLocal, get_db
 from events import broadcast_msg

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -820,15 +820,7 @@ async def _run_foreman_ai(
             for b in resp.content:
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
-                    await broadcast_msg(
-                        guild_id,
-                        ChatMsg(
-                            from_="foreman",
-                            to="user",
-                            content=b.text.strip(),
-                            createdAt=_now.isoformat(),
-                        ),
-                    )
+                    await _emit_foreman_chat(guild_id, b.text.strip(), _now.isoformat())
 
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
             if not tool_uses:
@@ -1035,16 +1027,10 @@ async def _run_foreman_ai(
             for b in wrap_resp.content:
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
-                    await broadcast_msg(
-                        guild_id,
-                        ChatMsg(from_="foreman", to="user", content=b.text.strip(), createdAt=_now),
-                    )
+                    await _emit_foreman_chat(guild_id, b.text.strip(), _now)
             cap_note = f"_(Foreman hit {cfg_max_rounds}-round safety cap and stopped.)_"
             text_parts.append(cap_note)
-            await broadcast_msg(
-                guild_id,
-                ChatMsg(from_="foreman", to="user", content=cap_note, createdAt=_now),
-            )
+            await _emit_foreman_chat(guild_id, cap_note, _now)
 
         response_text = "\n".join(text_parts).strip()
         if response_text:

--- a/backend/main.py
+++ b/backend/main.py
@@ -426,6 +426,7 @@ from routes import agents as _agents_routes  # noqa: E402
 from routes import auth as _auth_routes  # noqa: E402
 from routes import cost as _cost_routes  # noqa: E402
 from routes import debug as _debug_routes  # noqa: E402
+from routes import discord_users as _discord_users_routes  # noqa: E402
 from routes import foreman as _foreman_routes  # noqa: E402
 from routes import guilds as _guilds_routes  # noqa: E402
 from routes import issues as _issues_routes  # noqa: E402
@@ -454,6 +455,7 @@ app.include_router(_debug_routes.router)
 app.include_router(_models_routes.router)
 app.include_router(_issues_routes.router)
 app.include_router(_cost_routes.router)
+app.include_router(_discord_users_routes.router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/models.py
+++ b/backend/models.py
@@ -550,6 +550,48 @@ class DiscordThread(SQLModel, table=True):
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
+class DiscordForemanThread(SQLModel, table=True):
+    """Persisted mapping from a Foreman chat session to a Discord thread channel ID.
+
+    One thread per guild per calendar day (UTC) keeps a whole day's Foreman
+    conversation together in the notification channel without spawning a new
+    thread on every turn.
+    """
+
+    __tablename__ = "discord_foreman_threads"  # type: ignore[assignment]
+    __table_args__ = (
+        Index(
+            "uq_discord_foreman_threads_guild_session",
+            "guild_id",
+            "session_key",
+            unique=True,
+        ),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    guild_id: str  # guild slug
+    session_key: str  # e.g. "2026-07-04"
+    thread_id: str  # Discord channel ID of the thread
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
+class DiscordUser(SQLModel, table=True):
+    """Maps a GitHub login to a Discord user ID for @-mentions in notifications.
+
+    Populated via the ``/api/discord-users`` REST endpoints (no automated
+    discovery — a human links the two accounts). Lookups are graceful: a
+    missing mapping just means notifications fall back to a plain ``@login``
+    string instead of a real Discord mention.
+    """
+
+    __tablename__ = "discord_users"  # type: ignore[assignment]
+
+    github_login: str = Field(primary_key=True)  # stored lowercase
+    discord_user_id: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
 class ModelCatalog(SQLModel, table=True):
     """Persisted snapshot of models.dev provider/model entries.
 

--- a/backend/routes/discord_users.py
+++ b/backend/routes/discord_users.py
@@ -1,0 +1,103 @@
+"""CRUD for the ``discord_users`` GitHub-login -> Discord-user-ID mapping.
+
+Populated manually by any authenticated user (there is no automated
+discovery of GitHub <-> Discord identity). ``discord_notifier.mention_or_login``
+reads this table to turn a GitHub login into a real ``<@id>`` mention,
+falling back to a plain ``@login`` string when no row exists.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from auth_deps import require_user
+from database import get_db_dep
+from fastapi import APIRouter, Depends, HTTPException
+from models import DiscordUser
+from pydantic import BaseModel, Field
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import col, delete, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+router = APIRouter()
+
+
+class DiscordUserUpsert(BaseModel):
+    discord_user_id: str = Field(min_length=1, max_length=64)
+
+
+def _serialize(row: DiscordUser) -> dict:
+    return {
+        "github_login": row.github_login,
+        "discord_user_id": row.discord_user_id,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+
+@router.get("/api/discord-users")
+async def list_discord_users(
+    github_user_id: str = Depends(require_user),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """List every GitHub login -> Discord user ID mapping."""
+    result = await db.exec(select(DiscordUser).order_by(col(DiscordUser.github_login)))
+    return [_serialize(row) for row in result.all()]
+
+
+@router.get("/api/discord-users/{github_login}")
+async def get_discord_user(
+    github_login: str,
+    github_user_id: str = Depends(require_user),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Return the Discord mapping for a single GitHub login, or 404."""
+    result = await db.exec(
+        select(DiscordUser).where(col(DiscordUser.github_login) == github_login.lower())
+    )
+    row = result.one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="No Discord mapping for this GitHub login")
+    return _serialize(row)
+
+
+@router.put("/api/discord-users/{github_login}")
+async def upsert_discord_user(
+    github_login: str,
+    data: DiscordUserUpsert,
+    github_user_id: str = Depends(require_user),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Create or update the Discord mapping for a GitHub login."""
+    login = github_login.lower()
+    now = datetime.now(UTC)
+    stmt = (
+        pg_insert(DiscordUser)
+        .values(
+            github_login=login,
+            discord_user_id=data.discord_user_id,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_update(
+            index_elements=["github_login"],
+            set_={"discord_user_id": data.discord_user_id, "updated_at": now},
+        )
+    )
+    await db.exec(stmt)
+    await db.commit()
+    result = await db.exec(select(DiscordUser).where(col(DiscordUser.github_login) == login))
+    return _serialize(result.one())
+
+
+@router.delete("/api/discord-users/{github_login}")
+async def delete_discord_user(
+    github_login: str,
+    github_user_id: str = Depends(require_user),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Remove the Discord mapping for a GitHub login."""
+    login = github_login.lower()
+    await db.exec(delete(DiscordUser).where(col(DiscordUser.github_login) == login))
+    await db.commit()
+    return {"status": "removed", "github_login": login}

--- a/backend/routes/discord_users.py
+++ b/backend/routes/discord_users.py
@@ -13,10 +13,9 @@ from datetime import UTC, datetime
 from auth_deps import require_user
 from database import get_db_dep
 from fastapi import APIRouter, Depends, HTTPException
-from models import DiscordUser
+from models import DiscordUser, GithubToken
 from pydantic import BaseModel, Field
-from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlmodel import col, delete, select
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 router = APIRouter()
@@ -33,6 +32,18 @@ def _serialize(row: DiscordUser) -> dict:
         "created_at": row.created_at,
         "updated_at": row.updated_at,
     }
+
+
+async def _require_own_login(github_login: str, github_user_id: str, db: AsyncSession) -> None:
+    """Raise 403 unless *github_user_id* is authenticated as *github_login*."""
+    result = await db.exec(
+        select(col(GithubToken.github_username)).where(
+            col(GithubToken.github_user_id) == github_user_id
+        )
+    )
+    own_login = result.one_or_none()
+    if not own_login or own_login.lower() != github_login.lower():
+        raise HTTPException(status_code=403, detail="You may only modify your own Discord mapping")
 
 
 @router.get("/api/discord-users")
@@ -68,26 +79,28 @@ async def upsert_discord_user(
     github_user_id: str = Depends(require_user),
     db: AsyncSession = Depends(get_db_dep),
 ):
-    """Create or update the Discord mapping for a GitHub login."""
+    """Create or update the Discord mapping for a GitHub login (own login only)."""
     login = github_login.lower()
+    await _require_own_login(login, github_user_id, db)
     now = datetime.now(UTC)
-    stmt = (
-        pg_insert(DiscordUser)
-        .values(
+
+    result = await db.exec(select(DiscordUser).where(col(DiscordUser.github_login) == login))
+    row = result.one_or_none()
+    if row:
+        row.discord_user_id = data.discord_user_id
+        row.updated_at = now
+        db.add(row)
+    else:
+        row = DiscordUser(
             github_login=login,
             discord_user_id=data.discord_user_id,
             created_at=now,
             updated_at=now,
         )
-        .on_conflict_do_update(
-            index_elements=["github_login"],
-            set_={"discord_user_id": data.discord_user_id, "updated_at": now},
-        )
-    )
-    await db.exec(stmt)
+        db.add(row)
     await db.commit()
-    result = await db.exec(select(DiscordUser).where(col(DiscordUser.github_login) == login))
-    return _serialize(result.one())
+    await db.refresh(row)
+    return _serialize(row)
 
 
 @router.delete("/api/discord-users/{github_login}")
@@ -96,8 +109,14 @@ async def delete_discord_user(
     github_user_id: str = Depends(require_user),
     db: AsyncSession = Depends(get_db_dep),
 ):
-    """Remove the Discord mapping for a GitHub login."""
+    """Remove the Discord mapping for a GitHub login (own login only)."""
     login = github_login.lower()
-    await db.exec(delete(DiscordUser).where(col(DiscordUser.github_login) == login))
+    await _require_own_login(login, github_user_id, db)
+
+    result = await db.exec(select(DiscordUser).where(col(DiscordUser.github_login) == login))
+    row = result.one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="No Discord mapping for this GitHub login")
+    await db.delete(row)
     await db.commit()
     return {"status": "removed", "github_login": login}

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -833,10 +833,11 @@ async def github_webhook(
         pr_title = (pr_obj.get("title") or "")[:120]
         assignees = pr_obj.get("assignees") or []
         labels = pr_obj.get("labels") or []
-        assignee_str = (
-            ", ".join(f"@{a['login']}" for a in assignees if isinstance(a, dict) and a.get("login"))
-            or "None"
-        )
+        assignee_logins = [a["login"] for a in assignees if isinstance(a, dict) and a.get("login")]
+        assignee_mentions = [
+            await discord_notifier.mention_or_login(login) for login in assignee_logins
+        ]
+        assignee_str = ", ".join(assignee_mentions) or "None"
         labels_str = (
             ", ".join(lb["name"] for lb in labels if isinstance(lb, dict) and lb.get("name"))
             or "None"

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -565,3 +565,111 @@ async def test_archive_thread_http_error_does_not_raise(monkeypatch):
 
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.archive_thread(THREAD_ID)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Foreman chat threads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_foreman_chat_creates_thread_and_posts(monkeypatch):
+    """notify_foreman_chat ensures a per-day thread exists and posts the message."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_foreman_chat("guild-1", "Spun up worker w-abc.")
+
+    mock_client.post.assert_called_once()
+    call = mock_client.post.call_args
+    assert f"/channels/{THREAD_ID}/messages" in call[0][0]
+    assert call[1]["json"]["content"] == "Spun up worker w-abc."
+
+
+@pytest.mark.asyncio
+async def test_notify_foreman_chat_no_op_when_blank(monkeypatch):
+    """notify_foreman_chat is a no-op for empty/whitespace-only content."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    with patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_mock:
+        await discord_notifier.notify_foreman_chat("guild-1", "   ")
+
+    ensure_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_foreman_chat_no_op_when_not_configured(monkeypatch):
+    """notify_foreman_chat is a no-op when the bot token/channel are unset."""
+    with patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_mock:
+        await discord_notifier.notify_foreman_chat("guild-1", "hello")
+
+    ensure_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_foreman_chat_reuses_thread_for_same_session(monkeypatch):
+    """Two calls with the same session_key reuse the same thread (one lookup each, no dupes)."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_foreman_thread", AsyncMock(return_value=THREAD_ID)),
+        patch.object(discord_notifier, "_save_foreman_thread", AsyncMock()) as save_mock,
+    ):
+        await discord_notifier.notify_foreman_chat("guild-1", "first", session_key="2026-07-04")
+        await discord_notifier.notify_foreman_chat("guild-1", "second", session_key="2026-07-04")
+
+    save_mock.assert_not_called()
+    assert mock_client.post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: GitHub login -> Discord user mentions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mention_or_login_returns_mention_when_mapped():
+    """mention_or_login resolves a mapped GitHub login to a <@id> mention."""
+    with patch.object(discord_notifier, "_lookup_discord_user", AsyncMock(return_value="999")):
+        result = await discord_notifier.mention_or_login("alice")
+
+    assert result == "<@999>"
+
+
+@pytest.mark.asyncio
+async def test_mention_or_login_falls_back_to_plain_login():
+    """mention_or_login falls back to a plain @login string when no mapping exists."""
+    with patch.object(discord_notifier, "_lookup_discord_user", AsyncMock(return_value=None)):
+        result = await discord_notifier.mention_or_login("bob")
+
+    assert result == "@bob"
+
+
+@pytest.mark.asyncio
+async def test_mention_or_login_empty_for_blank_login():
+    """mention_or_login returns an empty string for a missing login without querying the DB."""
+    with patch.object(discord_notifier, "_lookup_discord_user", AsyncMock()) as lookup_mock:
+        result = await discord_notifier.mention_or_login(None)
+
+    assert result == ""
+    lookup_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lookup_discord_user_db_error_returns_none():
+    """_lookup_discord_user swallows DB errors and returns None (never raises)."""
+    with patch("database.AsyncSessionLocal", side_effect=RuntimeError("db down")):
+        result = await discord_notifier._lookup_discord_user("carol")
+
+    assert result is None

--- a/backend/tests/test_discord_users_api.py
+++ b/backend/tests/test_discord_users_api.py
@@ -28,7 +28,7 @@ def test_list_requires_auth(client):
 
 def test_upsert_creates_mapping(client):
     test_client, db_url = client
-    token = _login(db_url)
+    token = _login(db_url, user_id="gh-alice", username="alice")
     headers = {"Authorization": f"Bearer {token}"}
 
     resp = test_client.put(
@@ -49,7 +49,7 @@ def test_upsert_creates_mapping(client):
 
 def test_upsert_is_idempotent_and_updates_existing(client):
     test_client, db_url = client
-    token = _login(db_url)
+    token = _login(db_url, user_id="gh-bob", username="bob")
     headers = {"Authorization": f"Bearer {token}"}
 
     test_client.put("/api/discord-users/bob", json={"discord_user_id": "111"}, headers=headers)
@@ -65,7 +65,7 @@ def test_upsert_is_idempotent_and_updates_existing(client):
 
 def test_upsert_lowercases_login(client):
     test_client, db_url = client
-    token = _login(db_url)
+    token = _login(db_url, user_id="gh-carol", username="CarolCase")
     headers = {"Authorization": f"Bearer {token}"}
 
     test_client.put(
@@ -87,7 +87,7 @@ def test_get_unknown_login_returns_404(client):
 
 def test_delete_removes_mapping(client):
     test_client, db_url = client
-    token = _login(db_url)
+    token = _login(db_url, user_id="gh-dave", username="dave")
     headers = {"Authorization": f"Bearer {token}"}
 
     test_client.put("/api/discord-users/dave", json={"discord_user_id": "444"}, headers=headers)
@@ -98,9 +98,18 @@ def test_delete_removes_mapping(client):
     assert resp.status_code == 404
 
 
+def test_delete_unknown_login_returns_404(client):
+    test_client, db_url = client
+    token = _login(db_url, user_id="gh-frank", username="frank")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = test_client.delete("/api/discord-users/frank", headers=headers)
+    assert resp.status_code == 404
+
+
 def test_list_includes_created_mappings(client):
     test_client, db_url = client
-    token = _login(db_url)
+    token = _login(db_url, user_id="gh-erin", username="erin")
     headers = {"Authorization": f"Bearer {token}"}
 
     test_client.put("/api/discord-users/erin", json={"discord_user_id": "555"}, headers=headers)
@@ -108,3 +117,30 @@ def test_list_includes_created_mappings(client):
     assert resp.status_code == 200
     logins = {row["github_login"] for row in resp.json()}
     assert "erin" in logins
+
+
+def test_upsert_other_login_returns_403(client):
+    test_client, db_url = client
+    token = _login(db_url, user_id="gh-mallory", username="mallory")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = test_client.put(
+        "/api/discord-users/victim",
+        json={"discord_user_id": "999"},
+        headers=headers,
+    )
+    assert resp.status_code == 403
+
+
+def test_delete_other_login_returns_403(client):
+    test_client, db_url = client
+    owner_token = _login(db_url, user_id="gh-owner", username="owner")
+    owner_headers = {"Authorization": f"Bearer {owner_token}"}
+    test_client.put(
+        "/api/discord-users/owner", json={"discord_user_id": "777"}, headers=owner_headers
+    )
+
+    attacker_token = _login(db_url, user_id="gh-mallory2", username="mallory2")
+    attacker_headers = {"Authorization": f"Bearer {attacker_token}"}
+    resp = test_client.delete("/api/discord-users/owner", headers=attacker_headers)
+    assert resp.status_code == 403

--- a/backend/tests/test_discord_users_api.py
+++ b/backend/tests/test_discord_users_api.py
@@ -52,9 +52,7 @@ def test_upsert_is_idempotent_and_updates_existing(client):
     token = _login(db_url)
     headers = {"Authorization": f"Bearer {token}"}
 
-    test_client.put(
-        "/api/discord-users/bob", json={"discord_user_id": "111"}, headers=headers
-    )
+    test_client.put("/api/discord-users/bob", json={"discord_user_id": "111"}, headers=headers)
     resp = test_client.put(
         "/api/discord-users/bob", json={"discord_user_id": "222"}, headers=headers
     )
@@ -92,9 +90,7 @@ def test_delete_removes_mapping(client):
     token = _login(db_url)
     headers = {"Authorization": f"Bearer {token}"}
 
-    test_client.put(
-        "/api/discord-users/dave", json={"discord_user_id": "444"}, headers=headers
-    )
+    test_client.put("/api/discord-users/dave", json={"discord_user_id": "444"}, headers=headers)
     resp = test_client.delete("/api/discord-users/dave", headers=headers)
     assert resp.status_code == 200
 
@@ -107,9 +103,7 @@ def test_list_includes_created_mappings(client):
     token = _login(db_url)
     headers = {"Authorization": f"Bearer {token}"}
 
-    test_client.put(
-        "/api/discord-users/erin", json={"discord_user_id": "555"}, headers=headers
-    )
+    test_client.put("/api/discord-users/erin", json={"discord_user_id": "555"}, headers=headers)
     resp = test_client.get("/api/discord-users", headers=headers)
     assert resp.status_code == 200
     logins = {row["github_login"] for row in resp.json()}

--- a/backend/tests/test_discord_users_api.py
+++ b/backend/tests/test_discord_users_api.py
@@ -1,0 +1,116 @@
+"""Tests for the /api/discord-users CRUD endpoints.
+
+Covers the auth gate, create/update (upsert), lookup, listing, and delete —
+the REST surface that lets a human link a GitHub login to a Discord user ID
+for @-mention resolution in discord_notifier.mention_or_login.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from helpers import _sync_session, make_auth_token
+from models import DiscordUser
+from sqlalchemy import select
+
+
+def _login(db_url: str, user_id: str = "gh-user-test", username: str = "testuser") -> str:
+    return make_auth_token(db_url, user_id=user_id, username=username)
+
+
+def test_list_requires_auth(client):
+    test_client, _ = client
+    resp = test_client.get("/api/discord-users")
+    assert resp.status_code == 401
+
+
+def test_upsert_creates_mapping(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = test_client.put(
+        "/api/discord-users/alice",
+        json={"discord_user_id": "123456"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["github_login"] == "alice"
+    assert body["discord_user_id"] == "123456"
+
+    with _sync_session(db_url) as session:
+        row = session.scalar(select(DiscordUser).where(DiscordUser.github_login == "alice"))
+        assert row is not None
+        assert row.discord_user_id == "123456"
+
+
+def test_upsert_is_idempotent_and_updates_existing(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    test_client.put(
+        "/api/discord-users/bob", json={"discord_user_id": "111"}, headers=headers
+    )
+    resp = test_client.put(
+        "/api/discord-users/bob", json={"discord_user_id": "222"}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["discord_user_id"] == "222"
+
+    resp = test_client.get("/api/discord-users/bob", headers=headers)
+    assert resp.json()["discord_user_id"] == "222"
+
+
+def test_upsert_lowercases_login(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    test_client.put(
+        "/api/discord-users/CarolCase", json={"discord_user_id": "333"}, headers=headers
+    )
+    resp = test_client.get("/api/discord-users/carolcase", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["github_login"] == "carolcase"
+
+
+def test_get_unknown_login_returns_404(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = test_client.get("/api/discord-users/nonexistent-user", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_delete_removes_mapping(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    test_client.put(
+        "/api/discord-users/dave", json={"discord_user_id": "444"}, headers=headers
+    )
+    resp = test_client.delete("/api/discord-users/dave", headers=headers)
+    assert resp.status_code == 200
+
+    resp = test_client.get("/api/discord-users/dave", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_list_includes_created_mappings(client):
+    test_client, db_url = client
+    token = _login(db_url)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    test_client.put(
+        "/api/discord-users/erin", json={"discord_user_id": "555"}, headers=headers
+    )
+    resp = test_client.get("/api/discord-users", headers=headers)
+    assert resp.status_code == 200
+    logins = {row["github_login"] for row in resp.json()}
+    assert "erin" in logins


### PR DESCRIPTION
Closes #717

## Summary
- Mirrors Foreman → user chat narration into a per-guild, per-UTC-day Discord thread (`discord_foreman_threads` table), reusing the Phase 2 bot token/channel.
- Adds a `discord_users` table mapping `github_login` → `discord_user_id`, with full CRUD REST endpoints (`GET /api/discord-users`, `GET/PUT/DELETE /api/discord-users/{github_login}`).
- Wires `discord_notifier.mention_or_login()` into the PR-assignee notification path so GitHub logins resolve to real `<@id>` Discord mentions when a mapping exists, falling back to a plain `@login` string (never raises) when it doesn't.

## Details
- `backend/models.py`: `DiscordForemanThread` and `DiscordUser` SQLModel tables.
- `backend/alembic/versions/20260704_000001_add_discord_users.py` and `..._000002_add_discord_foreman_threads.py`: migrations, chained cleanly onto the current single head.
- `backend/discord_notifier.py`: `notify_foreman_chat()` (create/reuse per-session thread + post) and `mention_or_login()` (lookup + graceful fallback), documented alongside the existing Phase 1/2 helpers.
- `backend/foreman/runner.py`: every Foreman → user text line now routes through `_emit_foreman_chat()`, which broadcasts over the existing WS channel and fires-and-forgets the Discord mirror via `spawn()` so a Discord outage never blocks chat.
- `backend/routes/discord_users.py` (+ registered in `main.py`): auth-gated CRUD for the mapping table.

## Test plan
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `pytest backend/tests/test_discord_notifier.py` — 41 passed (mocked HTTP/DB, no infra needed)
- [ ] `pytest backend/tests/test_discord_users_api.py` — requires the `postgres-test` container (`docker compose up -d postgres-test`), not available in this sandbox; reviewed manually, endpoints follow the same patterns as existing DB-backed routes.