### PR TITLE
Descope Discord webhook URL in favor of the bot (gateway app)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,20 +55,16 @@ CLAUDE_CODE_OAUTH_TOKEN=
 GITHUB_TOKEN=
 
 # --- Discord notifications (optional, backend-only) ---
-# See docs/discord.md for full setup instructions.
+# See docs/discord.md for full setup instructions. All notifications are
+# driven by the bot (gateway app); with no bot token set they are a no-op.
 
-# Phase 1: incoming webhook URL for flat-channel embed notifications.
-# Used as a fallback when DISCORD_BOT_TOKEN is not set.
-# DISCORD_WEBHOOK_URL=
-
-# Phase 2/3: bot token for per-PR/issue thread notifications, the Foreman
-# chat mirror, and slash commands. Phase 2 requires it together with
-# DISCORD_CHANNEL_ID. When absent, falls back to DISCORD_WEBHOOK_URL (or
-# no-ops if that is also unset).
+# Bot token for flat-channel embeds, per-PR/issue thread notifications, the
+# Foreman chat mirror, and slash commands. Required together with
+# DISCORD_CHANNEL_ID; no-ops when unset.
 # WARNING: keep this value out of version control
 # DISCORD_BOT_TOKEN=
 
-# Phase 2/3: ID of the text channel where per-PR/issue threads and the
+# ID of the text channel where flat embeds, per-PR/issue threads, and the
 # Foreman chat mirror threads are created.
 # Right-click the channel in Discord (Developer Mode) → Copy Channel ID.
 # DISCORD_CHANNEL_ID=
@@ -97,7 +93,7 @@ GITHUB_TOKEN=
 # (Claude's assistant/thinking text) into a dedicated per-task Discord thread as
 # silent, low-priority messages. Off by default because the feed is high-volume.
 # Requires DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID (always routes into a thread,
-# never the flat webhook).
+# never a flat channel post).
 # DISCORD_STREAM_TASKS=false
 
 # Phase 4: enable the persistent Gateway websocket (backend/discord/gateway.py)

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -1,18 +1,16 @@
-"""Discord notification helpers: flat webhook (Phase 1), per-PR/issue threads (Phase 2),
-Foreman chat threads + user mentions (Phase 3), and live task-stream mirroring (Phase 4).
+"""Discord notification helpers, all driven by the bot (gateway app): flat-channel
+embeds, per-PR/issue threads, Foreman chat threads + user mentions, and live
+task-stream mirroring.
 
-Phase 1 — flat webhook
-    Set ``DISCORD_WEBHOOK_URL`` in the environment to post embeds to a single channel.
+Everything requires the bot. Set ``DISCORD_BOT_TOKEN`` **and** ``DISCORD_CHANNEL_ID``
+to post embeds to the configured channel and to create/reuse one Discord thread per
+GitHub PR or issue. The thread mapping is persisted in the ``discord_threads`` DB table
+so restarts never duplicate threads.
 
-Phase 2 — per-PR/issue threads
-    Set ``DISCORD_BOT_TOKEN`` **and** ``DISCORD_CHANNEL_ID`` to create/reuse one
-    Discord thread per GitHub PR or issue.  The mapping is persisted in the
-    ``discord_threads`` DB table so restarts never duplicate threads.
-
-    When ``DISCORD_BOT_TOKEN`` is absent, every thread-aware call transparently
-    falls back to the flat-webhook behaviour if ``DISCORD_WEBHOOK_URL`` is set.
-    Both tokens absent → silent no-op.  HTTP and DB failures are always logged
-    at WARNING level and never propagate.
+    When a thread-aware call has no ``(issue_repo, issue_number)`` — or thread
+    creation fails — it falls back to a flat embed posted to the resolved channel
+    via the bot. No bot token → silent no-op. HTTP and DB failures are always
+    logged at WARNING level and never propagate.
 
 Phase 3 — Foreman chat threads + user mentions
     ``notify_foreman_chat`` mirrors Foreman → user chat narration into Discord.
@@ -37,17 +35,17 @@ Phase 4 — live task-stream mirroring
     batch is posted as a *silent* message (``SUPPRESS_NOTIFICATIONS`` flag, no
     mentions parsed) so a firehose of build output never pings anyone — a
     genuinely low-priority feed. Opt-in via ``DISCORD_STREAM_TASKS`` (requires a
-    bot token, since the feed always routes into a thread — never the flat
-    webhook). The per-task thread mapping persists in ``discord_task_threads``.
+    bot token, since the feed always routes into a thread — never a flat channel
+    post). The per-task thread mapping persists in ``discord_task_threads``.
 
