### PR TITLE
feat(discord): /connect-account slash command

### DIFF
--- a/backend/alembic/versions/20260704_000004_add_discord_account_links.py
+++ b/backend/alembic/versions/20260704_000004_add_discord_account_links.py
@@ -1,0 +1,53 @@
+"""Add discord_connect_tokens and discord_account_links tables.
+
+Revision ID: 20260704_000004_add_discord_account_links
+Revises: 20260704_000003_add_discord_channel_guilds
+Create Date: 2026-07-04
+
+Backs the ``/connect-account`` slash command: a one-time token is minted
+into ``discord_connect_tokens`` and redeemed via ``POST /api/discord/connect``
+once the user is logged in, creating/updating a row in
+``discord_account_links``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260704_000004_add_discord_account_links"
+down_revision: str | Sequence[str] | None = "20260704_000003_add_discord_channel_guilds"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "discord_connect_tokens",
+        sa.Column("token", sa.Text(), nullable=False),
+        sa.Column("discord_user_id", sa.Text(), nullable=False),
+        sa.Column("discord_username", sa.Text(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("token"),
+    )
+
+    op.create_table(
+        "discord_account_links",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("ps_user_id", sa.Text(), nullable=False),
+        sa.Column("discord_user_id", sa.Text(), nullable=False),
+        sa.Column("discord_username", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["ps_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("discord_user_id", name="uq_discord_account_links_discord_user_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("discord_account_links")
+    op.drop_table("discord_connect_tokens")

--- a/backend/main.py
+++ b/backend/main.py
@@ -427,6 +427,7 @@ from routes import auth as _auth_routes  # noqa: E402
 from routes import cost as _cost_routes  # noqa: E402
 from routes import debug as _debug_routes  # noqa: E402
 from routes import discord as _discord_routes  # noqa: E402
+from routes import discord_connect as _discord_connect_routes  # noqa: E402
 from routes import discord_users as _discord_users_routes  # noqa: E402
 from routes import foreman as _foreman_routes  # noqa: E402
 from routes import guilds as _guilds_routes  # noqa: E402
@@ -457,6 +458,7 @@ app.include_router(_models_routes.router)
 app.include_router(_issues_routes.router)
 app.include_router(_cost_routes.router)
 app.include_router(_discord_routes.router)
+app.include_router(_discord_connect_routes.router)
 app.include_router(_discord_users_routes.router)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -618,6 +618,42 @@ class DiscordChannelGuild(SQLModel, table=True):
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
+class DiscordConnectToken(SQLModel, table=True):
+    """One-time token minted by the ``/connect-account`` slash command.
+
+    Redeemed by ``POST /api/discord/connect`` once the user is logged in to
+    Pioneer Square. Tokens expire 15 minutes after creation and can only be
+    redeemed once (``used_at`` is set on redemption).
+    """
+
+    __tablename__ = "discord_connect_tokens"  # type: ignore[assignment]
+
+    token: str = Field(primary_key=True)  # UUID4 string
+    discord_user_id: str  # Discord snowflake ID of the invoking user
+    discord_username: str
+    expires_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    used_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True)))
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
+class DiscordAccountLink(SQLModel, table=True):
+    """Links a Discord user to a Pioneer Square user account.
+
+    Created by redeeming a ``/connect-account`` token via
+    ``POST /api/discord/connect``. Unique on ``discord_user_id`` so a Discord
+    account is linked to at most one Pioneer Square user at a time;
+    re-linking updates the existing row.
+    """
+
+    __tablename__ = "discord_account_links"  # type: ignore[assignment]
+
+    id: int | None = Field(default=None, primary_key=True)
+    ps_user_id: str = Field(foreign_key="users.id")
+    discord_user_id: str = Field(unique=True)
+    discord_username: str
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
 class ModelCatalog(SQLModel, table=True):
     """Persisted snapshot of models.dev provider/model entries.
 

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -22,6 +22,7 @@ Registered slash commands (see scripts/register_discord_commands.py):
     /ps cancel <task-id>                — cancel a running task
     /join-channel <channel> [guild]     — wire a Discord channel to a Pioneer Square guild
     /leave-channel [channel]            — remove a channel's Pioneer Square guild binding
