### PR TITLE
feat(discord): persistent Gateway websocket for inbound messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,13 @@ GITHUB_TOKEN=
 # (up to 1 hour to propagate). Only used by scripts/register_discord_commands.py.
 # DISCORD_DEV_GUILD_ID=
 
+# Phase 4: enable the persistent Gateway websocket (backend/discord/gateway.py)
+# for receiving inbound MESSAGE_CREATE events, instead of only the
+# /discord/interactions webhook. Requires DISCORD_BOT_TOKEN, and the bot's
+# application must have the privileged "Message Content Intent" enabled on
+# the Bot page in the Discord Developer Portal.
+# DISCORD_GATEWAY_ENABLED=false
+
 # Build-only: GitHub token used by backend/Dockerfile to clone private dnsid-go.
 BUILD_GITHUB_TOKEN=
 

--- a/backend/discord/__init__.py
+++ b/backend/discord/__init__.py
@@ -1,0 +1,6 @@
+"""Discord Gateway package (Phase 4): persistent websocket for inbound messages.
+
+The flat ``discord_notifier.py`` (outbound notifications) and
+``routes/discord.py`` (interactions webhook) modules predate this package and
+are not moved here to keep this PR self-contained; ``gateway.py`` is additive.
+"""

--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -1,0 +1,308 @@
+"""Discord Gateway websocket client (Phase 4): transport for inbound messages.
+
+This module owns a single persistent connection to Discord's Gateway
+(``wss://gateway.discord.gg``) so the backend can receive ``MESSAGE_CREATE``
+events in real time, instead of only the one-shot ``POST /discord/interactions``
+webhook. It is transport-layer only: filtered events are handed to
+``gateway_message_queue`` for a downstream consumer (#744, Foreman routing) to
+read. This module never imports or calls into Foreman logic.
+
+Enable with::
+
+    DISCORD_GATEWAY_ENABLED=true
+    DISCORD_BOT_TOKEN=...          # reused from Phase 2/3
+
+The bot's Discord application must have the privileged "Message Content
+Intent" turned on in the Developer Portal (Bot page) — without it Discord
+rejects the IDENTIFY payload's ``MESSAGE_CONTENT`` intent bit.
+
+Protocol handled, per https://discord.com/developers/docs/topics/gateway:
+    HELLO (op 10)            -> start the heartbeat loop, then IDENTIFY/RESUME
+    HEARTBEAT_ACK (op 11)    -> mark the last heartbeat as acknowledged
+    DISPATCH (op 0)          -> READY stores session_id/resume url; MESSAGE_CREATE
+                                 is filtered and queued
+    RECONNECT (op 7)         -> close and reconnect, attempting RESUME
+    INVALID_SESSION (op 9)   -> RESUME if resumable, otherwise fresh IDENTIFY
+
+Filtering applied to ``MESSAGE_CREATE`` before anything is queued:
+    - ``author.bot is True``      -> discarded (avoids echoing discord_notifier)
+    - no ``guild_id`` (a DM)      -> discarded
+    - channel not in ``discord_channel_guilds`` -> discarded (not wired)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import random
+
+import websockets
+
+logger = logging.getLogger(__name__)
+
+_GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
+
+# GUILDS (1 << 0) | GUILD_MESSAGES (1 << 9) | MESSAGE_CONTENT (1 << 15)
+_INTENTS = 33281
+
+# Gateway opcodes.
+_OP_DISPATCH = 0
+_OP_HEARTBEAT = 1
+_OP_IDENTIFY = 2
+_OP_RESUME = 6
+_OP_RECONNECT = 7
+_OP_INVALID_SESSION = 9
+_OP_HELLO = 10
+_OP_HEARTBEAT_ACK = 11
+
+# Filtered MESSAGE_CREATE events for wired channels, consumed by #744.
+gateway_message_queue: asyncio.Queue[dict] = asyncio.Queue()
+
+
+def _bot_token() -> str | None:
+    return os.environ.get("DISCORD_BOT_TOKEN") or None
+
+
+def _gateway_enabled() -> bool:
+    return os.environ.get("DISCORD_GATEWAY_ENABLED", "false").strip().lower() == "true"
+
+
+def _backoff_delay(attempt: int, base: float = 2.0, cap: float = 60.0) -> float:
+    """Exponential backoff with full jitter."""
+    return min(cap, base * (2**attempt)) + random.uniform(0, base)
+
+
+async def _is_channel_wired(channel_id: str) -> bool:
+    """Return True if *channel_id* (a channel or thread) has a guild binding.
+
+    Backed by the ``discord_channel_guilds`` table populated by
+    ``/join-channel``. Never raises — DB errors are treated as "not wired".
+    """
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415
+        from models import DiscordChannelGuild  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(
+                select(DiscordChannelGuild.id).where(
+                    col(DiscordChannelGuild.discord_channel_id) == channel_id
+                )
+            )
+            return result.first() is not None
+    except Exception:
+        logger.warning(
+            "discord gateway: channel binding lookup failed channel=%s", channel_id, exc_info=True
+        )
+        return False
+
+
+class GatewayClient:
+    """Persistent Discord Gateway connection.
+
+    One instance owns exactly one logical session (across reconnects/resumes).
+    Run it as a single long-lived task via ``run()``; it loops forever,
+    reconnecting with backoff on any transport error.
+    """
+
+    def __init__(self, token: str, queue: asyncio.Queue | None = None) -> None:
+        self._token = token
+        self._queue = queue if queue is not None else gateway_message_queue
+        self._session_id: str | None = None
+        self._seq: int | None = None
+        self._resume_url: str = _GATEWAY_URL
+        self._heartbeat_task: asyncio.Task | None = None
+        self._heartbeat_acked = True
+
+    async def run(self) -> None:
+        """Connect and process Gateway events forever. Never returns normally."""
+        attempt = 0
+        while True:
+            url = self._resume_url if self._session_id else _GATEWAY_URL
+            try:
+                async with websockets.connect(url, max_size=8 * 1024 * 1024) as ws:
+                    attempt = 0
+                    await self._handle_connection(ws)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                delay = _backoff_delay(attempt)
+                logger.warning(
+                    "discord gateway: connection error (%s) — retrying in %.1fs", exc, delay
+                )
+                await asyncio.sleep(delay)
+                attempt += 1
+            finally:
+                await self._stop_heartbeat()
+
+    async def _handle_connection(self, ws) -> None:
+        """Run the HELLO handshake, then process frames until the socket closes."""
+        hello = json.loads(await ws.recv())
+        if hello.get("op") != _OP_HELLO:
+            logger.warning("discord gateway: expected HELLO, got op=%s", hello.get("op"))
+            return
+
+        interval = hello["d"]["heartbeat_interval"] / 1000.0
+        self._heartbeat_acked = True
+        self._heartbeat_task = asyncio.create_task(
+            self._heartbeat_loop(ws, interval), name="discord-gateway-heartbeat"
+        )
+
+        if self._session_id and self._seq is not None:
+            await self._send_resume(ws)
+        else:
+            await self._send_identify(ws)
+
+        async for raw in ws:
+            await self._handle_frame(ws, raw)
+
+    async def _heartbeat_loop(self, ws, interval: float) -> None:
+        # Discord: jitter the first heartbeat instead of firing exactly on the interval.
+        await asyncio.sleep(interval * random.random())
+        while True:
+            if not self._heartbeat_acked:
+                logger.warning("discord gateway: heartbeat not acked — forcing reconnect")
+                await ws.close(code=4000)
+                return
+            self._heartbeat_acked = False
+            await ws.send(json.dumps({"op": _OP_HEARTBEAT, "d": self._seq}))
+            await asyncio.sleep(interval)
+
+    async def _stop_heartbeat(self) -> None:
+        if self._heartbeat_task is None:
+            return
+        self._heartbeat_task.cancel()
+        try:
+            await self._heartbeat_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        self._heartbeat_task = None
+
+    async def _send_identify(self, ws) -> None:
+        await ws.send(
+            json.dumps(
+                {
+                    "op": _OP_IDENTIFY,
+                    "d": {
+                        "token": self._token,
+                        "intents": _INTENTS,
+                        "properties": {
+                            "os": "linux",
+                            "browser": "pioneer-square",
+                            "device": "pioneer-square",
+                        },
+                    },
+                }
+            )
+        )
+
+    async def _send_resume(self, ws) -> None:
+        await ws.send(
+            json.dumps(
+                {
+                    "op": _OP_RESUME,
+                    "d": {
+                        "token": self._token,
+                        "session_id": self._session_id,
+                        "seq": self._seq,
+                    },
+                }
+            )
+        )
+
+    async def _handle_frame(self, ws, raw) -> None:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.debug("discord gateway: non-JSON frame ignored: %r", raw[:120])
+            return
+
+        if data.get("s") is not None:
+            self._seq = data["s"]
+
+        op = data.get("op")
+        if op == _OP_DISPATCH:
+            await self._handle_dispatch(data)
+        elif op == _OP_HEARTBEAT_ACK:
+            self._heartbeat_acked = True
+        elif op == _OP_RECONNECT:
+            logger.info("discord gateway: server requested reconnect")
+            await ws.close()
+        elif op == _OP_INVALID_SESSION:
+            resumable = data.get("d") is True
+            logger.warning("discord gateway: invalid session (resumable=%s)", resumable)
+            if not resumable:
+                self._session_id = None
+                self._seq = None
+                self._resume_url = _GATEWAY_URL
+            await asyncio.sleep(1 + random.random() * 4)
+            if resumable and self._session_id:
+                await self._send_resume(ws)
+            else:
+                await self._send_identify(ws)
+
+    async def _handle_dispatch(self, data: dict) -> None:
+        event_type = data.get("t")
+        payload = data.get("d") or {}
+        if event_type == "READY":
+            self._session_id = payload.get("session_id")
+            self._resume_url = payload.get("resume_gateway_url") or _GATEWAY_URL
+            logger.info("discord gateway: READY session_id=%s", self._session_id)
+        elif event_type == "RESUMED":
+            logger.info("discord gateway: RESUMED session_id=%s", self._session_id)
+        elif event_type == "MESSAGE_CREATE":
+            await self._handle_message_create(payload)
+
+    async def _handle_message_create(self, message: dict) -> None:
+        author = message.get("author") or {}
+        if author.get("bot"):
+            return
+        if not message.get("guild_id"):
+            return  # DM — no guild_id on the message
+        channel_id = message.get("channel_id")
+        if not channel_id or not await _is_channel_wired(channel_id):
+            return
+        await self._queue.put(message)
+
+
+_gateway_task: asyncio.Task | None = None
+
+
+def start_gateway() -> asyncio.Task | None:
+    """Start the persistent Gateway task, spawned via ``util.tasks.spawn``.
+
+    No-op (returns None) when ``DISCORD_GATEWAY_ENABLED`` is not ``true`` or
+    ``DISCORD_BOT_TOKEN`` is unset. Safe to call more than once — returns the
+    existing task if one is already running.
+    """
+    global _gateway_task
+    if not _gateway_enabled():
+        return None
+    token = _bot_token()
+    if not token:
+        logger.warning(
+            "discord gateway: DISCORD_GATEWAY_ENABLED=true but DISCORD_BOT_TOKEN is unset; not starting"
+        )
+        return None
+    if _gateway_task is not None and not _gateway_task.done():
+        return _gateway_task
+
+    from util.tasks import spawn  # noqa: PLC0415 — avoid importing util at module load for tests
+
+    _gateway_task = spawn(GatewayClient(token).run(), name="discord-gateway")
+    return _gateway_task
+
+
+async def stop_gateway() -> None:
+    """Cancel the running Gateway task, if any, and wait for it to unwind."""
+    global _gateway_task
+    if _gateway_task is None:
+        return
+    _gateway_task.cancel()
+    try:
+        await _gateway_task
+    except (asyncio.CancelledError, Exception):
+        pass
+    _gateway_task = None

--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -37,6 +37,7 @@ import json
 import logging
 import os
 import random
+import time
 
 import websockets
 
@@ -74,11 +75,33 @@ def _backoff_delay(attempt: int, base: float = 2.0, cap: float = 60.0) -> float:
     return min(cap, base * (2**attempt)) + random.uniform(0, base)
 
 
+# Short-lived cache so a busy wired channel doesn't open a DB session on
+# every single message. Keyed on channel_id -> (wired, expires_at_monotonic).
+_CHANNEL_WIRED_CACHE_TTL = 30.0
+_channel_wired_cache: dict[str, tuple[bool, float]] = {}
+
+
 async def _is_channel_wired(channel_id: str) -> bool:
     """Return True if *channel_id* (a channel or thread) has a guild binding.
 
     Backed by the ``discord_channel_guilds`` table populated by
