### PR TITLE
fix: inject current UTC time into Foreman state (#748)

### DIFF
--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -1,5 +1,7 @@
 """Foreman system prompt and system-prompt builder."""
 
+from datetime import datetime, timezone
+
 FOREMAN_SYSTEM = """\
 You are the Foreman AI in Pioneer Square, a multi-agent coding workshop.
 You coordinate workers — each worker is a host process (w-xxx) that spawns agent subprocesses
@@ -169,9 +171,11 @@ redirect_task to course-correct or cancel_task if it's going in the wrong direct
 If an entire worker is wedged or no longer needed, use shutdown_worker to stop the process.
 
 ## Live state
-Each user turn is preceded by a `<state>` block containing the current online workers
-and recent tasks. Treat it as an operational briefing, not part of the human's message.
-The state reflects the moment this turn was sent — earlier turns saw earlier state.
+Each user turn is preceded by a `<state>` block containing the current UTC time, the
+current online workers, and recent tasks. Treat it as an operational briefing, not part
+of the human's message. The state reflects the moment this turn was sent — earlier turns
+saw earlier state. Use the "Current UTC time" line as your anchor for judging how old a
+task's `created_at` or a log line's `time` is — do not assume those timestamps are recent.
 
 Workers are configured with repos. Prefer workers whose repos cover the task.
 Be concise — one short paragraph maximum unless detail is requested.
@@ -226,15 +230,27 @@ state, the active agent and its state, and the last log lines. If it looks stall
 redirect_task to course-correct or cancel_task if it's going in the wrong direction.
 
 ## Live state
-Each user turn is preceded by a `<state>` block containing only this task's row and the
-worker assigned to it. Treat it as an operational briefing, not part of the human's
-message. The state reflects the moment this turn was sent.
+Each user turn is preceded by a `<state>` block containing the current UTC time, this
+task's row, and the worker assigned to it. Treat it as an operational briefing, not part
+of the human's message. The state reflects the moment this turn was sent. Use the
+"Current UTC time" line as your anchor for judging how old `created_at` or a log line's
+`time` is — do not assume those timestamps are recent.
 
 Be concise — one short paragraph maximum unless detail is requested.
 """
 
 
 _EMPTY_WORKERS_BLOCKS = {"[]", "[\n]"}
+
+
+def _current_time_line() -> str:
+    """Fresh per-turn UTC timestamp so the Foreman has a reliable "now" anchor.
+
+    Must never be memoized or hoisted into the cacheable stable system text —
+    it changes every turn and would otherwise poison the prompt cache.
+    """
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return f"Current UTC time: {now}\n\n"
 
 
 def _stable_system_text(primary_repo: str | None, system_prompt_suffix: str | None = None) -> str:
@@ -285,7 +301,7 @@ def build_state_preamble(
     body = f"{workers_section}## Recent tasks\n```json\n{tasks_block}\n```"
     if extra_context:
         body += f"\n\n## Context\n{extra_context}"
-    return f"<state>\n{body}\n</state>"
+    return f"<state>\n{_current_time_line()}{body}\n</state>"
 
 
 def _stable_child_system_text(
@@ -351,7 +367,7 @@ def build_child_state_preamble(
     body = f"{worker_section}## This task\n```json\n{task_block}\n```"
     if extra_context:
         body += f"\n\n## Context\n{extra_context}"
-    return f"<state>\n{body}\n</state>"
+    return f"<state>\n{_current_time_line()}{body}\n</state>"
 
 
 def build_system_prompt(

--- a/backend/tests/test_child_prompt.py
+++ b/backend/tests/test_child_prompt.py
@@ -58,6 +58,13 @@ def test_child_state_preamble_includes_worker_and_task():
     assert "t-abc" in out
 
 
+def test_child_state_preamble_includes_fresh_current_time():
+    out = build_child_state_preamble('{"id": "w-1"}', '{"id": "t-abc"}')
+    assert "Current UTC time: " in out
+    # Timestamp must precede the rest of the state, and land ahead of any state data.
+    assert out.index("Current UTC time: ") < out.index("Assigned worker")
+
+
 def test_child_state_preamble_handles_offline_worker():
     out = build_child_state_preamble("[]", '{"id": "t-abc"}')
     assert "not currently online" in out

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 import database as database_module
 from _test_config import TEST_DATABASE_URL  # noqa: E402
-from foreman.prompt import FOREMAN_SYSTEM, build_system_prompt
+from foreman.prompt import FOREMAN_SYSTEM, build_state_preamble, build_system_prompt
 from foreman.runner import (
     _fetch_online_workers,  # noqa: E402
     _load_history,
@@ -216,6 +216,20 @@ class TestBuildSystemPrompt:
         from foreman.prompt import FOREMAN_SYSTEM
 
         assert "shallow" in FOREMAN_SYSTEM or "fallback" in FOREMAN_SYSTEM
+
+    def test_state_preamble_includes_fresh_current_time(self):
+        """The dynamic <state> block must carry a per-turn UTC timestamp so the
+        Foreman has a reliable "now" anchor for judging task staleness (#748)."""
+        out = build_state_preamble("[]", "[]")
+        assert "Current UTC time: " in out
+        assert out.index("Current UTC time: ") < out.index("## Current workers")
+
+    def test_current_time_not_in_cacheable_stable_system_text(self):
+        """The dynamic timestamp line must never leak into the cached system
+        prefix, or it would poison the prompt cache on every turn. (The prose
+        that merely refers to the "Current UTC time" label is fine — it's
+        static and doesn't change per turn.)"""
+        assert "Current UTC time: " not in FOREMAN_SYSTEM
 
     def test_review_task_assign_requires_parent_task_id(self):
         """Prompt must instruct Foreman to pass parent_task_id when dispatching review sub-tasks."""


### PR DESCRIPTION
## Summary
- The Foreman LLM had no reliable "now" anchor when judging whether a task's `created_at` or a log line's `time` looked stale — it was reasoning about timestamps with no baseline for comparison.
- Adds a fresh per-turn `Current UTC time: <iso>` line to the dynamic `<state>` block built by `build_state_preamble` and `build_child_state_preamble`, kept out of the cacheable stable system prefix (`FOREMAN_SYSTEM`) so it doesn't poison the prompt cache on every turn.
- Updates the "Live state" sections of both the parent and child Foreman prompts to document the new anchor.

Closes #748

## Test plan
- [x] `pytest backend/tests/test_child_prompt.py backend/tests/test_foreman.py` — all pass, including new coverage:
  - `test_child_state_preamble_includes_fresh_current_time`
  - `test_state_preamble_includes_fresh_current_time`
  - `test_current_time_not_in_cacheable_stable_system_text` (fixed to check for the dynamic `"Current UTC time: "` marker specifically, since the prose referencing the label by name is legitimately static)
- [x] Full backend suite: 336 passed, 0 failed (remaining errors are pre-existing DB-connection failures from no local Postgres/Docker in this sandbox, unrelated to this change)