### PR TITLE
fix(discord): post to main channel when Foreman chat has no task context

### DIFF
--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -11,7 +11,8 @@ Thread routing model (reuses the two thread types that already exist):
     - a message in a thread mapped in ``discord_foreman_threads``, or in any
       other wired channel with no task binding, is general/ad-hoc chat for
       that Pioneer Square guild — routed with ``task_id=None``, so the reply
-      lands in (or creates) today's daily guild thread.
+      is posted directly to the guild's main configured channel (the dated
+      session thread is skipped entirely when there's no task context).
     - anything else has nowhere to route to and is silently ignored.
 
 Consumes ``discord.gateway.gateway_message_queue``. Enable with the same

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -15,15 +15,17 @@ Phase 2 — per-PR/issue threads
     at WARNING level and never propagate.
 
 Phase 3 — Foreman chat threads + user mentions
-    ``notify_foreman_chat`` mirrors Foreman → user chat narration into one
-    Discord thread per guild per UTC day (mapping persisted in
-    ``discord_foreman_threads``), reusing the same bot token/channel as Phase 2.
+    ``notify_foreman_chat`` mirrors Foreman → user chat narration into Discord.
 
     When a chat line is scoped to a task (``task_id`` passed through) and that
     task's linked GitHub issue/PR already has a thread in ``discord_threads``,
-    the line is posted there instead — so task-scoped narration stays with
-    that task's Discord history rather than the daily catch-all thread.
-    Falls back to the per-day thread whenever no per-task thread applies.
+    the line is posted there. Otherwise, for task-scoped lines, it falls back
+    to a per-guild, per-UTC-day thread (mapping persisted in
+    ``discord_foreman_threads``), reusing the same bot token/channel as Phase 2.
+
+    When there is no task context at all (``task_id`` is None), the dated
+    session thread is skipped entirely and the line is posted directly to the
+    guild's main configured Discord channel.
 
     ``mention_or_login`` resolves a GitHub login to a real ``<@id>`` Discord
     mention via the ``discord_users`` table (populated through the
@@ -544,18 +546,28 @@ async def notify_foreman_chat(
 ) -> None:
     """Mirror a Foreman → user chat line into Discord.
 
-    When *task_id* is given and resolves (via ``discord_threads``) to a
-    per-task thread already created for that task's linked PR/issue, the
-    line is posted there. Otherwise it falls back to the per-guild, per-day
-    thread — one thread per ``(guild_id, session_key)`` pair, *session_key*
-    defaulting to the current UTC date, so a whole day's un-scoped
-    conversation lands together. The message is only ever posted to one
-    thread. Silent no-op when the bot token or channel are not configured,
-    or when *content* is blank. Never raises.
+    When *task_id* is given, the line is task-scoped: if it resolves (via
+    ``discord_threads``) to a per-task thread already created for that
+    task's linked PR/issue, it's posted there; otherwise it falls back to
+    the per-guild, per-day thread — one thread per ``(guild_id,
+    session_key)`` pair, *session_key* defaulting to the current UTC date,
+    so a whole day's task-scoped-but-unthreaded conversation lands together.
+
+    When *task_id* is None (no task context), the dated session thread is
+    skipped entirely and the line is posted directly to the guild's main
+    configured Discord channel.
+
+    The message is only ever posted to one destination. Silent no-op when
+    the bot token or channel are not configured, or when *content* is
+    blank. Never raises.
     """
     if not content or not content.strip():
         return
     if not _bot_token():
+        return
+
+    channel = await _resolve_channel_for_guild(guild_id)
+    if not channel:
         return
 
     if task_id:
@@ -567,16 +579,15 @@ async def notify_foreman_chat(
                 await _post_foreman_chat_line(task_thread_id, content)
                 return
 
-    channel = await _resolve_channel_for_guild(guild_id)
-    if not channel:
+        key = session_key or datetime.now(UTC).strftime("%Y-%m-%d")
+        thread_name = f"Foreman session {key} ({guild_id})"[:100]
+        thread_id = await _ensure_foreman_thread(guild_id, key, thread_name, channel=channel)
+        if not thread_id:
+            return
+        await _post_foreman_chat_line(thread_id, content)
         return
 
-    key = session_key or datetime.now(UTC).strftime("%Y-%m-%d")
-    thread_name = f"Foreman session {key} ({guild_id})"[:100]
-    thread_id = await _ensure_foreman_thread(guild_id, key, thread_name, channel=channel)
-    if not thread_id:
-        return
-    await _post_foreman_chat_line(thread_id, content)
+    await _post_foreman_chat_line(channel, content)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -496,7 +496,7 @@ async def _emit_foreman_chat(
     traces) goes through here so the Discord thread mirror in discord_notifier
     stays in sync with the WS chat stream. *task_id*, when known, lets
     discord_notifier route the line to that task's per-task thread instead of
-    the daily guild thread.
+    posting directly to the guild's main channel.
     """
     await broadcast_msg(
         guild_id,

--- a/backend/main.py
+++ b/backend/main.py
@@ -358,9 +358,7 @@ async def lifespan(app: FastAPI):
         else None
     )
     reap_bg = (
-        spawn(force_kill_stale_workers(stale_ids), name="stale-worker-reap")
-        if stale_ids
-        else None
+        spawn(force_kill_stale_workers(stale_ids), name="stale-worker-reap") if stale_ids else None
     )
     # Refresh the models.dev catalog on startup: persist to DB and warm the
     # in-memory cache so the first /api/models request is fast.

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -573,8 +573,9 @@ async def test_archive_thread_http_error_does_not_raise(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_notify_foreman_chat_creates_thread_and_posts(monkeypatch):
-    """notify_foreman_chat ensures a per-day thread exists and posts the message."""
+async def test_notify_foreman_chat_no_task_id_posts_directly_to_channel(monkeypatch):
+    """With no task_id, notify_foreman_chat posts straight to the main channel,
+    skipping the dated session thread entirely."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
@@ -582,13 +583,14 @@ async def test_notify_foreman_chat_creates_thread_and_posts(monkeypatch):
 
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock(return_value=THREAD_ID)),
+        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_mock,
     ):
         await discord_notifier.notify_foreman_chat("guild-1", "Spun up worker w-abc.")
 
