### PR TITLE
feat: expose TaskLog.data in get_task_status tool (#782)

### DIFF
--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -899,6 +899,42 @@ class TestExecToolsDispatching:
         assert data["state"] == "working"
         assert "recent_logs" in data
 
+    async def test_get_task_status_includes_log_data(self, db_session):
+        insert_guild(db_session, "g-status-data")
+        _insert_worker(db_session, "g-status-data", "w-status-data")
+        _insert_task(db_session, "t-stat2", "g-status-data", "w-status-data", state="working")
+        now = datetime.now(UTC)
+        detail = {"tool": "Read", "input": {"file_path": "/tmp/foo.py"}, "output": "full contents"}
+        with _sync_session(db_session) as session:
+            session.add(
+                TaskLog(
+                    task_id="t-stat2",
+                    timestamp=now,
+                    line="Read /tmp/foo.py",
+                    worker_id="w-status-data",
+                    data=json.dumps(detail),
+                )
+            )
+            session.add(
+                TaskLog(
+                    task_id="t-stat2",
+                    timestamp=now,
+                    line="plain log line",
+                    worker_id="w-status-data",
+                )
+            )
+            session.commit()
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-status-data", [_fake_tool_use("get_task_status", {"task_id": "t-stat2"})]
+            )
+        data = json.loads(results[0]["content"])
+        logs = data["recent_logs"]
+        assert logs[0]["line"] == "Read /tmp/foo.py"
+        assert logs[0]["data"] == "full contents"
+        assert logs[1]["line"] == "plain log line"
+        assert "data" not in logs[1]
+
     async def test_unknown_tool_name_returns_empty_result(self, db_session):
         """An unknown tool name should not raise; result content may be empty."""
         insert_guild(db_session, "g-unknown")

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -70,6 +70,7 @@ async def test_run_sends_disconnect_before_ws_close():
     worker._send = capture_send
     worker._register = AsyncMock()
     worker._fetch_github_token_if_needed = AsyncMock()
+    worker._fetch_guild_env_vars = AsyncMock()
     worker._check_gh_auth = AsyncMock()
     worker._check_codex_doctor = AsyncMock()
     worker._check_claude_auth = AsyncMock()


### PR DESCRIPTION
## Summary
- `get_task_status`'s `recent_logs` entries now include the log line's `data` field (the structured tool/agent detail payload stored on `TaskLog.data`), parsed as JSON when present, so the Foreman can see rich agent output detail rather than just the raw log text.
- Updated the tool's description in `tools_schema.py` to mention the new `data` field.
- Added a regression test covering a log entry with structured `data` alongside a plain log entry without it.

Closes #782

## Test plan
- [x] `python -m pytest tests/test_foreman.py -k "get_task_status or large_result"`
- [x] `python -m pytest tests/test_foreman.py tests/test_foreman_runner.py tests/test_foreman_poll_backoff.py`
- [x] `ruff check foreman/tools.py foreman_core/tools_schema.py tests/test_foreman.py`