### PR TITLE
feat(foreman): 4x idle backoff multiplier (#755)

### DIFF
--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -457,7 +457,7 @@ class Foreman:
                         # sleep, that value will be smaller than sleep_duration, so
                         # we advance from the reset value (not from sleep_duration).
                         base = min(self._poll_interval, sleep_duration)
-                        self._poll_interval = min(base * 2, self._config.poll_max_interval)
+                        self._poll_interval = min(base * 4, self._config.poll_max_interval)
 
                         if active and not self._processing:
                             task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active)


### PR DESCRIPTION
## Summary
- Changes the Foreman's idle poll backoff multiplier from 2x to 4x in `foreman/pioneer_foreman/foreman.py`, so the periodic-check interval ramps up faster while idle.
- The existing `poll_max_interval` cap is unchanged and still applied via `min(base * 4, self._config.poll_max_interval)`.

## Test plan
- [x] Confirmed the single-line change is correctly scoped (only the multiplier, cap logic untouched).
- [x] Ran `foreman/tests/test_ws_integration.py` and `test_config.py`; pre-existing failures (missing `pytest-asyncio` plugin in this environment) reproduce identically on `main`, confirming they are unrelated to this change.

Closes #755