### PR TITLE
Discord: /join-channel and /leave-channel slash commands

### DIFF
--- a/backend/alembic/versions/20260704_000003_add_discord_channel_guilds.py
+++ b/backend/alembic/versions/20260704_000003_add_discord_channel_guilds.py
@@ -1,0 +1,45 @@
+"""Add discord_channel_guilds table binding Discord channels to PS guilds.
+
+Revision ID: 20260704_000003_add_discord_channel_guilds
+Revises: 20260704_000002_add_discord_foreman_threads
+Create Date: 2026-07-04
+
+Backs the ``/join-channel`` and ``/leave-channel`` slash commands, letting an
+operator wire a Discord channel to a Pioneer Square guild without editing
+env vars or restarting the bot.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260704_000003_add_discord_channel_guilds"
+down_revision: str | Sequence[str] | None = "20260704_000002_add_discord_foreman_threads"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "discord_channel_guilds",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("discord_guild_id", sa.Text(), nullable=False),
+        sa.Column("discord_channel_id", sa.Text(), nullable=False),
+        sa.Column("ps_guild_id", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_discord_channel_guilds_guild_channel",
+        "discord_channel_guilds",
+        ["discord_guild_id", "discord_channel_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_discord_channel_guilds_guild_channel", table_name="discord_channel_guilds")
+    op.drop_table("discord_channel_guilds")

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -182,6 +182,36 @@ async def _bot_request(
         return None
 
 
+async def _resolve_channel_for_guild(ps_guild_slug: str | None) -> str | None:
+    """Return the Discord channel wired to *ps_guild_slug* via ``/join-channel``.
+
+    Falls back to the flat ``DISCORD_CHANNEL_ID`` env var when no binding
+    exists in the ``discord_channel_guilds`` table (or *ps_guild_slug* is
+    None). Never raises.
+    """
+    if ps_guild_slug:
+        try:
+            from database import AsyncSessionLocal  # noqa: PLC0415
+            from models import DiscordChannelGuild  # noqa: PLC0415
+            from sqlmodel import col, select  # noqa: PLC0415
+
+            async with AsyncSessionLocal() as db:
+                rows = (
+                    await db.exec(
+                        select(DiscordChannelGuild.discord_channel_id).where(
+                            col(DiscordChannelGuild.ps_guild_id) == ps_guild_slug
+                        )
+                    )
+                ).all()
+                if rows:
+                    return rows[0]
+        except Exception:
+            logger.warning(
+                "discord: channel binding lookup failed guild=%s", ps_guild_slug, exc_info=True
+            )
+    return _channel_id()
+
+
 async def _lookup_thread(issue_repo: str, issue_number: int) -> str | None:
     """Return the persisted Discord thread_id for a PR/issue, or None."""
     try:
@@ -274,8 +304,13 @@ async def _create_thread_in_channel(channel: str, thread_name: str) -> str | Non
     return new_thread_id
 
 
-async def _ensure_thread(issue_repo: str, issue_number: int, thread_name: str) -> str | None:
+async def _ensure_thread(
+    issue_repo: str, issue_number: int, thread_name: str, channel: str | None = None
+) -> str | None:
     """Return the Discord thread_id for a PR/issue, creating it if necessary.
+
+    *channel* overrides the flat ``DISCORD_CHANNEL_ID`` env var when provided
+    (used to route to a per-guild channel bound via ``/join-channel``).
 
     Returns None when bot token or channel ID are not configured, or on API error.
     """
@@ -283,7 +318,7 @@ async def _ensure_thread(issue_repo: str, issue_number: int, thread_name: str) -
     if existing:
         return existing
 
-    channel = _channel_id()
+    channel = channel or _channel_id()
     if not channel:
         return None
 
@@ -409,8 +444,13 @@ async def _save_foreman_thread(guild_id: str, session_key: str, thread_id: str) 
         return None
 
 
-async def _ensure_foreman_thread(guild_id: str, session_key: str, thread_name: str) -> str | None:
+async def _ensure_foreman_thread(
+    guild_id: str, session_key: str, thread_name: str, channel: str | None = None
+) -> str | None:
     """Return the Discord thread_id for a Foreman chat session, creating it if necessary.
+
+    *channel* overrides the flat ``DISCORD_CHANNEL_ID`` env var when provided
+    (used to route to a per-guild channel bound via ``/join-channel``).
 
     Returns None when bot token or channel ID are not configured, or on API error.
     """
@@ -418,7 +458,7 @@ async def _ensure_foreman_thread(guild_id: str, session_key: str, thread_name: s
     if existing:
         return existing
 
-    channel = _channel_id()
+    channel = channel or _channel_id()
     if not channel:
         return None
 
@@ -439,12 +479,15 @@ async def notify_foreman_chat(guild_id: str, content: str, session_key: str | No
     """
     if not content or not content.strip():
         return
