### PR TITLE
fix(foreman): route child-context chat to the correct Discord thread + badge it in the UI

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -488,22 +488,42 @@ async def _fetch_online_workers(db, guild_id: str) -> list[dict]:
 
 
 async def _emit_foreman_chat(
-    guild_id: str, content: str, created_at: str, task_id: str | None = None
+    guild_id: str,
+    content: str,
+    created_at: str,
+    *,
+    child_task_id: str | None = None,
+    discord_task_id: str | None = None,
 ) -> None:
     """Broadcast a Foreman -> user narration line and mirror it into Discord.
 
     Every plain-text line the Foreman sends to the user (not tool_use/tool_result
     traces) goes through here so the Discord thread mirror in discord_notifier
-    stays in sync with the WS chat stream. *task_id*, when known, lets
-    discord_notifier route the line to that task's per-task thread instead of
-    posting directly to the guild's main channel.
+    stays in sync with the WS chat stream.
+
+    The two ids are deliberately separate (see docs/foreman-per-task-context.md):
+
+    - ``child_task_id`` tags the WS ``ChatMsg`` so the frontend can badge lines
+      produced inside a per-task child context. It is None for parent runs even
+      when the run concerns a task (e.g. a human chatting in a task's Discord
+      thread stays on the parent conversation).
+    - ``discord_task_id`` routes the Discord mirror to that task's thread. It is
+      set whenever the run concerns a task — including the parent-context reply
+      to a message posted in a task thread — so the reply always lands back in
+      the thread the human is talking in rather than the guild's main channel.
     """
     await broadcast_msg(
         guild_id,
-        ChatMsg(from_="foreman", to="user", content=content, createdAt=created_at),
+        ChatMsg(
+            from_="foreman",
+            to="user",
+            content=content,
+            createdAt=created_at,
+            taskId=child_task_id,
+        ),
     )
     spawn(
-        discord_notifier.notify_foreman_chat(guild_id, content, task_id=task_id),
+        discord_notifier.notify_foreman_chat(guild_id, content, task_id=discord_task_id),
         name=f"discord.foreman-chat:{guild_id}",
     )
 
@@ -667,6 +687,15 @@ async def _run_foreman_ai(
             # untagged (task_id IS NULL) so they don't pollute that task's
             # isolated child context on its next run.
             _task_id = None
+
+        # Discord routing target for narration mirrored back to the human.
+        # ``_task_id`` (history tag) is None for parent runs, but a parent run
+        # can still concern a task — e.g. a human message posted in that task's
+        # Discord thread arrives as an ``event="chat"`` trigger with a task_id
+        # that stays on the parent conversation. Route the reply back into that
+        # thread using the incoming ``task_id`` even though the turn isn't
+        # tagged as child history. See docs/foreman-per-task-context.md.
+        _discord_task_id: str | None = _task_id or task_id
     except Exception:
         await db.close()
         raise
@@ -849,7 +878,11 @@ async def _run_foreman_ai(
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
                     await _emit_foreman_chat(
-                        guild_id, b.text.strip(), _now.isoformat(), task_id=_task_id
+                        guild_id,
+                        b.text.strip(),
+                        _now.isoformat(),
+                        child_task_id=_task_id,
+                        discord_task_id=_discord_task_id,
                     )
 
             tool_uses = [b for b in resp.content if b.type == "tool_use"]
@@ -871,6 +904,7 @@ async def _run_foreman_ai(
                         toolInput=dict(tu.input) if tu.input else {},
                         toolId=tu.id,
                         createdAt=_now.isoformat(),
+                        taskId=_task_id,
                     ),
                 )
 
@@ -903,6 +937,7 @@ async def _run_foreman_ai(
                         toolOutput=result.get("content", ""),
                         isError=result.get("is_error", False),
                         createdAt=_now.isoformat(),
+                        taskId=_task_id,
                     ),
                 )
 
