### PR TITLE
Discord: /worker-spawn slash command (#769)

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -842,8 +842,14 @@ async def spawn_worker(
     guild_id: str,
     guild_pk: int | None,
     db,
+    user_id: str | None = None,
 ) -> tuple[str, bool]:
     """Spawn a new worker container.
+
+    *user_id* identifies the human on whose behalf the worker is being spawned
+    (e.g. a Discord user's linked Pioneer Square account) and is stamped onto
+    the new ``Worker`` row for ownership attribution. ``None`` for
+    unattributed spawns.
 
     Returns (result_text, is_error).
     """
@@ -867,6 +873,7 @@ async def spawn_worker(
             created_at=created_at,
             auth_token=auth_token,
             name=worker_name,
+            user_id=user_id,
         )
     )
     await db.commit()

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -23,6 +23,7 @@ Registered slash commands (see scripts/register_discord_commands.py):
     /join-channel <channel> [guild]     — wire a Discord channel to a Pioneer Square guild
     /leave-channel [channel]            — remove a channel's Pioneer Square guild binding
     /connect-account                    — link your Discord account to Pioneer Square
+    /worker-spawn [repos] [tools]       — spawn a new worker (requires a connected account)
 """
 
 from __future__ import annotations
@@ -43,6 +44,7 @@ from events import broadcast_msg
 from fastapi import APIRouter, BackgroundTasks, Request, Response
 from models import (
     Agent,
+    DiscordAccountLink,
     DiscordChannelGuild,
     DiscordConnectToken,
     Guild,
@@ -662,6 +664,99 @@ async def _cmd_connect_account(interaction: dict) -> None:
     )
 
 
+async def _cmd_worker_spawn(interaction: dict) -> None:
+    """Spawn a new worker via the same tool the Foreman AI uses to spawn workers.
+
+    Requires the invoking Discord user to have linked their account with
+    ``/connect-account`` first — spawning a worker starts a container and
+    consumes credentials, so it's gated on the same account link used to
+    resolve identity elsewhere (see ``discord/router.py::_resolve_identity``).
+    """
+    token = interaction.get("token", "")
+    data = interaction.get("data", {})
+
+    identity = _interaction_user(interaction)
+    if not identity:
+        await _send_followup(token, content="Could not determine your Discord account.")
+        return
+    discord_user_id, _ = identity
+
+    options = {o["name"]: o for o in data.get("options", [])}
+    repos_opt = options.get("repos")
+    tools_opt = options.get("tools")
+    repos = (
+        [r.strip() for r in str(repos_opt["value"]).split(",") if r.strip()] if repos_opt else []
+    )
+    tools_list = (
+        [t.strip() for t in str(tools_opt["value"]).split(",") if t.strip()] if tools_opt else []
+    )
+
+    guild_slug = _pioneer_guild_slug() or ""
+
+    try:
+        async with AsyncSessionLocal() as db:
+            link_result = await db.exec(
+                select(col(DiscordAccountLink.ps_user_id)).where(
+                    col(DiscordAccountLink.discord_user_id) == discord_user_id
+                )
+            )
+            if not link_result.one_or_none():
+                await _send_followup(
+                    token,
+                    content=(
+                        "Your Discord account isn't linked to Pioneer Square yet. "
+                        "Run `/connect-account` first, then try again."
+                    ),
+                )
+                return
+
+            guild_result = await db.exec(select(Guild).where(col(Guild.slug) == guild_slug))
+            guild = guild_result.one_or_none()
+            if not guild:
+                await _send_followup(token, content=f"Pioneer guild `{guild_slug}` not found.")
+                return
+
+            from foreman.tools import spawn_worker  # noqa: PLC0415
+
+            result_text, is_error = await spawn_worker(
+                inp={"repos": repos, "tools": tools_list or None},
+                guild_id=guild_slug,
+                guild_pk=guild.id,
+                db=db,
+            )
+
+            if is_error:
+                await _send_followup(token, content=f"Failed to spawn worker: {result_text}")
+                return
+
+            info = json.loads(result_text)
+            worker_id = info.get("worker_id", "unknown")
+
+            state_result = await db.exec(
+                select(col(Worker.state)).where(col(Worker.id) == worker_id)
+            )
+            state = state_result.one_or_none() or "offline"
+    except Exception:
+        logger.exception("discord: /worker-spawn failed")
+        await _send_followup(token, content="Failed to spawn worker.")
+        return
+
+    status = "online" if state not in ("offline", "spawn_failed") else "queued"
+    embeds = [
+        {
+            "title": f"Worker Spawned: {worker_id}",
+            "description": (
+                f"Status: **{status}**\n"
+                f"Repos: {', '.join(repos) if repos else '—'}\n"
+                f"Tools: {', '.join(tools_list) if tools_list else 'default'}"
+            ),
+            "color": 0xF39C12,
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+    ]
+    await _send_followup(token, embeds=embeds)
+
+
 async def _permission_denied_message() -> str:
     return (
         "You need the `Manage Channels` permission or the "
@@ -831,6 +926,9 @@ async def _dispatch_command(interaction: dict) -> None:
         return
     if command_name == "connect-account":
         await _cmd_connect_account(interaction)
+        return
+    if command_name == "worker-spawn":
+        await _cmd_worker_spawn(interaction)
         return
 
     guild_slug = _pioneer_guild_slug() or ""

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -42,6 +42,7 @@ from database import AsyncSessionLocal
 from discord.auth import is_member_authorized
 from events import broadcast_msg
 from fastapi import APIRouter, BackgroundTasks, Request, Response
+from foreman.tools import spawn_worker
 from models import (
     Agent,
     DiscordAccountLink,
@@ -700,7 +701,8 @@ async def _cmd_worker_spawn(interaction: dict) -> None:
                     col(DiscordAccountLink.discord_user_id) == discord_user_id
                 )
             )
-            if not link_result.one_or_none():
+            ps_user_id = link_result.one_or_none()
+            if not ps_user_id:
                 await _send_followup(
                     token,
                     content=(
@@ -716,13 +718,12 @@ async def _cmd_worker_spawn(interaction: dict) -> None:
                 await _send_followup(token, content=f"Pioneer guild `{guild_slug}` not found.")
                 return
 
-            from foreman.tools import spawn_worker  # noqa: PLC0415
-
             result_text, is_error = await spawn_worker(
-                inp={"repos": repos, "tools": tools_list or None},
+                inp={"repos": repos or None, "tools": tools_list or None},
                 guild_id=guild_slug,
                 guild_pk=guild.id,
                 db=db,
+                user_id=ps_user_id,
             )
 
             if is_error:
@@ -741,7 +742,7 @@ async def _cmd_worker_spawn(interaction: dict) -> None:
         await _send_followup(token, content="Failed to spawn worker.")
         return
 
-    status = "online" if state not in ("offline", "spawn_failed") else "queued"
+    status = state if state == "online" else "queued"
     embeds = [
         {
             "title": f"Worker Spawned: {worker_id}",

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -558,7 +558,7 @@ async def test_cmd_cancel_already_done(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _cmd_worker_spawn — all DB calls and foreman.tools.spawn_worker mocked
+# _cmd_worker_spawn — all DB calls and routes.discord.spawn_worker mocked
 # ---------------------------------------------------------------------------
 
 
@@ -608,7 +608,7 @@ async def test_cmd_worker_spawn_success(monkeypatch):
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
         patch("routes.discord._discord_patch", new=fake_patch),
-        patch("foreman.tools.spawn_worker", new=fake_spawn_worker),
+        patch("routes.discord.spawn_worker", new=fake_spawn_worker),
     ):
         from routes.discord import _cmd_worker_spawn
 
@@ -619,11 +619,57 @@ async def test_cmd_worker_spawn_success(monkeypatch):
     assert call_kwargs["inp"] == {"repos": ["org/repo"], "tools": ["claude"]}
     assert call_kwargs["guild_id"] == "test-guild"
     assert call_kwargs["guild_pk"] == 1
+    assert call_kwargs["user_id"] == "ps-user-1"
 
     assert sent
     embed = sent[0]["embeds"][0]
     assert "w-abc123" in embed["title"]
     assert "online" in embed["description"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_worker_spawn_reports_queued_status(monkeypatch):
+    """_cmd_worker_spawn reports 'queued' (not 'online') for a freshly-spawned worker."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    monkeypatch.setenv("DISCORD_PIONEER_GUILD_SLUG", "test-guild")
+
+    guild = MagicMock()
+    guild.id = 1
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value="ps-user-1")),  # account link lookup
+            MagicMock(one_or_none=MagicMock(return_value=guild)),  # guild lookup
+            MagicMock(one_or_none=MagicMock(return_value="spawning")),  # worker state lookup
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    fake_spawn_worker = AsyncMock(
+        return_value=(json.dumps({"worker_id": "w-abc123", "repos": ["org/repo"]}), False)
+    )
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("routes.discord.spawn_worker", new=fake_spawn_worker),
+    ):
+        from routes.discord import _cmd_worker_spawn
+
+        await _cmd_worker_spawn(_worker_spawn_interaction())
+
+    assert sent
+    embed = sent[0]["embeds"][0]
+    assert "queued" in embed["description"]
+    assert "online" not in embed["description"]
 
 
 @pytest.mark.asyncio
