### PR TITLE
fix(foreman): route child-context chat to the right Discord thread + badge it

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -488,22 +488,42 @@ async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
 
 
 async def _emit_foreman_chat(
-    guild_id: str, content: str, created_at: str, task_id: str | None = None
+    guild_id: str,
+    content: str,
+    created_at: str,
+    *,
+    child_task_id: str | None = None,
+    discord_task_id: str | None = None,
 ) -> None:
     """Broadcast a Foreman -> user narration line and mirror it into Discord.
 
     Every plain-text line the Foreman sends to the user (not tool_use/tool_result
     traces) goes through here so the Discord thread mirror in discord_notifier
-    stays in sync with the WS chat stream. *task_id*, when known, lets
-    discord_notifier route the line to that task's per-task thread instead of
-    posting directly to the guild's main channel.
+    stays in sync with the WS chat stream.
+
+    The two ids are deliberately separate (see docs/foreman-per-task-context.md):
+
+    - ``child_task_id`` tags the WS ``ChatMsg`` so the frontend can badge lines
+      produced inside a per-task child context. It is None for parent runs even
+      when the run concerns a task (e.g. a human chatting in a task's Discord
+      thread stays on the parent conversation).
+    - ``discord_task_id`` routes the Discord mirror to that task's thread. It is
+      set whenever the run concerns a task — including the parent-context reply
+      to a message posted in a task thread — so the reply always lands back in
+      the thread the human is talking in rather than the guild's main channel.
     """
     await broadcast_msg(
         guild_id,
-        ChatMsg(from_="foreman", to="user", content=content, createdAt=created_at),
+        ChatMsg(
+            from_="foreman",
+            to="user",
+            content=content,
+            createdAt=created_at,
+            taskId=child_task_id,
+        ),
     )
     spawn(
-        discord_notifier.notify_foreman_chat(guild_id, content, task_id=task_id),
+        discord_notifier.notify_foreman_chat(guild_id, content, task_id=discord_task_id),
         name=f"discord.foreman-chat:{guild_id}",
     )
 
@@ -667,6 +687,15 @@ async def _run_foreman_ai(
             # untagged (task_id IS NULL) so they don't pollute that task's
             # isolated child context on its next run.
             _task_id = None
+
+        # Discord routing target for narration mirrored back to the human.
+        # ``_task_id`` (history tag) is None for parent runs, but a parent run
+        # can still concern a task — e.g. a human message posted in that task's
+        # Discord thread arrives as an ``event="chat"`` trigger with a task_id
+        # that stays on the parent conversation. Route the reply back into that
+        # thread using the incoming ``task_id`` even though the turn isn't
+        # tagged as child history. See docs/foreman-per-task-context.md.
+        _discord_task_id: str | None = _task_id or task_id
     except Exception:
         await db.close()
         raise
@@ -849,7 +878,11 @@ async def _run_foreman_ai(
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
                     await _emit_foreman_chat(
-                        guild_id, b.text.strip(), _now.isoformat(), task_id=_task_id
+                        guild_id,
+                        b.text.strip(),
+                        _now.isoformat(),
+                        child_task_id=_task_id,
+                        discord_task_id=_discord_task_id,
                     )
 
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
@@ -871,6 +904,7 @@ async def _run_foreman_ai(
                         toolInput=dict(tu.input) if tu.input else {},
                         toolId=tu.id,
                         createdAt=_now.isoformat(),
+                        taskId=_task_id,
                     ),
                 )
 
@@ -903,6 +937,7 @@ async def _run_foreman_ai(
                         toolOutput=result.get("content", ""),
                         isError=result.get("is_error", False),
                         createdAt=_now.isoformat(),
+                        taskId=_task_id,
                     ),
                 )
 