-    if not (_bot_token() and _channel_id()):
+    if not _bot_token():
+        return
+    channel = await _resolve_channel_for_guild(guild_id)
+    if not channel:
         return
 
     key = session_key or datetime.now(UTC).strftime("%Y-%m-%d")
     thread_name = f"Foreman session {key} ({guild_id})"[:100]
-    thread_id = await _ensure_foreman_thread(guild_id, key, thread_name)
+    thread_id = await _ensure_foreman_thread(guild_id, key, thread_name, channel=channel)
     if not thread_id:
         return
     await _bot_request("post", f"/channels/{thread_id}/messages", {"content": content[:2000]})
@@ -503,12 +546,18 @@ async def notify_event(
     thread_name: str | None = None,
     header_fields: dict[str, str] | None = None,
     close: bool = False,
+    ps_guild_slug: str | None = None,
 ) -> None:
     """Post a Discord notification, routing to a per-PR/issue thread when possible.
 
     Thread routing is attempted when ``DISCORD_BOT_TOKEN`` is set **and** both
     ``issue_repo`` and ``issue_number`` are provided.  The thread is lazily
     created on first use and its ID cached in the ``discord_threads`` table.
+
+    When *ps_guild_slug* is provided, the destination channel is resolved via
+    the ``discord_channel_guilds`` binding table (populated by
+    ``/join-channel``) before falling back to the flat ``DISCORD_CHANNEL_ID``
+    env var.
 
     When ``close=True`` the thread is archived after the message is posted
     (used for PR merge/close events).
@@ -519,7 +568,8 @@ async def notify_event(
     """
     if _bot_token() and issue_repo and issue_number is not None:
         tn = thread_name or f"#{issue_number}: {title}"