@@ -648,7 +694,7 @@ async def test_cmd_worker_spawn_requires_connected_account(monkeypatch):
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
         patch("routes.discord._discord_patch", new=fake_patch),
-        patch("foreman.tools.spawn_worker", new=fake_spawn_worker),
+        patch("routes.discord.spawn_worker", new=fake_spawn_worker),
     ):
         from routes.discord import _cmd_worker_spawn
 
@@ -726,7 +772,7 @@ async def test_cmd_worker_spawn_reports_tool_error(monkeypatch):
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
         patch("routes.discord._discord_patch", new=fake_patch),
-        patch("foreman.tools.spawn_worker", new=fake_spawn_worker),
+        patch("routes.discord.spawn_worker", new=fake_spawn_worker),
     ):
         from routes.discord import _cmd_worker_spawn
 

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -558,6 +558,186 @@ async def test_cmd_cancel_already_done(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# _cmd_worker_spawn — all DB calls and foreman.tools.spawn_worker mocked
+# ---------------------------------------------------------------------------
+
+
+def _worker_spawn_interaction(repos: str | None = "org/repo", tools: str | None = "claude"):
+    options = []
+    if repos is not None:
+        options.append({"name": "repos", "value": repos})
+    if tools is not None:
+        options.append({"name": "tools", "value": tools})
+    return {
+        "token": "tok-spawn",
+        "data": {"name": "worker-spawn", "options": options},
+        "member": {"user": {"id": "discord-1", "username": "alice"}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_cmd_worker_spawn_success(monkeypatch):
+    """_cmd_worker_spawn spawns a worker and reports its id and status."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    monkeypatch.setenv("DISCORD_PIONEER_GUILD_SLUG", "test-guild")
+
+    guild = MagicMock()
+    guild.id = 1
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value="ps-user-1")),  # account link lookup
+            MagicMock(one_or_none=MagicMock(return_value=guild)),  # guild lookup
+            MagicMock(one_or_none=MagicMock(return_value="online")),  # worker state lookup
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    fake_spawn_worker = AsyncMock(
+        return_value=(json.dumps({"worker_id": "w-abc123", "repos": ["org/repo"]}), False)
+    )
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("foreman.tools.spawn_worker", new=fake_spawn_worker),
+    ):
+        from routes.discord import _cmd_worker_spawn
+
+        await _cmd_worker_spawn(_worker_spawn_interaction())
+
+    assert fake_spawn_worker.called
+    call_kwargs = fake_spawn_worker.call_args.kwargs
+    assert call_kwargs["inp"] == {"repos": ["org/repo"], "tools": ["claude"]}
+    assert call_kwargs["guild_id"] == "test-guild"
+    assert call_kwargs["guild_pk"] == 1
+
+    assert sent
+    embed = sent[0]["embeds"][0]
+    assert "w-abc123" in embed["title"]
+    assert "online" in embed["description"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_worker_spawn_requires_connected_account(monkeypatch):
+    """_cmd_worker_spawn refuses when the Discord account isn't linked."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    monkeypatch.setenv("DISCORD_PIONEER_GUILD_SLUG", "test-guild")
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=None)))
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    fake_spawn_worker = AsyncMock()
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("foreman.tools.spawn_worker", new=fake_spawn_worker),
+    ):
+        from routes.discord import _cmd_worker_spawn
+
+        await _cmd_worker_spawn(_worker_spawn_interaction())
+
+    fake_spawn_worker.assert_not_called()
+    assert sent
+    assert "isn't linked" in sent[0]["content"]
+    assert "/connect-account" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_worker_spawn_unknown_guild(monkeypatch):
+    """_cmd_worker_spawn reports an error when the configured guild slug is missing."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    monkeypatch.setenv("DISCORD_PIONEER_GUILD_SLUG", "missing-guild")
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value="ps-user-1")),
+            MagicMock(one_or_none=MagicMock(return_value=None)),
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+    ):
+        from routes.discord import _cmd_worker_spawn
+
+        await _cmd_worker_spawn(_worker_spawn_interaction())
+
+    assert sent
+    assert "not found" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_worker_spawn_reports_tool_error(monkeypatch):
+    """_cmd_worker_spawn surfaces the tool's error message (e.g. missing repos)."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    monkeypatch.setenv("DISCORD_PIONEER_GUILD_SLUG", "test-guild")
+
+    guild = MagicMock()
+    guild.id = 1
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value="ps-user-1")),
+            MagicMock(one_or_none=MagicMock(return_value=guild)),
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    fake_spawn_worker = AsyncMock(
+        return_value=("spawn_worker requires at least one repo in the 'repos' list.", True)
+    )
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("foreman.tools.spawn_worker", new=fake_spawn_worker),
+    ):
+        from routes.discord import _cmd_worker_spawn
+
+        await _cmd_worker_spawn(_worker_spawn_interaction(repos=None, tools=None))
+
+    assert sent
+    assert "Failed to spawn worker" in sent[0]["content"]
+    assert "at least one repo" in sent[0]["content"]
+
+
+# ---------------------------------------------------------------------------
 # Permission helpers for /join-channel and /leave-channel (pure unit)
 # ---------------------------------------------------------------------------
 

