### PR TITLE
feat(discord): route PR notifications into the linked issue's thread

### DIFF
--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -93,6 +93,8 @@ _COLOURS: dict[str, int] = {
     "task-followup": 0xF1C40F,  # yellow
     "task-redirect": 0xE67E22,  # orange
     "pr-opened": 0x3498DB,  # blue
+    "pr-updated": 0x5DADE2,  # light blue
+    "pr-review": 0xF39C12,  # gold
     "pr-merged": 0x9B59B6,  # purple
     "pr-closed": 0x95A5A6,  # grey
     "worker-online": 0x1ABC9C,  # teal
@@ -529,12 +531,28 @@ async def notify_event(
     header_fields: dict[str, str] | None = None,
     close: bool = False,
     ps_guild_slug: str | None = None,
+    linked_issue_repo: str | None = None,
+    linked_issue_number: int | None = None,
+    task_id: str | None = None,
 ) -> None:
     """Post a Discord notification, routing to a per-PR/issue thread when possible.
 
     Thread routing is attempted when ``DISCORD_BOT_TOKEN`` is set **and** both
     ``issue_repo`` and ``issue_number`` are provided.  The thread is lazily
     created on first use and its ID cached in the ``discord_threads`` table.
+
+    When *linked_issue_repo*/*linked_issue_number* are given (a PR's linked
+    GitHub issue, e.g. via ``Closes #N`` or the task's ``issue_number``) and
+    that issue already has a Discord thread on record, the message is posted
+    there instead — no new PR-numbered thread is created, and *close* is
+    ignored (the issue's thread outlives any single PR closing/merging into
+    it). Falls back to the ``issue_repo``/``issue_number`` (PR-keyed) behaviour
+    below when the linked issue has no thread yet.
+
+    When *linked_issue_repo*/*linked_issue_number* are omitted but *task_id*
+    is given, the linked issue is resolved from ``Task.issue_repo``/
+    ``Task.issue_number`` (same lookup ``notify_foreman_chat`` uses) — a
+    convenience for callers that only have a task_id on hand.
 
     When *ps_guild_slug* is provided, the destination channel is resolved via
     the ``discord_channel_guilds`` binding table (populated by
@@ -548,6 +566,25 @@ async def notify_event(
     operations fail. Silent no-op when the bot token is not configured.
     Never raises.
     """
+    if _bot_token() and not (linked_issue_repo and linked_issue_number is not None) and task_id:
+        coords = await _lookup_task_issue_coords(task_id)
+        if coords:
+            linked_issue_repo, linked_issue_number = coords
+
+    if _bot_token() and linked_issue_repo and linked_issue_number is not None:
+        linked_thread_id = await _lookup_thread(linked_issue_repo, linked_issue_number)
+        if linked_thread_id:
+            await _post_to_thread(
+                linked_thread_id,
+                event_type,
+                title,
+                description,
+                url=url,
+                color=color,
+                fields=header_fields,
+            )
+            return
+
     if _bot_token() and issue_repo and issue_number is not None:
         tn = thread_name or f"#{issue_number}: {title}"
         channel = await _resolve_channel_for_guild(ps_guild_slug)

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -443,11 +443,13 @@ def _extract_pr_info(payload: dict) -> tuple[int | None, str | None, str | None]
 async def _find_task(db, guild_pk: int, repo: str | None, pr_number: int | None):
     """Match a webhook to one of this guild's tasks by (repo, pr_number).
 
-    Returns the task row (id, user_id, issue_repo, issue_number) or ``None``.
-    The user_id is needed so foreman dispatch routes back to the user who
-    originally created the task; issue_repo/issue_number is the task's linked
-    GitHub issue (set at ``assign_task`` time), used to route PR Discord
-    notifications into that issue's existing thread instead of a new one.
+    Returns the task row (id, user_id, issue_repo, issue_number, branch) or
+    ``None``. The user_id is needed so foreman dispatch routes back to the
+    user who originally created the task; issue_repo/issue_number is the
+    task's linked GitHub issue (set at ``assign_task`` time), used to route
+    PR Discord notifications into that issue's existing thread instead of a
+    new one; branch is the fallback source for that linkage when the PR
+    payload itself doesn't carry a head ref.
     """
     if not repo or pr_number is None:
         return None
@@ -457,6 +459,7 @@ async def _find_task(db, guild_pk: int, repo: str | None, pr_number: int | None)
             col(Task.user_id),
             col(Task.issue_repo),
             col(Task.issue_number),
+            col(Task.branch),
         )
         .where(
             col(Task.guild_id) == guild_pk,

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -392,6 +392,22 @@ def _linked_issue_number_from_body(body: str | None) -> int | None:
     return int(match.group(1)) if match else None
 
 
+# Matches the issue number embedded in a task branch name, e.g.
+# "claude/discord-associate-pr-threads-773-t-0jlq" -> 773. The branch is
+# always set by the system when a task is created (unlike a "Closes #N" line,
+# which depends on the PR author remembering to write one), so this is
+# preferred over _linked_issue_number_from_body when both are available.
+_BRANCH_ISSUE_RE = re.compile(r"-(\d+)-t-[a-z0-9]+$")
+
+
+def _linked_issue_number_from_branch(branch: str | None) -> int | None:
+    """Return the issue number embedded in *branch*'s "-<N>-t-<id>" suffix."""
+    if not branch:
+        return None
+    match = _BRANCH_ISSUE_RE.search(branch)
+    return int(match.group(1)) if match else None
+
+
 def _extract_pr_info(payload: dict) -> tuple[int | None, str | None, str | None]:
     """Pull (pr_number, pr_url, repo) out of a webhook payload.
 
@@ -735,19 +751,32 @@ async def github_webhook(
     # The issue this PR is linked to, if any — used to route PR Discord
     # notifications into the issue's existing thread rather than a new one.
     # Prefer the task's own issue_number (set by the foreman at assign_task
-    # time); fall back to a "Closes #N"-style reference in the PR body for
-    # PRs not driven through a task (e.g. opened by a human).
+    # time); then the branch name's "-<N>-t-<id>" suffix (always set by the
+    # system, whether the branch comes from the PR payload itself or the
+    # task record); fall back to a "Closes #N"-style reference in the PR
+    # body last, since that depends on the author remembering to write one.
     linked_issue_repo: str | None = None
     linked_issue_number: int | None = None
     if task_row and task_row.issue_repo and task_row.issue_number is not None:
         linked_issue_repo, linked_issue_number = task_row.issue_repo, task_row.issue_number
     elif repo:
         pr_obj_for_link = payload.get("pull_request")
-        body_issue_number = _linked_issue_number_from_body(
-            pr_obj_for_link.get("body") if isinstance(pr_obj_for_link, dict) else None
+        head_ref = (
+            (pr_obj_for_link.get("head") or {}).get("ref")
+            if isinstance(pr_obj_for_link, dict)
+            else None
         )
-        if body_issue_number is not None:
-            linked_issue_repo, linked_issue_number = repo, body_issue_number
+        branch_issue_number = _linked_issue_number_from_branch(
+            head_ref or (task_row.branch if task_row else None)
+        )
+        if branch_issue_number is not None:
+            linked_issue_repo, linked_issue_number = repo, branch_issue_number
+        else:
+            body_issue_number = _linked_issue_number_from_body(
+                pr_obj_for_link.get("body") if isinstance(pr_obj_for_link, dict) else None
+            )
+            if body_issue_number is not None:
+                linked_issue_repo, linked_issue_number = repo, body_issue_number
 
     # Trim the persisted payload so a runaway diff hunk can't balloon the DB.
     body_text = body.decode("utf-8", errors="replace")

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -20,6 +20,7 @@ import hmac
 import json
 import logging
 import os
+import re
 from datetime import UTC, datetime, timedelta
 
 import discord_notifier
@@ -376,6 +377,21 @@ def _verify_signature(secret: str, body: bytes, signature_header: str | None) ->
     return hmac.compare_digest(expected, provided)
 
 
+# Matches "Closes #123", "Fixes #123", "Resolves #123" (and closed/fixed/
+# resolved variants) in a PR body — GitHub's own auto-close syntax. Used to
+# find the issue a PR is linked to when the task record has no issue_number
+# set (mirrors the same pattern used for task-tree grouping in routes/tasks.py).
+_CLOSES_ISSUE_RE = re.compile(r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE)
+
+
+def _linked_issue_number_from_body(body: str | None) -> int | None:
+    """Return the issue number referenced by a "Closes #N"-style line in *body*."""
+    if not body:
+        return None
+    match = _CLOSES_ISSUE_RE.search(body)
+    return int(match.group(1)) if match else None
+
+
 def _extract_pr_info(payload: dict) -> tuple[int | None, str | None, str | None]:
     """Pull (pr_number, pr_url, repo) out of a webhook payload.
 
@@ -411,13 +427,21 @@ def _extract_pr_info(payload: dict) -> tuple[int | None, str | None, str | None]
 async def _find_task(db, guild_pk: int, repo: str | None, pr_number: int | None):
     """Match a webhook to one of this guild's tasks by (repo, pr_number).
 
-    Returns the task row (id + user_id) or ``None``. The user_id is needed so
-    foreman dispatch routes back to the user who originally created the task.
+    Returns the task row (id, user_id, issue_repo, issue_number) or ``None``.
+    The user_id is needed so foreman dispatch routes back to the user who
+    originally created the task; issue_repo/issue_number is the task's linked
+    GitHub issue (set at ``assign_task`` time), used to route PR Discord
+    notifications into that issue's existing thread instead of a new one.
     """
     if not repo or pr_number is None:
         return None
     res = await db.exec(
-        select(col(Task.id), col(Task.user_id))
+        select(
+            col(Task.id),
+            col(Task.user_id),
+            col(Task.issue_repo),
+            col(Task.issue_number),
+        )
         .where(
             col(Task.guild_id) == guild_pk,
             col(Task.pr_repo) == repo,
@@ -708,6 +732,23 @@ async def github_webhook(
     task_id = task_row.id if task_row else None
     task_user_id = task_row.user_id if task_row else None
 
+    # The issue this PR is linked to, if any — used to route PR Discord
+    # notifications into the issue's existing thread rather than a new one.
+    # Prefer the task's own issue_number (set by the foreman at assign_task
+    # time); fall back to a "Closes #N"-style reference in the PR body for
+    # PRs not driven through a task (e.g. opened by a human).
+    linked_issue_repo: str | None = None
+    linked_issue_number: int | None = None
+    if task_row and task_row.issue_repo and task_row.issue_number is not None:
+        linked_issue_repo, linked_issue_number = task_row.issue_repo, task_row.issue_number
+    elif repo:
+        pr_obj_for_link = payload.get("pull_request")
+        body_issue_number = _linked_issue_number_from_body(
+            pr_obj_for_link.get("body") if isinstance(pr_obj_for_link, dict) else None
+        )
+        if body_issue_number is not None:
+            linked_issue_repo, linked_issue_number = repo, body_issue_number
+
     # Trim the persisted payload so a runaway diff hunk can't balloon the DB.
     body_text = body.decode("utf-8", errors="replace")
     if len(body_text) > _MAX_PAYLOAD_BYTES:
@@ -853,6 +894,8 @@ async def github_webhook(
                 thread_name=f"#{pr_number}: {pr_title}" if pr_title else f"#{pr_number}",
                 header_fields={"Assignee": assignee_str, "Labels": labels_str},
                 ps_guild_slug=guild_id,
+                linked_issue_repo=linked_issue_repo,
+                linked_issue_number=linked_issue_number,
             ),
             name=f"discord.pr-opened:{_pr_label}",
         )
@@ -870,6 +913,8 @@ async def github_webhook(
                     issue_number=pr_number,
                     close=True,
                     ps_guild_slug=guild_id,
+                    linked_issue_repo=linked_issue_repo,
+                    linked_issue_number=linked_issue_number,
                 ),
                 name=f"discord.pr-merged:{_pr_label}",
             )
@@ -885,9 +930,48 @@ async def github_webhook(
                     issue_number=pr_number,
                     close=True,
                     ps_guild_slug=guild_id,
+                    linked_issue_repo=linked_issue_repo,
+                    linked_issue_number=linked_issue_number,
                 ),
                 name=f"discord.pr-closed:{_pr_label}",
             )
+    elif event_type == "pull_request" and action == "synchronize":
+        spawn(
+            discord_notifier.notify_event(
+                "pr-updated",
+                title=f"PR updated: {_pr_label}",
+                description=f"New commits pushed to `{_pr_label}`."
+                + (f" Task: `{task_id}`." if task_id else ""),
+                url=pr_url or None,
+                issue_repo=repo,
+                issue_number=pr_number,
+                ps_guild_slug=guild_id,
+                linked_issue_repo=linked_issue_repo,
+                linked_issue_number=linked_issue_number,
+            ),
+            name=f"discord.pr-updated:{_pr_label}",
+        )
+    elif event_type == "pull_request_review" and action == "submitted":
+        review = payload.get("review") or {}
+        state = review.get("state") or "commented"
+        reviewer_mention = await discord_notifier.mention_or_login(
+            (review.get("user") or {}).get("login")
+        )
+        spawn(
+            discord_notifier.notify_event(
+                "pr-review",
+                title=f"PR review {state.replace('_', ' ')}: {_pr_label}",
+                description=f"{reviewer_mention} {state.replace('_', ' ')} `{_pr_label}`."
+                + (f" Task: `{task_id}`." if task_id else ""),
+                url=(review.get("html_url") or pr_url) or None,
+                issue_repo=repo,
+                issue_number=pr_number,
+                ps_guild_slug=guild_id,
+                linked_issue_repo=linked_issue_repo,
+                linked_issue_number=linked_issue_number,
+            ),
+            name=f"discord.pr-review:{_pr_label}",
+        )
     elif event_type in {"check_run", "check_suite"}:
         node = payload.get(event_type) or {}
         conclusion = node.get("conclusion") if isinstance(node, dict) else None
@@ -907,6 +991,8 @@ async def github_webhook(
                     issue_repo=repo,
                     issue_number=pr_number,
                     ps_guild_slug=guild_id,
+                    linked_issue_repo=linked_issue_repo,
+                    linked_issue_number=linked_issue_number,
                 ),
                 name=f"discord.ci-pass:{_pr_label}",
             )