-        thread_id = await _ensure_thread(issue_repo, issue_number, tn)
+        channel = await _resolve_channel_for_guild(ps_guild_slug)
+        thread_id = await _ensure_thread(issue_repo, issue_number, tn, channel=channel)
         if thread_id:
             await _post_to_thread(
                 thread_id,

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -196,11 +196,14 @@ async def _resolve_channel_for_guild(ps_guild_slug: str | None) -> str | None:
             from sqlmodel import col, select  # noqa: PLC0415
 
             async with AsyncSessionLocal() as db:
+                # Multiple channels can be bound to the same PS guild; order by
+                # created_at so the first-registered channel always wins rather
+                # than an arbitrary, backend-dependent row order.
                 rows = (
                     await db.exec(
-                        select(DiscordChannelGuild.discord_channel_id).where(
-                            col(DiscordChannelGuild.ps_guild_id) == ps_guild_slug
-                        )
+                        select(DiscordChannelGuild.discord_channel_id)
+                        .where(col(DiscordChannelGuild.ps_guild_id) == ps_guild_slug)
+                        .order_by(col(DiscordChannelGuild.created_at).asc())
                     )
                 ).all()
                 if rows:

--- a/backend/models.py
+++ b/backend/models.py
@@ -592,6 +592,32 @@ class DiscordUser(SQLModel, table=True):
     updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
+class DiscordChannelGuild(SQLModel, table=True):
+    """Binds a Discord channel to a Pioneer Square guild for event routing.
+
+    Populated by the ``/join-channel`` slash command (and removed by
+    ``/leave-channel``); the event notifier consults this table to decide
+    which Discord channel should receive events for a given PS guild,
+    instead of relying solely on the flat ``DISCORD_CHANNEL_ID`` env var.
+    """
+
+    __tablename__ = "discord_channel_guilds"  # type: ignore[assignment]
+    __table_args__ = (
+        Index(
+            "uq_discord_channel_guilds_guild_channel",
+            "discord_guild_id",
+            "discord_channel_id",
+            unique=True,
+        ),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    discord_guild_id: str  # Discord server (guild) snowflake ID
+    discord_channel_id: str  # Discord channel snowflake ID
+    ps_guild_id: str  # Pioneer Square guild slug
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
 class ModelCatalog(SQLModel, table=True):
     """Persisted snapshot of models.dev provider/model entries.
 

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -6,17 +6,22 @@ Required env vars:
     DISCORD_PUBLIC_KEY          Ed25519 public key (hex) from Discord developer portal
     DISCORD_APPLICATION_ID      Discord application/bot ID (used for followup URLs)
     DISCORD_BOT_TOKEN           Discord bot token (reuses Phase 2 var)
-    DISCORD_PIONEER_GUILD_SLUG  Pioneer Square guild slug to target for all commands
+    DISCORD_PIONEER_GUILD_SLUG  Pioneer Square guild slug to target for /ps commands
 
 Optional env vars:
     DISCORD_ALLOWED_ROLE_IDS    Comma-separated Discord role IDs; empty = allow all
+    DISCORD_OPERATOR_ROLE_NAME  Discord role name allowed to run /join-channel and
+                                /leave-channel (in addition to Manage Channels
+                                permission); default "Pioneer Square Operator"
 
 Registered slash commands (see scripts/register_discord_commands.py):
-    /ps status              — formatted embed with worker states and active task counts
-    /ps workers             — list all workers with state, repos, and agent count
-    /ps pickup <issue-url>  — claim an issue and assign to an idle worker
-    /ps review <pr-url>     — trigger a PR review task
-    /ps cancel <task-id>    — cancel a running task
+    /ps status                          — formatted embed with worker states and active task counts
+    /ps workers                         — list all workers with state, repos, and agent count
+    /ps pickup <issue-url>              — claim an issue and assign to an idle worker
+    /ps review <pr-url>                 — trigger a PR review task
+    /ps cancel <task-id>                — cancel a running task
+    /join-channel <channel> [guild]     — wire a Discord channel to a Pioneer Square guild
+    /leave-channel [channel]            — remove a channel's Pioneer Square guild binding
 """
 
 from __future__ import annotations
@@ -33,7 +38,7 @@ import httpx
 from database import AsyncSessionLocal
 from events import broadcast_msg
 from fastapi import APIRouter, BackgroundTasks, Request, Response
-from models import Agent, Guild, Task, Worker, live_tasks_filter
+from models import Agent, DiscordChannelGuild, Guild, Task, Worker, live_tasks_filter
 from sqlalchemy import func, update
 from sqlmodel import col, select
 from ws_types import TaskCancelMsg, TaskCreatedMsg, TaskUpdateMsg
@@ -58,6 +63,11 @@ _EPHEMERAL = 64
 
 # Default soft-delete window for cancelled tasks
 _CANCEL_TTL = timedelta(days=3)
+
+# Discord permission bit for MANAGE_CHANNELS (see Discord's permissions bitfield docs)
+_MANAGE_CHANNELS_BIT = 0x10
+
+_DEFAULT_OPERATOR_ROLE_NAME = "Pioneer Square Operator"
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +94,10 @@ def _pioneer_guild_slug() -> str | None:
 def _allowed_role_ids() -> set[str]:
     raw = os.environ.get("DISCORD_ALLOWED_ROLE_IDS", "")
     return {r.strip() for r in raw.split(",") if r.strip()}
+
+
+def _operator_role_name() -> str:
+    return os.environ.get("DISCORD_OPERATOR_ROLE_NAME") or _DEFAULT_OPERATOR_ROLE_NAME
 
 
 # ---------------------------------------------------------------------------
@@ -123,9 +137,67 @@ def _is_authorized(interaction: dict) -> bool:
     return bool(set(user_roles) & allowed)
 
 
+def _has_manage_channels(member: dict) -> bool:
+    """Return True if the member's computed permission bitfield includes MANAGE_CHANNELS."""
+    perms = member.get("permissions")
+    if not perms:
+        return False
+    try:
+        return (int(perms) & _MANAGE_CHANNELS_BIT) != 0
+    except (TypeError, ValueError):
+        return False
+
+
+async def _has_operator_role(interaction: dict) -> bool:
+    """Return True if the invoking member holds the configured Operator role.
+
+    Resolves the role name to Discord role IDs via a live API call (interaction
+    payloads only carry role IDs, not names) and checks against the member's roles.
+    """
+    member = interaction.get("member") or {}
+    discord_guild_id = interaction.get("guild_id")
+    user_role_ids: set[str] = set(member.get("roles", []))
+    if not discord_guild_id or not user_role_ids:
+        return False
+
+    roles = await _discord_get(f"/guilds/{discord_guild_id}/roles")
+    if not roles:
+        return False
+    role_name = _operator_role_name()
+    operator_role_ids = {r["id"] for r in roles if isinstance(r, dict) and r.get("name") == role_name}
+    return bool(user_role_ids & operator_role_ids)
+
+
+async def _can_manage_channel_bindings(interaction: dict) -> bool:
+    """Return True if the invoking user may run /join-channel or /leave-channel.
+
+    Requires Discord's Manage Channels permission or the configured Operator role.
+    """
+    member = interaction.get("member") or {}
+    if _has_manage_channels(member):
+        return True
+    return await _has_operator_role(interaction)
+
+
 # ---------------------------------------------------------------------------
 # Discord API helper
 # ---------------------------------------------------------------------------
+
+
+async def _discord_get(path: str) -> list | dict | None:
+    """GET a Discord REST endpoint. Returns parsed JSON, or None on error/no token."""
+    token = _bot_token()
+    if not token:
+        return None
+    headers = {"Authorization": f"Bot {token}"}
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(f"{_DISCORD_API_BASE}{path}", headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+    except Exception:
+        logger.warning("discord: GET %s failed", path, exc_info=True)
+        return None
 
 
 async def _discord_patch(path: str, payload: dict) -> None:
@@ -525,6 +597,158 @@ async def _cmd_cancel(interaction_token: str, guild_slug: str, task_id: str) -> 
         await _send_followup(interaction_token, content="Failed to cancel task.")
 
 
+async def _permission_denied_message() -> str:
+    return (
+        "You need the `Manage Channels` permission or the "
+        f"`{_operator_role_name()}` role to run this command."
+    )
+
+
+async def _cmd_join_channel(interaction: dict) -> None:
+    """Wire a Discord channel to a Pioneer Square guild (creating or updating the binding)."""
+    token = interaction.get("token", "")
+    data = interaction.get("data", {})
+    discord_guild_id = interaction.get("guild_id")
+
+    if not discord_guild_id:
+        await _send_followup(token, content="This command can only be used in a server.")
+        return
+
+    if not await _can_manage_channel_bindings(interaction):
+        await _send_followup(token, content=await _permission_denied_message())
+        return
+
+    options = {o["name"]: o for o in data.get("options", [])}
+    channel_opt = options.get("channel")
+    if not channel_opt:
+        await _send_followup(token, content="A channel must be specified.")
+        return
+    discord_channel_id = str(channel_opt["value"])
+
+    guild_opt = options.get("guild")
+    guild_slug = str(guild_opt["value"]).strip() if guild_opt else None
+
+    try:
+        async with AsyncSessionLocal() as db:
+            if guild_slug:
+                result = await db.exec(select(Guild).where(col(Guild.slug) == guild_slug))
+                if result.one_or_none() is None:
+                    await _send_followup(
+                        token, content=f"Pioneer guild `{guild_slug}` not found."
+                    )
+                    return
+            else:
+                all_guilds = (
+                    await db.exec(select(Guild).where(col(Guild.deleted_at).is_(None)))
+                ).all()
+                if len(all_guilds) != 1:
+                    await _send_followup(
+                        token,
+                        content=(
+                            "Multiple Pioneer guilds are configured — specify `guild:<slug>`."
+                            if len(all_guilds) > 1
+                            else "No Pioneer guilds are configured."
+                        ),
+                    )
+                    return
+                guild_slug = all_guilds[0].slug
+
+            existing_result = await db.exec(
+                select(DiscordChannelGuild).where(
+                    col(DiscordChannelGuild.discord_guild_id) == discord_guild_id,
+                    col(DiscordChannelGuild.discord_channel_id) == discord_channel_id,
+                )
+            )
+            existing = existing_result.one_or_none()
+            if existing:
+                existing.ps_guild_id = guild_slug
+                db.add(existing)
+                await db.commit()
+                await _send_followup(
+                    token,
+                    content=(
+                        f"Updated binding: <#{discord_channel_id}> is now wired to "
+                        f"Pioneer Square guild `{guild_slug}`."
+                    ),
+                )
+                return
+
+            db.add(
+                DiscordChannelGuild(
+                    discord_guild_id=discord_guild_id,
+                    discord_channel_id=discord_channel_id,
+                    ps_guild_id=guild_slug,
+                    created_at=datetime.now(UTC),
+                )
+            )
+            await db.commit()
+    except Exception:
+        logger.exception(
+            "discord: /join-channel failed channel=%s guild=%s", discord_channel_id, guild_slug
+        )
+        await _send_followup(token, content="Failed to wire channel to guild.")
+        return
+
+    await _send_followup(
+        token,
+        content=(
+            f"✅ <#{discord_channel_id}> is now wired to Pioneer Square guild `{guild_slug}`.\n"
+            "Task events, PR notifications, and CI alerts will be posted here."
+        ),
+    )
+
+
+async def _cmd_leave_channel(interaction: dict) -> None:
+    """Remove a Discord channel's Pioneer Square guild binding."""
+    token = interaction.get("token", "")
+    data = interaction.get("data", {})
+    discord_guild_id = interaction.get("guild_id")
+
+    if not discord_guild_id:
+        await _send_followup(token, content="This command can only be used in a server.")
+        return
+
+    if not await _can_manage_channel_bindings(interaction):
+        await _send_followup(token, content=await _permission_denied_message())
+        return
+
+    options = {o["name"]: o for o in data.get("options", [])}
+    channel_opt = options.get("channel")
+    if channel_opt:
+        discord_channel_id = str(channel_opt["value"])
+    else:
+        current_channel_id = interaction.get("channel_id") or (interaction.get("channel") or {}).get(
+            "id"
+        )
+        if not current_channel_id:
+            await _send_followup(token, content="Could not determine the current channel.")
+            return
+        discord_channel_id = str(current_channel_id)
+
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(
+                select(DiscordChannelGuild).where(
+                    col(DiscordChannelGuild.discord_guild_id) == discord_guild_id,
+                    col(DiscordChannelGuild.discord_channel_id) == discord_channel_id,
+                )
+            )
+            existing = result.one_or_none()
+            if not existing:
+                await _send_followup(token, content="No binding found for this channel.")
+                return
+            await db.delete(existing)
+            await db.commit()
+    except Exception:
+        logger.exception("discord: /leave-channel failed channel=%s", discord_channel_id)
+        await _send_followup(token, content="Failed to remove channel binding.")
+        return
+
+    await _send_followup(
+        token, content=f"✅ <#{discord_channel_id}> has been unwired from Pioneer Square."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Command dispatcher
 # ---------------------------------------------------------------------------
@@ -534,6 +758,15 @@ async def _dispatch_command(interaction: dict) -> None:
     """Parse the interaction data and dispatch to the appropriate command handler."""
     token = interaction.get("token", "")
     data = interaction.get("data", {})
+    command_name = data.get("name", "")
+
+    if command_name == "join-channel":
+        await _cmd_join_channel(interaction)
+        return
+    if command_name == "leave-channel":
+        await _cmd_leave_channel(interaction)
+        return
+
     guild_slug = _pioneer_guild_slug() or ""
 
     options: list[dict] = data.get("options", [])

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -164,7 +164,9 @@ async def _has_operator_role(interaction: dict) -> bool:
     if not roles:
         return False
     role_name = _operator_role_name()
-    operator_role_ids = {r["id"] for r in roles if isinstance(r, dict) and r.get("name") == role_name}
+    operator_role_ids = {
+        r["id"] for r in roles if isinstance(r, dict) and r.get("name") == role_name
+    }
     return bool(user_role_ids & operator_role_ids)
 
 
@@ -633,9 +635,7 @@ async def _cmd_join_channel(interaction: dict) -> None:
             if guild_slug:
                 result = await db.exec(select(Guild).where(col(Guild.slug) == guild_slug))
                 if result.one_or_none() is None:
-                    await _send_followup(
-                        token, content=f"Pioneer guild `{guild_slug}` not found."
-                    )
+                    await _send_followup(token, content=f"Pioneer guild `{guild_slug}` not found.")
                     return
             else:
                 all_guilds = (
@@ -717,9 +717,9 @@ async def _cmd_leave_channel(interaction: dict) -> None:
     if channel_opt:
         discord_channel_id = str(channel_opt["value"])
     else:
-        current_channel_id = interaction.get("channel_id") or (interaction.get("channel") or {}).get(
-            "id"
-        )
+        current_channel_id = interaction.get("channel_id") or (
+            interaction.get("channel") or {}
+        ).get("id")
         if not current_channel_id:
             await _send_followup(token, content="Could not determine the current channel.")
             return

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -852,6 +852,7 @@ async def github_webhook(
                 issue_number=pr_number,
                 thread_name=f"#{pr_number}: {pr_title}" if pr_title else f"#{pr_number}",
                 header_fields={"Assignee": assignee_str, "Labels": labels_str},
+                ps_guild_slug=guild_id,
             ),
             name=f"discord.pr-opened:{_pr_label}",
         )
@@ -868,6 +869,7 @@ async def github_webhook(
                     issue_repo=repo,
                     issue_number=pr_number,
                     close=True,
+                    ps_guild_slug=guild_id,
                 ),
                 name=f"discord.pr-merged:{_pr_label}",
             )
@@ -882,6 +884,7 @@ async def github_webhook(
                     issue_repo=repo,
                     issue_number=pr_number,
                     close=True,
+                    ps_guild_slug=guild_id,
                 ),
                 name=f"discord.pr-closed:{_pr_label}",
             )
@@ -903,6 +906,7 @@ async def github_webhook(
                     url=pr_url or None,
                     issue_repo=repo,
                     issue_number=pr_number,
+                    ps_guild_slug=guild_id,
                 ),
                 name=f"discord.ci-pass:{_pr_label}",
             )
@@ -916,6 +920,7 @@ async def github_webhook(
                     url=pr_url or None,
                     issue_repo=repo,
                     issue_number=pr_number,
+                    ps_guild_slug=guild_id,
                 ),
                 name=f"discord.ci-fail:{_pr_label}",
             )

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -555,3 +555,452 @@ async def test_cmd_cancel_already_done(monkeypatch):
 
     assert sent
     assert "already" in sent[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Permission helpers for /join-channel and /leave-channel (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def test_has_manage_channels_true():
+    from routes.discord import _has_manage_channels
+
+    # 0x10 (MANAGE_CHANNELS) is set among other bits
+    assert _has_manage_channels({"permissions": str(0x10 | 0x8)}) is True
+
+
+def test_has_manage_channels_false():
+    from routes.discord import _has_manage_channels
+
+    assert _has_manage_channels({"permissions": str(0x8)}) is False
+    assert _has_manage_channels({}) is False
+    assert _has_manage_channels({"permissions": "not-a-number"}) is False
+
+
+@pytest.mark.asyncio
+async def test_has_operator_role_matches(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    from routes.discord import _has_operator_role
+
+    interaction = {
+        "guild_id": "g1",
+        "member": {"roles": ["role-1", "role-2"]},
+    }
+    roles = [
+        {"id": "role-1", "name": "Someone Else"},
+        {"id": "role-2", "name": "Pioneer Square Operator"},
+    ]
+    with patch("routes.discord._discord_get", new=AsyncMock(return_value=roles)):
+        assert await _has_operator_role(interaction) is True
+
+
+@pytest.mark.asyncio
+async def test_has_operator_role_no_match(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    from routes.discord import _has_operator_role
+
+    interaction = {"guild_id": "g1", "member": {"roles": ["role-1"]}}
+    roles = [{"id": "role-1", "name": "Someone Else"}]
+    with patch("routes.discord._discord_get", new=AsyncMock(return_value=roles)):
+        assert await _has_operator_role(interaction) is False
+
+
+@pytest.mark.asyncio
+async def test_has_operator_role_no_roles_short_circuits():
+    """No member roles at all → deny without calling the Discord API."""
+    from routes.discord import _has_operator_role
+
+    with patch("routes.discord._discord_get", new=AsyncMock()) as mock_get:
+        assert await _has_operator_role({"guild_id": "g1", "member": {"roles": []}}) is False
+        mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_can_manage_channel_bindings_via_permission():
+    from routes.discord import _can_manage_channel_bindings
+
+    interaction = {"member": {"permissions": str(0x10)}}
+    with patch("routes.discord._has_operator_role", new=AsyncMock()) as mock_role:
+        assert await _can_manage_channel_bindings(interaction) is True
+        mock_role.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_can_manage_channel_bindings_via_role():
+    from routes.discord import _can_manage_channel_bindings
+
+    interaction = {"member": {"permissions": "0"}}
+    with patch("routes.discord._has_operator_role", new=AsyncMock(return_value=True)):
+        assert await _can_manage_channel_bindings(interaction) is True
+
+
+@pytest.mark.asyncio
+async def test_can_manage_channel_bindings_denied():
+    from routes.discord import _can_manage_channel_bindings
+
+    interaction = {"member": {"permissions": "0"}}
+    with patch("routes.discord._has_operator_role", new=AsyncMock(return_value=False)):
+        assert await _can_manage_channel_bindings(interaction) is False
+
+
+# ---------------------------------------------------------------------------
+# _cmd_join_channel / _cmd_leave_channel — all DB calls mocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cmd_join_channel_creates_new_binding(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    guild = MagicMock()
+    guild.slug = "my-guild"
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value=guild)),  # Guild lookup
+            MagicMock(one_or_none=MagicMock(return_value=None)),  # existing binding lookup
+        ]
+    )
+    mock_db.add = MagicMock()
+    mock_db.commit = AsyncMock()
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-join",
+        "guild_id": "dg-1",
+        "data": {
+            "name": "join-channel",
+            "options": [
+                {"name": "channel", "value": "12345"},
+                {"name": "guild", "value": "my-guild"},
+            ],
+        },
+        "member": {"permissions": str(0x10)},
+    }
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_join_channel
+
+        await _cmd_join_channel(interaction)
+
+    assert mock_db.add.called
+    added = mock_db.add.call_args[0][0]
+    assert added.discord_guild_id == "dg-1"
+    assert added.discord_channel_id == "12345"
+    assert added.ps_guild_id == "my-guild"
+    assert mock_db.commit.called
+    assert sent
+    assert "✅" in sent[0]["content"]
+    assert "my-guild" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_join_channel_updates_existing_binding(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    guild = MagicMock()
+    guild.slug = "new-guild"
+
+    existing = MagicMock()
+    existing.ps_guild_id = "old-guild"
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value=guild)),
+            MagicMock(one_or_none=MagicMock(return_value=existing)),
+        ]
+    )
+    mock_db.add = MagicMock()
+    mock_db.commit = AsyncMock()
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-join2",
+        "guild_id": "dg-1",
+        "data": {
+            "name": "join-channel",
+            "options": [
+                {"name": "channel", "value": "12345"},
+                {"name": "guild", "value": "new-guild"},
+            ],
+        },
+        "member": {"permissions": str(0x10)},
+    }
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_join_channel
+
+        await _cmd_join_channel(interaction)
+
+    assert existing.ps_guild_id == "new-guild"
+    assert mock_db.commit.called
+    assert sent
+    assert "Updated binding" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_join_channel_unknown_guild_slug(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=None)))
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-join3",
+        "guild_id": "dg-1",
+        "data": {
+            "name": "join-channel",
+            "options": [
+                {"name": "channel", "value": "12345"},
+                {"name": "guild", "value": "nonexistent"},
+            ],
+        },
+        "member": {"permissions": str(0x10)},
+    }
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_join_channel
+
+        await _cmd_join_channel(interaction)
+
+    assert sent
+    assert "not found" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_join_channel_denies_without_permission(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-join4",
+        "guild_id": "dg-1",
+        "data": {
+            "name": "join-channel",
+            "options": [{"name": "channel", "value": "12345"}],
+        },
+        "member": {"permissions": "0", "roles": []},
+    }
+
+    with (
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("routes.discord._has_operator_role", new=AsyncMock(return_value=False)),
+    ):
+        from routes.discord import _cmd_join_channel
+
+        await _cmd_join_channel(interaction)
+
+    assert sent
+    assert "Manage Channels" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_join_channel_requires_guild_context(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-join5",
+        "data": {"name": "join-channel", "options": [{"name": "channel", "value": "12345"}]},
+        "member": {"permissions": str(0x10)},
+    }
+
+    with patch("routes.discord._discord_patch", new=fake_patch):
+        from routes.discord import _cmd_join_channel
+
+        await _cmd_join_channel(interaction)
+
+    assert sent
+    assert "only be used in a server" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_leave_channel_deletes_binding(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    existing = MagicMock()
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=existing)))
+    mock_db.delete = AsyncMock()
+    mock_db.commit = AsyncMock()
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-leave",
+        "guild_id": "dg-1",
+        "channel_id": "12345",
+        "data": {"name": "leave-channel", "options": []},
+        "member": {"permissions": str(0x10)},
+    }
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_leave_channel
+
+        await _cmd_leave_channel(interaction)
+
+    mock_db.delete.assert_called_once_with(existing)
+    assert mock_db.commit.called
+    assert sent
+    assert "✅" in sent[0]["content"]
+    assert "unwired" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_leave_channel_explicit_channel_option(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    existing = MagicMock()
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=existing)))
+    mock_db.delete = AsyncMock()
+    mock_db.commit = AsyncMock()
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-leave2",
+        "guild_id": "dg-1",
+        "channel_id": "current-chan",
+        "data": {
+            "name": "leave-channel",
+            "options": [{"name": "channel", "value": "other-chan"}],
+        },
+        "member": {"permissions": str(0x10)},
+    }
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_leave_channel
+
+        await _cmd_leave_channel(interaction)
+
+    assert sent
+    assert "other-chan" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_leave_channel_no_binding_found(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=None)))
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-leave3",
+        "guild_id": "dg-1",
+        "channel_id": "12345",
+        "data": {"name": "leave-channel", "options": []},
+        "member": {"permissions": str(0x10)},
+    }
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_leave_channel
+
+        await _cmd_leave_channel(interaction)
+
+    assert sent
+    assert "No binding found" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_leave_channel_denies_without_permission(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-leave4",
+        "guild_id": "dg-1",
+        "channel_id": "12345",
+        "data": {"name": "leave-channel", "options": []},
+        "member": {"permissions": "0", "roles": []},
+    }
+
+    with (
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("routes.discord._has_operator_role", new=AsyncMock(return_value=False)),
+    ):
+        from routes.discord import _cmd_leave_channel
+
+        await _cmd_leave_channel(interaction)
+
+    assert sent
+    assert "Manage Channels" in sent[0]["content"]

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -844,6 +844,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
                 url=pr_url or None,
                 issue_repo=_pr_repo_disc,
                 issue_number=_pr_num_disc,
