### PR TITLE
fix(worker-lifecycle): stop leaking stale worker containers on restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,18 @@ RUN npm run build
 # ---- shared base: unified pioneer CLI ----
 FROM python:3.11-slim AS base
 
+# Stamped at build time (e.g. `--build-arg PIONEER_VERSION=$(git rev-parse --short HEAD)`).
+# backend/worker_lifecycle.py compares this across restarts to detect stale
+# worker containers spawned by a previous deploy; without it every restart
+# cannot tell old workers from current ones and conservatively drains all of
+# them. There is no git binary or .git directory in this image, so the
+# build-arg is the only source of truth — it does not fall back to git at runtime.
+ARG PIONEER_VERSION=
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIONEER_ROOT=/app
+    PIONEER_ROOT=/app \
+    PIONEER_VERSION=${PIONEER_VERSION}
 
 WORKDIR /app
 

--- a/backend/foreman_core/prompt.py
+++ b/backend/foreman_core/prompt.py
@@ -1,6 +1,6 @@
 """Foreman system prompt and system-prompt builder."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 FOREMAN_SYSTEM = """\
 You are the Foreman AI in Pioneer Square, a multi-agent coding workshop.
@@ -249,7 +249,7 @@ def _current_time_line() -> str:
     Must never be memoized or hoisted into the cacheable stable system text —
     it changes every turn and would otherwise poison the prompt cache.
     """
-    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    now = datetime.now(UTC).isoformat(timespec="seconds")
     return f"Current UTC time: {now}\n\n"
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,11 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from util.tasks import spawn
-from worker_lifecycle import drain_stale_workers_on_startup, spawn_replacement_workers
+from worker_lifecycle import (
+    drain_stale_workers_on_startup,
+    force_kill_stale_workers,
+    spawn_replacement_workers,
+)
 from ws_types import WorkerPingMsg
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
@@ -345,10 +349,16 @@ async def lifespan(app: FastAPI):
 
     await reset_connection_state()
 
-    # Phase 2: after the drain window, force-kill any surviving stale containers.
-    # Runs in background so it does not block startup or the first request.
+    # Phase 2: spawn fresh replacements immediately, and separately force-kill
+    # any surviving stale containers once the drain window elapses. Both run
+    # in the background so neither blocks startup or the first request.
     drain_bg = (
-        spawn(spawn_replacement_workers(stale_ids), name="stale-worker-drain")
+        spawn(spawn_replacement_workers(stale_ids), name="stale-worker-respawn")
+        if stale_ids
+        else None
+    )
+    reap_bg = (
+        spawn(force_kill_stale_workers(stale_ids), name="stale-worker-reap")
         if stale_ids
         else None
     )
@@ -376,6 +386,8 @@ async def lifespan(app: FastAPI):
         sweeper.cancel()
         if drain_bg is not None:
             drain_bg.cancel()
+        if reap_bg is not None:
+            reap_bg.cancel()
         if discord_gw_task is not None:
             discord_gw_task.cancel()
         try:
@@ -385,6 +397,11 @@ async def lifespan(app: FastAPI):
         if drain_bg is not None:
             try:
                 await drain_bg
+            except (asyncio.CancelledError, Exception):
+                pass
+        if reap_bg is not None:
+            try:
+                await reap_bg
             except (asyncio.CancelledError, Exception):
                 pass
         if discord_gw_task is not None:

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -16,6 +16,7 @@ Lifecycle steps on backend startup
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -200,3 +201,72 @@ async def drain_stale_workers_on_startup() -> list[str]:
         await db.commit()
 
     return [worker.id for worker, _ in rows]
+
+
+async def force_kill_stale_workers(stale_ids: list[str]) -> None:
+    """Wait the drain window then force-kill surviving stale containers.
+
+    Must be spawned as a background task *after* reset_connection_state() has
+    run.  Because reset_connection_state() marks all workers offline in the DB,
+    a worker row flipping back to non-offline means its container reconnected
+    instead of honoring the graceful-shutdown signal — that's who we kill.
+    """
+    if not stale_ids:
+        return
+
+    # Poll every 5 s so we exit early if all stale workers self-terminate
+    # before the full drain window elapses.
+    poll_interval = 5.0
+    elapsed = 0.0
+    while elapsed < WORKER_DRAIN_TIMEOUT:
+        async with AsyncSessionLocal() as db:
+            remaining = (
+                await db.exec(
+                    select(col(Worker.id)).where(
+                        col(Worker.id).in_(stale_ids), col(Worker.state) != "offline"
+                    )
+                )
+            ).all()
+        if not remaining:
+            logger.info("worker_lifecycle: all stale workers exited cleanly after %.0fs", elapsed)
+            return
+        await asyncio.sleep(min(poll_interval, WORKER_DRAIN_TIMEOUT - elapsed))
+        elapsed += poll_interval
+
+    # Fetch stale workers that have a container_id to kill.
+    async with AsyncSessionLocal() as db:
+        workers = (await db.exec(select(Worker).where(col(Worker.id).in_(stale_ids)))).all()
+
+    # Create the Docker client once; avoids per-container connection overhead and
+    # ensures consistent failure behaviour across all kills in this batch.
+    docker_client = None
+    for worker in workers:
+        if worker.container_id:
+            try:
+                import docker  # noqa: PLC0415
+
+                # Use asyncio.to_thread for all blocking Docker SDK calls.
+                if docker_client is None:
+                    docker_client = await asyncio.to_thread(docker.from_env)
+                container = await asyncio.to_thread(
+                    docker_client.containers.get, worker.container_id
+                )
+                await asyncio.to_thread(container.kill)
+                logger.info(
+                    "worker_lifecycle: force-killed container %s (worker %s)",
+                    worker.container_id[:12],
+                    worker.id,
+                )
+            except Exception:
+                logger.warning(
+                    "worker_lifecycle: failed to force-kill container for worker %s",
+                    worker.id,
+                    exc_info=True,
+                )
+        else:
+            # Non-Docker worker (started via compose or manual CLI): cannot force-kill.
+            logger.warning(
+                "worker_lifecycle: stale worker %s has no container_id; "
+                "relying on graceful-shutdown signal only",
+                worker.id,
+            )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
       context: .
       dockerfile: Dockerfile
       target: backend
+      args:
+        # Stamps backend/worker_lifecycle.py's version check so restarts can
+        # tell current-deploy workers from stale ones instead of draining
+        # everything. Set PIONEER_VERSION before building, e.g.:
+        #   PIONEER_VERSION=$(git rev-parse --short HEAD) docker compose build backend
+        PIONEER_VERSION: ${PIONEER_VERSION:-}
       secrets:
         - build_github_token
     ports:


### PR DESCRIPTION
## Summary
- Restores `force_kill_stale_workers()` (deleted in 9abda04) as a background task in `main.py`, so worker containers that don't honor the graceful WS shutdown signal — which is best-effort and misses anything not connected at the exact moment of drain, i.e. every cold restart — are actually `docker kill`ed after the drain window instead of leaking forever.
- Stamps `PIONEER_VERSION` at image build time (Dockerfile ARG/ENV + compose build arg) so `get_current_version()` can tell current-deploy workers from stale ones, rather than always returning `None` (no git binary/`.git` in the image) and conservatively draining every worker on every restart.

Found this after 46 `pioneer-square-worker` containers had accumulated in production over a single day of backend restarts — each restart cloned the entire live worker fleet without ever killing the old one. Manually killed the leaked containers as part of this investigation.

## Test plan
- [x] `backend/tests/test_worker_lifecycle.py` — 16/16 pass
- [x] `ruff check` clean on changed files
- [ ] Deploy and confirm restart count stays flat (container count no longer grows across restarts)