@@ -921,6 +1007,8 @@ async def github_webhook(
                     issue_repo=repo,
                     issue_number=pr_number,
                     ps_guild_slug=guild_id,
+                    linked_issue_repo=linked_issue_repo,
+                    linked_issue_number=linked_issue_number,
                 ),
                 name=f"discord.ci-fail:{_pr_label}",
             )

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -505,6 +505,159 @@ async def test_notify_event_falls_back_to_channel_when_thread_creation_fails(mon
 
 
 @pytest.mark.asyncio
+async def test_notify_event_routes_pr_into_linked_issue_thread(monkeypatch):
+    """A PR notification with a linked issue thread posts there, not a new PR thread."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client(status_code=204)
+    issue_thread_id = "111222333444"
+
+    async def fake_lookup_thread(repo, number):
+        assert (repo, number) == ("org/repo", 7)
+        return issue_thread_id
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_thread", fake_lookup_thread),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock()) as ensure_mock,
+    ):
+        await discord_notifier.notify_event(
+            "pr-opened",
+            title="PR opened: org/repo#42",
+            description="New PR",
+            issue_repo="org/repo",
+            issue_number=42,
+            linked_issue_repo="org/repo",
+            linked_issue_number=7,
+        )
+
+    # Posted straight into the issue's existing thread...
+    mock_client.post.assert_called_once()
+    call_url = mock_client.post.call_args[0][0]
+    assert f"/channels/{issue_thread_id}/messages" in call_url
+    # ...and never created (or looked up) a separate PR-numbered thread.
+    ensure_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_event_falls_back_to_pr_thread_when_no_linked_issue_thread(monkeypatch):
+    """No thread on record for the linked issue: falls back to the PR-keyed thread."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client(status_code=204)
+    pr_thread_id = "555666777888"
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=pr_thread_id)),
+    ):
+        await discord_notifier.notify_event(
+            "pr-opened",
+            title="PR opened: org/repo#42",
+            description="New PR",
+            issue_repo="org/repo",
+            issue_number=42,
+            linked_issue_repo="org/repo",
+            linked_issue_number=7,
+        )
+
+    mock_client.post.assert_called_once()
+    call_url = mock_client.post.call_args[0][0]
+    assert f"/channels/{pr_thread_id}/messages" in call_url
+
+
+@pytest.mark.asyncio
+async def test_notify_event_ignores_close_when_routed_to_linked_issue_thread(monkeypatch):
+    """close=True must not archive the issue's thread — only a PR-owned thread."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client(status_code=204)
+    issue_thread_id = "111222333444"
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=issue_thread_id)),
+    ):
+        await discord_notifier.notify_event(
+            "pr-merged",
+            title="PR merged",
+            description="Merged!",
+            issue_repo="org/repo",
+            issue_number=42,
+            close=True,
+            linked_issue_repo="org/repo",
+            linked_issue_number=7,
+        )
+
+    mock_client.post.assert_called_once()
+    mock_client.patch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_event_resolves_linked_issue_from_task_id(monkeypatch):
+    """When only task_id is given, the linked issue is resolved via Task.issue_repo/number."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client(status_code=204)
+    issue_thread_id = "999000111222"
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(
+            discord_notifier,
+            "_lookup_task_issue_coords",
+            AsyncMock(return_value=("org/repo", 7)),
+        ),
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=issue_thread_id)),
+    ):
+        await discord_notifier.notify_event(
+            "task-complete",
+            title="Task complete",
+            description="desc",
+            issue_repo="org/repo",
+            issue_number=42,
+            task_id="t-abc",
+        )
+
+    mock_client.post.assert_called_once()
+    call_url = mock_client.post.call_args[0][0]
+    assert f"/channels/{issue_thread_id}/messages" in call_url
+
+
+@pytest.mark.asyncio
+async def test_notify_event_task_id_skipped_when_linked_issue_explicit(monkeypatch):
+    """Explicit linked_issue_repo/number take precedence — task_id lookup is skipped."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+
+    mock_client = _make_mock_client(status_code=204)
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock()) as coords_mock,
+        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_event(
+            "pr-opened",
+            title="PR opened",
+            description="desc",
+            issue_repo="org/repo",
+            issue_number=42,
+            linked_issue_repo="org/repo",
+            linked_issue_number=7,
+            task_id="t-abc",
+        )
+
+    coords_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_notify_existing_thread_posts_when_thread_found(monkeypatch):
     """notify_existing_thread posts to the thread when one is already persisted."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -47,6 +47,8 @@ from models import (
 from routes.webhooks import (  # noqa: E402
     _build_foreman_summary,
     _get_guild_owner_github_login,
+    _linked_issue_number_from_body,
+    _linked_issue_number_from_branch,
     _should_dispatch_to_foreman,
 )
 from sqlalchemy import update  # noqa: E402