@@ -1057,10 +1092,22 @@ async def _run_foreman_ai(
             for b in wrap_resp.content:
                 if b.type == "text" and b.text.strip():
                     text_parts.append(b.text.strip())
-                    await _emit_foreman_chat(guild_id, b.text.strip(), _now, task_id=_task_id)
+                    await _emit_foreman_chat(
+                        guild_id,
+                        b.text.strip(),
+                        _now,
+                        child_task_id=_task_id,
+                        discord_task_id=_discord_task_id,
+                    )
             cap_note = f"_(Foreman hit {cfg_max_rounds}-round safety cap and stopped.)_"
             text_parts.append(cap_note)
-            await _emit_foreman_chat(guild_id, cap_note, _now, task_id=_task_id)
+            await _emit_foreman_chat(
+                guild_id,
+                cap_note,
+                _now,
+                child_task_id=_task_id,
+                discord_task_id=_discord_task_id,
+            )
 
         response_text = "\n".join(text_parts).strip()
         if response_text:

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -618,6 +618,7 @@ async def create_message(
             content=body.content,
             createdAt=created_at.isoformat(),
             source=source,
+            taskId=body.task_id,
             **({"userId": body.user_id} if body.user_id else {}),
         ),
     )

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -42,6 +42,12 @@ def _message_dict(m: Message) -> dict:
         except json.JSONDecodeError:
             logger.warning("guild messages: failed to parse meta JSON for message id=%s", m.id)
             d["metaParseError"] = True
+    # Expose the per-task child-context id under the same camelCase key the live
+    # WS broadcast (ChatMsg.taskId) and the frontend badge read. row_to_dict
+    # yields the raw column name `task_id`, which the chat pane doesn't look at,
+    # so a child-context Foreman line loaded from history would otherwise render
+    # without its task badge. See docs/foreman-per-task-context.md.
+    d["taskId"] = d.pop("task_id", None)
     return d
 
 

--- a/backend/tests/test_foreman_child_context.py
+++ b/backend/tests/test_foreman_child_context.py
@@ -202,3 +202,88 @@ async def test_trigger_foreman_child_routing(monkeypatch, event, expect_child):
     assert captured["kwargs"].get("child") is expect_child
     if expect_child:
         assert captured["kwargs"].get("task_id") == "t-xyz"
+
+
+# ── _emit_foreman_chat: frontend badge vs Discord routing ────────────────────
+
+
+def _patch_emit(monkeypatch):
+    """Patch broadcast_msg / discord mirror / spawn on foreman.runner.
+
+    Returns ``(sent_msgs, discord_calls)`` — the ChatMsg objects broadcast to
+    WS clients and the ``(content, task_id)`` tuples passed to the Discord
+    mirror. ``spawn`` is replaced with a version that actually awaits the
+    coroutine so the Discord call is observed.
+    """
+    import foreman.runner as runner
+
+    sent_msgs: list = []
+    discord_calls: list = []
+
+    async def fake_broadcast(guild_id, msg):
+        sent_msgs.append(msg)
+
+    async def fake_notify(guild_id, content, task_id=None):
+        discord_calls.append((content, task_id))
+
+    def fake_spawn(coro, name=None):
+        return asyncio.ensure_future(coro)
+
+    monkeypatch.setattr(runner, "broadcast_msg", fake_broadcast)
+    monkeypatch.setattr(runner.discord_notifier, "notify_foreman_chat", fake_notify)
+    monkeypatch.setattr(runner, "spawn", fake_spawn)
+    return sent_msgs, discord_calls
+
+
+async def test_emit_child_run_badges_and_routes_to_task_thread(monkeypatch):
+    """A child run tags the WS message and mirrors to the task's Discord thread."""
+    import foreman.runner as runner
+
+    sent_msgs, discord_calls = _patch_emit(monkeypatch)
+
+    await runner._emit_foreman_chat(
+        "g1",
+        "working on it",
+        "2026-01-01T00:00:00Z",
+        child_task_id="t-abc",
+        discord_task_id="t-abc",
+    )
+    await asyncio.sleep(0)  # let the spawned Discord mirror run
+
+    assert sent_msgs[0].taskId == "t-abc"
+    assert discord_calls == [("working on it", "t-abc")]
+
+
+async def test_emit_parent_thread_chat_routes_to_thread_without_badge(monkeypatch):
+    """A parent run answering a task-thread message still replies in that thread.
+
+    The frontend badge (``taskId`` on the WS ChatMsg) stays absent — the run is
+    the parent/whole-guild conversation — but the Discord mirror routes to the
+    task's thread so the reply lands where the human is talking.
+    """
+    import foreman.runner as runner
+
+    sent_msgs, discord_calls = _patch_emit(monkeypatch)
+
+    await runner._emit_foreman_chat(
+        "g1", "here you go", "2026-01-01T00:00:00Z", child_task_id=None, discord_task_id="t-abc"
+    )
+    await asyncio.sleep(0)
+
+    assert sent_msgs[0].taskId is None
+    assert discord_calls == [("here you go", "t-abc")]
+
+
+async def test_emit_plain_parent_run_has_no_task_routing(monkeypatch):
+    """A parent run with no task concern badges nothing and posts to main channel."""
+    import foreman.runner as runner
+
+    sent_msgs, discord_calls = _patch_emit(monkeypatch)
+
+    await runner._emit_foreman_chat(
+        "g1", "guild status", "2026-01-01T00:00:00Z", child_task_id=None, discord_task_id=None
+    )
+    await asyncio.sleep(0)
+
+    assert sent_msgs[0].taskId is None
+    assert discord_calls == [("guild status", None)]

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -64,6 +64,66 @@ def test_get_guild_found(client):
     assert "messages" in data
 
 
