### PR TITLE
fix(foreman): parent context unbounded + mis-tagged turns

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -57,6 +57,10 @@ logger = logging.getLogger(__name__)
 POLL_MIN_SECS = 60  # initial poll interval: 1 minute
 POLL_MAX_SECS = 14400  # maximum poll interval: 4 hours
 
+# Upper bound on rows fetched by _load_history before Python-side windowing,
+# so query cost stays flat regardless of the table's total lifetime turn count.
+_HISTORY_FETCH_LIMIT = 100
+
 # Per-guild background poll task registry
 _poll_tasks: dict[str, "asyncio.Task[None]"] = {}
 # Guilds whose embedded poll loop is suppressed while an external foreman owns polling.
@@ -157,8 +161,14 @@ async def _load_history(guild_id: str, user_id: str, task_id: str | None = None)
         )
         if task_id is not None:
             stmt = stmt.where(col(ForemanTurn.task_id) == task_id)
-        result = await db.exec(stmt.order_by(col(ForemanTurn.id)))
-        turns = result.all()
+        else:
+            # Parent-mode reads must never re-absorb per-task child conversations.
+            stmt = stmt.where(col(ForemanTurn.task_id).is_(None))
+        # Fetch only the most recent rows at the SQL level so query cost doesn't
+        # scale with the table's total lifetime turn count; the Python-side
+        # windowing below then trims this small set down further.
+        result = await db.exec(stmt.order_by(col(ForemanTurn.id).desc()).limit(_HISTORY_FETCH_LIMIT))
+        turns = list(reversed(result.all()))
     finally:
         await db.close()
 
@@ -619,8 +629,15 @@ async def _run_foreman_ai(
             worker_rows = [r for r in worker_rows if r["id"] == child_worker_id]
             task_rows = [child_task_row] if child_task_row else []
             _task_id: str | None = task_id
-        else:
+        elif child:
             _task_id = task_rows[0]["id"] if len(task_rows) == 1 else None
+        else:
+            # Parent runs (periodic-check, worker lifecycle, human chat) must
+            # never tag turns with a child task_id, even when exactly one
+            # non-terminal task happens to exist — those turns must stay
+            # untagged (task_id IS NULL) so they don't pollute that task's
+            # isolated child context on its next run.
+            _task_id = None
     except Exception:
         await db.close()
         raise


### PR DESCRIPTION
## Summary
- `_load_history()` now filters parent-mode reads (`task_id=None`) to `task_id IS NULL` instead of fetching every turn ever recorded for the guild+user, and caps the SQL fetch at 100 rows (most recent first, then reversed) so query cost stays flat as the table grows.
- `_run_foreman_ai()` no longer applies the "single active task" heuristic in parent mode — cross-cutting events (periodic-check, worker-online/offline, human chat) are only tagged with a child `task_id` when actually running in child mode. Parent runs always persist with `task_id = NULL`.

Together these keep the whole-guild "parent" foreman context and each task's isolated "child" context from bleeding into each other, per docs/foreman-per-task-context.md.

Closes #726, Closes #727

## Test plan
- [x] `ruff check backend/foreman/runner.py` passes
- [x] Ran `pytest backend/tests/test_foreman*.py` — 120 non-DB tests pass; DB-backed tests error identically before and after this change due to no Postgres/Docker available in this sandbox (pre-existing environment limitation, not caused by this diff)
- [ ] Verify against a real Postgres instance / staging guild that parent turns persist with `task_id IS NULL` and child task history no longer contains periodic-check/worker-lifecycle chatter