+    /connect-account                    — link your Discord account to Pioneer Square
 """
 
 from __future__ import annotations
@@ -32,13 +33,23 @@ import os
 import random
 import re
 import string
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import httpx
 from database import AsyncSessionLocal
 from events import broadcast_msg
 from fastapi import APIRouter, BackgroundTasks, Request, Response
-from models import Agent, DiscordChannelGuild, Guild, Task, Worker, live_tasks_filter
+from models import (
+    Agent,
+    DiscordChannelGuild,
+    DiscordConnectToken,
+    Guild,
+    Task,
+    Worker,
+    live_tasks_filter,
+)
+from oauth import FRONTEND_URL
 from sqlalchemy import func, update
 from sqlmodel import col, select
 from ws_types import TaskCancelMsg, TaskCreatedMsg, TaskUpdateMsg
@@ -63,6 +74,9 @@ _EPHEMERAL = 64
 
 # Default soft-delete window for cancelled tasks
 _CANCEL_TTL = timedelta(days=3)
+
+# Lifetime of a /connect-account one-time token
+_CONNECT_TOKEN_TTL = timedelta(minutes=15)
 
 # Discord permission bit for MANAGE_CHANNELS (see Discord's permissions bitfield docs)
 _MANAGE_CHANNELS_BIT = 0x10
@@ -599,6 +613,69 @@ async def _cmd_cancel(interaction_token: str, guild_slug: str, task_id: str) -> 
         await _send_followup(interaction_token, content="Failed to cancel task.")
 
 
+def _interaction_user(interaction: dict) -> tuple[str, str] | None:
+    """Return (discord_user_id, display_name) for the invoking user, or None.
+
+    Guild interactions carry the user under ``member.user``; DM interactions
+    carry it directly under ``user``.
+    """
+    member = interaction.get("member") or {}
+    user = member.get("user") or interaction.get("user") or {}
+    user_id = user.get("id")
+    if not user_id:
+        return None
+    username = user.get("global_name") or user.get("username") or str(user_id)
+    return str(user_id), str(username)
+
+
+async def _cmd_connect_account(interaction: dict) -> None:
+    """Mint a one-time token and reply with a link to connect this Discord account.
+
+    The link points the user at ``/auth/discord/connect?token=<token>``, which
+    (once they're logged in to Pioneer Square) redeems the token via
+    ``POST /api/discord/connect`` and creates the account link.
+    """
+    interaction_token = interaction.get("token", "")
+    identity = _interaction_user(interaction)
+    if not identity:
+        await _send_followup(interaction_token, content="Could not determine your Discord account.")
+        return
+    discord_user_id, discord_username = identity
+
+    connect_token = str(uuid.uuid4())
+    now = datetime.now(UTC)
+
+    try:
+        async with AsyncSessionLocal() as db:
+            db.add(
+                DiscordConnectToken(
+                    token=connect_token,
+                    discord_user_id=discord_user_id,
+                    discord_username=discord_username,
+                    expires_at=now + _CONNECT_TOKEN_TTL,
+                    created_at=now,
+                )
+            )
+            await db.commit()
+    except Exception:
+        logger.exception(
+            "discord: /connect-account failed to mint token for %s", discord_user_id
+        )
+        await _send_followup(
+            interaction_token, content="Failed to generate a connect link. Try again later."
+        )
+        return
+
+    link = f"{FRONTEND_URL.rstrip('/')}/auth/discord/connect?token={connect_token}"
+    await _send_followup(
+        interaction_token,
+        content=(
+            f"Connect your Pioneer Square account: {link}\n"
+            "This link expires in 15 minutes and can only be used once."
+        ),
+    )
+
+
 async def _permission_denied_message() -> str:
     return (
         "You need the `Manage Channels` permission or the "
@@ -765,6 +842,9 @@ async def _dispatch_command(interaction: dict) -> None:
         return
     if command_name == "leave-channel":
         await _cmd_leave_channel(interaction)
+        return
+    if command_name == "connect-account":
+        await _cmd_connect_account(interaction)
         return
 
     guild_slug = _pioneer_guild_slug() or ""

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -658,9 +658,7 @@ async def _cmd_connect_account(interaction: dict) -> None:
             )
             await db.commit()
     except Exception:
-        logger.exception(
-            "discord: /connect-account failed to mint token for %s", discord_user_id
-        )
+        logger.exception("discord: /connect-account failed to mint token for %s", discord_user_id)
         await _send_followup(
             interaction_token, content="Failed to generate a connect link. Try again later."
         )

--- a/backend/routes/discord_connect.py
+++ b/backend/routes/discord_connect.py
@@ -1,0 +1,72 @@
+"""POST /api/discord/connect — redeem a one-time token from /connect-account.
+
+Links the authenticated Pioneer Square user to the Discord account that
+generated the token via the ``/connect-account`` slash command (see
+``routes/discord.py``). Tokens are single-use and expire 15 minutes after
+creation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from auth_deps import require_user
+from database import get_db_dep
+from fastapi import APIRouter, Depends, HTTPException
+from models import DiscordAccountLink, DiscordConnectToken
+from pydantic import BaseModel, Field
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+router = APIRouter()
+
+
+class DiscordConnectRequest(BaseModel):
+    token: str = Field(min_length=1)
+
+
+@router.post("/api/discord/connect")
+async def connect_discord_account(
+    data: DiscordConnectRequest,
+    github_user_id: str = Depends(require_user),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Redeem a one-time /connect-account token and link the Discord account
+    to the currently authenticated Pioneer Square user."""
+    result = await db.exec(
+        select(DiscordConnectToken).where(col(DiscordConnectToken.token) == data.token)
+    )
+    token_row = result.one_or_none()
+    if not token_row:
+        raise HTTPException(status_code=404, detail="Invalid or unknown connect token")
+    if token_row.used_at is not None:
+        raise HTTPException(status_code=400, detail="This connect link has already been used")
+    if token_row.expires_at < datetime.now(UTC):
+        raise HTTPException(status_code=400, detail="This connect link has expired")
+
+    now = datetime.now(UTC)
+    token_row.used_at = now
+    db.add(token_row)
+
+    stmt = pg_insert(DiscordAccountLink).values(
+        ps_user_id=github_user_id,
+        discord_user_id=token_row.discord_user_id,
+        discord_username=token_row.discord_username,
+        created_at=now,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["discord_user_id"],
+        set_={
+            "ps_user_id": stmt.excluded.ps_user_id,
+            "discord_username": stmt.excluded.discord_username,
+        },
+    )
+    await db.exec(stmt)
+    await db.commit()
+
+    return {
+        "status": "linked",
+        "discord_user_id": token_row.discord_user_id,
+        "discord_username": token_row.discord_username,
+    }

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -107,6 +107,17 @@ def make_auth_token(db_url: str, user_id: str = "gh-user-test", username: str = 
     token = "test-session-" + secrets.token_hex(8)
     now = datetime.now(UTC)
     with _sync_session(db_url) as session:
+        session.execute(
+            pg_insert(User)
+            .values(
+                id=user_id,
+                github_id=user_id,
+                github_login=username,
+                created_at=now,
+                updated_at=now,
+            )
+            .on_conflict_do_nothing(index_elements=["id"])
+        )
         stmt = (
             pg_insert(GithubToken)
             .values(

--- a/backend/tests/test_discord_connect.py
+++ b/backend/tests/test_discord_connect.py
@@ -174,9 +174,7 @@ def test_connect_valid_token_links_account(client):
     headers = {"Authorization": f"Bearer {login_token}"}
     connect_token = _insert_connect_token(db_url, discord_user_id="dc-2", discord_username="dUser2")
 
-    resp = test_client.post(
-        "/api/discord/connect", json={"token": connect_token}, headers=headers
-    )
+    resp = test_client.post("/api/discord/connect", json={"token": connect_token}, headers=headers)
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["status"] == "linked"
@@ -198,9 +196,7 @@ def test_connect_already_used_token_returns_400(client):
     headers = {"Authorization": f"Bearer {login_token}"}
     connect_token = _insert_connect_token(db_url, discord_user_id="dc-3", used=True)
 
-    resp = test_client.post(
-        "/api/discord/connect", json={"token": connect_token}, headers=headers
-    )
+    resp = test_client.post("/api/discord/connect", json={"token": connect_token}, headers=headers)
     assert resp.status_code == 400
     assert "already been used" in resp.json()["detail"]
 
@@ -213,9 +209,7 @@ def test_connect_expired_token_returns_400(client):
         db_url, discord_user_id="dc-4", expires_in=timedelta(minutes=-1)
     )
 
-    resp = test_client.post(
-        "/api/discord/connect", json={"token": connect_token}, headers=headers
-    )
+    resp = test_client.post("/api/discord/connect", json={"token": connect_token}, headers=headers)
     assert resp.status_code == 400
     assert "expired" in resp.json()["detail"]
 
@@ -243,8 +237,6 @@ def test_connect_relinking_discord_user_updates_owner(client):
     assert resp2.status_code == 200
 
     with _sync_session(db_url) as session:
-        link = (
-            session.query(DiscordAccountLink).filter_by(discord_user_id="dc-5").one_or_none()
-        )
+        link = session.query(DiscordAccountLink).filter_by(discord_user_id="dc-5").one_or_none()
         assert link is not None
         assert link.ps_user_id == "gh-conn-5b"

--- a/backend/tests/test_discord_connect.py
+++ b/backend/tests/test_discord_connect.py
@@ -1,0 +1,250 @@
+"""Tests for the /connect-account slash command and POST /api/discord/connect.
+
+Covers: (1) the pure-unit `_interaction_user` helper, (2) `_cmd_connect_account`
+token minting with all DB/Discord calls mocked, and (3) the HTTP endpoint that
+redeems a token (valid, expired, already-used, unknown, unauthenticated).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from helpers import _sync_session, make_auth_token
+from models import DiscordAccountLink, DiscordConnectToken
+
+# ---------------------------------------------------------------------------
+# _interaction_user (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def test_interaction_user_from_guild_member():
+    from routes.discord import _interaction_user
+
+    interaction = {"member": {"user": {"id": "123", "username": "alice", "global_name": "Alice"}}}
+    assert _interaction_user(interaction) == ("123", "Alice")
+
+
+def test_interaction_user_falls_back_to_username():
+    from routes.discord import _interaction_user
+
+    interaction = {"member": {"user": {"id": "123", "username": "alice"}}}
+    assert _interaction_user(interaction) == ("123", "alice")
+
+
+def test_interaction_user_from_dm():
+    from routes.discord import _interaction_user
+
+    interaction = {"user": {"id": "456", "username": "bob"}}
+    assert _interaction_user(interaction) == ("456", "bob")
+
+
+def test_interaction_user_missing():
+    from routes.discord import _interaction_user
+
+    assert _interaction_user({}) is None
+    assert _interaction_user({"member": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# _cmd_connect_account (DB calls mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cmd_connect_account_mints_token_and_sends_link(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.add = MagicMock()
+    mock_db.commit = AsyncMock()
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    interaction = {
+        "token": "tok-connect",
+        "member": {"user": {"id": "999", "username": "carol", "global_name": "Carol"}},
+    }
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("routes.discord.FRONTEND_URL", "https://pioneer-square.example"),
+    ):
+        from routes.discord import _cmd_connect_account
+
+        await _cmd_connect_account(interaction)
+
+    assert mock_db.add.called
+    added_token = mock_db.add.call_args[0][0]
+    assert added_token.discord_user_id == "999"
+    assert added_token.discord_username == "Carol"
+    assert added_token.used_at is None
+    assert mock_db.commit.called
+
+    assert sent
+    content = sent[0]["content"]
+    assert "https://pioneer-square.example/auth/discord/connect?token=" in content
+    assert added_token.token in content
+
+
+@pytest.mark.asyncio
+async def test_cmd_connect_account_unknown_user_sends_error(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    with patch("routes.discord._discord_patch", new=fake_patch):
+        from routes.discord import _cmd_connect_account
+
+        await _cmd_connect_account({"token": "tok-noone"})
+
+    assert sent
+    assert "Could not determine" in sent[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/discord/connect (HTTP endpoint, real test DB)
+# ---------------------------------------------------------------------------
+
+
+def _insert_connect_token(
+    db_url: str,
+    token: str | None = None,
+    discord_user_id: str = "dc-user-1",
+    discord_username: str = "dc-username",
+    expires_in: timedelta = timedelta(minutes=15),
+    used: bool = False,
+) -> str:
+    token = token or str(uuid.uuid4())
+    now = datetime.now(UTC)
+    with _sync_session(db_url) as session:
+        session.add(
+            DiscordConnectToken(
+                token=token,
+                discord_user_id=discord_user_id,
+                discord_username=discord_username,
+                expires_at=now + expires_in,
+                used_at=now if used else None,
+                created_at=now,
+            )
+        )
+        session.commit()
+    return token
+
+
+def test_connect_requires_auth(client):
+    test_client, _ = client
+    resp = test_client.post("/api/discord/connect", json={"token": "whatever"})
+    assert resp.status_code == 401
+
+
+def test_connect_unknown_token_returns_404(client):
+    test_client, db_url = client
+    token = make_auth_token(db_url, user_id="gh-conn-1", username="conn1")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = test_client.post(
+        "/api/discord/connect", json={"token": "does-not-exist"}, headers=headers
+    )
+    assert resp.status_code == 404
+
+
+def test_connect_valid_token_links_account(client):
+    test_client, db_url = client
+    login_token = make_auth_token(db_url, user_id="gh-conn-2", username="conn2")
+    headers = {"Authorization": f"Bearer {login_token}"}
+    connect_token = _insert_connect_token(db_url, discord_user_id="dc-2", discord_username="dUser2")
+
+    resp = test_client.post(
+        "/api/discord/connect", json={"token": connect_token}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "linked"
+    assert body["discord_user_id"] == "dc-2"
+    assert body["discord_username"] == "dUser2"
+
+    with _sync_session(db_url) as session:
+        link = session.query(DiscordAccountLink).filter_by(discord_user_id="dc-2").one_or_none()
+        assert link is not None
+        assert link.ps_user_id == "gh-conn-2"
+
+        used_row = session.get(DiscordConnectToken, connect_token)
+        assert used_row.used_at is not None
+
+
+def test_connect_already_used_token_returns_400(client):
+    test_client, db_url = client
+    login_token = make_auth_token(db_url, user_id="gh-conn-3", username="conn3")
+    headers = {"Authorization": f"Bearer {login_token}"}
+    connect_token = _insert_connect_token(db_url, discord_user_id="dc-3", used=True)
+
+    resp = test_client.post(
+        "/api/discord/connect", json={"token": connect_token}, headers=headers
+    )
+    assert resp.status_code == 400
+    assert "already been used" in resp.json()["detail"]
+
+
+def test_connect_expired_token_returns_400(client):
+    test_client, db_url = client
+    login_token = make_auth_token(db_url, user_id="gh-conn-4", username="conn4")
+    headers = {"Authorization": f"Bearer {login_token}"}
+    connect_token = _insert_connect_token(
+        db_url, discord_user_id="dc-4", expires_in=timedelta(minutes=-1)
+    )
+
+    resp = test_client.post(
+        "/api/discord/connect", json={"token": connect_token}, headers=headers
+    )
+    assert resp.status_code == 400
+    assert "expired" in resp.json()["detail"]
+
+
+def test_connect_relinking_discord_user_updates_owner(client):
+    """Re-running /connect-account for the same Discord user updates ps_user_id."""
+    test_client, db_url = client
+    first_login = make_auth_token(db_url, user_id="gh-conn-5a", username="conn5a")
+    second_login = make_auth_token(db_url, user_id="gh-conn-5b", username="conn5b")
+
+    token_1 = _insert_connect_token(db_url, discord_user_id="dc-5", discord_username="dUser5")
+    resp1 = test_client.post(
+        "/api/discord/connect",
+        json={"token": token_1},
+        headers={"Authorization": f"Bearer {first_login}"},
+    )
+    assert resp1.status_code == 200
+
+    token_2 = _insert_connect_token(db_url, discord_user_id="dc-5", discord_username="dUser5")
+    resp2 = test_client.post(
+        "/api/discord/connect",
+        json={"token": token_2},
+        headers={"Authorization": f"Bearer {second_login}"},
+    )
+    assert resp2.status_code == 200
+
+    with _sync_session(db_url) as session:
+        link = (
+            session.query(DiscordAccountLink).filter_by(discord_user_id="dc-5").one_or_none()
+        )
+        assert link is not None
+        assert link.ps_user_id == "gh-conn-5b"

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LandingView from '../views/LandingView.vue'
 import AppView from '../views/AppView.vue'
+import DiscordConnectView from '../views/DiscordConnectView.vue'
 
 export function getRootOrigin(): string | null {
   const hostname = window.location.hostname
@@ -42,6 +43,10 @@ const router = createRouter({
         {
           path: '/',
           component: LandingView,
+        },
+        {
+          path: '/auth/discord/connect',
+          component: DiscordConnectView,
         },
         {
           path: '/:guildId',

--- a/frontend/src/views/DiscordConnectView.vue
+++ b/frontend/src/views/DiscordConnectView.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="discord-connect">
+    <div class="connect-card">
+      <div class="connect-icon">⚙</div>
+      <div class="connect-title">CONNECT DISCORD ACCOUNT</div>
+
+      <div v-if="status === 'redirecting'" class="connect-sub">
+        Redirecting you to sign in to Pioneer Square...
+      </div>
+      <div v-else-if="status === 'linking'" class="connect-sub">Linking your account...</div>
+      <div v-else-if="status === 'success'" class="connect-success">
+        ✅ Your Discord account (<strong>{{ discordUsername }}</strong
+        >) is now linked to Pioneer Square.
+      </div>
+      <div v-else class="connect-error">{{ error }}</div>
+
+      <button class="pixel-btn connect-btn" @click="router.push('/')">Go to Pioneer Square</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
+import { api, ApiError } from '../utils/api'
+
+const PENDING_TOKEN_KEY = 'discord_connect_pending_token'
+
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+
+const status = ref<'redirecting' | 'linking' | 'success' | 'error'>('linking')
+const error = ref('')
+const discordUsername = ref('')
+
+onMounted(async () => {
+  const token = (route.query.token as string) || ''
+  if (!token) {
+    status.value = 'error'
+    error.value = 'Missing connect token — use the link Discord gave you.'
+    return
+  }
+
+  if (!authStore.isLoggedIn) {
+    status.value = 'redirecting'
+    localStorage.setItem(PENDING_TOKEN_KEY, token)
+    try {
+      await authStore.loginWithGitHub()
+    } catch (e: unknown) {
+      status.value = 'error'
+      error.value = e instanceof Error ? e.message : String(e)
+    }
+    return
+  }
+
+  status.value = 'linking'
+  try {
+    const data = await api<{ discord_username: string }>('/api/discord/connect', {
+      method: 'POST',
+      json: { token },
+    })
+    discordUsername.value = data.discord_username
+    status.value = 'success'
+  } catch (e: unknown) {
+    status.value = 'error'
+    error.value = e instanceof ApiError ? e.message : 'Failed to link your Discord account.'
+  }
+})
+</script>
+
+<style scoped>
+.discord-connect {
+  width: 100vw;
+  height: 100dvh;
+  background: var(--color-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.connect-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 48px 40px;
+  background: var(--color-bg-secondary);
+  border: 2px solid var(--color-brass-dark);
+  box-shadow: 0 0 32px rgba(232, 170, 0, 0.1);
+  max-width: 440px;
+  width: 100%;
+  text-align: center;
+}
+
+.connect-icon {
+  font-size: 48px;
+  opacity: 0.4;
+  animation: spin 8s linear infinite;
+}
+
+.connect-title {
+  font-family: var(--font-pixel);
+  font-size: 9px;
+  color: var(--color-brass-light);
+  letter-spacing: 2px;
+}
+
+.connect-sub {
+  font-size: 12px;
+  color: var(--color-text-dim);
+  line-height: 1.6;
+}
+
+.connect-success {
+  font-size: 13px;
+  color: var(--color-teal);
+  line-height: 1.6;
+}
+
+.connect-error {
+  font-size: 12px;
+  color: var(--color-red);
+  padding: 6px 10px;
+  background: rgba(238, 51, 34, 0.1);
+  border: 1px solid rgba(238, 51, 34, 0.3);
+  width: 100%;
+}
+
+.connect-btn {
+  font-size: 9px;
+  padding: 12px 24px;
+  margin-top: 8px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -97,6 +97,10 @@ const creating = ref(false)
 const loggingIn = ref(false)
 const loginError = ref('')
 
+// Set by DiscordConnectView before kicking off GitHub login, so the
+// /connect-account flow can resume once the user is signed in.
+const PENDING_DISCORD_TOKEN_KEY = 'discord_connect_pending_token'
+
 onMounted(async () => {
   const params = new URLSearchParams(window.location.search)
   if (params.has('code') && params.has('state')) {
@@ -140,6 +144,12 @@ onMounted(async () => {
   }
 
   if (authStore.isLoggedIn) {
+    const pendingDiscordToken = localStorage.getItem(PENDING_DISCORD_TOKEN_KEY)
+    if (pendingDiscordToken) {
+      localStorage.removeItem(PENDING_DISCORD_TOKEN_KEY)
+      router.push({ path: '/auth/discord/connect', query: { token: pendingDiscordToken } })
+      return
+    }
     await guildStore.loadGuilds()
     guilds.value = guildStore.guilds
   }

--- a/scripts/register_discord_commands.py
+++ b/scripts/register_discord_commands.py
@@ -114,6 +114,11 @@ COMMANDS = [
             },
         ],
     },
+    {
+        "name": "connect-account",
+        "description": "Link your Discord account to your Pioneer Square account",
+        "options": [],
+    },
 ]
 
 DISCORD_API = "https://discord.com/api/v10"


### PR DESCRIPTION
## Summary
- Add `/connect-account` Discord slash command that mints a one-time token and replies ephemerally with a link to connect the user's Discord account to Pioneer Square
- Add `discord_connect_tokens` and `discord_account_links` tables via Alembic migration
- Add `POST /api/discord/connect` endpoint that validates/redeems the token (expiry + single-use) and upserts the account link
- Add `DiscordConnectView.vue` frontend page and route to complete the connect flow after login
- Register the new slash command in `scripts/register_discord_commands.py`

## Test plan
- [x] `python -m ast` / import checks pass for all new/changed backend modules
- [ ] `cd backend && python -m pytest` (requires `docker compose up -d postgres-test`, unavailable in this sandbox — added `backend/tests/test_discord_connect.py` covering token minting, valid/expired/already-used token redemption, and re-linking)
- [ ] `cd frontend && npm test && npm run type-check`

Closes #735