+def test_message_dict_exposes_task_id_as_camelcase():
+    """History reload must carry the child-context id under `taskId` (the key
+    the live WS broadcast and the frontend badge use), not the raw `task_id`
+    column name row_to_dict would otherwise emit."""
+    from models import Message
+    from routes.guilds import _message_dict
+
+    m = Message(
+        guild_id=1,
+        from_agent="foreman",
+        to_agent="user",
+        content="working on it",
+        message_type="chat",
+        task_id="t-abc",
+    )
+    d = _message_dict(m)
+    assert d["taskId"] == "t-abc"
+    assert "task_id" not in d
+
+
+def test_message_dict_parent_message_has_null_task_id():
+    from models import Message
+    from routes.guilds import _message_dict
+
+    m = Message(
+        guild_id=1,
+        from_agent="foreman",
+        to_agent="user",
+        content="guild status",
+        message_type="chat",
+    )
+    d = _message_dict(m)
+    assert d["taskId"] is None
+    assert "task_id" not in d
+
+
+def test_message_dict_merges_meta_and_keeps_task_badge():
+    """A child-context tool_use row keeps both its merged meta (toolName/toolId)
+    and its camelCase taskId badge after serialization."""
+    import json
+
+    from models import Message
+    from routes.guilds import _message_dict
+
+    m = Message(
+        guild_id=1,
+        from_agent="foreman",
+        to_agent="user",
+        content="▶ send_followup",
+        message_type="chat",
+        role="tool_use",
+        task_id="t-abc",
+        meta=json.dumps({"toolId": "tu-1", "toolName": "send_followup"}),
+    )
+    d = _message_dict(m)
+    assert d["taskId"] == "t-abc"
+    assert d["toolName"] == "send_followup"
+    assert d["toolId"] == "tu-1"
+
+
 def test_get_guild_forbidden_for_non_member(client):
     test_client, db_url = client
     insert_guild(db_url, "private01", name="Private")

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -95,6 +95,11 @@ class ChatMsg(_WS):
     # Origin of the message: "web", "discord", "api". Omitted (None) means
     # "web" — the frontend only renders an origin label for non-web sources.
     source: str | None = None
+    # Set on Foreman → user messages produced inside a per-task child context
+    # (see docs/foreman-per-task-context.md). None for parent/whole-guild runs.
+    # The frontend badges child-context messages so it's clear which are scoped
+    # to a single task rather than the guild-wide Foreman conversation.
+    taskId: str | None = None
 
 
 class TerminalOutputMsg(_WS):

--- a/foreman/pioneer_foreman/http_client.py
+++ b/foreman/pioneer_foreman/http_client.py
@@ -180,8 +180,14 @@ class ForemanHTTPClient:
         *,
         user_id: str | None = None,
         message_type: str = "chat",
+        task_id: str | None = None,
     ) -> dict:
