### PR TITLE
fix: branch names truncate task ID to 4 chars (#775)

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1887,7 +1887,7 @@ class Worker:
         name = task.get("name") or desc
         # On follow-ups we must continue on the existing branch — the original
         # worker pushed it and the foreman wants the same PR updated.
-        branch = followup_branch or f"claude/{_slug(name)}-{task_id[:6]}"
+        branch = followup_branch or f"claude/{_slug(name)}-{task_id}"
         work_dir = os.path.join(self.cfg.work_dir, self.cfg.guild_id, self.cfg.worker_id, task_id)
         logger.info(
             "Task %s branch=%s work_dir=%s followup=%s", task_id, branch, work_dir, is_followup


### PR DESCRIPTION
## Summary
- `worker/pioneer_worker/worker.py` built new-task branch names with `task_id[:6]`, but `task_id` is `"t-" + 6 random chars` (8 chars total). Slicing to 6 chars kept only 4 of the actual ID characters (e.g. `t-0jlqri` → `t-0jlq`), risking collisions between different tasks.
- Fixed to use the full `task_id` in the branch name (e.g. `claude/<slug>-t-0jlqri`).
- Verified there's no branch-parsing regex elsewhere hardcoded to a 4-char task ID; the one existing regex (`foreman/pioneer_foreman/foreman.py`) already uses `[a-z0-9]+` (one-or-more), so no change needed there.

## Test plan
- [x] `python -m pytest worker/tests/ -k branch` passes
- [x] `python -m pytest worker/tests/test_followup_branch_reuse.py` passes

Closes #775