### PR TITLE
fix(ws): release pooled DB connection after each dispatch

### DIFF
--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -135,6 +135,14 @@ async def websocket_endpoint(websocket: WebSocket, guild_id: str):
 
             await ws_handlers.dispatch(ctx, data)
 
+            # Safety net: a handler that returns with an open (uncommitted)
+            # transaction — e.g. an early `return` after a SELECT — would pin
+            # this connection's pooled DB connection for the socket's entire
+            # lifetime, eventually exhausting the pool. Committed work is
+            # already flushed, so this rollback is a no-op for well-behaved
+            # handlers and releases the connection for leaky ones.
+            await db.rollback()
+
     except WebSocketDisconnect:
         if guild_id in connections and websocket in connections[guild_id]:
             connections[guild_id].remove(websocket)


### PR DESCRIPTION
## Problem

Websocket connections were exhausting the SQLAlchemy pool, causing `pool.connect()` to block until `pool_timeout` and crash — taking down unrelated HTTP routes (e.g. `list_tasks`) as collateral, since they share the pool.

Traceback frames observed: `handle_join` (websocket) and `list_tasks` (HTTP), both dying at `self.pool.connect()`.

## Root cause

Each websocket holds one long-lived `AsyncSession` for its entire lifetime. A handler that returns with an open (uncommitted) transaction pins that session's pooled connection forever. The clearest offender: `handle_join` runs a guild-membership `SELECT`, then `return`s on the not-a-member path without commit/rollback (`ws_handlers.py:291`).

With the default pool (`pool_size=5 + max_overflow=10 = 15`), a handful of these drain the pool permanently.

## Fix

Roll back any lingering transaction after each `dispatch` in the message loop. It's a no-op for handlers that commit their work, and reclaims the connection from leaky ones — closing the whole class rather than patching each handler individually.

## Deploy note

Restart the backend to clear connections already pinned by existing sockets; the fix only prevents new leaks (old ones free when those sockets close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)