-    ``/join-channel``. Never raises — DB errors are treated as "not wired".
+    ``/join-channel``, through a short TTL cache so repeated messages in the
+    same channel don't each pay for a DB round-trip.
+    """
+    now = time.monotonic()
+    cached = _channel_wired_cache.get(channel_id)
+    if cached is not None and cached[1] > now:
+        return cached[0]
+
+    wired = await _query_channel_wired(channel_id)
+    _channel_wired_cache[channel_id] = (wired, now + _CHANNEL_WIRED_CACHE_TTL)
+    return wired
+
+
+async def _query_channel_wired(channel_id: str) -> bool:
+    """Query the ``discord_channel_guilds`` table directly, bypassing the cache.
+
+    Never raises — DB errors are treated as "not wired".
     """
     try:
         from database import AsyncSessionLocal  # noqa: PLC0415
@@ -164,6 +187,12 @@ class GatewayClient:
         while True:
             if not self._heartbeat_acked:
                 logger.warning("discord gateway: heartbeat not acked — forcing reconnect")
+                # A local close() with a non-1000/1001 code makes `websockets`
+                # raise ConnectionClosedError out of the concurrent
+                # `async for raw in ws` read loop in _handle_connection
+                # immediately (verified against websockets 16.0) — so this
+                # unblocks the reader promptly rather than leaving it hung,
+                # and run()'s except Exception handles the reconnect/backoff.
                 await ws.close(code=4000)
                 return
             self._heartbeat_acked = False
@@ -229,6 +258,10 @@ class GatewayClient:
             self._heartbeat_acked = True
         elif op == _OP_RECONNECT:
             logger.info("discord gateway: server requested reconnect")
+            # Stop the heartbeat first so it can't send/close against a socket
+            # we're already tearing down here (that raced "warning" was the
+            # heartbeat loop hitting ConnectionClosed on its own).
+            await self._stop_heartbeat()
             await ws.close()
         elif op == _OP_INVALID_SESSION:
             resumable = data.get("d") is True

--- a/backend/main.py
+++ b/backend/main.py
@@ -367,15 +367,17 @@ async def lifespan(app: FastAPI):
 
     # Discord Gateway (Phase 4): persistent websocket for inbound messages.
     # No-op unless DISCORD_GATEWAY_ENABLED=true and DISCORD_BOT_TOKEN are set.
-    from discord.gateway import start_gateway, stop_gateway  # noqa: PLC0415
+    from discord.gateway import start_gateway  # noqa: PLC0415
 
-    start_gateway()
+    discord_gw_task = start_gateway()
     try:
         yield
     finally:
         sweeper.cancel()
         if drain_bg is not None:
             drain_bg.cancel()
+        if discord_gw_task is not None:
+            discord_gw_task.cancel()
         try:
             await sweeper
         except (asyncio.CancelledError, Exception):
@@ -385,7 +387,11 @@ async def lifespan(app: FastAPI):
                 await drain_bg
             except (asyncio.CancelledError, Exception):
                 pass
-        await stop_gateway()
+        if discord_gw_task is not None:
+            try:
+                await discord_gw_task
+            except (asyncio.CancelledError, Exception):
+                pass
         await _shutdown_webhook_debouncer()
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -364,6 +364,12 @@ async def lifespan(app: FastAPI):
 
     asyncio.ensure_future(_startup_refresh_catalog())
     sweeper = spawn(_stale_worker_sweeper(), name="stale-worker-sweeper")
+
+    # Discord Gateway (Phase 4): persistent websocket for inbound messages.
+    # No-op unless DISCORD_GATEWAY_ENABLED=true and DISCORD_BOT_TOKEN are set.
+    from discord.gateway import start_gateway, stop_gateway  # noqa: PLC0415
+
+    start_gateway()
     try:
         yield
     finally:
@@ -379,6 +385,7 @@ async def lifespan(app: FastAPI):
                 await drain_bg
             except (asyncio.CancelledError, Exception):
                 pass
+        await stop_gateway()
         await _shutdown_webhook_debouncer()
 
 

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -245,9 +245,7 @@ async def test_message_create_dispatch_reaches_queue_end_to_end():
 
 @pytest.mark.asyncio
 async def test_is_channel_wired_caches_positive_result():
-    with patch(
-        "discord.gateway._query_channel_wired", new=AsyncMock(return_value=True)
-    ) as query:
+    with patch("discord.gateway._query_channel_wired", new=AsyncMock(return_value=True)) as query:
         assert await gateway._is_channel_wired("c-wired") is True
         assert await gateway._is_channel_wired("c-wired") is True
     query.assert_awaited_once_with("c-wired")
@@ -255,9 +253,7 @@ async def test_is_channel_wired_caches_positive_result():
 
 @pytest.mark.asyncio
 async def test_is_channel_wired_requeries_after_ttl_expires():
-    with patch(
-        "discord.gateway._query_channel_wired", new=AsyncMock(return_value=False)
-    ) as query:
+    with patch("discord.gateway._query_channel_wired", new=AsyncMock(return_value=False)) as query:
         assert await gateway._is_channel_wired("c-unwired") is False
         gateway._channel_wired_cache["c-unwired"] = (False, 0.0)  # force expiry
         assert await gateway._is_channel_wired("c-unwired") is False

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -1,0 +1,278 @@
+"""Unit tests for the Discord Gateway websocket client (Phase 4).
+
+No real Discord connection is made — ``websockets.connect`` is patched with a
+``FakeGatewayWebSocket`` that feeds pre-scripted frames and records sent
+frames. No DB is used — ``_is_channel_wired`` is patched directly for the
+MESSAGE_CREATE filtering tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from discord import gateway  # noqa: E402
+
+_CLOSE = object()
+
+
+class FakeGatewayWebSocket:
+    """Minimal async-context-manager + async-iterator fake of a Gateway connection."""
+
+    def __init__(self, frames):
+        self._frames: asyncio.Queue = asyncio.Queue()
+        for frame in frames:
+            self._frames.put_nowait(frame)
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def recv(self):
+        frame = await self._frames.get()
+        if frame is _CLOSE:
+            raise StopAsyncIteration
+        return frame
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        frame = await self._frames.get()
+        if frame is _CLOSE:
+            raise StopAsyncIteration
+        return frame
+
+    async def send(self, data):
+        self.sent.append(json.loads(data))
+
+    async def close(self, code=1000, reason=""):
+        self.closed = True
+        await self._frames.put(_CLOSE)
+
+
+def _hello(interval_ms=41250):
+    return json.dumps({"op": gateway._OP_HELLO, "d": {"heartbeat_interval": interval_ms}})
+
+
+def _dispatch(event_type, data, seq=1):
+    return json.dumps({"op": gateway._OP_DISPATCH, "t": event_type, "s": seq, "d": data})
+
+
+async def _run_briefly(client, ws):
+    """Run client.run() against ws for a short window, then cancel it."""
+    with patch("discord.gateway.websockets.connect", return_value=ws):
+        task = asyncio.create_task(client.run())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+# ---------------------------------------------------------------------------
+# IDENTIFY / RESUME handshake
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identify_sent_after_hello_with_no_prior_session():
+    ws = FakeGatewayWebSocket([_hello(), _CLOSE])
+    client = gateway.GatewayClient("test-token")
+    await _run_briefly(client, ws)
+
+    identify = [m for m in ws.sent if m["op"] == gateway._OP_IDENTIFY]
+    assert len(identify) == 1
+    assert identify[0]["d"]["token"] == "test-token"
+    assert identify[0]["d"]["intents"] == 33281
+
+
+@pytest.mark.asyncio
+async def test_resume_sent_when_session_already_known():
+    ws = FakeGatewayWebSocket([_hello(), _CLOSE])
+    client = gateway.GatewayClient("test-token")
+    client._session_id = "sess-123"
+    client._seq = 42
+    await _run_briefly(client, ws)
+
+    resume = [m for m in ws.sent if m["op"] == gateway._OP_RESUME]
+    assert len(resume) == 1
+    assert resume[0]["d"] == {"token": "test-token", "session_id": "sess-123", "seq": 42}
+    assert [m for m in ws.sent if m["op"] == gateway._OP_IDENTIFY] == []
+
+
+@pytest.mark.asyncio
+async def test_ready_stores_session_id_and_resume_url():
+    ready = _dispatch(
+        "READY", {"session_id": "sess-abc", "resume_gateway_url": "wss://resume.example/"}
+    )
+    ws = FakeGatewayWebSocket([_hello(), ready, _CLOSE])
+    client = gateway.GatewayClient("test-token")
+    await _run_briefly(client, ws)
+
+    assert client._session_id == "sess-abc"
+    assert client._resume_url == "wss://resume.example/"
+    assert client._seq == 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_ack_is_tracked():
+    ws = FakeGatewayWebSocket([_hello(), json.dumps({"op": gateway._OP_HEARTBEAT_ACK}), _CLOSE])
+    client = gateway.GatewayClient("test-token")
+    await _run_briefly(client, ws)
+
+    assert client._heartbeat_acked is True
+
+
+@pytest.mark.asyncio
+async def test_invalid_session_not_resumable_clears_state_and_reidentifies():
+    """Exercises _handle_frame directly — patching asyncio.sleep globally would
+    also stall the wall-clock wait in _run_briefly, so the full run() loop
+    isn't used here."""
+    ws = FakeGatewayWebSocket([])
+    client = gateway.GatewayClient("test-token")
+    client._session_id = "stale-session"
+    client._seq = 7
+
+    with patch("discord.gateway.asyncio.sleep", new=AsyncMock()):
+        await client._handle_frame(ws, json.dumps({"op": gateway._OP_INVALID_SESSION, "d": False}))
+
+    assert client._session_id is None
+    assert client._seq is None
+    identify = [m for m in ws.sent if m["op"] == gateway._OP_IDENTIFY]
+    assert len(identify) == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_session_resumable_sends_resume_and_keeps_state():
+    ws = FakeGatewayWebSocket([])
+    client = gateway.GatewayClient("test-token")
+    client._session_id = "sess-keep"
+    client._seq = 9
+
+    with patch("discord.gateway.asyncio.sleep", new=AsyncMock()):
+        await client._handle_frame(ws, json.dumps({"op": gateway._OP_INVALID_SESSION, "d": True}))
+
+    resume = [m for m in ws.sent if m["op"] == gateway._OP_RESUME]
+    assert len(resume) == 1
+    assert client._session_id == "sess-keep"
+
+
+# ---------------------------------------------------------------------------
+# MESSAGE_CREATE filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_create_filters_bot_author():
+    client = gateway.GatewayClient("token", queue=asyncio.Queue())
+    message = {"author": {"bot": True}, "guild_id": "g1", "channel_id": "c1"}
+    with patch("discord.gateway._is_channel_wired", new=AsyncMock(return_value=True)):
+        await client._handle_message_create(message)
+    assert client._queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_message_create_filters_dm_with_no_guild_id():
+    client = gateway.GatewayClient("token", queue=asyncio.Queue())
+    message = {"author": {"bot": False}, "channel_id": "c1"}
+    with patch("discord.gateway._is_channel_wired", new=AsyncMock(return_value=True)):
+        await client._handle_message_create(message)
+    assert client._queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_message_create_filters_unwired_channel():
+    client = gateway.GatewayClient("token", queue=asyncio.Queue())
+    message = {"author": {"bot": False}, "guild_id": "g1", "channel_id": "c-unwired"}
+    with patch("discord.gateway._is_channel_wired", new=AsyncMock(return_value=False)):
+        await client._handle_message_create(message)
+    assert client._queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_message_create_queued_when_wired():
+    q: asyncio.Queue = asyncio.Queue()
+    client = gateway.GatewayClient("token", queue=q)
+    message = {
+        "author": {"bot": False},
+        "guild_id": "g1",
+        "channel_id": "c-wired",
+        "content": "hi",
+    }
+    with patch("discord.gateway._is_channel_wired", new=AsyncMock(return_value=True)):
+        await client._handle_message_create(message)
+    assert q.qsize() == 1
+    queued = await q.get()
+    assert queued["content"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_message_create_dispatch_reaches_queue_end_to_end():
+    """A full MESSAGE_CREATE dispatch frame reaches the queue for a wired channel."""
+    q: asyncio.Queue = asyncio.Queue()
+    message = {
+        "author": {"bot": False, "id": "u1"},
+        "guild_id": "g1",
+        "channel_id": "c-wired",
+        "content": "hello",
+    }
+    frame = _dispatch("MESSAGE_CREATE", message)
+    ws = FakeGatewayWebSocket([_hello(), frame, _CLOSE])
+    client = gateway.GatewayClient("test-token", queue=q)
+
+    with patch("discord.gateway._is_channel_wired", new=AsyncMock(return_value=True)):
+        await _run_briefly(client, ws)
+
+    assert q.qsize() == 1
+    assert (await q.get())["content"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# start_gateway / stop_gateway env gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_gateway_task():
+    gateway._gateway_task = None
+    yield
+    gateway._gateway_task = None
+
+
+def test_start_gateway_noop_when_disabled(monkeypatch):
+    monkeypatch.delenv("DISCORD_GATEWAY_ENABLED", raising=False)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    assert gateway.start_gateway() is None
+
+
+def test_start_gateway_noop_without_bot_token(monkeypatch):
+    monkeypatch.setenv("DISCORD_GATEWAY_ENABLED", "true")
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    assert gateway.start_gateway() is None
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_spawns_task_and_stop_gateway_cancels_it(monkeypatch):
+    monkeypatch.setenv("DISCORD_GATEWAY_ENABLED", "true")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    ws = FakeGatewayWebSocket([])  # never yields HELLO — recv() blocks until cancelled
+
+    with patch("discord.gateway.websockets.connect", return_value=ws):
+        task = gateway.start_gateway()
+        assert task is not None
+        assert gateway.start_gateway() is task  # idempotent while already running
+
+        await gateway.stop_gateway()
+
+    assert gateway._gateway_task is None

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -239,6 +239,32 @@ async def test_message_create_dispatch_reaches_queue_end_to_end():
 
 
 # ---------------------------------------------------------------------------
+# _is_channel_wired TTL cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_channel_wired_caches_positive_result():
+    with patch(
+        "discord.gateway._query_channel_wired", new=AsyncMock(return_value=True)
+    ) as query:
+        assert await gateway._is_channel_wired("c-wired") is True
+        assert await gateway._is_channel_wired("c-wired") is True
+    query.assert_awaited_once_with("c-wired")
+
+
+@pytest.mark.asyncio
+async def test_is_channel_wired_requeries_after_ttl_expires():
+    with patch(
+        "discord.gateway._query_channel_wired", new=AsyncMock(return_value=False)
+    ) as query:
+        assert await gateway._is_channel_wired("c-unwired") is False
+        gateway._channel_wired_cache["c-unwired"] = (False, 0.0)  # force expiry
+        assert await gateway._is_channel_wired("c-unwired") is False
+    assert query.await_count == 2
+
+
+# ---------------------------------------------------------------------------
 # start_gateway / stop_gateway env gating
 # ---------------------------------------------------------------------------
 
@@ -246,8 +272,10 @@ async def test_message_create_dispatch_reaches_queue_end_to_end():
 @pytest.fixture(autouse=True)
 def _reset_gateway_task():
     gateway._gateway_task = None
+    gateway._channel_wired_cache.clear()
     yield
     gateway._gateway_task = None
+    gateway._channel_wired_cache.clear()
 
 
 def test_start_gateway_noop_when_disabled(monkeypatch):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,10 @@ services:
       DISCORD_PUBLIC_KEY: ${DISCORD_PUBLIC_KEY:-}
       DISCORD_ALLOWED_ROLE_IDS: ${DISCORD_ALLOWED_ROLE_IDS:-}
       DISCORD_PIONEER_GUILD_SLUG: ${DISCORD_PIONEER_GUILD_SLUG:-}
+      # Phase 4: persistent Gateway websocket for inbound messages. Requires
+      # DISCORD_BOT_TOKEN and the "Message Content Intent" enabled on the
+      # bot's Bot page in the Discord Developer Portal.
+      DISCORD_GATEWAY_ENABLED: ${DISCORD_GATEWAY_ENABLED:-false}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "cd backend && alembic upgrade head && cd .. && pioneer serve"


### PR DESCRIPTION
## Summary
- Adds `backend/discord/gateway.py`: a persistent websocket client to the Discord Gateway (`wss://gateway.discord.gg/?v=10&encoding=json`) with `IDENTIFY` (intents bitmask `33281` = GUILDS | GUILD_MESSAGES | MESSAGE_CONTENT), a heartbeat loop driven by `HELLO`/`HEARTBEAT_ACK`, and reconnect logic that attempts `RESUME` with the stored `session_id`/`seq`, falling back to fresh `IDENTIFY` on `INVALID_SESSION`.
- Filters `MESSAGE_CREATE` events: drops bot-authored messages, DMs (no `guild_id`), and channels/threads not present in `DiscordChannelGuild`. Wired-channel events are pushed onto a module-level `gateway_message_queue` for #744 to consume — no Foreman routing logic here.
- Runs as a single long-lived `asyncio.Task`, started/stopped from the FastAPI `lifespan` in `backend/main.py`, gated on the new `DISCORD_GATEWAY_ENABLED` env var (default `false`).
- Documents `DISCORD_GATEWAY_ENABLED` in `.env.example` and `docker-compose.yml`, noting the Message Content privileged intent must be enabled in the Discord Developer Portal.

Closes #743

## Test plan
- [x] `pytest backend/tests/test_discord_gateway.py` — 14/14 passed (mocked websocket: IDENTIFY, heartbeat, RESUME, INVALID_SESSION fallback, MESSAGE_CREATE filtering)
- [x] Full backend suite passes (74 passed)
- [ ] Manual verification against live Discord Gateway (requires `DISCORD_GATEWAY_ENABLED=true` + bot token with Message Content intent enabled)