-Required bot permissions for Phase 2/3: ``SEND_MESSAGES``, ``CREATE_PUBLIC_THREADS``, ``MANAGE_THREADS``.
+Required bot permissions: ``SEND_MESSAGES``, ``CREATE_PUBLIC_THREADS``, ``MANAGE_THREADS``.
 
 Usage::
 
-    # Legacy flat webhook (unchanged):
+    # Flat embed posted to the configured channel via the bot:
     await discord_notifier.notify("task-complete", "Task done", "t-abc finished")
 
-    # Thread-aware (routes to a per-PR thread or falls back):
+    # Thread-aware (routes to a per-PR thread or falls back to the channel):
     await discord_notifier.notify_event(
         "pr-opened",
         title="#42: Fix the bug",
@@ -112,11 +110,6 @@ def _get_client() -> httpx.AsyncClient:
     return _client
 
 
-def _webhook_url() -> str | None:
-    url = os.environ.get("DISCORD_WEBHOOK_URL")
-    return url if url else None
-
-
 def _bot_token() -> str | None:
     return os.environ.get("DISCORD_BOT_TOKEN") or None
 
@@ -126,17 +119,17 @@ def _channel_id() -> str | None:
 
 
 def is_configured() -> bool:
-    """Return True if either the flat webhook or the bot-thread path is set up.
+    """Return True if the Discord bot (gateway app) is set up.
 
     Cheap, side-effect-free check callers can use to skip expensive prep work
     (e.g. a live GitHub API call to resolve a thread title) when Discord
     notifications are disabled entirely.
     """
-    return bool(_bot_token() or _webhook_url())
+    return bool(_bot_token())
 
 
 # ---------------------------------------------------------------------------
-# Phase 1: flat webhook
+# Flat-channel notification (posted via the bot)
 # ---------------------------------------------------------------------------
 
 
@@ -146,38 +139,28 @@ async def notify(
     description: str,
     url: str | None = None,
     color: int | None = None,
+    ps_guild_slug: str | None = None,
 ) -> None:
-    """Post a Discord embed to the configured webhook.
+    """Post a Discord embed to the bot's configured channel.
 
-    Silent no-op when ``DISCORD_WEBHOOK_URL`` is not set.
-    Never raises — HTTP errors are logged at WARNING level.
+    Resolves the destination channel via the ``discord_channel_guilds``
+    binding for *ps_guild_slug* (when given), falling back to the flat
+    ``DISCORD_CHANNEL_ID`` env var. Silent no-op when the bot token or a
+    destination channel are not configured. Never raises — errors are logged
+    at WARNING level by the underlying bot request.
     """
-    webhook_url = _webhook_url()
-    if not webhook_url:
+    if not _bot_token():
         return
 
-    resolved_color = color if color is not None else _COLOURS.get(event_type, _DEFAULT_COLOUR)
+    channel = await _resolve_channel_for_guild(ps_guild_slug)
+    if not channel:
+        return
 
-    embed: dict = {
-        "title": title,
-        "description": description,
-        "color": resolved_color,
-    }
-    if url:
-        embed["url"] = url
-
-    payload = {"embeds": [embed]}
-
-    try:
-        client = _get_client()
-        resp = await client.post(webhook_url, json=payload)
-        resp.raise_for_status()
-    except Exception:
-        logger.warning("Discord webhook notify failed (event=%s)", event_type, exc_info=True)
+    await _post_to_thread(channel, event_type, title, description, url=url, color=color)
 
 
 # ---------------------------------------------------------------------------
-# Phase 2: bot-based thread helpers
+# Bot-based thread helpers
 # ---------------------------------------------------------------------------
 
 
@@ -561,8 +544,8 @@ async def notify_event(
     When ``close=True`` the thread is archived after the message is posted
     (used for PR merge/close events).
 
-    Falls back to the flat webhook when the bot token is absent or thread
-    operations fail.  Silent no-op when neither token is configured.
+    Falls back to a flat embed posted to the resolved channel when thread
+    operations fail. Silent no-op when the bot token is not configured.
     Never raises.
     """
     if _bot_token() and issue_repo and issue_number is not None:
@@ -583,8 +566,8 @@ async def notify_event(
                 await archive_thread(thread_id)
             return
 
-    # Fallback: flat webhook
-    await notify(event_type, title, description, url=url, color=color)
+    # Fallback: flat embed to the resolved channel
+    await notify(event_type, title, description, url=url, color=color, ps_guild_slug=ps_guild_slug)
 
 
 async def notify_existing_thread(
@@ -610,9 +593,9 @@ async def notify_existing_thread(
     would then be scattered across that wrong thread.
 
     ``notify_existing_thread`` avoids that by only ever looking up the thread
-    persisted in ``discord_threads``; when there isn't one, it falls back to
-    the flat webhook channel instead of creating anything. Silent no-op /
-    never raises, same guarantees as ``notify_event``.
+    persisted in ``discord_threads``; when there isn't one, it falls back to a
+    flat embed on the configured channel instead of creating anything. Silent
+    no-op / never raises, same guarantees as ``notify_event``.
     """
     if _bot_token() and issue_repo and issue_number is not None:
         thread_id = await _lookup_thread(issue_repo, issue_number)
@@ -620,7 +603,7 @@ async def notify_existing_thread(
             await _post_to_thread(thread_id, event_type, title, description, url=url, color=color)
             return
         logger.debug(
-            "notify_existing_thread: no thread on record for %s#%s, falling back to flat webhook",
+            "notify_existing_thread: no thread on record for %s#%s, falling back to flat channel",
             issue_repo,
             issue_number,
         )
@@ -657,7 +640,7 @@ def _stream_enabled() -> bool:
 
     Off by default: streaming a task's full terminal feed into Discord is
     high-volume and opt-in. Requires a bot token as well, since the feed is
-    always routed into a per-task thread (never the flat webhook).
+    always routed into a per-task thread (never a flat channel post).
     """
     flag = os.environ.get("DISCORD_STREAM_TASKS", "").strip().lower()
     return bool(_bot_token()) and flag in ("1", "true", "yes", "on")

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -19,7 +19,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import discord_notifier
 
-WEBHOOK_URL = "https://discord.com/api/webhooks/test/token"
 BOT_TOKEN = "Bot.test.token"
 CHANNEL_ID = "111222333444"
 THREAD_ID = "555666777888"
@@ -28,7 +27,6 @@ THREAD_ID = "555666777888"
 @pytest.fixture(autouse=True)
 def reset_env(monkeypatch):
     """Start each test with no tokens set."""
-    monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
     monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
     monkeypatch.delenv("DISCORD_CHANNEL_ID", raising=False)
     monkeypatch.delenv("DISCORD_STREAM_TASKS", raising=False)
@@ -76,13 +74,24 @@ def _make_mock_client(status_code: int = 204, side_effect=None, json_response: d
 
 
 # ---------------------------------------------------------------------------
-# Phase 1: flat webhook (unchanged behaviour)
+# Flat-channel notification (posted via the bot)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_notify_no_op_when_env_unset():
-    """notify() must not make any HTTP call when DISCORD_WEBHOOK_URL is unset."""
+async def test_notify_no_op_when_bot_token_unset():
+    """notify() must not make any HTTP call when DISCORD_BOT_TOKEN is unset."""
+    mock_client = _make_mock_client()
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier.notify("task-complete", "Done", "All good")
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_no_op_when_channel_unset(monkeypatch):
+    """notify() must not post when a destination channel cannot be resolved."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    # no DISCORD_CHANNEL_ID
     mock_client = _make_mock_client()
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
         await discord_notifier.notify("task-complete", "Done", "All good")
@@ -91,8 +100,9 @@ async def test_notify_no_op_when_env_unset():
 
 @pytest.mark.asyncio
 async def test_notify_posts_correct_embed(monkeypatch):
-    """notify() builds the right embed payload and POSTs it to the webhook."""
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    """notify() builds the right embed payload and POSTs it to the channel via the bot."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
     mock_client = _make_mock_client()
 
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
@@ -101,8 +111,9 @@ async def test_notify_posts_correct_embed(monkeypatch):
         )
 
     mock_client.post.assert_called_once()
-    _, kwargs = mock_client.post.call_args
-    body = kwargs["json"]
+    call_url = mock_client.post.call_args[0][0]
+    assert f"/channels/{CHANNEL_ID}/messages" in call_url
+    body = mock_client.post.call_args[1]["json"]
     assert body["embeds"][0]["title"] == "PR #42 opened"
     assert body["embeds"][0]["description"] == "New pull request"
     assert body["embeds"][0]["url"] == "https://example.com/pr/42"
@@ -112,7 +123,8 @@ async def test_notify_posts_correct_embed(monkeypatch):
 @pytest.mark.asyncio
 async def test_notify_no_url_field_when_omitted(monkeypatch):
     """url field must be absent from the embed when url=None."""
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
     mock_client = _make_mock_client()
 
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
@@ -145,7 +157,8 @@ async def test_notify_no_url_field_when_omitted(monkeypatch):
     ],
 )
 async def test_colour_by_event_type(monkeypatch, event_type, expected_color):
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
     mock_client = _make_mock_client()
 
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
@@ -158,7 +171,8 @@ async def test_colour_by_event_type(monkeypatch, event_type, expected_color):
 @pytest.mark.asyncio
 async def test_custom_color_overrides_event_type(monkeypatch):
     """Explicit color= kwarg takes precedence over the event-type colour map."""
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
     mock_client = _make_mock_client()
 
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
@@ -176,7 +190,8 @@ async def test_custom_color_overrides_event_type(monkeypatch):
 @pytest.mark.asyncio
 async def test_http_error_does_not_raise(monkeypatch):
     """An HTTP error must be swallowed and logged, never propagated."""
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
     mock_client = _make_mock_client(status_code=500)
 
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
@@ -186,7 +201,8 @@ async def test_http_error_does_not_raise(monkeypatch):
 @pytest.mark.asyncio
 async def test_network_error_does_not_raise(monkeypatch):
     """A network-level exception (connection refused etc.) must be swallowed."""
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
     mock_client = _make_mock_client(side_effect=httpx.ConnectError("refused"))
 
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
@@ -438,16 +454,15 @@ async def test_notify_event_archives_thread_on_close(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Phase 2: graceful fallback
+# Graceful fallback
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_notify_event_falls_back_to_webhook_when_no_bot_token(monkeypatch):
-    """notify_event falls back to flat webhook when DISCORD_BOT_TOKEN is absent."""
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
-    # no bot token
-
+async def test_notify_event_noop_when_no_bot_token(monkeypatch):
+    """notify_event is a no-op when DISCORD_BOT_TOKEN is absent."""
+    # no bot token — the flat-channel fallback also runs through the bot, so
+    # without a token there is nothing to post through.
     mock_client = _make_mock_client(status_code=204)
 
     with patch.object(discord_notifier, "_get_client", return_value=mock_client):
@@ -460,18 +475,14 @@ async def test_notify_event_falls_back_to_webhook_when_no_bot_token(monkeypatch)
             issue_number=1,
         )
 
-    # Should use the webhook URL, not a bot API endpoint
-    mock_client.post.assert_called_once()
-    call_url = mock_client.post.call_args[0][0]
-    assert call_url == WEBHOOK_URL
+    mock_client.post.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_notify_event_falls_back_when_thread_creation_fails(monkeypatch):
-    """notify_event falls back to flat webhook when thread creation returns None."""
+async def test_notify_event_falls_back_to_channel_when_thread_creation_fails(monkeypatch):
+    """notify_event falls back to a flat channel embed when thread creation returns None."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
 
     mock_client = _make_mock_client(status_code=204)
 
@@ -487,10 +498,10 @@ async def test_notify_event_falls_back_when_thread_creation_fails(monkeypatch):
             issue_number=1,
         )
 
-    # Should use the webhook URL as fallback
+    # Should post a flat embed to the configured channel via the bot
     mock_client.post.assert_called_once()
     call_url = mock_client.post.call_args[0][0]
-    assert call_url == WEBHOOK_URL
+    assert f"/channels/{CHANNEL_ID}/messages" in call_url
 
 
 @pytest.mark.asyncio
@@ -544,10 +555,10 @@ async def test_notify_existing_thread_never_creates_new_thread(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_notify_existing_thread_falls_back_to_webhook_when_no_thread(monkeypatch):
-    """notify_existing_thread falls back to the flat webhook when no thread is persisted."""
+async def test_notify_existing_thread_falls_back_to_channel_when_no_thread(monkeypatch):
+    """notify_existing_thread falls back to a flat channel embed when no thread is persisted."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
     mock_client = _make_mock_client(status_code=204)
 
@@ -565,14 +576,14 @@ async def test_notify_existing_thread_falls_back_to_webhook_when_no_thread(monke
 
     mock_client.post.assert_called_once()
     call_url = mock_client.post.call_args[0][0]
-    assert call_url == WEBHOOK_URL
+    assert f"/channels/{CHANNEL_ID}/messages" in call_url
 
 
 @pytest.mark.asyncio
-async def test_notify_existing_thread_without_issue_coords_uses_webhook(monkeypatch):
-    """notify_existing_thread without repo/number skips the lookup and uses the webhook."""
+async def test_notify_existing_thread_without_issue_coords_uses_channel(monkeypatch):
+    """notify_existing_thread without repo/number skips the lookup and posts to the channel."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
     mock_client = _make_mock_client(status_code=204)
 
@@ -589,13 +600,13 @@ async def test_notify_existing_thread_without_issue_coords_uses_webhook(monkeypa
     lookup_mock.assert_not_called()
     mock_client.post.assert_called_once()
     call_url = mock_client.post.call_args[0][0]
-    assert call_url == WEBHOOK_URL
+    assert f"/channels/{CHANNEL_ID}/messages" in call_url
 
 
 @pytest.mark.asyncio
-async def test_notify_event_silent_noop_when_no_tokens(monkeypatch):
-    """notify_event is a no-op when neither bot token nor webhook are set."""
-    # no bot token, no webhook URL
+async def test_notify_event_silent_noop_when_no_bot_token(monkeypatch):
+    """notify_event is a no-op when the bot token is not set."""
+    # no bot token
 
     mock_client = _make_mock_client()
 
@@ -616,10 +627,10 @@ async def test_notify_event_silent_noop_when_no_tokens(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_notify_event_without_issue_coords_uses_webhook(monkeypatch):
-    """notify_event without repo/number falls back to flat webhook (no thread attempt)."""
+async def test_notify_event_without_issue_coords_uses_channel(monkeypatch):
+    """notify_event without repo/number falls back to a flat channel embed (no thread attempt)."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
-    monkeypatch.setenv("DISCORD_WEBHOOK_URL", WEBHOOK_URL)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
     mock_client = _make_mock_client(status_code=204)
 
@@ -632,7 +643,7 @@ async def test_notify_event_without_issue_coords_uses_webhook(monkeypatch):
 
     mock_client.post.assert_called_once()
     call_url = mock_client.post.call_args[0][0]
-    assert call_url == WEBHOOK_URL
+    assert f"/channels/{CHANNEL_ID}/messages" in call_url
 
 
 # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,10 +59,8 @@ services:
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
       # --- Discord notifications (optional, see docs/discord.md) ---
-      # Phase 1: flat-channel webhook notifications.
-      DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL:-}
-      # Phase 2: bot-based per-PR/issue thread notifications. Both required
-      # together; used when DISCORD_BOT_TOKEN is absent; falls back to webhook-only mode.
+      # Bot (gateway app) drives all notifications: flat-channel embeds and
+      # per-PR/issue thread notifications. Both required together; no-op when unset.
       DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
       DISCORD_CHANNEL_ID: ${DISCORD_CHANNEL_ID:-}
       # Phase 3: slash commands & bidirectional control.

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -5,16 +5,16 @@ discussion threads, a live Foreman chat feed, and `/ps` slash commands that let 
 the factory floor from Discord. Everything is optional and additive — with no Discord env
 vars set, the integration is a silent no-op.
 
-The integration shipped in three phases, all backwards-compatible with the phase before it:
+Everything is driven by the Discord bot (the "gateway app"). The feature set layers up as you
+add credentials:
 
-| Phase | What it adds | Needs |
+| Layer | What it adds | Needs |
 |---|---|---|
-| 1 | Flat-channel webhook notifications | `DISCORD_WEBHOOK_URL` |
-| 2 | Per-PR/issue threads, thread archiving | `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` |
-| 3 | Slash commands, Foreman chat mirror, @-mentions | `DISCORD_APPLICATION_ID` + `DISCORD_PUBLIC_KEY` (+ Phase 2 vars) |
+| Notifications | Flat-channel embeds, per-PR/issue threads, thread archiving | `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` |
+| Slash commands | `/ps` commands, Foreman chat mirror, @-mentions | `DISCORD_APPLICATION_ID` + `DISCORD_PUBLIC_KEY` (+ the bot vars) |
 
-You can stop at any phase — e.g. run Phase 1 only for simple notifications, or Phase 1 + 2
-without ever setting up slash commands.
+You can stop after the notification layer — set the bot token and channel for embeds and
+threads without ever setting up slash commands.
 
 ## Setup guide
 
@@ -27,7 +27,7 @@ In the [Discord Developer Portal](https://discord.com/developers/applications):
    Keep it out of version control.
 3. Under **General Information**, copy the **Application ID** (`DISCORD_APPLICATION_ID`) and
    **Public Key** (`DISCORD_PUBLIC_KEY`).
-4. If you plan to use slash commands (Phase 3), set **Interactions Endpoint URL** on the same
+4. If you plan to use slash commands, set **Interactions Endpoint URL** on the same
    page to `https://<your-domain>/discord/interactions` (e.g.
    `https://pioneer-square.melloy.life/discord/interactions`) — the backend serves both the
    SPA and the API from a single public origin, so this is the same host users open in a
@@ -46,11 +46,11 @@ In the [Discord Developer Portal](https://discord.com/developers/applications):
 | Permission | Needed for |
 |---|---|
 | `SEND_MESSAGES` | Posting notifications and thread starter messages |
-| `CREATE_PUBLIC_THREADS` | Creating per-PR/issue threads (Phase 2) |
-| `MANAGE_THREADS` | Archiving threads on PR merge/close (Phase 2) |
+| `CREATE_PUBLIC_THREADS` | Creating per-PR/issue threads |
+| `MANAGE_THREADS` | Archiving threads on PR merge/close |
 
 Build an invite URL with the **OAuth2 URL Generator** (OAuth2 → URL Generator):
-- Scopes: `bot` (and `applications.commands` if you want slash commands — Phase 3)
+- Scopes: `bot` (and `applications.commands` if you want slash commands)
 - Bot permissions: the three above
 
 Open the generated URL and invite the bot to your server before setting any env vars — the
@@ -58,18 +58,17 @@ bot must already be a member of the guild that owns `DISCORD_CHANNEL_ID`.
 
 ### 3. Environment variables
 
-| Variable | Phase | Required | Description |
-|---|---|---|---|
-| `DISCORD_WEBHOOK_URL` | 1 | No | Incoming webhook URL for flat-channel embeds. Create one via a channel's *Integrations → Webhooks*. Also used as the fallback target when the bot token is unset or thread routing fails. |
-| `DISCORD_BOT_TOKEN` | 2/3 | No | Bot token from the Developer Portal. Enables thread routing, slash commands, and the Foreman chat mirror. Reused across all three phases. |
-| `DISCORD_CHANNEL_ID` | 2/3 | With `DISCORD_BOT_TOKEN` | ID of the text channel new threads are created in. Enable Developer Mode in Discord settings, then right-click the channel → *Copy Channel ID*. |
-| `DISCORD_APPLICATION_ID` | 3 | For slash commands | Application ID, used to build the followup-message URL when editing a deferred slash command reply. |
-| `DISCORD_PUBLIC_KEY` | 3 | For slash commands | Ed25519 public key (hex) used to verify `POST /discord/interactions` requests. Without it, the endpoint refuses all requests with 401. |
-| `DISCORD_ALLOWED_ROLE_IDS` | 3 | No | Comma-separated Discord role IDs allowed to run `/ps` commands. Empty/unset = everyone allowed. DM interactions are always denied when this is set (no role info is available outside a guild). |
-| `DISCORD_PIONEER_GUILD_SLUG` | 3 | For slash commands | The Pioneer Square guild (workspace) slug that `/ps` commands operate against. Not a Discord ID — see [Terminology note](#terminology-note-guild-vs-guild) below. |
-| `DISCORD_OPERATOR_ROLE_NAME` | 3 | No | Discord role name (in addition to the Manage Channels permission) allowed to run `/join-channel` and `/leave-channel`. Default `Pioneer Square Operator`. |
-| `DISCORD_DEV_GUILD_ID` | 3 (registration only) | No | Discord server ID. When set, `scripts/register_discord_commands.py` registers commands to that one server (near-instant) instead of globally (up to 1 hour to propagate). |
-| `DISCORD_STREAM_TASKS` | 2+ | No | When truthy (`1`/`true`/`yes`/`on`), mirror each working task's live terminal output into a dedicated per-task Discord thread as silent, low-priority messages. Off by default (high-volume). Requires `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` — the feed always routes into a thread, never the flat webhook. |
+| Variable | Required | Description |
+|---|---|---|
+| `DISCORD_BOT_TOKEN` | For any notifications | Bot token from the Developer Portal. Drives flat-channel embeds, thread routing, slash commands, and the Foreman chat mirror. |
+| `DISCORD_CHANNEL_ID` | With `DISCORD_BOT_TOKEN` | ID of the text channel where flat embeds are posted and new threads are created. Enable Developer Mode in Discord settings, then right-click the channel → *Copy Channel ID*. |
+| `DISCORD_APPLICATION_ID` | For slash commands | Application ID, used to build the followup-message URL when editing a deferred slash command reply. |
+| `DISCORD_PUBLIC_KEY` | For slash commands | Ed25519 public key (hex) used to verify `POST /discord/interactions` requests. Without it, the endpoint refuses all requests with 401. |
+| `DISCORD_ALLOWED_ROLE_IDS` | No | Comma-separated Discord role IDs allowed to run `/ps` commands. Empty/unset = everyone allowed. DM interactions are always denied when this is set (no role info is available outside a guild). |
+| `DISCORD_PIONEER_GUILD_SLUG` | For slash commands | The Pioneer Square guild (workspace) slug that `/ps` commands operate against. Not a Discord ID — see [Terminology note](#terminology-note-guild-vs-guild) below. |
+| `DISCORD_OPERATOR_ROLE_NAME` | No | Discord role name (in addition to the Manage Channels permission) allowed to run `/join-channel` and `/leave-channel`. Default `Pioneer Square Operator`. |
+| `DISCORD_DEV_GUILD_ID` | No (registration only) | Discord server ID. When set, `scripts/register_discord_commands.py` registers commands to that one server (near-instant) instead of globally (up to 1 hour to propagate). |
+| `DISCORD_STREAM_TASKS` | No | When truthy (`1`/`true`/`yes`/`on`), mirror each working task's live terminal output into a dedicated per-task Discord thread as silent, low-priority messages. Off by default (high-volume). Requires `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` — the feed always routes into a thread, never a flat channel post. |
 
 `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` must be set **together** — the bot needs both
 the credential and a destination channel to create threads.
@@ -82,7 +81,7 @@ a **Pioneer Square** guild slug, not a Discord server ID — it tells the `/ps` 
 which Pioneer Square workspace to query and mutate. The Discord server your bot lives in is
 identified only implicitly, via `DISCORD_CHANNEL_ID`.
 
-### 4. Register slash commands (Phase 3 only)
+### 4. Register slash commands (slash commands only)
 
 Slash commands aren't automatically registered — run this once after deploying, and again
 whenever `scripts/register_discord_commands.py` changes:
@@ -105,14 +104,12 @@ DISCORD_APPLICATION_ID=<id> DISCORD_BOT_TOKEN=<token> \
 them in your `.env` (copy from `.env.example`):
 
 ```dotenv
-# Phase 1: flat-channel webhook notifications.
-DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy
-
-# Phase 2: bot-based per-PR/issue thread notifications. Both required together.
+# Bot-based flat-channel embeds and per-PR/issue thread notifications.
+# Both required together.
 DISCORD_BOT_TOKEN=MTxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 DISCORD_CHANNEL_ID=1234567890123456789
 
-# Phase 3: slash commands & bidirectional control.
+# Slash commands & bidirectional control.
 DISCORD_APPLICATION_ID=1234567890123456789
 DISCORD_PUBLIC_KEY=<hex public key>
 DISCORD_ALLOWED_ROLE_IDS=1111111111111111,2222222222222222
@@ -125,9 +122,10 @@ docker compose up --build backend
 
 ## Feature reference
 
-### Phase 1 — flat webhook notifications
+### Flat-channel notifications
 
-Set only `DISCORD_WEBHOOK_URL` to post colour-coded embeds to a single channel. Delivery is
+With `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` set, events that don't map to a per-PR/issue
+thread post colour-coded embeds directly to the configured channel via the bot. Delivery is
 fire-and-forget: notifications run as detached background tasks and never block the caller;
 HTTP failures are logged at WARNING and swallowed, never raised.
 
@@ -147,13 +145,11 @@ Colour palette (sidebar colour of the embed):
 `task-failed` and `task-cancelled` have colours reserved but are not currently emitted by any
 call site — only the events listed below actually fire notifications today:
 
-- `worker-online` / `worker-offline` — always flat (never thread-routed), fired on WebSocket
-  worker connect/disconnect.
 - `pr-opened`, `pr-merged`, `pr-closed` — fired from the GitHub webhook handler.
 - `ci-pass`, `ci-fail` — fired from GitHub `check_run`/`check_suite` webhook events.
 - `task-complete` — fired when a worker reports a task finished.
 
-### Phase 2 — per-PR/issue threads
+### Per-PR/issue threads
 
 Add `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` to route PR/issue-related events into one
 Discord thread per `(issue_repo, issue_number)` pair instead of a flat channel.
@@ -171,16 +167,15 @@ Discord thread per `(issue_repo, issue_number)` pair instead of a flat channel.
 4. **Archive** — on `pr-merged` or `pr-closed`, a closing summary is posted and the thread is
    archived (`PATCH` with `archived: true`).
 
-**Fallback behaviour** — thread routing is attempted only when `DISCORD_BOT_TOKEN` is set
-*and* the event carries `issue_repo`/`issue_number`. It falls back to the Phase 1 flat webhook
-when:
-- `DISCORD_BOT_TOKEN` is unset, or
-- thread creation fails (missing channel, Discord API error, DB error).
+**Fallback behaviour** — thread routing is attempted only when the event carries
+`issue_repo`/`issue_number`. When it doesn't, or when thread creation fails (missing channel,
+Discord API error, DB error), the event falls back to a flat embed posted to the configured
+channel via the bot.
 
-If neither `DISCORD_BOT_TOKEN` nor `DISCORD_WEBHOOK_URL` is set, notifications are a silent
-no-op — nothing is sent and nothing is logged as an error.
+If `DISCORD_BOT_TOKEN` is not set, notifications are a silent no-op — nothing is sent and
+nothing is logged as an error.
 
-### Phase 3 — slash commands & bidirectional control
+### Slash commands & bidirectional control
 
 Adds `POST /discord/interactions`, a signed webhook endpoint Discord calls for every
 interaction (health-check pings and slash-command invocations).
@@ -215,7 +210,7 @@ sends to a user (not tool-call traces) is mirrored into Discord via
 
 ### Live task-stream mirroring
 
-Set `DISCORD_STREAM_TASKS` (plus the Phase 2 `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID`) to
+Set `DISCORD_STREAM_TASKS` (plus `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID`) to
 mirror a worker task's **live terminal output** into Discord while it runs — a low-priority
 feed of what each agent is actually doing, without leaving the app.
 
@@ -303,8 +298,8 @@ rendered in a notification (currently: PR-opened assignees). It:
 
 | Symptom | Likely cause |
 |---|---|
-| No Discord messages at all, no errors | Neither `DISCORD_WEBHOOK_URL` nor `DISCORD_BOT_TOKEN` is set — this is a silent no-op by design. Check `docker compose config` to confirm the vars actually reach the `backend` container. |
-| Notifications land in the flat channel instead of a thread | `DISCORD_BOT_TOKEN` is set but `DISCORD_CHANNEL_ID` is missing, or thread creation failed and it fell back to `DISCORD_WEBHOOK_URL`. Check backend logs for `discord: bot API request failed` / `discord: thread DB save failed` warnings. |
+| No Discord messages at all, no errors | `DISCORD_BOT_TOKEN` is not set — this is a silent no-op by design. Check `docker compose config` to confirm the vars actually reach the `backend` container. |
+| Notifications land in the flat channel instead of a thread | The event carries no `issue_repo`/`issue_number`, or thread creation failed and it fell back to a flat channel embed. Check backend logs for `discord: bot API request failed` / `discord: thread DB save failed` warnings. |
 | Bot API calls fail with 403 | Bot is missing `SEND_MESSAGES`, `CREATE_PUBLIC_THREADS`, or `MANAGE_THREADS` — re-invite it with the correct OAuth2 scopes/permissions, or grant channel-level permission overwrites. |
 | Slash commands don't appear in Discord | Commands were never registered, or registered globally and haven't propagated yet (up to 1 hour). Run `scripts/register_discord_commands.py`; use `DISCORD_DEV_GUILD_ID` for instant guild-scoped registration while iterating. |
 | `POST /discord/interactions` returns `401 Invalid signature` | `DISCORD_PUBLIC_KEY` is unset or doesn't match the application, or a reverse proxy is rewriting/re-encoding the raw request body (the signature is computed over the exact bytes Discord sent). |


### PR DESCRIPTION
Remove DISCORD_WEBHOOK_URL support. All Discord notifications are now driven
by the bot: flat/non-threaded events post embeds to the resolved channel via
the bot API instead of an incoming webhook, and thread-aware calls fall back
to that same bot channel post when no thread applies or thread creation fails.

- discord_notifier.notify() now posts via the bot (resolving the channel,
  with optional ps_guild_slug), rather than POSTing to DISCORD_WEBHOOK_URL
- is_configured() keys off the bot token only
- Drop DISCORD_WEBHOOK_URL from .env.example and docker-compose.yml
- Update docs/discord.md and tests accordingly

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AEUPrHwHKyNYWsdgj2mAqT