### PR TITLE
Show Discord/API-originated messages in Foreman chat panel

### DIFF
--- a/backend/alembic/versions/20260705_000000_add_source_to_messages.py
+++ b/backend/alembic/versions/20260705_000000_add_source_to_messages.py
@@ -25,7 +25,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     with op.batch_alter_table("messages") as batch_op:
         batch_op.add_column(
-            sa.Column("source", sa.Text(), nullable=True, server_default="web"),
+            sa.Column("source", sa.Text(), nullable=False, server_default="web"),
         )
 
 

--- a/backend/alembic/versions/20260705_000000_add_source_to_messages.py
+++ b/backend/alembic/versions/20260705_000000_add_source_to_messages.py
@@ -1,0 +1,34 @@
+"""add_source_to_messages
+
+Tags each chat message with its origin ("web", "discord", "api") so the
+frontend can show where a message came from (#753). Existing rows predate
+Discord/API routing and were all typed in the browser, so they backfill to
+"web" via the server default.
+
+Revision ID: 20260705_000000_add_source_to_messages
+Revises: 20260704_000004_add_discord_account_links
+Create Date: 2026-07-05
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260705_000000_add_source_to_messages"
+down_revision: str | Sequence[str] | None = "20260704_000004_add_discord_account_links"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("messages") as batch_op:
+        batch_op.add_column(
+            sa.Column("source", sa.Text(), nullable=True, server_default="web"),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("messages") as batch_op:
+        batch_op.drop_column("source")

--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -213,7 +213,15 @@ async def _route_inbound_message(message: dict) -> None:
     ps_user_id, label = await _resolve_identity(author.get("id"), author.get("username"))
     human_message = f"[Discord] {label}: {content}"
 
-    await _persist_inbound_message(guild_slug, content, user_id=ps_user_id, task_id=task_id)
+    try:
+        await _persist_inbound_message(guild_slug, content, user_id=ps_user_id, task_id=task_id)
+    except Exception:
+        logger.warning(
+            "discord router: failed to persist inbound message guild=%s — forwarding to "
+            "Foreman anyway",
+            guild_slug,
+            exc_info=True,
+        )
 
     from ws_handlers import _trigger_foreman  # noqa: PLC0415
 
@@ -236,8 +244,8 @@ async def _persist_inbound_message(
     """Write the inbound Discord message to the ``messages`` table and
     broadcast it over WS so the frontend chat panel shows it live, tagged
     ``source="discord"``. Best-effort — a failure here must not stop the