--- a/scripts/register_discord_commands.py
+++ b/scripts/register_discord_commands.py
@@ -119,6 +119,24 @@ COMMANDS = [
         "description": "Link your Discord account to your Pioneer Square account",
         "options": [],
     },
+    {
+        "name": "worker-spawn",
+        "description": "Spawn a new Pioneer Square worker (requires a connected account)",
+        "options": [
+            {
+                "name": "repos",
+                "description": "Comma-separated owner/repo list (e.g. jmelloy/pioneer-square)",
+                "type": 3,  # STRING
+                "required": False,
+            },
+            {
+                "name": "tools",
+                "description": "Comma-separated tools/agents (e.g. claude,codex)",
+                "type": 3,  # STRING
+                "required": False,
+            },
+        ],
+    },
 ]
 
 DISCORD_API = "https://discord.com/api/v10"


### PR DESCRIPTION
## Summary
- Adds a `/worker-spawn` Discord slash command (with optional `repos` and `tools` comma-separated string options) alongside the existing `/ps`, `/join-channel`, `/leave-channel`, and `/connect-account` commands in `backend/routes/discord.py`.
- Requires the invoking Discord user to have already linked their account via `/connect-account` (checked against `DiscordAccountLink`), returning an ephemeral error otherwise.
- Reuses the existing `foreman.tools.spawn_worker` helper — the same worker-spawn logic the Foreman AI tool and worker-lifecycle replacement path already call — to pre-register the worker and start its Docker container.
- Replies with an ephemeral embed containing the new worker's id and a `queued`/`online` status derived from the worker's current DB state, or a clear error message on failure (unlinked account, unknown guild, or a tool-level error such as missing repos).
- Registers the new command's schema in `scripts/register_discord_commands.py`.

## Test plan
- [x] `ruff check .` / `ruff format . --check` — clean
- [x] `cd backend && python -m pytest tests/test_discord_interactions.py -k worker_spawn -v` — 4 new tests pass
- [x] `cd backend && python -m pytest` — 505 passed, 2 skipped; remaining errors are pre-existing DB-connection failures from the `postgres-test` container not being available in this sandbox (no Docker), unrelated to this change

Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)