### PR TITLE
Discord: remove dated-thread fallback, post to main channel (#760)

### DIFF
--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -31,12 +31,13 @@ Filtering applied to ``MESSAGE_CREATE`` before anything is queued:
 
 A channel or thread counts as "wired" if it is either a channel bound via
 ``/join-channel`` (``discord_channel_guilds``), or a thread Pioneer Square
-itself created — a per-PR/issue thread (``discord_threads``) or a per-guild
-daily Foreman chat thread (``discord_foreman_threads``). The latter two are
-child threads of a wired channel but carry their own ``channel_id`` in
-Discord's model, so they need their own lookup; the routing/reply layer
-(#744) does its own, more specific, reverse-lookup against those same two
-tables to decide *which* Foreman session a message belongs to.
+itself created — a per-PR/issue thread (``discord_threads``) or a legacy,
+no-longer-created dated Foreman thread (``discord_foreman_threads``, kept
+only so previously existing threads keep routing). The latter two are child
+threads of a wired channel but carry their own ``channel_id`` in Discord's
+model, so they need their own lookup; the routing/reply layer (#744) does
+its own, more specific, reverse-lookup against those same two tables to
+decide *which* Foreman session a message belongs to.
 """
 
 from __future__ import annotations
@@ -95,9 +96,9 @@ async def _is_channel_wired(channel_id: str) -> bool:
 
     Backed by ``discord_channel_guilds`` (bound via ``/join-channel``),
     ``discord_threads`` (per-PR/issue threads), and ``discord_foreman_threads``
-    (per-guild daily Foreman chat threads) — through a short TTL cache so
-    repeated messages in the same channel/thread don't each pay for a DB
-    round-trip.
+    (legacy, no-longer-created dated Foreman threads) — through a short TTL
+    cache so repeated messages in the same channel/thread don't each pay for
+    a DB round-trip.
     """
     now = time.monotonic()
     cached = _channel_wired_cache.get(channel_id)

--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -4,15 +4,17 @@ message belongs to, forwards it, and lets the existing Foreman chat mirror
 (``discord_notifier.notify_foreman_chat``) post the reply back into the same
 thread.
 
-Thread routing model (reuses the two thread types that already exist):
+Thread routing model:
     - a message in a thread mapped in ``discord_threads`` is chat about that
       task — routed with ``task_id`` set, so the reply lands in that task's
       thread (see ``discord_notifier.notify_foreman_chat``).
-    - a message in a thread mapped in ``discord_foreman_threads``, or in any
-      other wired channel with no task binding, is general/ad-hoc chat for
-      that Pioneer Square guild — routed with ``task_id=None``, so the reply
-      is posted directly to the guild's main configured channel (the dated
-      session thread is skipped entirely when there's no task context).
+    - a message in a thread mapped in ``discord_foreman_threads`` (a legacy,
+      no-longer-created dated Foreman thread — kept only so previously
+      existing threads keep routing), or in any other wired channel with no
+      task binding, is general/ad-hoc chat for that Pioneer Square guild —
+      routed with ``task_id=None``, so the reply is posted directly to the
+      guild's main configured channel. ``notify_foreman_chat`` never creates
+      a new dated thread; that fallback has been removed.
     - anything else has nowhere to route to and is silently ignored.
 
 Consumes ``discord.gateway.gateway_message_queue``. Enable with the same

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -19,13 +19,10 @@ Phase 3 — Foreman chat threads + user mentions
 
     When a chat line is scoped to a task (``task_id`` passed through) and that
     task's linked GitHub issue/PR already has a thread in ``discord_threads``,
-    the line is posted there. Otherwise, for task-scoped lines, it falls back
-    to a per-guild, per-UTC-day thread (mapping persisted in
-    ``discord_foreman_threads``), reusing the same bot token/channel as Phase 2.
-
-    When there is no task context at all (``task_id`` is None), the dated
-    session thread is skipped entirely and the line is posted directly to the
-    guild's main configured Discord channel.
+    the line is posted there. In every other case — no task context, or a
+    task with no linked thread yet — the line is posted directly to the
+    guild's main configured Discord channel. There is no dated/daily
+    fallback thread.
 
     ``mention_or_login`` resolves a GitHub login to a real ``<@id>`` Discord
     mention via the ``discord_users`` table (populated through the
@@ -51,7 +48,7 @@ Usage::
         header_fields={"Assignee": "@alice", "Labels": "bug"},
     )
 
-    # Foreman chat mirrored into a per-day thread (or a per-task thread when
+    # Foreman chat mirrored into the main channel (or a per-task thread when
     # task_id resolves to one):
     await discord_notifier.notify_foreman_chat(
         guild_id, "Spun up worker w-abc for t-123.", task_id="t-123"
@@ -425,114 +422,6 @@ async def _lookup_task_issue_coords(task_id: str) -> tuple[str, int] | None:
         return None
 
 
-async def _lookup_foreman_thread(guild_id: str, session_key: str) -> str | None:
-    """Return the persisted Discord thread_id for a Foreman chat session, or None."""
-    try:
-        from database import AsyncSessionLocal  # noqa: PLC0415
-        from models import DiscordForemanThread  # noqa: PLC0415
-        from sqlmodel import col, select  # noqa: PLC0415
-
-        async with AsyncSessionLocal() as db:
-            result = await db.exec(
-                select(DiscordForemanThread).where(
-                    col(DiscordForemanThread.guild_id) == guild_id,
-                    col(DiscordForemanThread.session_key) == session_key,
-                )
-            )
-            row = result.one_or_none()
-            return row.thread_id if row else None
-    except Exception:
-        logger.warning(
-            "discord: foreman thread DB lookup failed guild=%s session=%s",
-            guild_id,
-            session_key,
-            exc_info=True,
-        )
-        return None
-
-
-async def _save_foreman_thread(guild_id: str, session_key: str, thread_id: str) -> str | None:
-    """Persist a new Foreman thread mapping if one doesn't already exist.
-
-    Dialect-agnostic SELECT-then-INSERT (works on SQLite and Postgres alike).
-    Returns the thread_id that should be used going forward: *thread_id* on a
-    fresh insert, or the winning row's thread_id if a concurrent caller raced
-    us and inserted first. Returns None on error.
-    """
-    try:
-        from database import AsyncSessionLocal  # noqa: PLC0415
-        from models import DiscordForemanThread  # noqa: PLC0415
-        from sqlmodel import col, select  # noqa: PLC0415
-
-        async with AsyncSessionLocal() as db:
-            result = await db.exec(
-                select(DiscordForemanThread).where(
-                    col(DiscordForemanThread.guild_id) == guild_id,
-                    col(DiscordForemanThread.session_key) == session_key,
-                )
-            )
-            existing = result.one_or_none()
-            if existing:
-                return existing.thread_id
-
-            db.add(
-                DiscordForemanThread(
-                    guild_id=guild_id,
-                    session_key=session_key,
-                    thread_id=thread_id,
-                    created_at=datetime.now(UTC),
-                )
-            )
-            try:
-                await db.commit()
-            except Exception:
-                # Unique-index race: a concurrent caller inserted first. Use its row.
-                await db.rollback()
-                result = await db.exec(
-                    select(DiscordForemanThread).where(
-                        col(DiscordForemanThread.guild_id) == guild_id,
-                        col(DiscordForemanThread.session_key) == session_key,
-                    )
-                )
-                existing = result.one_or_none()
-                return existing.thread_id if existing else thread_id
-            return thread_id
-    except Exception:
-        logger.warning(
-            "discord: foreman thread DB save failed guild=%s session=%s thread=%s",
-            guild_id,
-            session_key,
-            thread_id,
-            exc_info=True,
-        )
-        return None
-
-
-async def _ensure_foreman_thread(
-    guild_id: str, session_key: str, thread_name: str, channel: str | None = None
-) -> str | None:
-    """Return the Discord thread_id for a Foreman chat session, creating it if necessary.
-
-    *channel* overrides the flat ``DISCORD_CHANNEL_ID`` env var when provided
-    (used to route to a per-guild channel bound via ``/join-channel``).
-
-    Returns None when bot token or channel ID are not configured, or on API error.
-    """
-    existing = await _lookup_foreman_thread(guild_id, session_key)
-    if existing:
-        return existing
-
-    channel = channel or _channel_id()
-    if not channel:
-        return None
-
-    new_thread_id = await _create_thread_in_channel(channel, thread_name)
-    if not new_thread_id:
-        return None
-
-    return await _save_foreman_thread(guild_id, session_key, new_thread_id) or new_thread_id
-
-
 # Discord's hard cap on a single message's content length.
 _MAX_MESSAGE_LENGTH = 2000
 
@@ -554,21 +443,16 @@ async def _post_foreman_chat_line(thread_id: str, content: str) -> None:
 async def notify_foreman_chat(
     guild_id: str,
     content: str,
-    session_key: str | None = None,
     task_id: str | None = None,
 ) -> None:
     """Mirror a Foreman → user chat line into Discord.
 
-    When *task_id* is given, the line is task-scoped: if it resolves (via
-    ``discord_threads``) to a per-task thread already created for that
-    task's linked PR/issue, it's posted there; otherwise it falls back to
-    the per-guild, per-day thread — one thread per ``(guild_id,
-    session_key)`` pair, *session_key* defaulting to the current UTC date,
-    so a whole day's task-scoped-but-unthreaded conversation lands together.
-
-    When *task_id* is None (no task context), the dated session thread is
-    skipped entirely and the line is posted directly to the guild's main
-    configured Discord channel.
+    When *task_id* is given and it resolves (via ``discord_threads``) to a
+    per-task thread already created for that task's linked PR/issue, the
+    line is posted there. In every other case — no *task_id*, or a *task_id*
+    with no linked thread yet — the line is posted directly to the guild's
+    main configured Discord channel; there is no dated/daily fallback
+    thread.
 
     The message is only ever posted to one destination. Silent no-op when
     the bot token or channel are not configured, or when *content* is
@@ -591,14 +475,6 @@ async def notify_foreman_chat(
             if task_thread_id:
                 await _post_foreman_chat_line(task_thread_id, content)
                 return
-
-        key = session_key or datetime.now(UTC).strftime("%Y-%m-%d")
-        thread_name = f"Foreman session {key} ({guild_id})"[:100]
-        thread_id = await _ensure_foreman_thread(guild_id, key, thread_name, channel=channel)
-        if not thread_id:
-            return
-        await _post_foreman_chat_line(thread_id, content)
-        return
 
     await _post_foreman_chat_line(channel, content)
 

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -673,20 +673,15 @@ async def test_archive_thread_http_error_does_not_raise(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_notify_foreman_chat_no_task_id_posts_directly_to_channel(monkeypatch):
-    """With no task_id, notify_foreman_chat posts straight to the main channel,
-    skipping the dated session thread entirely."""
+    """With no task_id, notify_foreman_chat posts straight to the main channel."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
     mock_client = _make_mock_client()
 
-    with (
-        patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_mock,
-    ):
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify_foreman_chat("guild-1", "Spun up worker w-abc.")
 
-    ensure_mock.assert_not_called()
     mock_client.post.assert_called_once()
     call = mock_client.post.call_args
     assert f"/channels/{CHANNEL_ID}/messages" in call[0][0]
@@ -699,48 +694,28 @@ async def test_notify_foreman_chat_no_op_when_blank(monkeypatch):
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
-    with patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_mock:
+    mock_client = _make_mock_client()
+
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify_foreman_chat("guild-1", "   ")
 
-    ensure_mock.assert_not_called()
+    mock_client.post.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_notify_foreman_chat_no_op_when_not_configured(monkeypatch):
     """notify_foreman_chat is a no-op when the bot token/channel are unset."""
-    with patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_mock:
-        await discord_notifier.notify_foreman_chat("guild-1", "hello")
-
-    ensure_mock.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_notify_foreman_chat_no_task_id_never_touches_session_thread(monkeypatch):
-    """Repeated no-task_id calls each post directly to the channel; no session
-    thread is ever looked up or created."""
-    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
-    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
-
     mock_client = _make_mock_client()
 
-    with (
-        patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_lookup_foreman_thread", AsyncMock()) as lookup_mock,
-        patch.object(discord_notifier, "_save_foreman_thread", AsyncMock()) as save_mock,
-    ):
-        await discord_notifier.notify_foreman_chat("guild-1", "first", session_key="2026-07-04")
-        await discord_notifier.notify_foreman_chat("guild-1", "second", session_key="2026-07-04")
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier.notify_foreman_chat("guild-1", "hello")
 
-    lookup_mock.assert_not_called()
-    save_mock.assert_not_called()
-    assert mock_client.post.call_count == 2
-    for call in mock_client.post.call_args_list:
-        assert f"/channels/{CHANNEL_ID}/messages" in call[0][0]
+    mock_client.post.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_notify_foreman_chat_task_scoped_routes_to_task_thread(monkeypatch):
-    """A task-scoped message with an existing per-task thread posts there, not the daily thread."""
+    """A task-scoped message with an existing per-task thread posts there, not the main channel."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
@@ -755,11 +730,9 @@ async def test_notify_foreman_chat_task_scoped_routes_to_task_thread(monkeypatch
             AsyncMock(return_value=("org/repo", 42)),
         ),
         patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=task_thread_id)),
-        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_daily_mock,
     ):
         await discord_notifier.notify_foreman_chat("guild-1", "Working on it.", task_id="t-abc")
 
-    ensure_daily_mock.assert_not_called()
     mock_client.post.assert_called_once()
     call = mock_client.post.call_args
     assert f"/channels/{task_thread_id}/messages" in call[0][0]
@@ -767,9 +740,9 @@ async def test_notify_foreman_chat_task_scoped_routes_to_task_thread(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_notify_foreman_chat_no_task_id_skips_daily_thread(monkeypatch):
-    """A non-scoped message (no task_id) skips the dated session thread and the
-    per-task lookup entirely, posting straight to the resolved guild channel."""
+async def test_notify_foreman_chat_no_task_id_skips_task_lookup(monkeypatch):
+    """A non-scoped message (no task_id) skips the per-task lookup entirely,
+    posting straight to the resolved guild channel."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
@@ -778,12 +751,10 @@ async def test_notify_foreman_chat_no_task_id_skips_daily_thread(monkeypatch):
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
         patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock()) as coords_mock,
-        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock()) as ensure_mock,
     ):
         await discord_notifier.notify_foreman_chat("guild-1", "General update.")
 
     coords_mock.assert_not_called()
-    ensure_mock.assert_not_called()
     mock_client.post.assert_called_once()
     call = mock_client.post.call_args
     assert f"/channels/{CHANNEL_ID}/messages" in call[0][0]
@@ -791,8 +762,9 @@ async def test_notify_foreman_chat_no_task_id_skips_daily_thread(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_notify_foreman_chat_task_scoped_no_thread_falls_back_to_daily(monkeypatch):
-    """Task-scoped message with no per-task thread yet falls back to the daily thread."""
+async def test_notify_foreman_chat_task_scoped_no_thread_posts_to_main_channel(monkeypatch):
+    """Task-scoped message with no per-task thread yet posts to the main
+    channel — there is no dated/daily thread fallback."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
@@ -806,19 +778,18 @@ async def test_notify_foreman_chat_task_scoped_no_thread_falls_back_to_daily(mon
             AsyncMock(return_value=("org/repo", 42)),
         ),
         patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
-        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock(return_value=THREAD_ID)),
     ):
         await discord_notifier.notify_foreman_chat("guild-1", "No thread yet.", task_id="t-abc")
 
     mock_client.post.assert_called_once()
     call = mock_client.post.call_args
-    assert f"/channels/{THREAD_ID}/messages" in call[0][0]
+    assert f"/channels/{CHANNEL_ID}/messages" in call[0][0]
     assert call[1]["json"]["content"] == "No thread yet."
 
 
 @pytest.mark.asyncio
-async def test_notify_foreman_chat_task_with_no_linked_issue_falls_back_to_daily(monkeypatch):
-    """Task-scoped message where the task has no linked issue/PR falls back to the daily thread."""
+async def test_notify_foreman_chat_task_with_no_linked_issue_posts_to_main_channel(monkeypatch):
+    """Task-scoped message where the task has no linked issue/PR posts to the main channel."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
@@ -828,7 +799,6 @@ async def test_notify_foreman_chat_task_with_no_linked_issue_falls_back_to_daily
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
         patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock(return_value=None)),
         patch.object(discord_notifier, "_lookup_thread", AsyncMock()) as lookup_thread_mock,
-        patch.object(discord_notifier, "_ensure_foreman_thread", AsyncMock(return_value=THREAD_ID)),
     ):
         await discord_notifier.notify_foreman_chat(
             "guild-1", "No linked issue.", task_id="t-standalone"
@@ -837,7 +807,7 @@ async def test_notify_foreman_chat_task_with_no_linked_issue_falls_back_to_daily
     lookup_thread_mock.assert_not_called()
     mock_client.post.assert_called_once()
     call = mock_client.post.call_args
-    assert f"/channels/{THREAD_ID}/messages" in call[0][0]
+    assert f"/channels/{CHANNEL_ID}/messages" in call[0][0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `notify_foreman_chat` no longer creates or looks up a per-guild, per-UTC-day "dated" Foreman thread as a fallback destination for task-scoped chat lines that have no per-task thread yet — those lines (and all non-task-scoped lines, as before) now post directly to the guild's main configured Discord channel.
- Removed the now-dead `_ensure_foreman_thread`, `_lookup_foreman_thread`, and `_save_foreman_thread` helpers, and the unused `session_key` parameter.
- Per-task threads (looked up via `discord_threads`, keyed by linked GitHub issue/PR) are unaffected — those still route there first.
- Left the `discord_foreman_threads` table/model in place (used read-only by the inbound Discord router/gateway) so any dated threads created before this change keep routing inbound chat; no new rows are ever written to it going forward.
- Updated docstrings in `discord_notifier.py`, `discord/router.py`, and `discord/gateway.py` to reflect the new behavior.

## Test plan
- [x] `cd backend && python -m pytest tests/test_discord_notifier.py -q` — 49 passed
- [x] `ruff check` on touched files — all checks passed
- [ ] Full suite requires the `postgres-test` container (localhost:5433), unavailable in this sandbox — unrelated pre-existing DB-connectivity failures were confirmed present before this change too

Closes #760