@@ -1057,10 +1092,22 @@ async def _run_foreman_ai(
             for b in wrap_resp.content:
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
-                    await _emit_foreman_chat(guild_id, b.text.strip(), _now, task_id=_task_id)
+                    await _emit_foreman_chat(
+                        guild_id,
+                        b.text.strip(),
+                        _now,
+                        child_task_id=_task_id,
+                        discord_task_id=_discord_task_id,
+                    )
             cap_note = f"_(Foreman hit {cfg_max_rounds}-round safety cap and stopped.)_"
             text_parts.append(cap_note)
-            await _emit_foreman_chat(guild_id, cap_note, _now, task_id=_task_id)
+            await _emit_foreman_chat(
+                guild_id,
+                cap_note,
+                _now,
+                child_task_id=_task_id,
+                discord_task_id=_discord_task_id,
+            )
 
         response_text = "\n".join(text_parts).strip()
         if response_text:

--- a/backend/tests/test_foreman_child_context.py
+++ b/backend/tests/test_foreman_child_context.py
@@ -202,3 +202,88 @@ async def test_trigger_foreman_child_routing(monkeypatch, event, expect_child):
     assert captured["kwargs"].get("child") is expect_child
     if expect_child:
         assert captured["kwargs"].get("task_id") == "t-xyz"
+
+
+# ── _emit_foreman_chat: frontend badge vs Discord routing ────────────────────
+
+
+def _patch_emit(monkeypatch):
+    """Patch broadcast_msg / discord mirror / spawn on foreman.runner.
+
+    Returns ``(sent_msgs, discord_calls)`` — the ChatMsg objects broadcast to
+    WS clients and the ``(content, task_id)`` tuples passed to the Discord
+    mirror. ``spawn`` is replaced with a version that actually awaits the
+    coroutine so the Discord call is observed.
+    """
+    import foreman.runner as runner
+
+    sent_msgs: list = []
+    discord_calls: list = []
+
+    async def fake_broadcast(guild_id, msg):
+        sent_msgs.append(msg)
+
+    async def fake_notify(guild_id, content, task_id=None):
+        discord_calls.append((content, task_id))
+
+    def fake_spawn(coro, name=None):
+        return asyncio.ensure_future(coro)
+
+    monkeypatch.setattr(runner, "broadcast_msg", fake_broadcast)
+    monkeypatch.setattr(runner.discord_notifier, "notify_foreman_chat", fake_notify)
+    monkeypatch.setattr(runner, "spawn", fake_spawn)
+    return sent_msgs, discord_calls
+
+
+async def test_emit_child_run_badges_and_routes_to_task_thread(monkeypatch):
+    """A child run tags the WS message and mirrors to the task's Discord thread."""
+    import foreman.runner as runner
+
+    sent_msgs, discord_calls = _patch_emit(monkeypatch)
+
+    await runner._emit_foreman_chat(
+        "g1",
+        "working on it",
+        "2026-01-01T00:00:00Z",
+        child_task_id="t-abc",
+        discord_task_id="t-abc",
+    )
+    await asyncio.sleep(0)  # let the spawned Discord mirror run
+
+    assert sent_msgs[0].taskId == "t-abc"
+    assert discord_calls == [("working on it", "t-abc")]
+
+
+async def test_emit_parent_thread_chat_routes_to_thread_without_badge(monkeypatch):
+    """A parent run answering a task-thread message still replies in that thread.
+
+    The frontend badge (``taskId`` on the WS ChatMsg) stays absent — the run is
+    the parent/whole-guild conversation — but the Discord mirror routes to the
+    task's thread so the reply lands where the human is talking.
+    """
+    import foreman.runner as runner
+
+    sent_msgs, discord_calls = _patch_emit(monkeypatch)
+
+    await runner._emit_foreman_chat(
+        "g1", "here you go", "2026-01-01T00:00:00Z", child_task_id=None, discord_task_id="t-abc"
+    )
+    await asyncio.sleep(0)
+
+    assert sent_msgs[0].taskId is None
+    assert discord_calls == [("here you go", "t-abc")]
+
+
+async def test_emit_plain_parent_run_has_no_task_routing(monkeypatch):
+    """A parent run with no task concern badges nothing and posts to main channel."""
+    import foreman.runner as runner
+
+    sent_msgs, discord_calls = _patch_emit(monkeypatch)
+
+    await runner._emit_foreman_chat(
+        "g1", "guild status", "2026-01-01T00:00:00Z", child_task_id=None, discord_task_id=None
+    )
+    await asyncio.sleep(0)
+
+    assert sent_msgs[0].taskId is None
+    assert discord_calls == [("guild status", None)]

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -95,6 +95,11 @@ class ChatMsg(_WS):
     # Origin of the message: "web", "discord", "api". Omitted (None) means
     # "web" — the frontend only renders an origin label for non-web sources.
     source: str | None = None
+    # Set on Foreman → user messages produced inside a per-task child context
+    # (see docs/foreman-per-task-context.md). None for parent/whole-guild runs.
+    # The frontend badges child-context messages so it's clear which are scoped
+    # to a single task rather than the guild-wide Foreman conversation.
+    taskId: str | None = None
 
 
 class TerminalOutputMsg(_WS):

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -166,6 +166,11 @@ async def run_foreman_ai(
         raise ValueError("run_foreman_ai(child=True) requires a task_id")
     tools = CHILD_FOREMAN_TOOLS if child else FOREMAN_TOOLS
 
+    # Frontend badge id: set only on child (per-task) runs so the chat pane can
+    # mark lines scoped to a single task. Parent/whole-guild runs stay unbadged
+    # even when a task_id is present. See docs/foreman-per-task-context.md.
+    _badge_task_id = task_id if child else None
+
     if not HAS_ANTHROPIC:
         now = datetime.now(UTC).isoformat()
         await ws_send(
@@ -333,6 +338,7 @@ async def run_foreman_ai(
                             "to": "user",
                             "content": b.text.strip(),
                             "createdAt": _now,
+                            "taskId": _badge_task_id,
                         }
                     )
 
@@ -354,6 +360,7 @@ async def run_foreman_ai(
                         "toolInput": dict(tu.input) if tu.input else {},
                         "toolId": tu.id,
                         "createdAt": _now,
+                        "taskId": _badge_task_id,
                     }
                 )
 
@@ -394,6 +401,7 @@ async def run_foreman_ai(
                         "toolOutput": result.get("content", ""),
                         "isError": result.get("is_error", False),
                         "createdAt": _now,
+                        "taskId": _badge_task_id,
                     }
                 )
 