@@ -165,6 +167,48 @@ class TestShouldDispatch:
             "pull_request_review", "submitted", {}, "human-reviewer", "t-1"
         )
         assert ok
+
+
+# ---------------------------------------------------------------------------
+# Linked-issue extraction (branch name / PR body)
+# ---------------------------------------------------------------------------
+
+
+class TestLinkedIssueFromBranch:
+    def test_extracts_issue_number_before_task_suffix(self):
+        assert (
+            _linked_issue_number_from_branch(
+                "claude/discord-associate-pr-threads-with-issue-thread-773-t-0jlq"
+            )
+            == 773
+        )
+
+    def test_extracts_from_short_branch(self):
+        assert _linked_issue_number_from_branch("claude/fix-thing-123-t-abc123") == 123
+
+    def test_no_task_suffix_returns_none(self):
+        assert _linked_issue_number_from_branch("claude/fix-thing-123") is None
+
+    def test_none_branch_returns_none(self):
+        assert _linked_issue_number_from_branch(None) is None
+
+    def test_non_matching_branch_returns_none(self):
+        assert _linked_issue_number_from_branch("main") is None
+
+
+class TestLinkedIssueFromBody:
+    def test_extracts_closes_reference(self):
+        assert _linked_issue_number_from_body("Some PR body.\n\nCloses #42") == 42
+
+    def test_case_insensitive_and_variants(self):
+        assert _linked_issue_number_from_body("this fixed #7") == 7
+        assert _linked_issue_number_from_body("RESOLVES #99") == 99
+
+    def test_no_reference_returns_none(self):
+        assert _linked_issue_number_from_body("Just a description, no linkage.") is None
+
+    def test_none_body_returns_none(self):
+        assert _linked_issue_number_from_body(None) is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -906,6 +906,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
                 issue_repo=_pr_repo_disc,
                 issue_number=_pr_num_disc,
                 ps_guild_slug=ctx.guild_id,
