### PR TITLE
fix(discord): remove worker notifications from webhook notifier

### DIFF
--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -12,7 +12,6 @@ import logging
 from datetime import UTC, datetime
 
 import anyio
-import discord_notifier
 import ws_handlers
 from database import get_db
 from events import (
@@ -28,7 +27,6 @@ from models import Agent, Guild, UserSession, Worker
 from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
-from util.tasks import spawn
 from ws_types import AgentStateMsg
 
 from foreman import resume_foreman_poll
@@ -246,15 +244,6 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
                         offline_lines,
                         task_name="foreman.worker-offline:disconnect-batch",
                     )
-                    for wid in sorted(abrupt_worker_ids):
-                        spawn(
-                            discord_notifier.notify(
-                                "worker-offline",
-                                f"Worker offline: {wid}",
-                                f"Worker `{wid}` disconnected from guild `{guild_id}` (reason: disconnect).",
-                            ),
-                            name=f"discord.worker-offline:{wid}",
-                        )
             finally:
                 # If a cancellation was delivered inside a handler (e.g.
                 # handle_worker_disconnect) the underlying asyncpg connection

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -235,6 +235,10 @@ def test_worker_online_does_not_notify_discord(client):
                     "tools": ["claude"],
                 }
             )
+            # handle_worker_register no longer spawns any background tasks (the
+            # discord_notifier spawn call was removed), so once the ping is
+            # processed we know notify() would already have been called if it
+            # were going to be.
             ws.send_json({"type": "ping"})
             ws.receive_json()  # pong
 

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -5,13 +5,16 @@ Verifies that:
 - handle_worker_disconnect triggers [worker-offline] reason=shutdown
 - abrupt WebSocket disconnect triggers [worker-offline] reason=disconnect
 - task-complete with stopReason=max_turns triggers a max-turns foreman message
+- worker-online/worker-offline events never post to the Discord webhook
+  (they still notify the foreman, but Discord notifications are internal-only
+  noise — see #740)
 """
 
 from __future__ import annotations
 
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -23,6 +26,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
 import database as database_module  # noqa: E402
+import discord_notifier  # noqa: E402
 import main as main_module  # noqa: E402
 import ws_handlers  # noqa: E402
 from _test_config import TEST_DATABASE_URL  # noqa: E402
@@ -193,6 +197,114 @@ def test_abrupt_disconnect_notifies_foreman(client):
     _event, msg = offline[0]
     assert f"worker_id={worker_id}" in msg, msg
     assert "reason=disconnect" in msg, msg
+
+
+def test_worker_online_does_not_notify_discord(client):
+    """worker-register must not post a Discord webhook notification."""
+    test_client, db_url = client
+    guild_id = "nfy005"
+    worker_id = "w-nfy005"
+    agent_id = "a-nfy005"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    _triggered, fake_trigger = _make_trigger_spy()
+
+    with (
+        patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger),
+        patch.object(discord_notifier, "notify", new=AsyncMock()) as mock_notify,
+    ):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json(
+                {
+                    "type": "worker-register",
+                    "workerId": worker_id,
+                    "repos": ["org/repo1"],
+                    "tools": ["claude"],
+                }
+            )
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong
+
+        mock_notify.assert_not_called()
+
+
+def test_worker_graceful_offline_does_not_notify_discord(client):
+    """worker-disconnect must not post a Discord webhook notification."""
+    test_client, db_url = client
+    guild_id = "nfy006"
+    worker_id = "w-nfy006"
+    agent_id = "a-nfy006"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    _triggered, fake_trigger = _make_trigger_spy()
+
+    with (
+        patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger),
+        patch.object(discord_notifier, "notify", new=AsyncMock()) as mock_notify,
+    ):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json({"type": "worker-disconnect", "workerId": worker_id})
+            ws.receive_json()  # agent-state offline broadcast
+
+        mock_notify.assert_not_called()
+
+
+def test_abrupt_disconnect_does_not_notify_discord(client):
+    """Abrupt WebSocket close must not post a Discord webhook notification."""
+    test_client, db_url = client
+    guild_id = "nfy007"
+    worker_id = "w-nfy007"
+    agent_id = "a-nfy007"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+
+    _triggered, fake_trigger = _make_trigger_spy()
+
+    with (
+        patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger),
+        patch.object(discord_notifier, "notify", new=AsyncMock()) as mock_notify,
+    ):
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # agent-joined broadcast
+            # Close without sending worker-disconnect — simulates container crash.
+
+        mock_notify.assert_not_called()
 
 
 def test_task_complete_max_turns_notifies_foreman(client):

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -664,15 +664,6 @@ async def handle_worker_register(ctx: WSContext, data: dict) -> None:
         f"[worker-online] worker_id={worker_id} repos={repos_str} agent_count={agent_count}{tools_suffix}{provider_suffix}",
         task_name=f"foreman.worker-online:{worker_id}",
     )
-    spawn(
-        discord_notifier.notify(
-            "worker-online",
-            f"Worker online: {worker_id}",
-            f"Worker `{worker_id}` connected to guild `{ctx.guild_id}`."
-            + (f" Repos: {repos_str}." if repos_str else ""),
-        ),
-        name=f"discord.worker-online:{worker_id}",
-    )
 
 
 async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
@@ -716,14 +707,6 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
                 worker_id,
                 ctx.guild_id,
             )
-        spawn(
-            discord_notifier.notify(
-                "worker-offline",
-                f"Worker offline: {worker_id}",
-                f"Worker `{worker_id}` disconnected from guild `{ctx.guild_id}` (reason: shutdown).",
-            ),
-            name=f"discord.worker-offline:{worker_id}",
-        )
     reset_foreman_poll(ctx.guild_id)
 
 


### PR DESCRIPTION
## Summary
- Removes Discord webhook posts for `worker-online`/`worker-offline` events (both graceful disconnect and abrupt WebSocket close) — these are noisy internal signals that shouldn't surface in Discord.
- Foreman notifications for these same events are unchanged.

## Test plan
- [x] Added tests verifying `worker-register`, `worker-disconnect`, and abrupt disconnect no longer call `discord_notifier.notify`
- [x] Existing worker/foreman notification tests still pass

Closes #740