@@ -479,6 +487,7 @@ async def run_foreman_ai(
                             "to": "user",
                             "content": b.text.strip(),
                             "createdAt": _now,
+                            "taskId": _badge_task_id,
                         }
                     )
             cap_note = f"_(Foreman hit {config.max_rounds}-round safety cap and stopped.)_"
@@ -490,6 +499,7 @@ async def run_foreman_ai(
                     "to": "user",
                     "content": cap_note,
                     "createdAt": _now,
+                    "taskId": _badge_task_id,
                 }
             )
 

--- a/frontend/src/components/chat-pane/ChatTab.vue
+++ b/frontend/src/components/chat-pane/ChatTab.vue
@@ -13,6 +13,13 @@
           :class="'msg-from--' + (isToolUseGroup(msg) ? msg.from : msgSender(msg as ChatMessage))"
           >{{ isToolUseGroup(msg) ? '⚙ FOREMAN' : senderLabel(msg as ChatMessage) }}</span
         >
+        <span
+          v-if="taskBadge(msg)"
+          class="msg-task-badge"
+          :title="'Scoped to task ' + taskBadge(msg)"
+        >
+          ⛬ {{ taskBadge(msg) }}
+        </span>
         <span v-if="!isToolUseGroup(msg) && sourceLabel(msg as ChatMessage)" class="msg-source">
           via {{ sourceLabel(msg as ChatMessage) }}
         </span>
@@ -76,6 +83,7 @@ import { renderMarkdown } from '../../utils/markdown'
 import { useGuildStore } from '../../stores/guild'
 import { formatClock } from '../../utils/format'
 import { useChatGrouping, isToolUseGroup } from '../../composables/useChatGrouping'
+import type { GroupedMessage } from '../../composables/useChatGrouping'
 import type { ChatMessage } from '../../types'
 
 const guildStore = useGuildStore()
@@ -106,6 +114,14 @@ function senderLabel(msg: ChatMessage): string {
   if (sender === 'system') return 'SYS'
   if (sender === 'foreman') return '⚙ FOREMAN'
   return sender.toUpperCase()
+}
+
+// A Foreman line produced inside a per-task child context carries a taskId
+// (see docs/foreman-per-task-context.md). Badge it so it's clear the line is
+// scoped to a single task rather than the guild-wide Foreman conversation.
+function taskBadge(msg: GroupedMessage): string | null {
+  const taskId = (msg as { taskId?: string | null }).taskId
+  return taskId ? taskId : null
 }
 
 const SOURCE_LABELS: Record<string, string> = { discord: 'Discord', api: 'API', web: 'Web' }