+                task_id=task_id,
             ),
             name=f"discord.task-complete:{task_id}",
         )


### PR DESCRIPTION
## Summary

Implements #773: when a PR is linked to an issue, its Discord notifications now post into that issue's existing thread instead of spawning a new top-level PR thread.

- **`backend/discord_notifier.py`** — `notify_event()` gains `linked_issue_repo`/`linked_issue_number`/`task_id` params. When the linked issue already has a Discord thread (looked up via the existing `discord_threads` store), the message is posted there and no PR-numbered thread is created. `close=True` is ignored in that path since the issue thread outlives any single PR. When only `task_id` is given, the linked issue is resolved from `Task.issue_repo`/`Task.issue_number` (same lookup `notify_foreman_chat` already uses). Falls back to the current PR-keyed-thread behavior when there's no linked issue or no thread for it yet.
- **`backend/routes/webhooks.py`** — resolves the PR's linked issue per webhook: prefers the task's `issue_repo`/`issue_number` (set at `assign_task` time), falling back to a `Closes #N` / `Fixes #N` / `Resolves #N` reference parsed from the PR body for PRs not driven through a task. Threads this through to `pr-opened`, `pr-merged`, `pr-closed`, and the CI pass/fail notifications. Also adds two previously-missing PR events: `pr-updated` (on `synchronize`) and `pr-review` (on review submitted), both wired into the same linked-issue routing.
- **`backend/ws_handlers.py`** — passes `task_id` through on the task-complete PR notification so it can resolve its linked issue thread too.
- **`backend/tests/test_discord_notifier.py`** — new tests covering: routing into a linked issue thread, falling back to PR-thread creation when no linked thread exists, `close` being ignored when routed to an issue thread, resolving the linked issue from `task_id`, and explicit `linked_issue_*` args taking precedence over the `task_id` lookup.

## Test plan

- [x] `python -m pytest backend/tests/test_discord_notifier.py -q` — 68 passed
- [x] `python -m pytest backend/tests/test_github_webhooks.py backend/tests/test_github_webhooks_phase2.py -q` — all non-DB-dependent tests pass (DB-dependent tests error in this sandbox due to no local Postgres, unrelated to this change)

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)