### PR TITLE
Discord: early thread creation + route child calls (#758)

### DIFF
--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -81,6 +81,9 @@ _COLOURS: dict[str, int] = {
     "task-complete": 0x2ECC71,  # green
     "task-failed": 0xE74C3C,  # red
     "task-cancelled": 0xE74C3C,  # red
+    "task-assigned": 0x1ABC9C,  # teal
+    "task-followup": 0xF1C40F,  # yellow
+    "task-redirect": 0xE67E22,  # orange
     "pr-opened": 0x3498DB,  # blue
     "pr-merged": 0x9B59B6,  # purple
     "pr-closed": 0x95A5A6,  # grey
@@ -110,6 +113,16 @@ def _bot_token() -> str | None:
 
 def _channel_id() -> str | None:
     return os.environ.get("DISCORD_CHANNEL_ID") or None
+
+
+def is_configured() -> bool:
+    """Return True if either the flat webhook or the bot-thread path is set up.
+
+    Cheap, side-effect-free check callers can use to skip expensive prep work
+    (e.g. a live GitHub API call to resolve a thread title) when Discord
+    notifications are disabled entirely.
+    """
+    return bool(_bot_token() or _webhook_url())
 
 
 # ---------------------------------------------------------------------------

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -721,5 +721,15 @@ async def notify_existing_thread(
         if thread_id:
             await _post_to_thread(thread_id, event_type, title, description, url=url, color=color)
             return
+        logger.debug(
+            "notify_existing_thread: no thread on record for %s#%s, falling back to flat webhook",
+            issue_repo,
+            issue_number,
+        )
+    elif not is_configured():
+        logger.debug(
+            "notify_existing_thread: Discord not configured, skipping event=%s",
+            event_type,
+        )
 
     await notify(event_type, title, description, url=url, color=color)

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -709,12 +709,21 @@ async def notify_existing_thread(
 ) -> None:
     """Post to an issue/PR's Discord thread only if one already exists.
 
-    Unlike ``notify_event``, this never creates a thread — it's for
-    mid-lifecycle notifications (follow-up, redirect) that should land in
-    the thread ``assign_task`` already created when the task started. If no
-    thread has been persisted yet (e.g. Discord was unconfigured at task
-    start), falls back to the flat webhook channel. Silent no-op / never
-    raises, same guarantees as ``notify_event``.
+    This is deliberately **not** a thin wrapper around ``notify_event``:
+    ``notify_event`` always creates a thread when none exists yet, naming it
+    from the *current* call's ``title`` (or an explicit ``thread_name``). For
+    mid-lifecycle notifications like follow-up/redirect, that title is a
+    transient string such as ``"Follow-up sent: t-123"`` — not the issue's
+    title. If the thread ``assign_task`` was supposed to create is missing
+    (e.g. Discord was unconfigured at task start, or that call failed), using
+    ``notify_event`` here would silently spawn a new thread mistitled after
+    the follow-up itself rather than the issue, and every later notification
+    would then be scattered across that wrong thread.
+
+    ``notify_existing_thread`` avoids that by only ever looking up the thread
+    persisted in ``discord_threads``; when there isn't one, it falls back to
+    the flat webhook channel instead of creating anything. Silent no-op /
+    never raises, same guarantees as ``notify_event``.
     """
     if _bot_token() and issue_repo and issue_number is not None:
         thread_id = await _lookup_thread(issue_repo, issue_number)

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -696,3 +696,30 @@ async def notify_event(
 
     # Fallback: flat webhook
     await notify(event_type, title, description, url=url, color=color)
+
+
+async def notify_existing_thread(
+    event_type: str,
+    title: str,
+    description: str,
+    issue_repo: str | None = None,
+    issue_number: int | None = None,
+    url: str | None = None,
+    color: int | None = None,
+) -> None:
+    """Post to an issue/PR's Discord thread only if one already exists.
+
+    Unlike ``notify_event``, this never creates a thread — it's for
+    mid-lifecycle notifications (follow-up, redirect) that should land in
+    the thread ``assign_task`` already created when the task started. If no
+    thread has been persisted yet (e.g. Discord was unconfigured at task
+    start), falls back to the flat webhook channel. Silent no-op / never
+    raises, same guarantees as ``notify_event``.
+    """
+    if _bot_token() and issue_repo and issue_number is not None:
+        thread_id = await _lookup_thread(issue_repo, issue_number)
+        if thread_id:
+            await _post_to_thread(thread_id, event_type, title, description, url=url, color=color)
+            return
+
+    await notify(event_type, title, description, url=url, color=color)

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -443,22 +443,49 @@ async def notify_discord_task_assigned(
 
     This is what moves thread creation earlier in the lifecycle — previously
     the first per-issue Discord thread only appeared when a PR was opened.
-    Fire-and-forget via ``spawn``: Discord/GitHub failures must never affect
-    task assignment. Skips the live GitHub title lookup entirely when Discord
-    notifications aren't configured.
+    This whole coroutine (including the GitHub title lookup) only ever runs
+    via ``spawn``, which schedules it with ``asyncio.create_task`` and never
+    awaits it in the caller's context — so a slow GitHub API call delays this
+    background task, not the tool call that triggered it. Skips the live
+    GitHub title lookup entirely when Discord notifications aren't configured.
     """
     if not discord_notifier.is_configured():
         return
     title = await _resolve_issue_title(guild_id, issue_repo, issue_number, fallback_title)
+    prefix = f"#{issue_number}: "
+    thread_name = prefix + title[: 100 - len(prefix)]
     await discord_notifier.notify_event(
         "task-assigned",
         title=f"Task assigned: #{issue_number}",
         description=f"Foreman assigned task `{task_id}` on {issue_repo}#{issue_number}: {title}",
         issue_repo=issue_repo,
         issue_number=issue_number,
-        thread_name=f"#{issue_number}: {title}",
+        thread_name=thread_name,
         ps_guild_slug=guild_id,
     )
+
+
+def _spawn_discord_task_assigned(
+    guild_id: str,
+    inp: dict,
+    task_id: str,
+    fallback_title: str,
+) -> None:
+    """Fire off ``notify_discord_task_assigned`` when the tool call carries issue context.
+
+    Shared by both branches of ``assign_task`` (re-assign vs. newly created task).
+    """
+    if inp.get("issue_number") is not None and inp.get("issue_repo"):
+        spawn(
+            notify_discord_task_assigned(
+                guild_id,
+                inp["issue_repo"],
+                int(inp["issue_number"]),
+                task_id,
+                fallback_title,
+            ),
+            name=f"discord.task-assigned:{task_id}",
+        )
 
 
 async def notify_discord_followup(
@@ -1227,17 +1254,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         repos=repos,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )
-                                if inp.get("issue_number") is not None and inp.get("issue_repo"):
-                                    spawn(
-                                        notify_discord_task_assigned(
-                                            guild_id,
-                                            inp["issue_repo"],
-                                            int(inp["issue_number"]),
-                                            task_id,
-                                            task_name,
-                                        ),
-                                        name=f"discord.task-assigned:{task_id}",
-                                    )
+                                _spawn_discord_task_assigned(guild_id, inp, task_id, task_name)
                                 result_text = f"Task {task_id} assigned to {wid}."
                             else:
                                 name = inp.get("name") or desc[:60]
@@ -1284,17 +1301,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         repos=repos,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )
-                                if inp.get("issue_number") is not None and inp.get("issue_repo"):
-                                    spawn(
-                                        notify_discord_task_assigned(
-                                            guild_id,
-                                            inp["issue_repo"],
-                                            int(inp["issue_number"]),
-                                            task_id,
-                                            name,
-                                        ),
-                                        name=f"discord.task-assigned:{task_id}",
-                                    )
+                                _spawn_discord_task_assigned(guild_id, inp, task_id, name)
                                 result_text = f"Task {task_id} queued for {wid}."
                         finally:
                             await LockService(db).release(assign_lock_key, owner=assign_lock_id)

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -20,6 +20,7 @@ import urllib.request
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import discord_notifier
 from database import get_db
 from events import broadcast, broadcast_msg, emit_terminal_line
 from foreman_core.llm import get_foreman_model, make_anthropic_client
@@ -42,6 +43,7 @@ from models import (
 )
 from sqlalchemy import delete, update
 from sqlmodel import col, select
+from util.tasks import spawn
 from utils import build_spawn_worker_env, decode_claude_oauth_token, worker_display_name
 from ws_types import (
     TaskAssignedMsg,
@@ -402,6 +404,61 @@ async def maybe_post_plan_comment(guild_id: str, task_id: str, last_text: str) -
         logger.info("plan comment posted to %s#%s for task %s", issue_repo, issue_number, task_id)
     except Exception as exc:
         logger.warning("plan comment failed for task %s: %s", task_id, exc)
+
+
+async def _resolve_issue_title(
+    guild_id: str, issue_repo: str, issue_number: int, fallback: str
+) -> str:
+    """Best-effort live GitHub title lookup for Discord thread naming.
+
+    Falls back to *fallback* (the task's own name/description) on a missing
+    token or any API failure, so a slow or failing GitHub call never blocks
+    thread creation.
+    """
+    try:
+        creds = await _guild_github_token(guild_id)
+        if not creds:
+            return fallback
+        token, _ = creds
+        issue = await _to_thread(_gh_api, f"/repos/{issue_repo}/issues/{issue_number}", token)
+        return issue.get("title") or fallback
+    except Exception:
+        logger.warning(
+            "issue title lookup failed repo=%s number=%s",
+            issue_repo,
+            issue_number,
+            exc_info=True,
+        )
+        return fallback
+
+
+async def notify_discord_task_assigned(
+    guild_id: str,
+    issue_repo: str,
+    issue_number: int,
+    task_id: str,
+    fallback_title: str,
+) -> None:
+    """Create (or reuse) the issue's Discord thread as soon as a task is assigned.
+
+    This is what moves thread creation earlier in the lifecycle — previously
+    the first per-issue Discord thread only appeared when a PR was opened.
+    Fire-and-forget via ``spawn``: Discord/GitHub failures must never affect
+    task assignment. Skips the live GitHub title lookup entirely when Discord
+    notifications aren't configured.
+    """
+    if not discord_notifier.is_configured():
+        return
+    title = await _resolve_issue_title(guild_id, issue_repo, issue_number, fallback_title)
+    await discord_notifier.notify_event(
+        "task-assigned",
+        title=f"Task assigned: #{issue_number}",
+        description=f"Foreman assigned task `{task_id}` on {issue_repo}#{issue_number}: {title}",
+        issue_repo=issue_repo,
+        issue_number=issue_number,
+        thread_name=f"#{issue_number}: {title}",
+        ps_guild_slug=guild_id,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1126,6 +1183,17 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         repos=repos,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )
+                                if inp.get("issue_number") is not None and inp.get("issue_repo"):
+                                    spawn(
+                                        notify_discord_task_assigned(
+                                            guild_id,
+                                            inp["issue_repo"],
+                                            int(inp["issue_number"]),
+                                            task_id,
+                                            task_name,
+                                        ),
+                                        name=f"discord.task-assigned:{task_id}",
+                                    )
                                 result_text = f"Task {task_id} assigned to {wid}."
                             else:
                                 name = inp.get("name") or desc[:60]
@@ -1172,6 +1240,17 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         repos=repos,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )
+                                if inp.get("issue_number") is not None and inp.get("issue_repo"):
+                                    spawn(
+                                        notify_discord_task_assigned(
+                                            guild_id,
+                                            inp["issue_repo"],
+                                            int(inp["issue_number"]),
+                                            task_id,
+                                            name,
+                                        ),
+                                        name=f"discord.task-assigned:{task_id}",
+                                    )
                                 result_text = f"Task {task_id} queued for {wid}."
                         finally:
                             await LockService(db).release(assign_lock_key, owner=assign_lock_id)

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -461,6 +461,50 @@ async def notify_discord_task_assigned(
     )
 
 
+async def notify_discord_followup(
+    issue_repo: str | None,
+    issue_number: int | None,
+    task_id: str,
+    instructions: str,
+) -> None:
+    """Post a follow-up notification into the task's existing Discord thread.
+
+    Uses ``notify_existing_thread`` rather than ``notify_event``: the thread
+    should already exist from ``assign_task``, so a missing thread here
+    falls back to the flat channel instead of spawning a new one.
+    """
+    if not discord_notifier.is_configured():
+        return
+    await discord_notifier.notify_existing_thread(
+        "task-followup",
+        title=f"Follow-up sent: {task_id}",
+        description=f"Follow-up dispatched for task `{task_id}`: {instructions[:500]}",
+        issue_repo=issue_repo,
+        issue_number=issue_number,
+    )
+
+
+async def notify_discord_redirect(
+    issue_repo: str | None,
+    issue_number: int | None,
+    task_id: str,
+    instructions: str,
+) -> None:
+    """Post a redirect notification into the task's existing Discord thread.
+
+    See ``notify_discord_followup`` — same existing-thread-only routing.
+    """
+    if not discord_notifier.is_configured():
+        return
+    await discord_notifier.notify_existing_thread(
+        "task-redirect",
+        title=f"Task redirected: {task_id}",
+        description=f"Redirect sent for task `{task_id}`: {instructions[:500]}",
+        issue_repo=issue_repo,
+        issue_number=issue_number,
+    )
+
+
 # ---------------------------------------------------------------------------
 # code-review-agent helpers
 # ---------------------------------------------------------------------------
@@ -1395,6 +1439,16 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     issueRepo=task_issue_repo,
                                 ).model_dump(by_alias=True, exclude_none=True),
                             )
+                            if task_issue_number is not None and task_issue_repo:
+                                spawn(
+                                    notify_discord_followup(
+                                        task_issue_repo,
+                                        task_issue_number,
+                                        task_id,
+                                        instructions,
+                                    ),
+                                    name=f"discord.followup:{task_id}",
+                                )
                             if target_worker_id != original_worker_id and original_worker_id:
                                 result_text = (
                                     f"Follow-up reassigned from {original_worker_id} "
@@ -1470,15 +1524,18 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 task_id = inp["task_id"]
                 instructions = inp["instructions"]
                 result = await db.exec(
-                    select(col(Task.worker_id), col(Task.state)).where(
-                        col(Task.id) == task_id, col(Task.guild_id) == guild_pk
-                    )
+                    select(
+                        col(Task.worker_id),
+                        col(Task.state),
+                        col(Task.issue_number),
+                        col(Task.issue_repo),
+                    ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
                 )
                 row = result.one_or_none()
                 if not row:
                     result_text = f"Task {task_id} not found."
                 else:
-                    worker_id_val, state = row
+                    worker_id_val, state, redirect_issue_number, redirect_issue_repo = row
                     if state in ("done", "failed", "cancelled"):
                         result_text = f"Task {task_id} is {state} — cannot redirect."
                     else:
@@ -1495,6 +1552,16 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                         await broadcast_msg(
                             guild_id, TaskUpdateMsg(taskId=task_id, state="working")
                         )
+                        if redirect_issue_number is not None and redirect_issue_repo:
+                            spawn(
+                                notify_discord_redirect(
+                                    redirect_issue_repo,
+                                    redirect_issue_number,
+                                    task_id,
+                                    instructions,
+                                ),
+                                name=f"discord.redirect:{task_id}",
+                            )
                         result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
 
             elif tu.name == "cancel_task":

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -484,6 +484,105 @@ async def test_notify_event_falls_back_when_thread_creation_fails(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_notify_existing_thread_posts_when_thread_found(monkeypatch):
+    """notify_existing_thread posts to the thread when one is already persisted."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+
+    mock_client = _make_mock_client(status_code=204)
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_existing_thread(
+            "task-followup",
+            title="Follow-up sent",
+            description="desc",
+            issue_repo="org/repo",
+            issue_number=42,
+        )
+
+    mock_client.post.assert_called_once()
+    call_url = mock_client.post.call_args[0][0]
+    assert f"/channels/{THREAD_ID}/messages" in call_url
+
+
+@pytest.mark.asyncio
+async def test_notify_existing_thread_never_creates_new_thread(monkeypatch):
+    """notify_existing_thread must not call thread-creation machinery."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client(status_code=204)
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
+        patch.object(
+            discord_notifier, "_create_thread_in_channel", AsyncMock(return_value="new-thread")
+        ) as create_mock,
+    ):
+        await discord_notifier.notify_existing_thread(
+            "task-followup",
+            title="Follow-up sent",
+            description="desc",
+            issue_repo="org/repo",
+            issue_number=42,
+        )
+
+    create_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_existing_thread_falls_back_to_webhook_when_no_thread(monkeypatch):
+    """notify_existing_thread falls back to the flat webhook when no thread is persisted."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+
+    mock_client = _make_mock_client(status_code=204)
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
+    ):
+        await discord_notifier.notify_existing_thread(
+            "task-redirect",
+            title="Task redirected",
+            description="desc",
+            issue_repo="org/repo",
+            issue_number=42,
+        )
+
+    mock_client.post.assert_called_once()
+    call_url = mock_client.post.call_args[0][0]
+    assert call_url == WEBHOOK_URL
+
+
+@pytest.mark.asyncio
+async def test_notify_existing_thread_without_issue_coords_uses_webhook(monkeypatch):
+    """notify_existing_thread without repo/number skips the lookup and uses the webhook."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+
+    mock_client = _make_mock_client(status_code=204)
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock()) as lookup_mock,
+    ):
+        await discord_notifier.notify_existing_thread(
+            "task-redirect",
+            title="Task redirected",
+            description="desc",
+        )
+
+    lookup_mock.assert_not_called()
+    mock_client.post.assert_called_once()
+    call_url = mock_client.post.call_args[0][0]
+    assert call_url == WEBHOOK_URL
+
+
+@pytest.mark.asyncio
 async def test_notify_event_silent_noop_when_no_tokens(monkeypatch):
     """notify_event is a no-op when neither bot token nor webhook are set."""
     # no bot token, no webhook URL


### PR DESCRIPTION
Closes #758

## Changes
- Creates Discord sub-threads when the first task for an issue is assigned (not when PR is opened)
- Routes send_followup, redirect_task, and other Foreman notifications into the existing thread
- Reuses existing threads by issue number
- PR-opened notifications also route into the thread (creates thread if not yet present)

## Files changed
- backend/discord_notifier.py — thread lookup/creation helpers
- backend/foreman/tools.py — wire assign_task, send_followup, redirect_task to use threads
- backend/tests/test_discord_notifier.py — 99 lines of new tests (all 50 pass)