### PR TITLE
fix(discord): /discord/interactions via frontend dev proxy (#736)

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -28,9 +28,12 @@ In the [Discord Developer Portal](https://discord.com/developers/applications):
 3. Under **General Information**, copy the **Application ID** (`DISCORD_APPLICATION_ID`) and
    **Public Key** (`DISCORD_PUBLIC_KEY`).
 4. If you plan to use slash commands (Phase 3), set **Interactions Endpoint URL** on the same
-   page to `https://<your-backend-host>/discord/interactions`. Discord will send a PING to
-   this URL and expects a signed PONG back — it won't save the URL until the backend is
-   reachable and `DISCORD_PUBLIC_KEY` is configured, so deploy the backend first.
+   page to `${FRONTEND_URL}/discord/interactions` (e.g.
+   `https://pioneer-square.melloy.life/discord/interactions`) — the backend serves both the
+   SPA and the API from a single public origin, so this is the same host users open in a
+   browser, not a separate backend-only address. Discord will send a PING to this URL and
+   expects a signed PONG back — it won't save the URL until the backend is reachable and
+   `DISCORD_PUBLIC_KEY` is configured, so deploy the backend first.
 
    > **Ordering matters:** `DISCORD_PUBLIC_KEY` (see [step 3](#3-environment-variables)) must
    > already be set on the *running* backend before you try to save the Interactions Endpoint

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -28,7 +28,7 @@ In the [Discord Developer Portal](https://discord.com/developers/applications):
 3. Under **General Information**, copy the **Application ID** (`DISCORD_APPLICATION_ID`) and
    **Public Key** (`DISCORD_PUBLIC_KEY`).
 4. If you plan to use slash commands (Phase 3), set **Interactions Endpoint URL** on the same
-   page to `${FRONTEND_URL}/discord/interactions` (e.g.
+   page to `https://<your-domain>/discord/interactions` (e.g.
    `https://pioneer-square.melloy.life/discord/interactions`) — the backend serves both the
    SPA and the API from a single public origin, so this is the same host users open in a
    browser, not a separate backend-only address. Discord will send a PING to this URL and

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,12 +26,15 @@ export default defineConfig({
       ? { hmr: { protocol: 'ws', host: 'localhost', clientPort: hmrClientPort } }
       : {}),
     // Forward backend routes when running `npm run dev` so the SPA can
-    // call /auth, /guilds, /ws against the dev server. In production
-    // these are handled by nginx-in-container (see frontend/nginx.conf).
+    // call /auth, /guilds, /ws, /discord against the dev server. In
+    // production these are all served from the same FastAPI origin as
+    // the built SPA (see backend/main.py) — there is no separate reverse
+    // proxy in front of the backend.
     proxy: {
-      '/auth':   { target: backendUrl,   changeOrigin: true },
-      '/guilds': { target: backendUrl,   changeOrigin: true },
-      '/ws':     { target: backendWsUrl, ws: true, changeOrigin: true },
+      '/auth':    { target: backendUrl,   changeOrigin: true },
+      '/guilds':  { target: backendUrl,   changeOrigin: true },
+      '/discord': { target: backendUrl,   changeOrigin: true },
+      '/ws':      { target: backendWsUrl, ws: true, changeOrigin: true },
     },
   },
   preview: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
     proxy: {
       '/auth':    { target: backendUrl,   changeOrigin: true },
       '/guilds':  { target: backendUrl,   changeOrigin: true },
+      // Intentionally proxies all /discord/* paths (not just /discord/interactions)
+      // so any future Discord routes are covered automatically in dev.
       '/discord': { target: backendUrl,   changeOrigin: true },
       '/ws':      { target: backendWsUrl, ws: true, changeOrigin: true },
     },


### PR DESCRIPTION
## Summary

Issue #736 assumed a separate frontend reverse proxy exists in front of the backend (mirroring `/ws`'s proxy rule) and that the interactions endpoint lives at `/api/discord/interactions`. After auditing the actual architecture, neither is quite right:

- This app has **no separate frontend proxy in production**. `backend/main.py` mounts every route — `/auth`, `/guilds`, `/ws`, `/discord/interactions`, etc. — on one FastAPI app, and that same app serves the built SPA as static files from the same origin (see the "Static SPA assets" section of `backend/main.py`). There's no `frontend/nginx.conf` (it doesn't exist) and no separate `frontend` service in `docker-compose.yml` for production.
- The endpoint's real path is `POST /discord/interactions` (no `/api` prefix) — confirmed in `backend/routes/discord.py:570` and `backend/tests/test_discord_interactions.py`. It's already mounted on the same app that serves `/ws`, so no backend route change was needed.
- No `DISCORD_INTERACTIONS_URL` (or similar) env var exists anywhere in the codebase — the Discord Developer Portal's "Interactions Endpoint URL" is configured manually and points at the public host, same as documented.

The one real gap: `frontend/vite.config.ts`'s dev-server proxy (used only when running bare `npm run dev` without docker-compose) forwarded `/auth`, `/guilds`, and `/ws` to the backend, but not `/discord`. It also had a stale comment referencing a nonexistent `frontend/nginx.conf`.

## Changes

- `frontend/vite.config.ts`: add `/discord` to the dev proxy alongside `/auth`/`/guilds`, and fix the comment to describe the actual single-origin architecture instead of a nonexistent nginx container.
- `docs/discord.md`: clarify that the Interactions Endpoint URL is `${FRONTEND_URL}/discord/interactions` — the same public host as the SPA, not a distinct backend-only address.

Closes #736

## Test plan

- [x] `cd backend && python -m pytest tests/test_discord_interactions.py -q` — all DB-independent unit tests (signature verification, PING) pass; DB-backed tests error locally only because no Postgres is running in this sandbox (no Docker available), unrelated to this change.
- [x] `cd frontend && npm run type-check` — passes
- [x] `cd frontend && npx eslint vite.config.ts` — no errors
- [x] `cd frontend && npm test` — 103 passed, 4 skipped