-        """Persist a chat message. Returns {message_id, created_at}."""
+        """Persist a chat message. Returns {message_id, created_at}.
+
+        ``task_id`` tags the row with the per-task child context that produced
+        it so it is stored — and reloaded — with the same badge the live WS
+        broadcast carries. See docs/foreman-per-task-context.md.
+        """
         body: dict = {
             "from_agent": from_agent,
             "to_agent": to_agent,
@@ -190,6 +196,8 @@ class ForemanHTTPClient:
         }
         if user_id:
             body["user_id"] = user_id
+        if task_id:
+            body["task_id"] = task_id
         return await self._post(self._guild_url("/messages"), body)
 
     # ── Tool execution ─────────────────────────────────────────────────────

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -166,6 +166,11 @@ async def run_foreman_ai(
         raise ValueError("run_foreman_ai(child=True) requires a task_id")
     tools = CHILD_FOREMAN_TOOLS if child else FOREMAN_TOOLS
 
+    # Frontend badge id: set only on child (per-task) runs so the chat pane can
+    # mark lines scoped to a single task. Parent/whole-guild runs stay unbadged
+    # even when a task_id is present. See docs/foreman-per-task-context.md.
+    _badge_task_id = task_id if child else None
+
     if not HAS_ANTHROPIC:
         now = datetime.now(UTC).isoformat()
         await ws_send(
@@ -333,6 +338,7 @@ async def run_foreman_ai(
                             "to": "user",
                             "content": b.text.strip(),
                             "createdAt": _now,
+                            "taskId": _badge_task_id,
                         }
                     )
 
@@ -354,6 +360,7 @@ async def run_foreman_ai(
                         "toolInput": dict(tu.input) if tu.input else {},
                         "toolId": tu.id,
                         "createdAt": _now,
+                        "taskId": _badge_task_id,
                     }
                 )
 
@@ -394,6 +401,7 @@ async def run_foreman_ai(
                         "toolOutput": result.get("content", ""),
                         "isError": result.get("is_error", False),
                         "createdAt": _now,
+                        "taskId": _badge_task_id,
                     }
                 )
 
@@ -479,6 +487,7 @@ async def run_foreman_ai(
                             "to": "user",
                             "content": b.text.strip(),
                             "createdAt": _now,
+                            "taskId": _badge_task_id,
                         }
                     )
             cap_note = f"_(Foreman hit {config.max_rounds}-round safety cap and stopped.)_"
@@ -490,6 +499,7 @@ async def run_foreman_ai(
                     "to": "user",
                     "content": cap_note,
                     "createdAt": _now,
+                    "taskId": _badge_task_id,
                 }
             )
 

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -510,6 +510,7 @@ async def run_foreman_ai(
                 "user",
                 response_text,
                 user_id=user_id,
+                task_id=_badge_task_id,
             )
 
     except Exception as exc:

--- a/frontend/src/components/chat-pane/ChatTab.vue
+++ b/frontend/src/components/chat-pane/ChatTab.vue
@@ -13,6 +13,13 @@
           :class="'msg-from--' + (isToolUseGroup(msg) ? msg.from : msgSender(msg as ChatMessage))"
           >{{ isToolUseGroup(msg) ? '⚙ FOREMAN' : senderLabel(msg as ChatMessage) }}</span
         >
+        <span
+          v-if="taskBadge(msg)"
+          class="msg-task-badge"
+          :title="'Scoped to task ' + taskBadge(msg)"
+        >
+          ⛬ {{ taskBadge(msg) }}
+        </span>
         <span v-if="!isToolUseGroup(msg) && sourceLabel(msg as ChatMessage)" class="msg-source">
           via {{ sourceLabel(msg as ChatMessage) }}
         </span>
@@ -76,6 +83,7 @@ import { renderMarkdown } from '../../utils/markdown'
 import { useGuildStore } from '../../stores/guild'
 import { formatClock } from '../../utils/format'
 import { useChatGrouping, isToolUseGroup } from '../../composables/useChatGrouping'
+import type { GroupedMessage } from '../../composables/useChatGrouping'
 import type { ChatMessage } from '../../types'
 
 const guildStore = useGuildStore()
