### PR TITLE
fix(foreman): await _get_docker_client() in spawn_worker

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -777,7 +777,7 @@ async def spawn_worker(
     )
 
     try:
-        docker_client = _get_docker_client()
+        docker_client = await _get_docker_client()
         image = os.environ.get("WORKER_IMAGE", "pioneer-square-worker")
 
         network = None

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1238,6 +1238,37 @@ class TestExecToolsDispatching:
         assert ev is None, "No pending-followup event should be queued — follow-up was dispatched"
 
 
+class TestSpawnWorker:
+    """spawn_worker() is not in FOREMAN_TOOLS (see #567) but is still invoked
+    directly by worker_lifecycle.spawn_replacement_workers() on backend startup.
+    Regression test for a missing ``await`` on ``_get_docker_client()`` that
+    made every real invocation of this path fail (see #725).
+    """
+
+    async def test_spawn_worker_starts_container(self, db_session):
+        insert_guild(db_session, "g-spawn")
+
+        fake_container = SimpleNamespace(id="abcdef0123456789")
+        fake_docker_client = MagicMock()
+        fake_docker_client.containers.get.side_effect = Exception("not found")
+        fake_docker_client.containers.run.return_value = fake_container
+
+        with (
+            patch("foreman.tools._get_docker_client", AsyncMock(return_value=fake_docker_client)),
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        ):
+            results = await exec_tools(
+                "g-spawn",
+                [_fake_tool_use("spawn_worker", {"repos": ["acme/widgets"]})],
+            )
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.get("is_error") is not True, f"spawn_worker failed: {r['content']}"
+        assert "abcdef012345" in r["content"]
+        fake_docker_client.containers.run.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # 4. Tool result handling — serialisation, error capture, edge cases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `spawn_worker()` called `_get_docker_client()` (an `async def`) without `await`, so `docker_client` was an unawaited coroutine and every `docker_client.containers.*` call raised `AttributeError: 'coroutine' object has no attribute 'containers'`.
- This function is not currently exposed to the foreman AI (`spawn_worker` is intentionally excluded from `FOREMAN_TOOLS`, see #567), so the **only** live caller is `worker_lifecycle.spawn_replacement_workers()`, run on every backend startup to replace workers that were online before the previous deploy.
- Confirmed in production logs from this session: after the latest backend restart, the stale-worker sweeper attempted 124 replacement spawns and **all 124 failed** with this exact error; the `workers` table shows 124 rows stuck in `spawn_failed`.
- Regression-tested: added `TestSpawnWorker::test_spawn_worker_starts_container` in `backend/tests/test_foreman.py`, which mocks `_get_docker_client` and asserts `spawn_worker` succeeds. Verified it fails with the exact production error message when the `await` is reverted, and passes with the fix.

Fixes #725.

## Test plan
- [x] `pytest tests/test_foreman.py -k spawn_worker` — new regression test passes with the fix, reproduces the exact prod error when reverted
- [x] `pytest tests/test_foreman.py` — 124 passed
- [x] `pytest tests/test_worker_lifecycle.py tests/test_tools_dedup.py` — 20 passed
- [x] `ruff check` / `ruff format --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)