+                ps_guild_slug=ctx.guild_id,
             ),
             name=f"discord.task-complete:{task_id}",
         )

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -64,6 +64,7 @@ bot must already be a member of the guild that owns `DISCORD_CHANNEL_ID`.
 | `DISCORD_PUBLIC_KEY` | 3 | For slash commands | Ed25519 public key (hex) used to verify `POST /discord/interactions` requests. Without it, the endpoint refuses all requests with 401. |
 | `DISCORD_ALLOWED_ROLE_IDS` | 3 | No | Comma-separated Discord role IDs allowed to run `/ps` commands. Empty/unset = everyone allowed. DM interactions are always denied when this is set (no role info is available outside a guild). |
 | `DISCORD_PIONEER_GUILD_SLUG` | 3 | For slash commands | The Pioneer Square guild (workspace) slug that `/ps` commands operate against. Not a Discord ID — see [Terminology note](#terminology-note-guild-vs-guild) below. |
+| `DISCORD_OPERATOR_ROLE_NAME` | 3 | No | Discord role name (in addition to the Manage Channels permission) allowed to run `/join-channel` and `/leave-channel`. Default `Pioneer Square Operator`. |
 | `DISCORD_DEV_GUILD_ID` | 3 (registration only) | No | Discord server ID. When set, `scripts/register_discord_commands.py` registers commands to that one server (near-instant) instead of globally (up to 1 hour to propagate). |
 
 `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` must be set **together** — the bot needs both
@@ -210,9 +211,8 @@ sends to a user (not tool-call traces) is mirrored into Discord via
 
 ## Slash command reference
 
-All commands are subcommands of `/ps` and are scoped to the guild in
-`DISCORD_PIONEER_GUILD_SLUG`. Every reply is ephemeral. Requires a role in
-`DISCORD_ALLOWED_ROLE_IDS` (or no restriction configured).
+The `/ps` subcommands are scoped to the guild in `DISCORD_PIONEER_GUILD_SLUG`. Every reply is
+ephemeral. Requires a role in `DISCORD_ALLOWED_ROLE_IDS` (or no restriction configured).
 
 | Command | Description | Notes |
 |---|---|---|
@@ -221,9 +221,24 @@ All commands are subcommands of `/ps` and are scoped to the guild in
 | `/ps pickup <issue-url>` | Creates a `pending` task (`phase=execute`) for a GitHub issue URL and queues it for an idle worker | URL must match `https://github.com/<owner>/<repo>/issues/<number>` |
 | `/ps review <pr-url>` | Creates a `pending` review task (`phase=review`) for a GitHub PR URL | URL must match `https://github.com/<owner>/<repo>/pull/<number>` |
 | `/ps cancel <task-id>` | Cancels a running task and soft-deletes it after a 3-day TTL | No-op reply if the task is already `done`/`failed`/`cancelled` |
+| `/join-channel <channel> [guild]` | Wires a Discord channel to a Pioneer Square guild so its events post there | Requires **Manage Channels** or the `DISCORD_OPERATOR_ROLE_NAME` role. `guild` is optional if exactly one Pioneer Square guild is configured. Re-running on an already-wired channel updates the binding. |
+| `/leave-channel [channel]` | Removes a channel's Pioneer Square guild binding (defaults to the current channel) | Same permission check as `/join-channel`. Replies "No binding found" if the channel isn't wired. |
 
 Commands are defined in `scripts/register_discord_commands.py` and must be re-registered
 (see [Setup guide](#4-register-slash-commands-phase-3-only)) whenever that file changes.
+
+### Per-channel guild routing (`/join-channel` / `/leave-channel`)
+
+By default, all Discord notifications go to the single channel in `DISCORD_CHANNEL_ID`. The
+`discord_channel_guilds` table lets you fan events for a specific Pioneer Square guild out to
+additional channels — e.g. one channel per team, each wired to its own guild:
+
+- `/join-channel channel:#my-team-updates guild:my-guild-slug` upserts a
+  `(discord_guild_id, discord_channel_id) → ps_guild_id` row.
+- `notify_event(...)` and `notify_foreman_chat(...)` resolve the destination channel by looking
+  up the event's Pioneer Square guild in `discord_channel_guilds` first, falling back to
+  `DISCORD_CHANNEL_ID` when no binding exists.
+- `/leave-channel` deletes the row; events for that guild then fall back to `DISCORD_CHANNEL_ID`.
 
 ## User identity linking
 

--- a/scripts/register_discord_commands.py
+++ b/scripts/register_discord_commands.py
@@ -83,7 +83,37 @@ COMMANDS = [
                 ],
             },
         ],
-    }
+    },
+    {
+        "name": "join-channel",
+        "description": "Wire this (or a chosen) Discord channel to a Pioneer Square guild",
+        "options": [
+            {
+                "name": "channel",
+                "description": "Discord channel to wire up",
+                "type": 7,  # CHANNEL
+                "required": True,
+            },
+            {
+                "name": "guild",
+                "description": "Pioneer Square guild slug (optional if only one guild is configured)",
+                "type": 3,  # STRING
+                "required": False,
+            },
+        ],
+    },
+    {
+        "name": "leave-channel",
+        "description": "Remove a Discord channel's Pioneer Square guild binding",
+        "options": [
+            {
+                "name": "channel",
+                "description": "Discord channel to unwire (defaults to the current channel)",
+                "type": 7,  # CHANNEL
+                "required": False,
+            },
+        ],
+    },
 ]
 
 DISCORD_API = "https://discord.com/api/v10"


### PR DESCRIPTION
Closes #738

## Summary
- DB migration: adds `discord_channel_guilds` table
- `/join-channel` and `/leave-channel` slash commands with permission checks
- Notifier integration for newly wired channels
- Unit and integration tests
- Updated docs/discord.md