@@ -106,6 +114,14 @@ function senderLabel(msg: ChatMessage): string {
   if (sender === 'system') return 'SYS'
   if (sender === 'foreman') return '⚙ FOREMAN'
   return sender.toUpperCase()
+}
+
+// A Foreman line produced inside a per-task child context carries a taskId
+// (see docs/foreman-per-task-context.md). Badge it so it's clear the line is
+// scoped to a single task rather than the guild-wide Foreman conversation.
+function taskBadge(msg: GroupedMessage): string | null {
+  const taskId = (msg as { taskId?: string | null }).taskId
+  return taskId ? taskId : null
 }
 
 const SOURCE_LABELS: Record<string, string> = { discord: 'Discord', api: 'API', web: 'Web' }
@@ -373,6 +389,19 @@ watch(
   color: var(--color-text-dim);
   font-style: italic;
   flex-shrink: 0;
+}
+
+.msg-task-badge {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 0.5px;
+  color: var(--color-amber);
+  background: rgba(232, 170, 0, 0.12);
+  border: 1px solid rgba(232, 170, 0, 0.4);
+  border-radius: 2px;
+  padding: 1px 4px;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .msg-time {

--- a/frontend/src/composables/__tests__/useChatGrouping.spec.ts
+++ b/frontend/src/composables/__tests__/useChatGrouping.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { useChatGrouping, isToolUseGroup } from '../useChatGrouping'
+import type { ChatMessage } from '../../types'
+
+function msg(overrides: Partial<ChatMessage>): ChatMessage {
+  return { type: 'chat', from: 'foreman', content: '', ...overrides }
+}
+
+describe('useChatGrouping', () => {
+  it('keeps a plain foreman message and its taskId badge', () => {
+    const messages = ref<ChatMessage[]>([msg({ content: 'on it', taskId: 't-abc' })])
+    const grouped = useChatGrouping(messages)
+    expect(grouped.value).toHaveLength(1)
+    const only = grouped.value[0]
+    expect(isToolUseGroup(only)).toBe(false)
+    expect((only as ChatMessage).taskId).toBe('t-abc')
+  })
+
+  it('propagates the taskId from the first tool_use into the group', () => {
+    const messages = ref<ChatMessage[]>([
+      msg({ role: 'tool_use', toolName: 'send_followup', toolId: 'tu-1', taskId: 't-abc' }),
+      msg({ role: 'tool_use', toolName: 'get_pr_status', toolId: 'tu-2', taskId: 't-abc' }),
+    ])
+    const grouped = useChatGrouping(messages)
+    expect(grouped.value).toHaveLength(1)
+    const group = grouped.value[0]
+    expect(isToolUseGroup(group)).toBe(true)
+    if (isToolUseGroup(group)) {
+      expect(group.tools).toEqual(['send_followup', 'get_pr_status'])
+      expect(group.taskId).toBe('t-abc')
+    }
+  })
+
+  it('leaves the group taskId null for a parent-context tool call', () => {
+    const messages = ref<ChatMessage[]>([
+      msg({ role: 'tool_use', toolName: 'create_task', toolId: 'tu-1' }),
+    ])
+    const grouped = useChatGrouping(messages)
+    const group = grouped.value[0]
+    expect(isToolUseGroup(group)).toBe(true)
+    if (isToolUseGroup(group)) {
+      expect(group.taskId).toBeNull()
+    }
+  })
+})

--- a/frontend/src/composables/useChatGrouping.ts
+++ b/frontend/src/composables/useChatGrouping.ts
@@ -8,6 +8,9 @@ export interface ToolUseGroup {
   from: string
   createdAt?: string
   created_at?: string
+  // Carried from the first tool_use in the group so a child-context turn's
+  // tool calls badge the same as its narration lines.
+  taskId?: string | null
 }
 
 export type GroupedMessage = ChatMessage | ToolUseGroup
@@ -53,6 +56,7 @@ export function useChatGrouping(
           from: (first.from || first.from_agent || 'foreman') as string,
           createdAt: first.createdAt,
           created_at: first.created_at,
+          taskId: (first.taskId as string | null | undefined) ?? null,
         })
       } else if (msg.role === 'tool_result') {
         i++

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -140,6 +140,10 @@ export interface ChatMessage {
   from_agent?: string
   // Origin of the message: "web", "discord", "api". Missing/undefined means "web".
   source?: string
+  // Set on Foreman messages produced inside a per-task child context. When
+  // present, the chat pane badges the line as scoped to that task rather than
+  // the guild-wide Foreman conversation. See docs/foreman-per-task-context.md.
+  taskId?: string | null
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## Problem

An audit of Foreman thread routing surfaced a Discord mis-route and a missing UI signal for per-task child contexts.

**Discord mis-route.** A human message posted in a task's Discord thread arrives as an `event="chat"` trigger carrying a `task_id`. Because `"chat"` isn't a child event, `_run_foreman_ai` runs the parent/whole-guild conversation and forces `_task_id=None` — and that `None` was then reused for Discord routing, so the reply landed in the guild's **main channel** instead of back in the task thread the human was talking in (contradicting the router's own docstring).

**No visual indication.** Nothing in the chat pane distinguished a per-task child-context Foreman line from the guild-wide parent conversation.

## Audit — parent vs. child routing

| Trigger | Site | Context |
|---|---|---|
| `task-complete`, `followup-done`, `needs-input`, `task-error` | `ws_handlers._trigger_foreman` (`_CHILD_FOREMAN_EVENTS`) | Child |
| GitHub webhook events for a known task | `routes/webhooks.py` debounce | Child |
| User-requested follow-up | `routes/tasks.py` | Child |
| Web chat, `worker-online/offline`, `claude-auth`, `periodic-check` | various | Parent |
| Discord general chat (no task binding) | `discord/router.py` | Parent |
| Discord chat inside a task thread | `discord/router.py` | Parent — reply was mis-routed to main channel (fixed) |

## Solution

**Discord routing fix** (`backend/foreman/runner.py`). `_emit_foreman_chat` now separates two concerns that were conflated in `_task_id`:
- `child_task_id` — tags the WS `ChatMsg` for the frontend badge; set only on real child runs, so parent history stays untagged and isolated child histories aren't polluted.
- `discord_task_id` — routes the Discord mirror to the task's thread whenever the run concerns a task, including the parent-context reply to a task-thread message, so replies always land where the human is talking.

**Per-task visual indication.** `ChatMsg` carries a new `taskId` on child-context Foreman lines (text, tool_use, tool_result); `useChatGrouping` propagates it to tool-use groups; `ChatTab` renders a small task badge. The standalone foreman broadcasts the same `taskId` for parity.

**Carry `taskId` through the DB load/persist paths** (second commit). The live broadcast had the flag, but on page load/reconnect the frontend reads history from the REST guild payload, which dropped it:
- `routes/guilds._message_dict` — `row_to_dict` emitted the raw column `task_id`; remapped to `taskId` so reloaded history matches the live WS shape and badges correctly. The embedded runner already tags every persisted `Message` (tool_use / tool_result / final response) with `_task_id`, so this remap is enough there.
- Standalone foreman final message (`http_client.save_message` + `pioneer_foreman/runner`) was persisted untagged, unlike the embedded runner — now threads the child badge id through.
- `create_message` broadcast (`routes/foreman`) — includes `taskId` so the standalone foreman's final combined message badges live too.

## Tests

- Backend: `_emit_foreman_chat` badge-vs-Discord routing (child, parent-thread, plain-parent cases); `_message_dict` camelCase remap, null for parent messages, and meta-merge preserved alongside the badge.
- Frontend: `taskId` propagation through chat grouping (plain message, tool-use group, parent tool call).

**Commands run:** `pytest` backend foreman/discord/guild suites (76 passed + new unit tests), standalone foreman `pytest` (98 passed), frontend `vitest` (106 passed), `vue-tsc` type-check, ruff + eslint clean. DB-backed integration tests require the postgres-test container (not available in this environment); the changed functions are covered by DB-free unit tests.

## Notes

Out of scope but worth flagging: Discord Foreman-chat mirroring only works with the **embedded** foreman — when a standalone/external foreman is connected, `handle_foreman_broadcast` fans chat out to WS clients only, never to Discord. Pre-existing architectural gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ecanq5cn8swAPp2PHkNkK3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ecanq5cn8swAPp2PHkNkK3)_