+    ensure_mock.assert_not_called()
     mock_client.post.assert_called_once()
     call = mock_client.post.call_args
-    assert f"/channels/{THREAD_ID}/messages" in call[0][0]
+    assert f"/channels/{CHANNEL_ID}/messages" in call[0][0]
     assert call[1]["json"]["content"] == "Spun up worker w-abc."
 
 
@@ -614,8 +616,9 @@ async def test_notify_foreman_chat_no_op_when_not_configured(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_notify_foreman_chat_reuses_thread_for_same_session(monkeypatch):
-    """Two calls with the same session_key reuse the same thread (one lookup each, no dupes)."""
+async def test_notify_foreman_chat_no_task_id_never_touches_session_thread(monkeypatch):
+    """Repeated no-task_id calls each post directly to the channel; no session
+    thread is ever looked up or created."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
@@ -623,14 +626,17 @@ async def test_notify_foreman_chat_reuses_thread_for_same_session(monkeypatch):
 
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_lookup_foreman_thread", AsyncMock(return_value=THREAD_ID)),
+        patch.object(discord_notifier, "_lookup_foreman_thread", AsyncMock()) as lookup_mock,
         patch.object(discord_notifier, "_save_foreman_thread", AsyncMock()) as save_mock,
     ):
         await discord_notifier.notify_foreman_chat("guild-1", "first", session_key="2026-07-04")
         await discord_notifier.notify_foreman_chat("guild-1", "second", session_key="2026-07-04")
 
+    lookup_mock.assert_not_called()
     save_mock.assert_not_called()
     assert mock_client.post.call_count == 2
+    for call in mock_client.post.call_args_list:
+        assert f"/channels/{CHANNEL_ID}/messages" in call[0][0]
 
 
 @pytest.mark.asyncio
@@ -662,8 +668,9 @@ async def test_notify_foreman_chat_task_scoped_routes_to_task_thread(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_notify_foreman_chat_no_task_id_uses_daily_thread(monkeypatch):
-    """A non-scoped message (no task_id) goes straight to the daily guild thread."""
+async def test_notify_foreman_chat_no_task_id_skips_daily_thread(monkeypatch):
+    """A non-scoped message (no task_id) skips the dated session thread and the
+    per-task lookup entirely, posting straight to the resolved guild channel."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
@@ -672,14 +679,15 @@ async def test_notify_foreman_chat_no_task_id_uses_daily_thread(monkeypatch):
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
         patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock()) as coords_mock,
-        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock(return_value=THREAD_ID)),
+        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_mock,
     ):
         await discord_notifier.notify_foreman_chat("guild-1", "General update.")
 
     coords_mock.assert_not_called()
+    ensure_mock.assert_not_called()
     mock_client.post.assert_called_once()
     call = mock_client.post.call_args
-    assert f"/channels/{THREAD_ID}/messages" in call[0][0]
+    assert f"/channels/{CHANNEL_ID}/messages" in call[0][0]
     assert call[1]["json"]["content"] == "General update."
 
 


### PR DESCRIPTION
## Summary
- `notify_foreman_chat` previously routed *every* task-scoped-or-not Foreman chat line into a dated per-guild session thread when no per-task thread applied — including lines with `task_id=None` (no task context at all).
- Now: `task_id` set → route to that task's thread, falling back to the dated session thread only if no per-task thread exists yet (unchanged). `task_id` is `None` → skip the dated session thread entirely and post directly to the guild's main configured Discord channel.

## Test plan
- [x] Updated `backend/tests/test_discord_notifier.py` to cover the new `task_id=None` direct-channel-post behavior and confirm the dated thread is never touched in that case.
- [x] `python -m pytest backend/tests/test_discord_notifier.py -q` — 46 passed.
- [x] `ruff check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)