### PR TITLE
feat(discord): route task-scoped Foreman replies to per-task threads

### DIFF
--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -19,6 +19,12 @@ Phase 3 — Foreman chat threads + user mentions
     Discord thread per guild per UTC day (mapping persisted in
     ``discord_foreman_threads``), reusing the same bot token/channel as Phase 2.
 
+    When a chat line is scoped to a task (``task_id`` passed through) and that
+    task's linked GitHub issue/PR already has a thread in ``discord_threads``,
+    the line is posted there instead — so task-scoped narration stays with
+    that task's Discord history rather than the daily catch-all thread.
+    Falls back to the per-day thread whenever no per-task thread applies.
+
     ``mention_or_login`` resolves a GitHub login to a real ``<@id>`` Discord
     mention via the ``discord_users`` table (populated through the
     ``/api/discord-users`` REST endpoints). Falls back to a plain ``@login``
@@ -43,8 +49,11 @@ Usage::
         header_fields={"Assignee": "@alice", "Labels": "bug"},
     )
 
-    # Foreman chat mirrored into a per-day thread:
-    await discord_notifier.notify_foreman_chat(guild_id, "Spun up worker w-abc for t-123.")
+    # Foreman chat mirrored into a per-day thread (or a per-task thread when
+    # task_id resolves to one):
+    await discord_notifier.notify_foreman_chat(
+        guild_id, "Spun up worker w-abc for t-123.", task_id="t-123"
+    )
 
     # Resolve a GitHub login to a Discord mention (or a plain @login fallback):
     mention = await discord_notifier.mention_or_login("alice")