@@ -373,6 +389,19 @@ watch(
   color: var(--color-text-dim);
   font-style: italic;
   flex-shrink: 0;
+}
+
+.msg-task-badge {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 0.5px;
+  color: var(--color-amber);
+  background: rgba(232, 170, 0, 0.12);
+  border: 1px solid rgba(232, 170, 0, 0.4);
+  border-radius: 2px;
+  padding: 1px 4px;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .msg-time {

--- a/frontend/src/composables/__tests__/useChatGrouping.spec.ts
+++ b/frontend/src/composables/__tests__/useChatGrouping.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { useChatGrouping, isToolUseGroup } from '../useChatGrouping'
+import type { ChatMessage } from '../../types'
+
+function msg(overrides: Partial<ChatMessage>): ChatMessage {
+  return { type: 'chat', from: 'foreman', content: '', ...overrides }
+}
+
+describe('useChatGrouping', () => {
+  it('keeps a plain foreman message and its taskId badge', () => {
+    const messages = ref<ChatMessage[]>([msg({ content: 'on it', taskId: 't-abc' })])
+    const grouped = useChatGrouping(messages)
+    expect(grouped.value).toHaveLength(1)
+    const only = grouped.value[0]
+    expect(isToolUseGroup(only)).toBe(false)
+    expect((only as ChatMessage).taskId).toBe('t-abc')
+  })
+
+  it('propagates the taskId from the first tool_use into the group', () => {
+    const messages = ref<ChatMessage[]>([
+      msg({ role: 'tool_use', toolName: 'send_followup', toolId: 'tu-1', taskId: 't-abc' }),
+      msg({ role: 'tool_use', toolName: 'get_pr_status', toolId: 'tu-2', taskId: 't-abc' }),
+    ])
+    const grouped = useChatGrouping(messages)
+    expect(grouped.value).toHaveLength(1)
+    const group = grouped.value[0]
+    expect(isToolUseGroup(group)).toBe(true)
+    if (isToolUseGroup(group)) {
+      expect(group.tools).toEqual(['send_followup', 'get_pr_status'])
+      expect(group.taskId).toBe('t-abc')
+    }
+  })
+
+  it('leaves the group taskId null for a parent-context tool call', () => {
+    const messages = ref<ChatMessage[]>([
+      msg({ role: 'tool_use', toolName: 'create_task', toolId: 'tu-1' }),
+    ])
+    const grouped = useChatGrouping(messages)
+    const group = grouped.value[0]
+    expect(isToolUseGroup(group)).toBe(true)
+    if (isToolUseGroup(group)) {
+      expect(group.taskId).toBeNull()
+    }
+  })
+})

--- a/frontend/src/composables/useChatGrouping.ts
+++ b/frontend/src/composables/useChatGrouping.ts
@@ -8,6 +8,9 @@ export interface ToolUseGroup {
   from: string
   createdAt?: string
   created_at?: string
+  // Carried from the first tool_use in the group so a child-context turn's
+  // tool calls badge the same as its narration lines.
+  taskId?: string | null
 }
 
 export type GroupedMessage = ChatMessage | ToolUseGroup
@@ -53,6 +56,7 @@ export function useChatGrouping(
           from: (first.from || first.from_agent || 'foreman') as string,
           createdAt: first.createdAt,
           created_at: first.created_at,
+          taskId: (first.taskId as string | null | undefined) ?? null,
         })
       } else if (msg.role === 'tool_result') {
         i++

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -140,6 +140,10 @@ export interface ChatMessage {
   from_agent?: string
   // Origin of the message: "web", "discord", "api". Missing/undefined means "web".
   source?: string
+  // Set on Foreman messages produced inside a per-task child context. When
+  // present, the chat pane badges the line as scoped to that task rather than
+  // the guild-wide Foreman conversation. See docs/foreman-per-task-context.md.
+  taskId?: string | null
   [key: string]: unknown
 }
 


### PR DESCRIPTION
Audit of foreman thread routing surfaced a Discord mis-route: a human message
posted in a task's Discord thread arrives as an `event="chat"` trigger carrying
a task_id, but "chat" isn't a child event, so `_run_foreman_ai` runs the parent
conversation and forces `_task_id=None`. That None was then used for Discord
routing, so the reply landed in the guild's main channel instead of back in the
task thread the human was talking in.

Decouple the two concerns in the embedded foreman's `_emit_foreman_chat`:
- `child_task_id` tags the WS ChatMsg for the frontend badge (child runs only,
  so parent history stays untagged and isolated child histories aren't polluted).
- `discord_task_id` routes the Discord mirror to the task's thread whenever the
  run concerns a task — including the parent-context reply to a task-thread
  message — so replies always land where the human is talking.

Add per-task visual indication in the chat pane: `ChatMsg` now carries `taskId`
on child-context foreman lines (text, tool_use, tool_result), the grouping
composable propagates it to tool-use groups, and ChatTab renders a small task
badge. The standalone foreman broadcasts the same `taskId` for parity.

Tests: `_emit_foreman_chat` badge-vs-Discord routing (backend) and taskId
propagation through chat grouping (frontend).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ecanq5cn8swAPp2PHkNkK3