### PR TITLE
feat(foreman): re-enable spawn_worker in FOREMAN_TOOLS

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -168,7 +168,9 @@ async def _load_history(guild_id: str, user_id: str, task_id: str | None = None)
         # Fetch only the most recent rows at the SQL level so query cost doesn't
         # scale with the table's total lifetime turn count; the Python-side
         # windowing below then trims this small set down further.
-        result = await db.exec(stmt.order_by(col(ForemanTurn.id).desc()).limit(_HISTORY_FETCH_LIMIT))
+        result = await db.exec(
+            stmt.order_by(col(ForemanTurn.id).desc()).limit(_HISTORY_FETCH_LIMIT)
+        )
         turns = list(reversed(result.all()))
     finally:
         await db.close()

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -704,8 +704,7 @@ def _post_agent_task(task_url: str, body: bytes) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# spawn_worker implementation (intentionally excluded from FOREMAN_TOOLS until
-# async/lock fixes in #551, #564, #566 are merged and tested — see #567)
+# spawn_worker implementation — re-enabled in FOREMAN_TOOLS after #551, #564, #566, #728
 # ---------------------------------------------------------------------------
 
 

--- a/backend/foreman_core/tools_schema.py
+++ b/backend/foreman_core/tools_schema.py
@@ -560,7 +560,54 @@ FOREMAN_TOOLS = [
             "required": ["agent_url", "skill"],
         },
     },
-    # spawn_worker intentionally disabled — see issues #551, #564, #566, #567
+    {
+        "name": "spawn_worker",
+        "description": (
+            "Start a new worker process pointed at a specific set of repos. "
+            "The worker is pre-registered in the database (so you have its worker_id "
+            "immediately) and a Docker container is launched automatically. "
+            "Use this when no idle worker covers the repos needed for a task — "
+            "call spawn_worker, wait briefly, then assign tasks to the returned worker_id. "
+            "Requires the Docker socket to be mounted on the backend."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repos": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "List of owner/repo strings the worker should clone and work on, "
+                        'e.g. ["acme/backend", "acme/frontend"].'
+                    ),
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["claude", "codex", "pi"],
+                    },
+                    "description": (
+                        "Optional list of agent runners to enable on this worker. "
+                        "Defaults to all available runners. "
+                        'Example: ["claude"] to restrict to Claude only.'
+                    ),
+                },
+                "agent_count": {
+                    "type": "integer",
+                    "description": (
+                        "Number of concurrent agent slots on this worker (default: 4). "
+                        "Increase for high-throughput workers; decrease to limit resource use."
+                    ),
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional human-readable name for the worker.",
+                },
+            },
+            "required": ["repos"],
+        },
+    },
 ]
 
 # Tools excluded from per-task child contexts. Child contexts manage a single,

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1239,10 +1239,10 @@ class TestExecToolsDispatching:
 
 
 class TestSpawnWorker:
-    """spawn_worker() is not in FOREMAN_TOOLS (see #567) but is still invoked
-    directly by worker_lifecycle.spawn_replacement_workers() on backend startup.
-    Regression test for a missing ``await`` on ``_get_docker_client()`` that
-    made every real invocation of this path fail (see #725).
+    """spawn_worker() is exposed in FOREMAN_TOOLS (re-enabled after #551/#564/#566/#728)
+    and is also invoked directly by worker_lifecycle.spawn_replacement_workers() on
+    backend startup. Regression test for a missing ``await`` on ``_get_docker_client()``
+    that made every real invocation of this path fail (see #725).
     """
 
     async def test_spawn_worker_starts_container(self, db_session):

--- a/backend/tests/test_tools_dedup.py
+++ b/backend/tests/test_tools_dedup.py
@@ -21,15 +21,12 @@ def test_foreman_tools_canonical_is_list():
     assert "assign_task" in names
 
 
-def test_spawn_worker_not_in_foreman_tools():
-    """spawn_worker must stay out of FOREMAN_TOOLS until async/lock fixes land (#567)."""
+def test_spawn_worker_in_foreman_tools():
+    """spawn_worker is exposed now that #551, #564, #566 have landed (see #567, #725)."""
     from backend.foreman_core.tools_schema import FOREMAN_TOOLS
 
     names = [t["name"] for t in FOREMAN_TOOLS]
-    assert "spawn_worker" not in names, (
-        "spawn_worker must not be exposed to the foreman AI until issues #551, #564, #566 "
-        "are merged and tested (see #567)"
-    )
+    assert "spawn_worker" in names
 
 
 def test_standalone_foreman_uses_canonical_tools():

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -67,20 +67,32 @@ async def test_run_sends_disconnect_before_ws_close():
         await asyncio.sleep(3600)
         yield {}  # Never reached; makes this an async generator
 
+    reached_main_loop = asyncio.Event()
+
+    async def fetch_pending_tasks():
+        # Last mocked call before run() enters the asyncio.wait() main loop —
+        # signal readiness instead of guessing with a fixed sleep, which was
+        # flaky under CI load (run() could still be in earlier startup steps).
+        reached_main_loop.set()
+        return []
+
     worker._send = capture_send
     worker._register = AsyncMock()
     worker._fetch_github_token_if_needed = AsyncMock()
     worker._check_gh_auth = AsyncMock()
     worker._check_codex_doctor = AsyncMock()
     worker._check_claude_auth = AsyncMock()
-    worker._fetch_pending_tasks = AsyncMock(return_value=[])
+    worker._fetch_pending_tasks = fetch_pending_tasks
     worker.ws.connect = AsyncMock()
     worker.ws.close = capture_close
     worker.ws.messages = hanging_messages
 
     task = asyncio.create_task(worker.run())
     # Allow run() to reach the asyncio.gather() await
-    await asyncio.sleep(0.1)
+    await asyncio.wait_for(reached_main_loop.wait(), timeout=5)
+    # fetch_pending_tasks() returning doesn't guarantee run() has entered the
+    # try/finally around asyncio.wait() yet — yield control once more.
+    await asyncio.sleep(0)
     task.cancel()
     try:
         await task


### PR DESCRIPTION
## Summary
- The `await` fix for `_get_docker_client()` in `spawn_worker` landed in #728 (Fixes #725).
- All other prerequisites that caused `spawn_worker` to be excluded from `FOREMAN_TOOLS` are now merged: lock guard (#551), async Docker/GitHub wrappers (#564), guild lock key fix (#566).
- This PR restores the `spawn_worker` tool schema in `FOREMAN_TOOLS` so the Foreman AI can spawn worker containers directly.
- Updates the stale exclusion comment in `tools.py` and the `TestSpawnWorker` docstring in `test_foreman.py`.

## Test plan
- [ ] `pytest backend/tests/test_foreman.py -k spawn_worker` — regression test for #725 (requires running PostgreSQL)
- [ ] `ruff check` / `ruff format --check` on changed files

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)