-    message from reaching the Foreman, so it's caught by the caller's
-    top-level ``route_inbound_message`` try/except.
+    message from reaching the Foreman, so the caller wraps this call in its
+    own try/except and forwards to ``_trigger_foreman`` regardless.
     """
     from auth_deps import get_guild_pk  # noqa: PLC0415
     from database import AsyncSessionLocal  # noqa: PLC0415

--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -213,9 +213,7 @@ async def _route_inbound_message(message: dict) -> None:
     ps_user_id, label = await _resolve_identity(author.get("id"), author.get("username"))
     human_message = f"[Discord] {label}: {content}"
 
-    await _persist_inbound_message(
-        guild_slug, content, user_id=ps_user_id, task_id=task_id
-    )
+    await _persist_inbound_message(guild_slug, content, user_id=ps_user_id, task_id=task_id)
 
     from ws_handlers import _trigger_foreman  # noqa: PLC0415
 

--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 
 from discord.auth import is_member_authorized
 from discord.gateway import gateway_message_queue
@@ -212,6 +213,10 @@ async def _route_inbound_message(message: dict) -> None:
     ps_user_id, label = await _resolve_identity(author.get("id"), author.get("username"))
     human_message = f"[Discord] {label}: {content}"
 
+    await _persist_inbound_message(
+        guild_slug, content, user_id=ps_user_id, task_id=task_id
+    )
+
     from ws_handlers import _trigger_foreman  # noqa: PLC0415
 
     from foreman import reset_foreman_poll  # noqa: PLC0415
@@ -225,6 +230,54 @@ async def _route_inbound_message(message: dict) -> None:
         task_name=f"foreman.discord-chat:{guild_slug}",
     )
     reset_foreman_poll(guild_slug)
+
+
+async def _persist_inbound_message(
+    guild_slug: str, content: str, *, user_id: str | None, task_id: str | None
+) -> None:
+    """Write the inbound Discord message to the ``messages`` table and
+    broadcast it over WS so the frontend chat panel shows it live, tagged
+    ``source="discord"``. Best-effort — a failure here must not stop the
+    message from reaching the Foreman, so it's caught by the caller's
+    top-level ``route_inbound_message`` try/except.
+    """
+    from auth_deps import get_guild_pk  # noqa: PLC0415
+    from database import AsyncSessionLocal  # noqa: PLC0415
+    from events import broadcast_msg  # noqa: PLC0415
+    from models import Message  # noqa: PLC0415
+    from ws_types import ChatMsg  # noqa: PLC0415
+
+    created_at = datetime.now(UTC)
+    async with AsyncSessionLocal() as db:
+        guild_pk = await get_guild_pk(db, guild_slug)
+        if guild_pk is None:
+            return
+        db.add(
+            Message(
+                guild_id=guild_pk,
+                from_agent="user",
+                to_agent="foreman",
+                content=content,
+                message_type="chat",
+                created_at=created_at,
+                user_id=user_id,
+                task_id=task_id,
+                source="discord",
+            )
+        )
+        await db.commit()
+
+    await broadcast_msg(
+        guild_slug,
+        ChatMsg(
+            from_="user",
+            to="foreman",
+            content=content,
+            createdAt=created_at.isoformat(),
+            userId=user_id,
+            source="discord",
+        ),
+    )
 
 
 async def _consume_forever(queue: asyncio.Queue) -> None:

--- a/backend/models.py
+++ b/backend/models.py
@@ -93,6 +93,10 @@ class Message(SQLModel, table=True):
     # Task this message is associated with. NULL for general chat and system messages
     # that are not scoped to a specific task (e.g. worker-online, periodic-check).
     task_id: str | None = Field(default=None, foreign_key="tasks.id", index=True)
+    # Origin of a chat message: "web" (browser chat box), "discord" (routed in
+    # via discord/router.py), or "api" (posted directly through the REST
+    # messages endpoint). Lets the frontend show where a message came from.
+    source: str | None = Field(default="web")
 
 
 class Worker(SQLModel, table=True):

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -32,6 +32,7 @@ import logging
 import random
 import string
 from datetime import UTC, datetime
+from typing import Literal
 
 from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
 from database import get_db_dep
@@ -565,7 +566,7 @@ class MessageCreate(BaseModel):
     message_type: str = "chat"
     user_id: str | None = None
     task_id: str | None = None
-    source: str | None = None
+    source: Literal["web", "discord", "api"] | None = None
 
 
 @router.post("/guilds/{guild_id}/messages")

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -565,6 +565,7 @@ class MessageCreate(BaseModel):
     message_type: str = "chat"
     user_id: str | None = None
     task_id: str | None = None
+    source: str | None = None
 
 
 @router.post("/guilds/{guild_id}/messages")
@@ -591,6 +592,7 @@ async def create_message(
     created_at = datetime.now(UTC)
     if body.task_id is not None:
         await _require_task_in_guild(db, body.task_id, guild_pk)
+    source = body.source or "web"
     msg = Message(
         guild_id=guild_pk,
         from_agent=body.from_agent,
@@ -600,6 +602,7 @@ async def create_message(
         created_at=created_at,
         user_id=body.user_id,
         task_id=body.task_id,
+        source=source,
     )
     db.add(msg)
     await db.commit()
@@ -613,6 +616,7 @@ async def create_message(
             to=body.to_agent,
             content=body.content,
             createdAt=created_at.isoformat(),
+            source=source,
             **({"userId": body.user_id} if body.user_id else {}),
         ),
     )

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -92,6 +92,9 @@ class ChatMsg(_WS):
     toolId: str | None = None
     toolOutput: str | None = None
     isError: bool | None = None
+    # Origin of the message: "web", "discord", "api". Omitted (None) means
+    # "web" — the frontend only renders an origin label for non-web sources.
+    source: str | None = None
 
 
 class TerminalOutputMsg(_WS):

--- a/frontend/src/components/chat-pane/ChatTab.vue
+++ b/frontend/src/components/chat-pane/ChatTab.vue
@@ -108,10 +108,12 @@ function senderLabel(msg: ChatMessage): string {
   return sender.toUpperCase()
 }
 
+const SOURCE_LABELS: Record<string, string> = { discord: 'Discord', api: 'API', web: 'Web' }
+
 function sourceLabel(msg: ChatMessage): string | null {
   const source = msg.source
   if (!source || source === 'web') return null
-  return source.charAt(0).toUpperCase() + source.slice(1)
+  return SOURCE_LABELS[source] ?? source
 }
 
 const formatTime = (iso?: string) => formatClock(iso)

--- a/frontend/src/components/chat-pane/ChatTab.vue
+++ b/frontend/src/components/chat-pane/ChatTab.vue
@@ -13,6 +13,9 @@
           :class="'msg-from--' + (isToolUseGroup(msg) ? msg.from : msgSender(msg as ChatMessage))"
           >{{ isToolUseGroup(msg) ? '⚙ FOREMAN' : senderLabel(msg as ChatMessage) }}</span
         >
+        <span v-if="!isToolUseGroup(msg) && sourceLabel(msg as ChatMessage)" class="msg-source">
+          via {{ sourceLabel(msg as ChatMessage) }}
+        </span>
         <span class="msg-time">{{
           formatTime(
             isToolUseGroup(msg)
@@ -103,6 +106,12 @@ function senderLabel(msg: ChatMessage): string {
   if (sender === 'system') return 'SYS'
   if (sender === 'foreman') return '⚙ FOREMAN'
   return sender.toUpperCase()
+}
+
+function sourceLabel(msg: ChatMessage): string | null {
+  const source = msg.source
+  if (!source || source === 'web') return null
+  return source.charAt(0).toUpperCase() + source.slice(1)
 }
 
 const formatTime = (iso?: string) => formatClock(iso)
@@ -355,6 +364,13 @@ watch(
   padding: 2px 8px;
   color: var(--color-text-dim);
   font-style: italic;
+}
+
+.msg-source {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  font-style: italic;
+  flex-shrink: 0;
 }
 
 .msg-time {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -138,6 +138,8 @@ export interface ChatMessage {
   toolInput?: Record<string, unknown>
   isError?: boolean
   from_agent?: string
+  // Origin of the message: "web", "discord", "api". Missing/undefined means "web".
+  source?: string
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## Summary
- Adds a `source` column to `messages` (`web` / `discord` / `api`) so every Foreman turn is tagged with where it came from, regardless of origin.
- Discord's inbound router (`backend/discord/router.py`) now persists the user's message to the shared conversation store and broadcasts it over the existing WebSocket channel with `source="discord"`, so it shows up in the frontend chat panel live rather than only being forwarded to the Foreman's turn handler.
- The REST message-create endpoint accepts an optional `source` (defaulting to `"web"`) for direct API callers.
- `ChatTab.vue` renders a small "via Discord" / "via Api" label next to non-web messages (`.msg-source` style), so users can see the origin at a glance. Web-originated messages are unaffected (label hidden).

## Test plan
- [ ] Run the alembic migration and confirm `messages.source` defaults to `web` for existing rows
- [ ] Send a message through the Discord bot to a routed guild/task and confirm it appears in the frontend chat panel in real time, labeled "via Discord"
- [ ] Confirm the Foreman's reply to that Discord message also appears in the panel
- [ ] Send a message from the web chat box and confirm no source label appears and existing behavior is unchanged
- [ ] `vue-tsc --noEmit` / `npm run build` in `frontend/` (not run in this environment — no `node_modules` installed)

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)