### PR TITLE
feat(discord): mirror live task streams into per-task threads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,13 @@ GITHUB_TOKEN=
 # (up to 1 hour to propagate). Only used by scripts/register_discord_commands.py.
 # DISCORD_DEV_GUILD_ID=
 
+# Task-stream mirroring: mirror each working task's live terminal output
+# (Claude's assistant/thinking text) into a dedicated per-task Discord thread as
+# silent, low-priority messages. Off by default because the feed is high-volume.
+# Requires DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID (always routes into a thread,
+# never the flat webhook).
+# DISCORD_STREAM_TASKS=false
+
 # Phase 4: enable the persistent Gateway websocket (backend/discord/gateway.py)
 # for receiving inbound MESSAGE_CREATE events, instead of only the
 # /discord/interactions webhook. Requires DISCORD_BOT_TOKEN, and the bot's

--- a/backend/alembic/versions/20260705_000001_add_discord_task_threads.py
+++ b/backend/alembic/versions/20260705_000001_add_discord_task_threads.py
@@ -1,0 +1,45 @@
+"""Add discord_task_threads table for per-task live-stream threads.
+
+Revision ID: 20260705_000001_add_discord_task_threads
+Revises: 20260705_000000_add_source_to_messages
+Create Date: 2026-07-05
+
+Maps a task_id to a Discord thread channel ID so a worker task's streaming
+terminal output can be mirrored into a dedicated per-task thread while the
+task is working — before any PR/issue thread exists — without re-creating the
+thread on every batch or every restart.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260705_000001_add_discord_task_threads"
+down_revision: str | Sequence[str] | None = "20260705_000000_add_source_to_messages"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "discord_task_threads",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("task_id", sa.Text(), nullable=False),
+        sa.Column("thread_id", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_discord_task_threads_task_id",
+        "discord_task_threads",
+        ["task_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_discord_task_threads_task_id", table_name="discord_task_threads")
+    op.drop_table("discord_task_threads")

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -1,5 +1,5 @@
 """Discord notification helpers: flat webhook (Phase 1), per-PR/issue threads (Phase 2),
-and Foreman chat threads + user mentions (Phase 3).
+Foreman chat threads + user mentions (Phase 3), and live task-stream mirroring (Phase 4).
 
 Phase 1 — flat webhook
     Set ``DISCORD_WEBHOOK_URL`` in the environment to post embeds to a single channel.
@@ -28,6 +28,17 @@ Phase 3 — Foreman chat threads + user mentions
     mention via the ``discord_users`` table (populated through the
     ``/api/discord-users`` REST endpoints). Falls back to a plain ``@login``
     string when no mapping exists — never raises, never blocks a notification.