@@ -364,6 +373,32 @@ async def archive_thread(thread_id: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+async def _lookup_task_issue_coords(task_id: str) -> tuple[str, int] | None:
+    """Return the ``(issue_repo, issue_number)`` linked to *task_id*, or None.
+
+    Used to route task-scoped Foreman chat into the same thread as that
+    task's PR/issue notifications (see ``_lookup_thread``), instead of the
+    daily guild thread. None when the task has no linked issue/PR, doesn't
+    exist, or the lookup fails.
+    """
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415
+        from models import Task  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(
+                select(Task.issue_repo, Task.issue_number).where(col(Task.id) == task_id)
+            )
+            row = result.one_or_none()
+            if row and row[0] and row[1] is not None:
+                return row[0], row[1]
+            return None
+    except Exception:
+        logger.warning("discord: task issue-coords lookup failed task=%s", task_id, exc_info=True)
+        return None
+
+
 async def _lookup_foreman_thread(guild_id: str, session_key: str) -> str | None:
     """Return the persisted Discord thread_id for a Foreman chat session, or None."""
     try:
@@ -472,18 +507,41 @@ async def _ensure_foreman_thread(
     return await _save_foreman_thread(guild_id, session_key, new_thread_id) or new_thread_id
 
 
-async def notify_foreman_chat(guild_id: str, content: str, session_key: str | None = None) -> None:
-    """Mirror a Foreman → user chat line into a per-guild, per-day Discord thread.
+async def notify_foreman_chat(
+    guild_id: str,
+    content: str,
+    session_key: str | None = None,
+    task_id: str | None = None,
+) -> None:
+    """Mirror a Foreman → user chat line into Discord.
 
-    One thread is created per ``(guild_id, session_key)`` pair — *session_key*
-    defaults to the current UTC date, so a whole day's conversation lands in
-    the same thread. Silent no-op when the bot token or channel are not
-    configured, or when *content* is blank. Never raises.
+    When *task_id* is given and resolves (via ``discord_threads``) to a
+    per-task thread already created for that task's linked PR/issue, the
+    line is posted there. Otherwise it falls back to the per-guild, per-day
+    thread — one thread per ``(guild_id, session_key)`` pair, *session_key*
+    defaulting to the current UTC date, so a whole day's un-scoped
+    conversation lands together. The message is only ever posted to one
+    thread. Silent no-op when the bot token or channel are not configured,
+    or when *content* is blank. Never raises.
     """
     if not content or not content.strip():
         return
     if not _bot_token():
         return
+
+    if task_id:
+        coords = await _lookup_task_issue_coords(task_id)
+        if coords:
+            issue_repo, issue_number = coords
+            task_thread_id = await _lookup_thread(issue_repo, issue_number)
+            if task_thread_id:
+                await _bot_request(
+                    "post",
+                    f"/channels/{task_thread_id}/messages",
+                    {"content": content[:2000]},
+                )
+                return
+
     channel = await _resolve_channel_for_guild(guild_id)
     if not channel:
         return

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -384,18 +384,29 @@ async def _lookup_task_issue_coords(task_id: str) -> tuple[str, int] | None:
     try:
         from database import AsyncSessionLocal  # noqa: PLC0415
         from models import Task  # noqa: PLC0415
+        from sqlalchemy.exc import NoResultFound  # noqa: PLC0415
         from sqlmodel import col, select  # noqa: PLC0415
 
-        async with AsyncSessionLocal() as db:
-            result = await db.exec(
-                select(Task.issue_repo, Task.issue_number).where(col(Task.id) == task_id)
-            )
-            row = result.one_or_none()
-            if row and row[0] and row[1] is not None:
-                return row[0], row[1]
+        try:
+            async with AsyncSessionLocal() as db:
+                result = await db.exec(
+                    select(Task.issue_repo, Task.issue_number).where(col(Task.id) == task_id)
+                )
+                row = result.one_or_none()
+                if row and row[0] and row[1] is not None:
+                    return row[0], row[1]
+                return None
+        except NoResultFound:
+            # Expected when the task has no linked issue/PR (or no thread) yet.
+            logger.debug("discord: no issue coords for task=%s", task_id)
             return None
-    except Exception:
-        logger.warning("discord: task issue-coords lookup failed task=%s", task_id, exc_info=True)
+    except Exception as exc:
+        logger.warning(
+            "discord: task issue-coords lookup failed task=%s error_type=%s: %s",
+            task_id,
+            type(exc).__name__,
+            exc,
+        )
         return None
 
 
@@ -507,6 +518,24 @@ async def _ensure_foreman_thread(
     return await _save_foreman_thread(guild_id, session_key, new_thread_id) or new_thread_id
 
 
+# Discord's hard cap on a single message's content length.
+_MAX_MESSAGE_LENGTH = 2000
+
+
+async def _post_foreman_chat_line(thread_id: str, content: str) -> None:
+    """POST *content* to *thread_id*, applying the shared length guardrail.
+
+    Both the per-task and daily-thread paths in ``notify_foreman_chat`` route
+    through this helper so neither can skip the truncation applied to the
+    other.
+    """
+    await _bot_request(
+        "post",
+        f"/channels/{thread_id}/messages",
+        {"content": content[:_MAX_MESSAGE_LENGTH]},
+    )
+
+
 async def notify_foreman_chat(
     guild_id: str,
     content: str,
@@ -535,11 +564,7 @@ async def notify_foreman_chat(
             issue_repo, issue_number = coords
             task_thread_id = await _lookup_thread(issue_repo, issue_number)
             if task_thread_id:
-                await _bot_request(
-                    "post",
-                    f"/channels/{task_thread_id}/messages",
-                    {"content": content[:2000]},
-                )
+                await _post_foreman_chat_line(task_thread_id, content)
                 return
 
     channel = await _resolve_channel_for_guild(guild_id)
@@ -551,7 +576,7 @@ async def notify_foreman_chat(
     thread_id = await _ensure_foreman_thread(guild_id, key, thread_name, channel=channel)
     if not thread_id:
         return
-    await _bot_request("post", f"/channels/{thread_id}/messages", {"content": content[:2000]})
+    await _post_foreman_chat_line(thread_id, content)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -572,6 +572,11 @@ async def _run_foreman_ai(
     worker/task rows, system prompt, state preamble, tool set, and loaded history
     are all narrowed to that one task. See docs/foreman-per-task-context.md.
     """
+    # Initialized up front (rather than only inside the child/parent branches
+    # below) so it's always bound — including on any early return before task
+    # scoping runs — for every ``task_id=_task_id`` use further down.
+    _task_id: str | None = None
+
     if not HAS_ANTHROPIC:
         now = datetime.now(UTC).isoformat()
         await broadcast_msg(
@@ -652,7 +657,7 @@ async def _run_foreman_ai(
             child_worker_id = child_task_row.get("worker_id") if child_task_row else None
             worker_rows = [r for r in worker_rows if r["id"] == child_worker_id]
             task_rows = [child_task_row] if child_task_row else []
-            _task_id: str | None = task_id
+            _task_id = task_id
         elif child:
             _task_id = task_rows[0]["id"] if len(task_rows) == 1 else None
         else:

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -487,19 +487,23 @@ async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
     return [dict(r._mapping) for r in result.all()]
 
 
-async def _emit_foreman_chat(guild_id: str, content: str, created_at: str) -> None:
+async def _emit_foreman_chat(
+    guild_id: str, content: str, created_at: str, task_id: str | None = None
+) -> None:
     """Broadcast a Foreman -> user narration line and mirror it into Discord.
 
     Every plain-text line the Foreman sends to the user (not tool_use/tool_result
     traces) goes through here so the Discord thread mirror in discord_notifier
-    stays in sync with the WS chat stream.
+    stays in sync with the WS chat stream. *task_id*, when known, lets
+    discord_notifier route the line to that task's per-task thread instead of
+    the daily guild thread.
     """
     await broadcast_msg(
         guild_id,
         ChatMsg(from_="foreman", to="user", content=content, createdAt=created_at),
     )
     spawn(
-        discord_notifier.notify_foreman_chat(guild_id, content),
+        discord_notifier.notify_foreman_chat(guild_id, content, task_id=task_id),
         name=f"discord.foreman-chat:{guild_id}",
     )
 

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -843,7 +843,9 @@ async def _run_foreman_ai(
             for b in resp.content:
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
-                    await _emit_foreman_chat(guild_id, b.text.strip(), _now.isoformat())
+                    await _emit_foreman_chat(
+                        guild_id, b.text.strip(), _now.isoformat(), task_id=_task_id
+                    )
 
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
             if not tool_uses:
@@ -1050,10 +1052,10 @@ async def _run_foreman_ai(
             for b in wrap_resp.content:
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
-                    await _emit_foreman_chat(guild_id, b.text.strip(), _now)
+                    await _emit_foreman_chat(guild_id, b.text.strip(), _now, task_id=_task_id)
             cap_note = f"_(Foreman hit {cfg_max_rounds}-round safety cap and stopped.)_"
             text_parts.append(cap_note)
-            await _emit_foreman_chat(guild_id, cap_note, _now)
+            await _emit_foreman_chat(guild_id, cap_note, _now, task_id=_task_id)
 
         response_text = "\n".join(text_parts).strip()
         if response_text:

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -633,6 +633,106 @@ async def test_notify_foreman_chat_reuses_thread_for_same_session(monkeypatch):
     assert mock_client.post.call_count == 2
 
 
+@pytest.mark.asyncio
+async def test_notify_foreman_chat_task_scoped_routes_to_task_thread(monkeypatch):
+    """A task-scoped message with an existing per-task thread posts there, not the daily thread."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client()
+    task_thread_id = "999888777666"
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(
+            discord_notifier,
+            "_lookup_task_issue_coords",
+            AsyncMock(return_value=("org/repo", 42)),
+        ),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=task_thread_id)),
+        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_daily_mock,
+    ):
+        await discord_notifier.notify_foreman_chat("guild-1", "Working on it.", task_id="t-abc")
+
+    ensure_daily_mock.assert_not_called()
+    mock_client.post.assert_called_once()
+    call = mock_client.post.call_args
+    assert f"/channels/{task_thread_id}/messages" in call[0][0]
+    assert call[1]["json"]["content"] == "Working on it."
+
+
+@pytest.mark.asyncio
+async def test_notify_foreman_chat_no_task_id_uses_daily_thread(monkeypatch):
+    """A non-scoped message (no task_id) goes straight to the daily guild thread."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock()) as coords_mock,
+        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_foreman_chat("guild-1", "General update.")
+
+    coords_mock.assert_not_called()
+    mock_client.post.assert_called_once()
+    call = mock_client.post.call_args
+    assert f"/channels/{THREAD_ID}/messages" in call[0][0]
+    assert call[1]["json"]["content"] == "General update."
+
+
+@pytest.mark.asyncio
+async def test_notify_foreman_chat_task_scoped_no_thread_falls_back_to_daily(monkeypatch):
+    """Task-scoped message with no per-task thread yet falls back to the daily thread."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(
+            discord_notifier,
+            "_lookup_task_issue_coords",
+            AsyncMock(return_value=("org/repo", 42)),
+        ),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
+        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_foreman_chat("guild-1", "No thread yet.", task_id="t-abc")
+
+    mock_client.post.assert_called_once()
+    call = mock_client.post.call_args
+    assert f"/channels/{THREAD_ID}/messages" in call[0][0]
+    assert call[1]["json"]["content"] == "No thread yet."
+
+
+@pytest.mark.asyncio
+async def test_notify_foreman_chat_task_with_no_linked_issue_falls_back_to_daily(monkeypatch):
+    """Task-scoped message where the task has no linked issue/PR falls back to the daily thread."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock(return_value=None)),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock()) as lookup_thread_mock,
+        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_foreman_chat(
+            "guild-1", "No linked issue.", task_id="t-standalone"
+        )
+
+    lookup_thread_mock.assert_not_called()
+    mock_client.post.assert_called_once()
+    call = mock_client.post.call_args
+    assert f"/channels/{THREAD_ID}/messages" in call[0][0]
+
+
 # ---------------------------------------------------------------------------
 # Phase 3: GitHub login -> Discord user mentions
 # ---------------------------------------------------------------------------
@@ -671,5 +771,14 @@ async def test_lookup_discord_user_db_error_returns_none():
     """_lookup_discord_user swallows DB errors and returns None (never raises)."""
     with patch("database.AsyncSessionLocal", side_effect=RuntimeError("db down")):
         result = await discord_notifier._lookup_discord_user("carol")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_task_issue_coords_db_error_returns_none():
+    """_lookup_task_issue_coords swallows DB errors and returns None (never raises)."""
+    with patch("database.AsyncSessionLocal", side_effect=RuntimeError("db down")):
+        result = await discord_notifier._lookup_task_issue_coords("t-abc")
 
     assert result is None


### PR DESCRIPTION
## Summary
- Foreman chat narration now posts to a task's per-task Discord thread (`discord_threads`, keyed by linked issue/PR) instead of always landing in the daily guild thread (`discord_foreman_threads`).
- `notify_foreman_chat` accepts an optional `task_id`; when it resolves to a task with a linked GitHub issue/PR that already has a thread, the message is posted there and the daily-thread fallback is skipped. When there's no task scope, or the task has no linked issue/thread yet, behavior is unchanged (daily guild thread).
- Wired `task_id` through `foreman/runner.py`'s `_emit_foreman_chat` call sites so the routing actually fires for real Foreman turns, not just in the notifier's own tests.

## Details
- `backend/discord_notifier.py`: added `_lookup_task_issue_coords()` to resolve a task's linked `(issue_repo, issue_number)`, reused the existing `_lookup_thread()` helper (same one Phase 2 PR/issue notifications use) to find that issue's thread, and updated `notify_foreman_chat()` to try the per-task thread first before falling back to the per-guild/per-day thread. A message is only ever posted once.
- `backend/foreman/runner.py`: `_emit_foreman_chat()` now takes `task_id` and forwards it to `notify_foreman_chat()`. All three call sites pass the already-in-scope `_task_id` for the current turn.

Closes #746

## Test plan
- [x] `pytest backend/tests/test_discord_notifier.py backend/tests/test_foreman_runner.py` — 55 passed, covering task-scoped → per-task thread, non-scoped → daily thread, and task-scoped-but-no-thread → daily thread fallback.
- [x] `ruff check` clean on changed files.