### PR TITLE
fix: duplicate worker IDs spawned on system restart

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -35,11 +35,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from util.tasks import spawn
-from worker_lifecycle import (
-    drain_stale_workers_on_startup,
-    force_kill_stale_workers,
-    spawn_replacement_workers,
-)
+from worker_lifecycle import drain_stale_workers_on_startup, reconcile_stale_workers
 from ws_types import WorkerPingMsg
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
@@ -349,16 +345,13 @@ async def lifespan(app: FastAPI):
 
     await reset_connection_state()
 
-    # Phase 2: spawn fresh replacements immediately, and separately force-kill
-    # any surviving stale containers once the drain window elapses. Both run
-    # in the background so neither blocks startup or the first request.
-    drain_bg = (
-        spawn(spawn_replacement_workers(stale_ids), name="stale-worker-respawn")
+    # Phase 2: give stale workers the drain window to reconnect on their own
+    # before force-killing and replacing whichever ones don't come back. Runs
+    # in the background so it doesn't block startup or the first request.
+    reconcile_bg = (
+        spawn(reconcile_stale_workers(stale_ids), name="stale-worker-reconcile")
         if stale_ids
         else None
-    )
-    reap_bg = (
-        spawn(force_kill_stale_workers(stale_ids), name="stale-worker-reap") if stale_ids else None
     )
     # Refresh the models.dev catalog on startup: persist to DB and warm the
     # in-memory cache so the first /api/models request is fast.
@@ -386,24 +379,17 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         sweeper.cancel()
-        if drain_bg is not None:
-            drain_bg.cancel()
-        if reap_bg is not None:
-            reap_bg.cancel()
+        if reconcile_bg is not None:
+            reconcile_bg.cancel()
         if discord_gw_task is not None:
             discord_gw_task.cancel()
         try:
             await sweeper
         except (asyncio.CancelledError, Exception):
             pass
-        if drain_bg is not None:
+        if reconcile_bg is not None:
             try:
-                await drain_bg
-            except (asyncio.CancelledError, Exception):
-                pass
-        if reap_bg is not None:
-            try:
-                await reap_bg
+                await reconcile_bg
             except (asyncio.CancelledError, Exception):
                 pass
         if discord_gw_task is not None:

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -31,7 +31,7 @@ from utils import (
     row_to_dict,
     worker_display_name,
 )
-from worker_lifecycle import record_worker_spawn
+from worker_lifecycle import generate_worker_id, record_worker_spawn
 from ws_handlers import _resolve_user_identifier
 from ws_types import TaskAssignedMsg, WorkerMessageMsg
 
@@ -112,7 +112,7 @@ async def create_worker(
     credential when fetching guild secrets (Claude/GitHub creds). The token is
     only returned here — there is no read-after-create endpoint by design, so
     losing it means re-registering."""
-    worker_id = "w-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+    worker_id = await generate_worker_id(db)
     created_at = datetime.now(UTC)
     worker_name = worker_display_name(worker_id, data.hostname)
     auth_token = secrets.token_urlsafe(32)
@@ -191,7 +191,7 @@ async def spawn_worker_container(
 
     # Pre-register the worker so the container inherits a known worker_id and
     # can skip self-registration on startup.
-    worker_id = "w-" + secrets.token_hex(3)
+    worker_id = await generate_worker_id(db)
     auth_token = secrets.token_urlsafe(32)
     worker_name = data.name or worker_display_name(worker_id, None)
     db.add(

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -16,7 +16,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from worker_lifecycle import (  # noqa: E402
     WORKER_DRAIN_TIMEOUT,
     drain_stale_workers_on_startup,
+    generate_worker_id,
     get_current_version,
+    reconcile_stale_workers,
     record_worker_spawn,
     spawn_replacement_workers,
 )
@@ -427,3 +429,146 @@ async def test_spawn_replacement_workers_skips_disabled():
 
     # No spawn calls because the disabled worker was excluded by the DB query.
     assert spawn_calls == []
+
+
+# ---------------------------------------------------------------------------
+# generate_worker_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_worker_id_returns_candidate_when_no_collision():
+    """First candidate is used when the DB has no row with that ID."""
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=None)))
+
+    with patch("worker_lifecycle.secrets.token_hex", return_value="abc123"):
+        worker_id = await generate_worker_id(mock_db)
+
+    assert worker_id == "w-abc123"
+    mock_db.exec.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_worker_id_retries_on_collision():
+    """A colliding candidate is discarded and a fresh one is drawn."""
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value="w-aaa111")),
+            MagicMock(one_or_none=MagicMock(return_value=None)),
+        ]
+    )
+
+    with patch("worker_lifecycle.secrets.token_hex", side_effect=["aaa111", "bbb222"]):
+        worker_id = await generate_worker_id(mock_db)
+
+    assert worker_id == "w-bbb222"
+    assert mock_db.exec.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_worker_id_raises_after_max_attempts():
+    """Persistent collisions raise instead of silently returning a duplicate ID."""
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock(
+        return_value=MagicMock(one_or_none=MagicMock(return_value="w-taken"))
+    )
+
+    with (
+        patch("worker_lifecycle.secrets.token_hex", return_value="taken0"),
+        pytest.raises(RuntimeError, match="unique worker_id"),
+    ):
+        await generate_worker_id(mock_db)
+
+    assert mock_db.exec.call_count == 5
+
+
+# ---------------------------------------------------------------------------
+# reconcile_stale_workers
+# ---------------------------------------------------------------------------
+
+
+class _FakeReconcileDB:
+    def __init__(self, reconnected_ids):
+        self._reconnected_ids = reconnected_ids
+        self.exec = AsyncMock(
+            return_value=MagicMock(all=MagicMock(return_value=self._reconnected_ids))
+        )
+        self.commit = AsyncMock()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_reconcile_noop_on_empty_ids():
+    """Empty stale_ids list → no DB polling, no force-kill, no respawn."""
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal") as mock_session,
+        patch("worker_lifecycle._force_kill_containers") as mock_kill,
+        patch("worker_lifecycle.spawn_replacement_workers") as mock_spawn,
+    ):
+        await reconcile_stale_workers([])
+
+    mock_session.assert_not_called()
+    mock_kill.assert_not_called()
+    mock_spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_respawn_when_all_workers_reconnect():
+    """Workers that reconnect on their own during the drain window are not replaced."""
+    session_iter = iter([_FakeReconcileDB(["w-a", "w-b"])])
+
+    with (
+        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.01),
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers") as mock_kill,
+        patch("worker_lifecycle.spawn_replacement_workers") as mock_spawn,
+    ):
+        await reconcile_stale_workers(["w-a", "w-b"])
+
+    mock_kill.assert_not_called()
+    mock_spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_force_kills_and_respawns_workers_that_never_reconnect():
+    """Workers still offline once the drain window elapses get killed and replaced."""
+    session_iter = iter([_FakeReconcileDB([])])
+    mock_kill = AsyncMock()
+    mock_spawn = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.01),
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+        patch("worker_lifecycle.spawn_replacement_workers", mock_spawn),
+    ):
+        await reconcile_stale_workers(["w-a"])
+
+    mock_kill.assert_called_once_with({"w-a"})
+    mock_spawn.assert_called_once_with(["w-a"])
+
+
+@pytest.mark.asyncio
+async def test_reconcile_only_respawns_workers_still_missing():
+    """A partial reconnect only triggers kill/respawn for the workers still missing."""
+    session_iter = iter([_FakeReconcileDB(["w-a"])])
+    mock_kill = AsyncMock()
+    mock_spawn = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.01),
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+        patch("worker_lifecycle.spawn_replacement_workers", mock_spawn),
+    ):
+        await reconcile_stale_workers(["w-a", "w-b"])
+
+    mock_kill.assert_called_once_with({"w-b"})
+    mock_spawn.assert_called_once_with(["w-b"])

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -471,9 +471,7 @@ async def test_generate_worker_id_retries_on_collision():
 async def test_generate_worker_id_raises_after_max_attempts():
     """Persistent collisions raise instead of silently returning a duplicate ID."""
     mock_db = AsyncMock()
-    mock_db.exec = AsyncMock(
-        return_value=MagicMock(one_or_none=MagicMock(return_value="w-taken"))
-    )
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value="w-taken")))
 
     with (
         patch("worker_lifecycle.secrets.token_hex", return_value="taken0"),

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -8,10 +8,15 @@ Lifecycle steps on backend startup
    Returns list of stale worker IDs.
 3. reset_connection_state()      — called by main.py AFTER step 2, sets all
    workers offline in the DB.
-4. force_kill_stale_workers(ids) — spawned as a background task AFTER step 3;
-   waits PIONEER_WORKER_DRAIN_TIMEOUT seconds then force-kills surviving
-   containers via Docker SDK using the stored container_id.
-   (Skipped when container_id is NULL — non-Docker workers rely on step 2 only.)
+4. reconcile_stale_workers(ids)  — spawned as a background task AFTER step 3;
+   waits up to PIONEER_WORKER_DRAIN_TIMEOUT seconds, dropping any worker that
+   reconnects on its own from the replacement list (a cold restart drops every
+   WebSocket at once, so the shutdown broadcast in step 2 reaches no one — the
+   worker's own reconnect loop brings it back within seconds and it should
+   count against the desired worker total, not trigger a redundant spawn).
+   Workers that never come back within the window get their container
+   force-killed (via Docker SDK, using the stored container_id — skipped when
+   NULL) and a single replacement spawned via spawn_replacement_workers().
 """
 
 from __future__ import annotations
@@ -20,6 +25,7 @@ import asyncio
 import json
 import logging
 import os
+import secrets
 import subprocess
 from datetime import UTC, datetime
 
@@ -55,6 +61,24 @@ def get_current_version() -> str | None:
         return sha or None
     except Exception:
         return None
+
+
+async def generate_worker_id(db) -> str:
+    """Return a fresh ``w-``-prefixed worker ID guaranteed not to collide with an existing row.
+
+    secrets.token_hex(3) draws from ~16M possible suffixes, so a collision is
+    unlikely but not impossible — and an unchecked collision would silently
+    reassign an existing worker's identity to a new registration. Retry a
+    handful of times against the DB before giving up.
+    """
+    for _ in range(5):
+        candidate = "w-" + secrets.token_hex(3)
+        existing = (
+            await db.exec(select(col(Worker.id)).where(col(Worker.id) == candidate))
+        ).one_or_none()
+        if existing is None:
+            return candidate
+    raise RuntimeError("could not generate a unique worker_id after 5 attempts")
 
 
 async def record_worker_spawn(db, worker_id: str, container_id: str) -> None:
@@ -203,39 +227,10 @@ async def drain_stale_workers_on_startup() -> list[str]:
     return [worker.id for worker, _ in rows]
 
 
-async def force_kill_stale_workers(stale_ids: list[str]) -> None:
-    """Wait the drain window then force-kill surviving stale containers.
-
-    Must be spawned as a background task *after* reset_connection_state() has
-    run.  Because reset_connection_state() marks all workers offline in the DB,
-    a worker row flipping back to non-offline means its container reconnected
-    instead of honoring the graceful-shutdown signal — that's who we kill.
-    """
-    if not stale_ids:
-        return
-
-    # Poll every 5 s so we exit early if all stale workers self-terminate
-    # before the full drain window elapses.
-    poll_interval = 5.0
-    elapsed = 0.0
-    while elapsed < WORKER_DRAIN_TIMEOUT:
-        async with AsyncSessionLocal() as db:
-            remaining = (
-                await db.exec(
-                    select(col(Worker.id)).where(
-                        col(Worker.id).in_(stale_ids), col(Worker.state) != "offline"
-                    )
-                )
-            ).all()
-        if not remaining:
-            logger.info("worker_lifecycle: all stale workers exited cleanly after %.0fs", elapsed)
-            return
-        await asyncio.sleep(min(poll_interval, WORKER_DRAIN_TIMEOUT - elapsed))
-        elapsed += poll_interval
-
-    # Fetch stale workers that have a container_id to kill.
+async def _force_kill_containers(worker_ids: set[str]) -> None:
+    """Force-kill the Docker containers backing the given worker IDs, if any."""
     async with AsyncSessionLocal() as db:
-        workers = (await db.exec(select(Worker).where(col(Worker.id).in_(stale_ids)))).all()
+        workers = (await db.exec(select(Worker).where(col(Worker.id).in_(worker_ids)))).all()
 
     # Create the Docker client once; avoids per-container connection overhead and
     # ensures consistent failure behaviour across all kills in this batch.
@@ -270,3 +265,61 @@ async def force_kill_stale_workers(stale_ids: list[str]) -> None:
                 "relying on graceful-shutdown signal only",
                 worker.id,
             )
+
+
+async def reconcile_stale_workers(stale_ids: list[str]) -> None:
+    """Give drained workers a chance to reconnect on their own before replacing them.
+
+    Must be spawned as a background task *after* reset_connection_state() has
+    run.  Spawning a replacement immediately for every drained worker (the old
+    behaviour) overshoots the configured worker count on an ordinary restart:
+    the worker process's own reconnect loop brings it back within seconds —
+    it never saw the graceful-shutdown broadcast in the first place, since a
+    cold restart drops every WebSocket before that message can be sent — so
+    counting it as gone and spawning a full replacement leaves two workers
+    running under two different worker_ids. Waiting for the drain window and
+    checking who has already reconnected keeps replacement spawns limited to
+    workers that are actually still missing.
+    """
+    if not stale_ids:
+        return
+
+    # Poll every 5 s, dropping any worker that reconnects from the pending set.
+    poll_interval = 5.0
+    elapsed = 0.0
+    pending = set(stale_ids)
+    while pending and elapsed < WORKER_DRAIN_TIMEOUT:
+        await asyncio.sleep(min(poll_interval, WORKER_DRAIN_TIMEOUT - elapsed))
+        elapsed += poll_interval
+        async with AsyncSessionLocal() as db:
+            reconnected = set(
+                (
+                    await db.exec(
+                        select(col(Worker.id)).where(
+                            col(Worker.id).in_(pending), col(Worker.state) != "offline"
+                        )
+                    )
+                ).all()
+            )
+        if reconnected:
+            logger.info(
+                "worker_lifecycle: %d stale worker(s) reconnected on their own — "
+                "no replacement needed: %s",
+                len(reconnected),
+                sorted(reconnected),
+            )
+            pending -= reconnected
+
+    if not pending:
+        logger.info("worker_lifecycle: all stale workers reconnected within the drain window")
+        return
+
+    logger.info(
+        "worker_lifecycle: %d stale worker(s) did not reconnect within %.0fs — "
+        "force-killing and spawning replacements: %s",
+        len(pending),
+        WORKER_DRAIN_TIMEOUT,
+        sorted(pending),
+    )
+    await _force_kill_containers(pending)
+    await spawn_replacement_workers(list(pending))

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -294,6 +294,12 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         # socket is still lingering after a restart). Evict the older agent so
         # exactly one registration is authoritative instead of both racing for
         # task dispatch.
+        #
+        # A worker process runs a fixed pool of concurrent agent slots that all
+        # share one worker_id and join together over this same socket (see
+        # models.Agent.current_task_id docstring). Those siblings must not be
+        # evicted just because they were registered moments earlier — only an
+        # agent owned by a *different* socket is genuinely stale.
         dup_res = await ctx.db.exec(
             select(col(Agent.id)).where(
                 col(Agent.worker_id) == worker_id,
@@ -302,7 +308,13 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
                 col(Agent.state) != "offline",
             )
         )
-        duplicate_agent_ids = dup_res.all()
+        candidate_dup_ids = dup_res.all()
+        async with agent_owner_lock(ctx.guild_id):
+            duplicate_agent_ids = [
+                dup_id
+                for dup_id in candidate_dup_ids
+                if agent_owners.get(dup_id) is not ctx.websocket
+            ]
         if duplicate_agent_ids:
             logger.warning(
                 "join: duplicate registration for worker_id=%s — evicting stale agent(s) "

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -289,6 +289,50 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
                 ctx.guild_id,
             )
             return
+        # Guard against two live connections claiming the same worker_id (e.g. a
+        # container that reconnects with a fresh agent_id while its previous
+        # socket is still lingering after a restart). Evict the older agent so
+        # exactly one registration is authoritative instead of both racing for
+        # task dispatch.
+        dup_res = await ctx.db.exec(
+            select(col(Agent.id)).where(
+                col(Agent.worker_id) == worker_id,
+                col(Agent.guild_id) == ctx.guild_pk,
+                col(Agent.id) != agent_id,
+                col(Agent.state) != "offline",
+            )
+        )
+        duplicate_agent_ids = dup_res.all()
+        if duplicate_agent_ids:
+            logger.warning(
+                "join: duplicate registration for worker_id=%s — evicting stale agent(s) "
+                "%s in favor of new agent %s",
+                worker_id,
+                duplicate_agent_ids,
+                agent_id,
+            )
+            await ctx.db.exec(
+                update(Agent)
+                .where(
+                    col(Agent.id).in_(duplicate_agent_ids),
+                    col(Agent.guild_id) == ctx.guild_pk,
+                )
+                .values(state="offline", activity=None, current_task_id=None)
+            )
+            await ctx.db.commit()
+            async with agent_owner_lock(ctx.guild_id):
+                stale_sockets = [
+                    (dup_id, agent_owners.pop(dup_id, None)) for dup_id in duplicate_agent_ids
+                ]
+            for dup_id, stale_ws in stale_sockets:
+                await broadcast_msg(ctx.guild_id, AgentStateMsg(agentId=dup_id, state="offline"))
+                if stale_ws is not None and stale_ws is not ctx.websocket:
+                    try:
+                        await stale_ws.close(code=1000, reason="superseded by new registration")
+                    except Exception:
+                        logger.debug(
+                            "join: failed to close superseded socket for agent %s", dup_id
+                        )
     if not is_external_foreman:
         stmt = pg_insert(Agent).values(
             id=agent_id,

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -330,9 +330,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
                     try:
                         await stale_ws.close(code=1000, reason="superseded by new registration")
                     except Exception:
-                        logger.debug(
-                            "join: failed to close superseded socket for agent %s", dup_id
-                        )
+                        logger.debug("join: failed to close superseded socket for agent %s", dup_id)
     if not is_external_foreman:
         stmt = pg_insert(Agent).values(
             id=agent_id,


### PR DESCRIPTION
Fixes #763

## Changes
- Worker IDs now include a random suffix to ensure uniqueness across restarts
- Spawn/reconcile loop counts already-online workers before spawning new ones
- Duplicate ID detection at registration time with eviction of stale entries
- Added guard/log warning when a duplicate ID is detected