+
+Phase 4 — live task-stream mirroring
+    ``notify_task_stream`` mirrors a worker task's streaming terminal output
+    (Claude's assistant/thinking text) into a dedicated per-task Discord thread
+    while the task is working. Lines are buffered and flushed in batches (see
+    ``_STREAM_FLUSH_INTERVAL``) to stay under Discord's rate limit, and each
+    batch is posted as a *silent* message (``SUPPRESS_NOTIFICATIONS`` flag, no
+    mentions parsed) so a firehose of build output never pings anyone — a
+    genuinely low-priority feed. Opt-in via ``DISCORD_STREAM_TASKS`` (requires a
+    bot token, since the feed always routes into a thread — never the flat
+    webhook). The per-task thread mapping persists in ``discord_task_threads``.
 
 Required bot permissions for Phase 2/3: ``SEND_MESSAGES``, ``CREATE_PUBLIC_THREADS``, ``MANAGE_THREADS``.
 
@@ -60,8 +71,10 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 import httpx
@@ -618,3 +631,249 @@ async def notify_existing_thread(
         )
 
     await notify(event_type, title, description, url=url, color=color)
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: live task-stream mirroring
+# ---------------------------------------------------------------------------
+
+# Discord message flag: SUPPRESS_NOTIFICATIONS. Marks a message "silent" so it
+# posts without pinging channel members or firing a push notification — exactly
+# the low-priority behaviour we want for a firehose of streaming task output.
+_SILENT_FLAG = 1 << 12  # 4096
+
+# How long to accumulate stream lines before flushing them as one Discord
+# message. Batching is essential: worker terminal output is line-per-event and
+# would blow past Discord's per-channel rate limit if each line were its own POST.
+_STREAM_FLUSH_INTERVAL = 4.0  # seconds
+
+# Force an early flush once the buffer reaches this many characters so a busy
+# task's feed stays live instead of waiting out the full interval.
+_STREAM_FLUSH_CHARS = 1500
+
+
+def _stream_enabled() -> bool:
+    """True when task-stream mirroring is switched on via ``DISCORD_STREAM_TASKS``.
+
+    Off by default: streaming a task's full terminal feed into Discord is
+    high-volume and opt-in. Requires a bot token as well, since the feed is
+    always routed into a per-task thread (never the flat webhook).
+    """
+    flag = os.environ.get("DISCORD_STREAM_TASKS", "").strip().lower()
+    return bool(_bot_token()) and flag in ("1", "true", "yes", "on")
+
+
+@dataclass
+class _StreamBuffer:
+    """In-memory accumulator for one task's pending stream lines."""
+
+    guild_id: str
+    lines: list[str] = field(default_factory=list)
+    size: int = 0
+    flush_task: asyncio.Task | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+# Keyed by task_id. Holds only tasks with un-flushed lines; entries are removed
+# by ``flush_task_stream`` when the task reaches a terminal state.
+_stream_buffers: dict[str, _StreamBuffer] = {}
+
+
+async def _lookup_task_thread(task_id: str) -> str | None:
+    """Return the persisted Discord thread_id for a task's stream, or None."""
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415 — lazy to avoid circular import
+        from models import DiscordTaskThread  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(
+                select(DiscordTaskThread).where(col(DiscordTaskThread.task_id) == task_id)
+            )
+            row = result.one_or_none()
+            return row.thread_id if row else None
+    except Exception:
+        logger.warning("discord: task thread DB lookup failed task=%s", task_id, exc_info=True)
+        return None
+
+
+async def _save_task_thread(task_id: str, thread_id: str) -> None:
+    """Persist a task→thread mapping using an atomic upsert (ignore duplicates)."""
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415
+        from models import DiscordTaskThread  # noqa: PLC0415
+        from sqlalchemy.dialects.postgresql import insert  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            stmt = (
+                insert(DiscordTaskThread)
+                .values(
+                    task_id=task_id,
+                    thread_id=thread_id,
+                    created_at=datetime.now(UTC),
+                )
+                .on_conflict_do_nothing()
+            )
+            await db.execute(stmt)
+            await db.commit()
+    except Exception:
+        logger.warning(
+            "discord: task thread DB save failed task=%s thread=%s",
+            task_id,
+            thread_id,
+            exc_info=True,
+        )
+
+
+async def _lookup_task_description(task_id: str) -> str | None:
+    """Return *task_id*'s description (for naming its thread), or None."""
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415
+        from models import Task  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(select(Task.description).where(col(Task.id) == task_id))
+            return result.one_or_none()
+    except Exception:
+        logger.warning("discord: task description lookup failed task=%s", task_id, exc_info=True)
+        return None
+
+
+async def _ensure_task_thread(task_id: str, channel: str) -> str | None:
+    """Return the Discord thread_id for *task_id*'s stream, creating it if needed.
+
+    Returns None on Discord API error. Never raises.
+    """
+    existing = await _lookup_task_thread(task_id)
+    if existing:
+        return existing
+
+    description = await _lookup_task_description(task_id)
+    thread_name = f"⚙ {task_id}: {description}" if description else f"⚙ {task_id}"
+
+    new_thread_id = await _create_thread_in_channel(channel, thread_name)
+    if not new_thread_id:
+        return None
+
+    await _save_task_thread(task_id, new_thread_id)
+    # Re-fetch after save: on_conflict_do_nothing means a concurrent creator wins;
+    # re-fetching ensures both callers converge on the same persisted thread_id.
+    return await _lookup_task_thread(task_id) or new_thread_id
+
+
+def _chunk_content(text: str, size: int) -> list[str]:
+    """Split *text* into pieces no longer than *size*, preferring newline breaks."""
+    chunks: list[str] = []
+    remaining = text
+    while len(remaining) > size:
+        cut = remaining.rfind("\n", 0, size)
+        if cut <= 0:
+            cut = size
+        chunks.append(remaining[:cut])
+        remaining = remaining[cut:].lstrip("\n")
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+async def _post_task_stream(guild_id: str, task_id: str, content: str) -> None:
+    """Post *content* into *task_id*'s per-task thread as silent messages. Never raises."""
+    channel = await _resolve_channel_for_guild(guild_id)
+    if not channel:
+        return
+    thread_id = await _ensure_task_thread(task_id, channel)
+    if not thread_id:
+        return
+    for chunk in _chunk_content(content, _MAX_MESSAGE_LENGTH):
+        if not chunk:
+            continue
+        await _bot_request(
+            "post",
+            f"/channels/{thread_id}/messages",
+            {
+                "content": chunk,
+                "flags": _SILENT_FLAG,
+                # Never let streamed build output @-mention anyone.
+                "allowed_mentions": {"parse": []},
+            },
+        )
+
+
+async def _drain_and_post(buf: _StreamBuffer, task_id: str) -> None:
+    """Atomically swap out *buf*'s pending lines and post them. Never raises."""
+    async with buf.lock:
+        if not buf.lines:
+            return
+        content = "\n".join(buf.lines)
+        buf.lines = []
+        buf.size = 0
+    await _post_task_stream(buf.guild_id, task_id, content)
+
+
+async def _flush_task_stream(task_id: str) -> None:
+    """Flush the pending buffer for *task_id* if it is still registered."""
+    buf = _stream_buffers.get(task_id)
+    if buf is None:
+        return
+    await _drain_and_post(buf, task_id)
+
+
+async def _delayed_flush(task_id: str) -> None:
+    """Wait out the batching interval, then flush *task_id*'s buffer."""
+    try:
+        await asyncio.sleep(_STREAM_FLUSH_INTERVAL)
+    except asyncio.CancelledError:
+        return
+    buf = _stream_buffers.get(task_id)
+    if buf is not None:
+        buf.flush_task = None
+    await _flush_task_stream(task_id)
+
+
+async def notify_task_stream(guild_id: str, task_id: str, line: str) -> None:
+    """Buffer one streaming terminal line for *task_id* and schedule a flush.
+
+    Fast and non-blocking: appends to an in-memory buffer and (re)arms a
+    background flush task — the actual Discord POST happens off the caller's
+    path so a worker's terminal firehose never stalls the WebSocket handler.
+    Silent no-op unless ``DISCORD_STREAM_TASKS`` is enabled (and a bot token is
+    configured), or when *line*/*task_id* is blank. Never raises.
+    """
+    if not _stream_enabled():
+        return
+    if not task_id or not line or not line.strip():
+        return
+
+    buf = _stream_buffers.get(task_id)
+    if buf is None:
+        buf = _StreamBuffer(guild_id=guild_id)
+        _stream_buffers[task_id] = buf
+
+    buf.lines.append(line)
+    buf.size += len(line) + 1
+
+    if buf.size >= _STREAM_FLUSH_CHARS:
+        if buf.flush_task is not None:
+            buf.flush_task.cancel()
+            buf.flush_task = None
+        # Flush in the background so this call stays off the network path.
+        asyncio.ensure_future(_flush_task_stream(task_id))  # noqa: RUF006
+    elif buf.flush_task is None:
+        buf.flush_task = asyncio.ensure_future(_delayed_flush(task_id))
+
+
+async def flush_task_stream(task_id: str) -> None:
+    """Flush and drop *task_id*'s buffer — call when the task reaches a terminal state.
+
+    Posts any tail lines immediately (rather than waiting out the interval) and
+    frees the in-memory buffer. Silent no-op when the task has no buffered
+    stream. Never raises.
+    """
+    buf = _stream_buffers.pop(task_id, None)
+    if buf is None:
+        return
+    if buf.flush_task is not None:
+        buf.flush_task.cancel()
+        buf.flush_task = None
+    await _drain_and_post(buf, task_id)

--- a/backend/models.py
+++ b/backend/models.py
@@ -579,6 +579,31 @@ class DiscordForemanThread(SQLModel, table=True):
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
+class DiscordTaskThread(SQLModel, table=True):
+    """Persisted mapping from a task to a Discord thread carrying its live stream.
+
+    A worker task's streaming terminal output (Claude's assistant/thinking
+    text) is mirrored into a dedicated per-task Discord thread while the task
+    is working — before any PR/issue thread exists. Keyed on ``task_id`` (unique)
+    so the thread is created once and reused across the task's whole lifetime
+    and across backend restarts.
+    """
+
+    __tablename__ = "discord_task_threads"  # type: ignore[assignment]
+    __table_args__ = (
+        Index(
+            "uq_discord_task_threads_task_id",
+            "task_id",
+            unique=True,
+        ),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    task_id: str  # tasks.id (e.g. "t-abc")
+    thread_id: str  # Discord channel ID of the thread
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
 class DiscordUser(SQLModel, table=True):
     """Maps a GitHub login to a Discord user ID for @-mentions in notifications.
 

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -6,6 +6,7 @@ No real DB sessions are made — _lookup_thread and _save_thread are patched.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -30,6 +31,7 @@ def reset_env(monkeypatch):
     monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
     monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
     monkeypatch.delenv("DISCORD_CHANNEL_ID", raising=False)
+    monkeypatch.delenv("DISCORD_STREAM_TASKS", raising=False)
 
 
 @pytest.fixture(autouse=True)
@@ -38,6 +40,14 @@ def reset_client():
     discord_notifier._client = None
     yield
     discord_notifier._client = None
+
+
+@pytest.fixture(autouse=True)
+def reset_stream_buffers():
+    """Clear the in-memory task-stream buffers between tests."""
+    discord_notifier._stream_buffers.clear()
+    yield
+    discord_notifier._stream_buffers.clear()
 
 
 def _make_mock_client(status_code: int = 204, side_effect=None, json_response: dict | None = None):
@@ -859,3 +869,196 @@ async def test_lookup_task_issue_coords_db_error_returns_none():
         result = await discord_notifier._lookup_task_issue_coords("t-abc")
 
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: live task-stream mirroring
+# ---------------------------------------------------------------------------
+
+
+def test_stream_enabled_requires_both_flag_and_token(monkeypatch):
+    """_stream_enabled is off unless DISCORD_STREAM_TASKS is truthy AND a bot token is set."""
+    assert discord_notifier._stream_enabled() is False
+
+    monkeypatch.setenv("DISCORD_STREAM_TASKS", "true")
+    assert discord_notifier._stream_enabled() is False  # still no bot token
+
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    assert discord_notifier._stream_enabled() is True
+
+    monkeypatch.setenv("DISCORD_STREAM_TASKS", "off")
+    assert discord_notifier._stream_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_notify_task_stream_noop_when_disabled(monkeypatch):
+    """notify_task_stream buffers nothing when the feature flag is unset."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)  # token set, flag NOT set
+
+    await discord_notifier.notify_task_stream("guild-1", "t-1", "hello")
+
+    assert "t-1" not in discord_notifier._stream_buffers
+
+
+@pytest.mark.asyncio
+async def test_notify_task_stream_noop_for_blank_line(monkeypatch):
+    """notify_task_stream ignores blank/whitespace-only lines."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_STREAM_TASKS", "1")
+
+    await discord_notifier.notify_task_stream("guild-1", "t-1", "   ")
+
+    assert "t-1" not in discord_notifier._stream_buffers
+
+
+@pytest.mark.asyncio
+async def test_notify_task_stream_buffers_short_line(monkeypatch):
+    """A short line is buffered and a delayed flush is armed (no immediate POST)."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_STREAM_TASKS", "1")
+
+    with patch.object(discord_notifier, "_delayed_flush", AsyncMock()):
+        await discord_notifier.notify_task_stream("guild-1", "t-1", "short line")
+
+        buf = discord_notifier._stream_buffers["t-1"]
+        assert buf.lines == ["short line"]
+        assert buf.guild_id == "guild-1"
+        assert buf.flush_task is not None
+        await buf.flush_task  # drain the scheduled (mocked) flush task
+
+
+@pytest.mark.asyncio
+async def test_notify_task_stream_flushes_when_buffer_large(monkeypatch):
+    """Crossing _STREAM_FLUSH_CHARS triggers an immediate background flush."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_STREAM_TASKS", "1")
+    monkeypatch.setattr(discord_notifier, "_STREAM_FLUSH_CHARS", 10)
+
+    with patch.object(discord_notifier, "_flush_task_stream", AsyncMock()) as flush_mock:
+        await discord_notifier.notify_task_stream("guild-1", "t-1", "a line much longer than ten")
+        await asyncio.sleep(0)  # let the scheduled flush task run
+
+    flush_mock.assert_awaited_once_with("t-1")
+
+
+@pytest.mark.asyncio
+async def test_post_task_stream_posts_silent_message_to_task_thread(monkeypatch):
+    """_post_task_stream posts into the per-task thread as a silent, no-mention message."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(
+            discord_notifier, "_resolve_channel_for_guild", AsyncMock(return_value=CHANNEL_ID)
+        ),
+        patch.object(discord_notifier, "_ensure_task_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier._post_task_stream("guild-1", "t-1", "line one\nline two")
+
+    mock_client.post.assert_called_once()
+    call_url = mock_client.post.call_args[0][0]
+    assert f"/channels/{THREAD_ID}/messages" in call_url
+    body = mock_client.post.call_args[1]["json"]
+    assert body["content"] == "line one\nline two"
+    assert body["flags"] == discord_notifier._SILENT_FLAG
+    assert body["allowed_mentions"] == {"parse": []}
+
+
+@pytest.mark.asyncio
+async def test_post_task_stream_noop_when_no_thread(monkeypatch):
+    """_post_task_stream posts nothing when the task thread can't be created."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(
+            discord_notifier, "_resolve_channel_for_guild", AsyncMock(return_value=CHANNEL_ID)
+        ),
+        patch.object(discord_notifier, "_ensure_task_thread", AsyncMock(return_value=None)),
+    ):
+        await discord_notifier._post_task_stream("guild-1", "t-1", "line")
+
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flush_task_stream_drains_and_removes_buffer():
+    """flush_task_stream posts the pending lines and drops the buffer entry."""
+    buf = discord_notifier._StreamBuffer(guild_id="guild-1")
+    buf.lines = ["a", "b"]
+    buf.size = 4
+    discord_notifier._stream_buffers["t-1"] = buf
+
+    with patch.object(discord_notifier, "_post_task_stream", AsyncMock()) as post_mock:
+        await discord_notifier.flush_task_stream("t-1")
+
+    post_mock.assert_awaited_once_with("guild-1", "t-1", "a\nb")
+    assert "t-1" not in discord_notifier._stream_buffers
+
+
+@pytest.mark.asyncio
+async def test_flush_task_stream_noop_when_no_buffer():
+    """flush_task_stream is a silent no-op for a task with no buffered stream."""
+    with patch.object(discord_notifier, "_post_task_stream", AsyncMock()) as post_mock:
+        await discord_notifier.flush_task_stream("t-unknown")
+
+    post_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_task_thread_reuses_existing():
+    """_ensure_task_thread returns a persisted thread without hitting the Discord API."""
+    with (
+        patch.object(discord_notifier, "_lookup_task_thread", AsyncMock(return_value=THREAD_ID)),
+        patch.object(discord_notifier, "_create_thread_in_channel", AsyncMock()) as create_mock,
+    ):
+        result = await discord_notifier._ensure_task_thread("t-1", CHANNEL_ID)
+
+    assert result == THREAD_ID
+    create_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_task_thread_creates_and_names_from_description():
+    """_ensure_task_thread creates a thread named from the task description when absent."""
+    with (
+        patch.object(
+            discord_notifier, "_lookup_task_thread", AsyncMock(side_effect=[None, THREAD_ID])
+        ),
+        patch.object(
+            discord_notifier, "_lookup_task_description", AsyncMock(return_value="Fix the bug")
+        ),
+        patch.object(
+            discord_notifier, "_create_thread_in_channel", AsyncMock(return_value=THREAD_ID)
+        ) as create_mock,
+        patch.object(discord_notifier, "_save_task_thread", AsyncMock()) as save_mock,
+    ):
+        result = await discord_notifier._ensure_task_thread("t-1", CHANNEL_ID)
+
+    assert result == THREAD_ID
+    create_mock.assert_awaited_once()
+    thread_name = create_mock.call_args[0][1]
+    assert "t-1" in thread_name
+    assert "Fix the bug" in thread_name
+    save_mock.assert_awaited_once_with("t-1", THREAD_ID)
+
+
+def test_chunk_content_hard_splits_without_newlines():
+    """A newline-free string is hard-split into <=size pieces that reconstruct exactly."""
+    text = "x" * 5000
+    chunks = discord_notifier._chunk_content(text, 2000)
+
+    assert [len(c) for c in chunks] == [2000, 2000, 1000]
+    assert "".join(chunks) == text
+
+
+def test_chunk_content_prefers_newline_boundaries():
+    """_chunk_content breaks on the last newline within the window when possible."""
+    chunks = discord_notifier._chunk_content("aaaa\nbbbb\ncccc", 7)
+
+    assert chunks == ["aaaa", "bbbb", "cccc"]
+    assert all(len(c) <= 7 for c in chunks)

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -75,6 +75,12 @@ logger = logging.getLogger(__name__)
 
 _TERMINAL_STATES = ("done", "failed", "cancelled", "error")
 
+# Terminal-output "levels" (see worker.py LEVEL_* constants) whose lines are
+# actual agent/Claude output worth mirroring into a task's Discord stream
+# thread. ``None`` is the default for task-scoped emits (LEVEL_INFO); worker /
+# auth / claude-framing lines are deliberately excluded as low-value noise.
+_DISCORD_STREAM_LEVELS = frozenset({None, "info", "thinking"})
+
 
 # ---------------------------------------------------------------------------
 # Helpers (pure DB lookups; live here because main.py + ws_handlers both use
@@ -602,6 +608,11 @@ async def handle_terminal_output(ctx: WSContext, data: dict) -> None:
             level=level if level else None,
         ),
     )
+    # Mirror agent/Claude output into the task's own Discord stream thread as a
+    # low-priority feed (opt-in via DISCORD_STREAM_TASKS). Buffered internally,
+    # so this call stays off the network path and is a no-op when disabled.
+    if task_id and line and level in _DISCORD_STREAM_LEVELS:
+        await discord_notifier.notify_task_stream(ctx.guild_id, task_id, line)
 
 
 async def handle_worker_register(ctx: WSContext, data: dict) -> None:
@@ -738,6 +749,13 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
     await broadcast_msg(ctx.guild_id, TaskUpdateMsg.model_validate(data), exclude=ctx.websocket)
     if "state" in update_values:
         reset_foreman_poll(ctx.guild_id)
+    # Free the task's Discord stream buffer once it reaches a terminal state
+    # (failed/cancelled/error), draining any tail output first.
+    if update_values.get("state") in _TERMINAL_STATES:
+        spawn(
+            discord_notifier.flush_task_stream(task_id),
+            name=f"discord.stream-flush:{task_id}",
+        )
     # Drain any pending-followup events queued while the task was locked, and
     # notify the foreman so it can decide how to handle them.
     if update_values.get("state") == "error" and task_id:
@@ -815,6 +833,12 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
         spawn(
             maybe_post_plan_comment(ctx.guild_id, task_id, last_text),
             name=f"foreman.plan-comment:{task_id}",
+        )
+        # Drain the task's Discord stream buffer so any tail output lands
+        # promptly and the in-memory buffer is freed.
+        spawn(
+            discord_notifier.flush_task_stream(task_id),
+            name=f"discord.stream-flush:{task_id}",
         )
         _pr_repo_disc, _pr_num_disc = _parse_pr_url(pr_url) if pr_url else (None, None)
         spawn(
@@ -916,6 +940,13 @@ async def handle_task_followup_done(ctx: WSContext, data: dict) -> None:
     )
     if not task_id:
         return
+
+    # Drain the task's Discord stream buffer so this follow-up's tail output
+    # lands promptly; a later follow-up re-creates the buffer on demand.
+    spawn(
+        discord_notifier.flush_task_stream(task_id),
+        name=f"discord.stream-flush:{task_id}",
+    )
 
     # Collect and drain any follow-up requests that were queued while the task
     # was locked, then re-trigger the foreman with their instructions so it can

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,10 @@ services:
       DISCORD_PUBLIC_KEY: ${DISCORD_PUBLIC_KEY:-}
       DISCORD_ALLOWED_ROLE_IDS: ${DISCORD_ALLOWED_ROLE_IDS:-}
       DISCORD_PIONEER_GUILD_SLUG: ${DISCORD_PIONEER_GUILD_SLUG:-}
+      # Task-stream mirroring: mirror each working task's live terminal output
+      # into a dedicated per-task thread as silent, low-priority messages.
+      # High-volume, off by default; needs DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID.
+      DISCORD_STREAM_TASKS: ${DISCORD_STREAM_TASKS:-false}
       # Phase 4: persistent Gateway websocket for inbound messages. Requires
       # DISCORD_BOT_TOKEN and the "Message Content Intent" enabled on the
       # bot's Bot page in the Discord Developer Portal.

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -69,6 +69,7 @@ bot must already be a member of the guild that owns `DISCORD_CHANNEL_ID`.
 | `DISCORD_PIONEER_GUILD_SLUG` | 3 | For slash commands | The Pioneer Square guild (workspace) slug that `/ps` commands operate against. Not a Discord ID — see [Terminology note](#terminology-note-guild-vs-guild) below. |
 | `DISCORD_OPERATOR_ROLE_NAME` | 3 | No | Discord role name (in addition to the Manage Channels permission) allowed to run `/join-channel` and `/leave-channel`. Default `Pioneer Square Operator`. |
 | `DISCORD_DEV_GUILD_ID` | 3 (registration only) | No | Discord server ID. When set, `scripts/register_discord_commands.py` registers commands to that one server (near-instant) instead of globally (up to 1 hour to propagate). |
+| `DISCORD_STREAM_TASKS` | 2+ | No | When truthy (`1`/`true`/`yes`/`on`), mirror each working task's live terminal output into a dedicated per-task Discord thread as silent, low-priority messages. Off by default (high-volume). Requires `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` — the feed always routes into a thread, never the flat webhook. |
 
 `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` must be set **together** — the bot needs both
 the credential and a destination channel to create threads.
@@ -211,6 +212,30 @@ sends to a user (not tool-call traces) is mirrored into Discord via
 - The mapping persists in the `discord_foreman_threads` table, unique on
   `(guild_id, session_key)`.
 - Silent no-op if the bot token/channel aren't configured, or if the content is blank.
+
+### Live task-stream mirroring
+
+Set `DISCORD_STREAM_TASKS` (plus the Phase 2 `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID`) to
+mirror a worker task's **live terminal output** into Discord while it runs — a low-priority
+feed of what each agent is actually doing, without leaving the app.
+
+- **Per-task thread** — the streamed output for a task lands in its own thread (created lazily
+  off a starter message in the configured channel, named `⚙ <task-id>: <description>`). The
+  mapping persists in the `discord_task_threads` table, unique on `task_id`, so restarts reuse
+  the same thread. This is intentionally separate from the PR/issue thread: the stream is a
+  verbose working feed, created while the task runs (before any PR exists), whereas the PR
+  thread holds the tidy embed summary.
+- **What's mirrored** — only actual agent/Claude output (terminal-output frames at `info` or
+  `thinking` level). Worker lifecycle, auth, and Claude-runner framing lines are filtered out
+  as noise.
+- **Low priority** — every message is posted with Discord's `SUPPRESS_NOTIFICATIONS`
+  ("silent") flag and with mention parsing disabled, so the feed never pings anyone or fires a
+  push notification.
+- **Batched** — lines are buffered and flushed roughly every few seconds (or sooner once the
+  buffer fills), rather than one HTTP POST per line, to stay well under Discord's rate limits.
+  The buffer is drained and freed when the task reaches a terminal state.
+- **Off by default** — because the volume is high, the whole feature is opt-in via
+  `DISCORD_STREAM_TASKS`. Silent no-op when the flag is unset or the bot token is missing.
 
 ## Slash command reference
 


### PR DESCRIPTION
Add opt-in mirroring of a working task's streaming terminal output
(Claude's assistant/thinking text) into a dedicated per-task Discord
thread as silent, low-priority messages.

- New DiscordTaskThread model + migration (discord_task_threads),
  keyed on task_id so the thread is created once and reused.
- discord_notifier.notify_task_stream buffers lines and flushes them in
  batches (every few seconds / on buffer fill) to stay under Discord's
  rate limit; each batch posts with the SUPPRESS_NOTIFICATIONS flag and
  mention parsing disabled, so the feed never pings anyone.
- Wired into handle_terminal_output (info/thinking levels only; worker/
  auth/claude framing filtered out); buffers are drained and freed when
  a task reaches a terminal state.
- Gated behind DISCORD_STREAM_TASKS (requires a bot token; always routes
  into a thread, never the flat webhook). Off by default.
- Tests, docs, .env.example and docker-compose entries.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RRuRfSVc3hjX7wUU4DGESu