### PR TITLE
feat: debounce passing CI check events

### DIFF
--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -23,6 +23,7 @@ import os
 import re
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
+from uuid import uuid4
 
 import discord_notifier
 from database import get_db_dep
@@ -148,19 +149,27 @@ async def _default_deliver(
 async def _deliver_ci_pass(
     key: str, guild_id: str, combined: str, items: list[_DebounceItem]
 ) -> None:
-    """Foreman delivery (as usual) plus one combined Discord "CI passed" post.
+    """Foreman delivery (when a task is attached) plus one combined Discord
+    "CI passed" post.
 
     Replaces the old per-check-event immediate Discord notification (issue
     #785): instead of one Discord message per passing check_run/check_suite
     event, the several events GitHub fires per commit coalesce into a single
     message listing every check name that passed.
-    """
-    await _default_deliver(key, guild_id, combined, items)
 
+    Some items reach this queue without a task_id (a passing check on a PR
+    with no matching task — see the `github_webhook` check_run/check_suite
+    branch); the foreman has no context to act on there
+    (`_should_dispatch_to_foreman`'s "no matching task" rule), so the foreman
+    call is skipped for those batches and only the Discord post fires.
+    """
     ctx = next((c for _, _, _, _, c in items if c), None) or {}
     check_names = _dedupe_labels(items)
     task_id = next((tid for _, _, tid, _, _ in items if tid), None)
     pr_label = ctx.get("pr_label") or "unknown"
+
+    if task_id:
+        await _default_deliver(key, guild_id, combined, items)
     spawn(
         discord_notifier.notify_event(
             "ci-pass",
@@ -793,20 +802,35 @@ async def _run_foreman_immediately(
     reset_foreman_poll(guild_id)
 
 
-async def _dispatch_immediately(
+def _dispatch_immediately(
     guild_id: str, summary: str, user_id: str | None, task_id: str | None
 ) -> None:
     """Bypass debounce entirely and fire the foreman right away.
 
-    Wrapped as its own module-level seam (rather than inlining ``spawn`` at
-    the call site) so tests can patch it exactly like ``_debounce_queue`` —
-    the webhook response must not block on the foreman AI call, so the
-    actual work runs as a retained background task (see ``util.tasks.spawn``).
+    Plain (non-async) function: it only calls ``spawn()``, which schedules
+    the actual foreman call as a retained background task and returns
+    immediately — there is nothing here to await. Wrapped as its own
+    module-level seam (rather than inlining ``spawn`` at the call site) so
+    tests can patch it exactly like ``_debounce_queue``.
     """
     spawn(
         _run_foreman_immediately(guild_id, summary, user_id, task_id),
         name=f"foreman.ci-fail:{guild_id}:{task_id}",
     )
+
+
+def _ci_pass_key(guild_id: str, pr_label: str, head_sha: str | None) -> str:
+    """Build the CI-pass debounce key for one passing check event.
+
+    Normally scoped to ``head_sha`` so unrelated commits never coalesce.
+    Some payloads (e.g. certain ``check_suite`` events) omit ``head_sha``;
+    falling back to a literal ``None`` there would collide across different
+    commits/PRs that all lack one, so each such event instead gets a unique
+    key and is delivered on its own after the debounce window.
+    """
+    if not head_sha:
+        return f"{guild_id}:ci-pass:{pr_label}:{uuid4()}"
+    return f"{guild_id}:ci-pass:{pr_label}:{head_sha}"
 
 
 async def _dispatch_check_event(
@@ -845,7 +869,7 @@ async def _dispatch_check_event(
         summary = _build_foreman_summary(
             event_type, action, payload, repo, pr_number, task_id or "", sender_login
         )
-        await _dispatch_immediately(guild_id, summary, task_user_id, task_id)
+        _dispatch_immediately(guild_id, summary, task_user_id, task_id)
         logger.info(
             "github webhook ci-check failure dispatched immediately guild=%s delivery=%s "
             "repo=%s pr=%s check=%s conclusion=%s",
@@ -863,7 +887,7 @@ async def _dispatch_check_event(
         header = f"[github-event] check_run/check_suite passed on {pr_label}" + (
             f" (task {task_id})" if task_id else ""
         )
-        key = f"{guild_id}:ci-pass:{pr_label}:{head_sha}"
+        key = _ci_pass_key(guild_id, pr_label, head_sha)
         context = {
             "pr_label": pr_label,
             "repo": repo,
@@ -1249,23 +1273,31 @@ async def github_webhook(
             # When `dispatch` is True, this event goes through
             # _dispatch_check_event → the CI-pass debounce queue, which
             # posts one combined "Checks passed: a, b, c" Discord message
-            # once the window closes (see _deliver_ci_pass). Only send this
-            # immediate, single-check notification for the (rare) case where
-            # there's no context to debounce against, e.g. no matching task.
-            spawn(
-                discord_notifier.notify_event(
-                    "ci-pass",
-                    title=f"CI passed: {_pr_label}",
-                    description=f"`{check_name}` passed on `{_pr_label}`."
-                    + (f" Task: `{task_id}`." if task_id else ""),
-                    url=pr_url or None,
-                    issue_repo=repo,
-                    issue_number=pr_number,
-                    ps_guild_slug=guild_id,
-                    linked_issue_repo=linked_issue_repo,
-                    linked_issue_number=linked_issue_number,
-                ),
-                name=f"discord.ci-pass:{_pr_label}",
+            # once the window closes (see _deliver_ci_pass). `dispatch` is
+            # False here only because there's no matching task
+            # (`_should_dispatch_to_foreman`'s "no matching task" rule) — so
+            # task_id is already None. Route through the same CI-pass queue
+            # (with task_id=None, which _deliver_ci_pass treats as "skip the
+            # foreman call, Discord-only") rather than posting immediately,
+            # so these still coalesce instead of one message per check.
+            head_sha = node.get("head_sha") if isinstance(node, dict) else None
+            key = _ci_pass_key(guild_id, _pr_label or (repo or "unknown"), head_sha)
+            context = {
+                "pr_label": _pr_label or "unknown",
+                "repo": repo,
+                "pr_number": pr_number,
+                "pr_url": pr_url,
+                "linked_issue_repo": linked_issue_repo,
+                "linked_issue_number": linked_issue_number,
+            }
+            await _ci_pass_debounce_queue.schedule(
+                key,
+                guild_id,
+                f"[github-event] check_run/check_suite passed on {_pr_label}",
+                task_user_id,
+                task_id=None,
+                label=check_name,
+                context=context,
             )
         elif conclusion in {"failure", "cancelled", "timed_out", "action_required"}:
             spawn(

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import re
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 
 import discord_notifier
@@ -52,6 +53,20 @@ router = APIRouter()
 # Configurable via WEBHOOK_DEBOUNCE_SECONDS (default: 30 seconds).
 DEBOUNCE_WINDOW_SECONDS: float = float(os.environ.get("WEBHOOK_DEBOUNCE_SECONDS", "30"))
 
+# How long (seconds) to wait for further *passing* check_run/check_suite
+# events on the same commit before delivering one combined "checks passed"
+# notification. Short by design (issue #785): passing CI checks aren't
+# actionable individually, so a short window is enough to coalesce the
+# handful of check_run/check_suite events GitHub sends per commit without
+# meaningfully delaying the foreman's view of a green PR. Configurable via
+# CI_PASS_DEBOUNCE_SECONDS (default: 7 seconds).
+CI_PASS_DEBOUNCE_SECONDS: float = float(os.environ.get("CI_PASS_DEBOUNCE_SECONDS", "7"))
+
+# Conclusions that must bypass debounce entirely and reach the foreman
+# immediately — these are actionable failures the foreman should react to
+# without waiting on a coalescing window.
+_FAILING_CHECK_CONCLUSIONS = frozenset({"failure", "action_required", "timed_out", "cancelled"})
+
 
 # Shared secret for the /foreman/ci-notify endpoint.  GitHub Actions sets
 # Authorization: Bearer <PIONEER_CI_KEY> on each CI completion POST.
@@ -74,16 +89,112 @@ _MAX_PAYLOAD_BYTES = 64 * 1024
 _BOT_OK_EVENTS = frozenset({"check_run", "check_suite", "status"})
 
 
+# (summary, user_id, task_id, label, context) — label and context are unused
+# by the default combine/deliver and only populated by the CI-pass queue
+# (label = check name, context = repo/PR/issue-linkage info needed to build
+# the combined Discord notification at delivery time).
+_DebounceItem = tuple[str, "str | None", "str | None", "str | None", "dict | None"]
+
+
+def _default_combine(items: list[_DebounceItem]) -> str:
+    """Join buffered summaries with a separator (the original combine behavior)."""
+    summaries = [s for s, _, _, _, _ in items]
+    return "\n\n---\n\n".join(summaries) if len(summaries) > 1 else summaries[0]
+
+
+def _combine_ci_pass_items(items: list[_DebounceItem]) -> str:
+    """Render one "checks passed" message listing every distinct check name.
+
+    Every item scheduled under a CI-pass key shares the same pre-built header
+    (see ``key`` construction in ``_dispatch_check_event``); only the label
+    (check name) varies, so the header is taken from the first item and check
+    names are deduped while preserving first-seen order.
+    """
+    header = items[0][0]
+    checks_str = ", ".join(_dedupe_labels(items)) or "checks"
+    return f"{header}\nChecks passed: {checks_str}"
+
+
+def _dedupe_labels(items: list[_DebounceItem]) -> list[str]:
+    """Distinct check names across *items*, preserving first-seen order."""
+    seen: set[str] = set()
+    names: list[str] = []
+    for _, _, _, label, _ in items:
+        if label and label not in seen:
+            seen.add(label)
+            names.append(label)
+    return names
+
+
+async def _default_deliver(
+    key: str, guild_id: str, combined: str, items: list[_DebounceItem]
+) -> None:
+    """Send the combined summary to the foreman (the original deliver behavior)."""
+    # Use the first non-bot user_id in the batch. All items share the same
+    # task owner, but a bot user_id (ending in "[bot]") is less useful for
+    # attribution than a real human.  Fall back to any non-None user_id if
+    # every entry is a bot, and to None if the batch is entirely anonymous.
+    user_id = next(
+        (uid for _, uid, _, _, _ in items if uid and not uid.endswith("[bot]")),
+        next((uid for _, uid, _, _, _ in items if uid), None),
+    )
+    # All events buffered under one key share a task (key is "{guild}:{task_id}");
+    # github events for a known task run in that task's isolated child context.
+    task_id = next((tid for _, _, tid, _, _ in items if tid), None)
+    await run_foreman_ai(guild_id, combined, user_id=user_id, task_id=task_id, child=bool(task_id))
+    reset_foreman_poll(guild_id)
+
+
+async def _deliver_ci_pass(
+    key: str, guild_id: str, combined: str, items: list[_DebounceItem]
+) -> None:
+    """Foreman delivery (as usual) plus one combined Discord "CI passed" post.
+
+    Replaces the old per-check-event immediate Discord notification (issue
+    #785): instead of one Discord message per passing check_run/check_suite
+    event, the several events GitHub fires per commit coalesce into a single
+    message listing every check name that passed.
+    """
+    await _default_deliver(key, guild_id, combined, items)
+
+    ctx = next((c for _, _, _, _, c in items if c), None) or {}
+    check_names = _dedupe_labels(items)
+    task_id = next((tid for _, _, tid, _, _ in items if tid), None)
+    pr_label = ctx.get("pr_label") or "unknown"
+    spawn(
+        discord_notifier.notify_event(
+            "ci-pass",
+            title=f"CI passed: {pr_label}",
+            description=f"Checks passed: {', '.join(check_names)}."
+            + (f" Task: `{task_id}`." if task_id else ""),
+            url=ctx.get("pr_url"),
+            issue_repo=ctx.get("repo"),
+            issue_number=ctx.get("pr_number"),
+            ps_guild_slug=guild_id,
+            linked_issue_repo=ctx.get("linked_issue_repo"),
+            linked_issue_number=ctx.get("linked_issue_number"),
+        ),
+        name=f"discord.ci-pass:{pr_label}",
+    )
+
+
 class DebounceQueue:
-    """Per-PR debounce queue that coalesces rapid webhook events.
+    """Per-key debounce queue that coalesces rapid webhook events.
 
     State is scoped to the instance so tests can create an isolated copy
     without touching the module-level singleton.
     """
 
-    def __init__(self, window_seconds: float = DEBOUNCE_WINDOW_SECONDS) -> None:
+    def __init__(
+        self,
+        window_seconds: float = DEBOUNCE_WINDOW_SECONDS,
+        combine: Callable[[list[_DebounceItem]], str] | None = None,
+        deliver: Callable[[str, str, str, list[_DebounceItem]], Awaitable[None]] | None = None,
+    ) -> None:
         self._window = window_seconds
-        self._buffers: dict[str, list[tuple[str, str | None, str | None]]] = {}
+        self._combine = combine or _default_combine
+        self._deliver_fn = deliver or _default_deliver
+        self._buffers: dict[str, list[_DebounceItem]] = {}
         self._tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
         self._generation: dict[str, int] = {}
 
@@ -129,26 +240,9 @@ class DebounceQueue:
                 exc_info=exc,
             )
 
-    async def _deliver(
-        self, key: str, guild_id: str, items: list[tuple[str, str | None, str | None]]
-    ) -> None:
-        summaries = [s for s, _, _ in items]
-        combined = "\n\n---\n\n".join(summaries) if len(summaries) > 1 else summaries[0]
-        # Use the first non-bot user_id in the batch. All items share the same
-        # task owner, but a bot user_id (ending in "[bot]") is less useful for
-        # attribution than a real human.  Fall back to any non-None user_id if
-        # every entry is a bot, and to None if the batch is entirely anonymous.
-        user_id = next(
-            (uid for _, uid, _ in items if uid and not uid.endswith("[bot]")),
-            next((uid for _, uid, _ in items if uid), None),
-        )
-        # All events buffered under one key share a task (key is "{guild}:{task_id}");
-        # github events for a known task run in that task's isolated child context.
-        task_id = next((tid for _, _, tid in items if tid), None)
-        await run_foreman_ai(
-            guild_id, combined, user_id=user_id, task_id=task_id, child=bool(task_id)
-        )
-        reset_foreman_poll(guild_id)
+    async def _deliver(self, key: str, guild_id: str, items: list[_DebounceItem]) -> None:
+        combined = self._combine(items)
+        await self._deliver_fn(key, guild_id, combined, items)
         logger.info(
             "github webhook debounce fired key=%s events=%d guild=%s",
             key,
@@ -192,13 +286,19 @@ class DebounceQueue:
         summary: str,
         user_id: str | None,
         task_id: str | None = None,
+        label: str | None = None,
+        context: dict | None = None,
     ) -> None:
-        """Buffer *summary* and (re)start the per-PR debounce timer.
+        """Buffer *summary* (optionally tagged with *label*/*context*) and (re)start the timer.
 
         Each call resets the window so the foreman is only invoked after
-        _window seconds of silence on this PR.  The old timer is cancelled
+        _window seconds of silence on this key.  The old timer is cancelled
         and awaited before the new one starts so there is never a window
-        where two timers for the same key are both live.
+        where two timers for the same key are both live. *label* and
+        *context* are passed through to the combine/deliver functions
+        untouched (e.g. a check name and repo/PR/issue info for the CI-pass
+        queue's "Checks passed: a, b, c" foreman + Discord rendering) and
+        ignored by the defaults.
         """
         existing = self._tasks.pop(key, None)
         # Snapshot the buffer BEFORE bumping the generation or cancelling.
@@ -220,7 +320,7 @@ class DebounceQueue:
         # above ensures the old task cannot also deliver the same events, so
         # there is no risk of double delivery.
         self._buffers[key] = snapshot
-        self._buffers[key].append((summary, user_id, task_id))
+        self._buffers[key].append((summary, user_id, task_id, label, context))
         # Use asyncio.create_task directly: the task is kept alive by
         # self._tasks[key] (a strong reference), so GC is not a concern.
         # _log_fire_error handles unexpected exceptions via the done callback.
@@ -238,6 +338,19 @@ class DebounceQueue:
 
 
 _debounce_queue = DebounceQueue()
+
+# Dedicated queue for passing check_run/check_suite events (issue #785).
+# Kept separate from _debounce_queue because it needs a much shorter window,
+# a different combine function (list of check names vs. joined summaries),
+# and a different deliver function (foreman + one combined Discord "CI
+# passed" post instead of just the foreman); failing/erroring checks never
+# go through either queue — they bypass debounce and reach the foreman (and
+# Discord) immediately (see github_webhook / _dispatch_check_event).
+_ci_pass_debounce_queue = DebounceQueue(
+    window_seconds=CI_PASS_DEBOUNCE_SECONDS,
+    combine=_combine_ci_pass_items,
+    deliver=_deliver_ci_pass,
+)
 
 _DEFAULT_FINALIZE_TTL_SECS = 3 * 24 * 60 * 60  # 3 days
 _DEFAULT_FAIL_TTL_SECS = 24 * 60 * 60  # 1 day
@@ -363,9 +476,13 @@ async def _auto_fail_task_on_pr_close(
 async def shutdown_debouncer() -> None:
     """Cancel all in-flight debounce timers and wait for them to complete.
 
-    Call at server shutdown and in async test teardown fixtures.
+    Call at server shutdown and in async test teardown fixtures. Sequential
+    (not asyncio.gather) so this stays anyio-backend-agnostic — some tests
+    run this fixture under the trio backend, where asyncio.gather isn't
+    usable.
     """
     await _debounce_queue.shutdown()
+    await _ci_pass_debounce_queue.shutdown()
 
 
 def _verify_signature(secret: str, body: bytes, signature_header: str | None) -> bool:
@@ -668,6 +785,114 @@ def _build_chat_line(
     return f"[github-event] {event_action}{pr_part}{extra_part}{task_part}"
 
 
+async def _run_foreman_immediately(
+    guild_id: str, summary: str, user_id: str | None, task_id: str | None
+) -> None:
+    """Invoke the foreman without debounce (used for failing CI checks)."""
+    await run_foreman_ai(guild_id, summary, user_id=user_id, task_id=task_id, child=bool(task_id))
+    reset_foreman_poll(guild_id)
+
+
+async def _dispatch_immediately(
+    guild_id: str, summary: str, user_id: str | None, task_id: str | None
+) -> None:
+    """Bypass debounce entirely and fire the foreman right away.
+
+    Wrapped as its own module-level seam (rather than inlining ``spawn`` at
+    the call site) so tests can patch it exactly like ``_debounce_queue`` —
+    the webhook response must not block on the foreman AI call, so the
+    actual work runs as a retained background task (see ``util.tasks.spawn``).
+    """
+    spawn(
+        _run_foreman_immediately(guild_id, summary, user_id, task_id),
+        name=f"foreman.ci-fail:{guild_id}:{task_id}",
+    )
+
+
+async def _dispatch_check_event(
+    guild_id: str,
+    delivery_id: str,
+    event_type: str,
+    action: str | None,
+    payload: dict,
+    repo: str | None,
+    pr_number: int | None,
+    pr_url: str | None,
+    task_id: str | None,
+    task_user_id: str | None,
+    sender_login: str | None,
+    linked_issue_repo: str | None,
+    linked_issue_number: int | None,
+) -> None:
+    """Route a dispatch-eligible check_run/check_suite event (issue #785).
+
+    Failing/erroring conclusions bypass debounce entirely and reach the
+    foreman immediately. Passing conclusions are buffered on a short,
+    per-(repo, PR, head_sha) debounce window so that the several check_run/
+    check_suite events GitHub fires per commit coalesce into a single
+    "checks passed" notification listing every check name.
+    """
+    node = payload.get(event_type) or {}
+    conclusion = node.get("conclusion") if isinstance(node, dict) else None
+    head_sha = node.get("head_sha") if isinstance(node, dict) else None
+    check_name = (
+        (node.get("name") or (node.get("app") or {}).get("slug") or "check")
+        if isinstance(node, dict)
+        else "check"
+    )
+
+    if conclusion in _FAILING_CHECK_CONCLUSIONS:
+        summary = _build_foreman_summary(
+            event_type, action, payload, repo, pr_number, task_id or "", sender_login
+        )
+        await _dispatch_immediately(guild_id, summary, task_user_id, task_id)
+        logger.info(
+            "github webhook ci-check failure dispatched immediately guild=%s delivery=%s "
+            "repo=%s pr=%s check=%s conclusion=%s",
+            guild_id,
+            delivery_id,
+            repo,
+            pr_number,
+            check_name,
+            conclusion,
+        )
+        return
+
+    if conclusion == "success":
+        pr_label = f"{repo}#{pr_number}" if repo and pr_number else (repo or "unknown")
+        header = f"[github-event] check_run/check_suite passed on {pr_label}" + (
+            f" (task {task_id})" if task_id else ""
+        )
+        key = f"{guild_id}:ci-pass:{pr_label}:{head_sha}"
+        context = {
+            "pr_label": pr_label,
+            "repo": repo,
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "linked_issue_repo": linked_issue_repo,
+            "linked_issue_number": linked_issue_number,
+        }
+        await _ci_pass_debounce_queue.schedule(
+            key,
+            guild_id,
+            header,
+            task_user_id,
+            task_id=task_id,
+            label=check_name,
+            context=context,
+        )
+        return
+
+    # Any other completed conclusion (e.g. an unrecognized value GitHub might
+    # add in the future) falls back to the generic per-task debounce so it
+    # still reaches the foreman rather than being silently dropped.
+    summary = _build_foreman_summary(
+        event_type, action, payload, repo, pr_number, task_id or "", sender_login
+    )
+    key = f"{guild_id}:{task_id}"
+    await _debounce_queue.schedule(key, guild_id, summary, task_user_id, task_id=task_id)
+
+
 @router.post("/webhooks/github/{guild_id}")
 async def github_webhook(
     guild_id: str,
@@ -899,6 +1124,14 @@ async def github_webhook(
         task_id,
     )
 
+    # Computed early so the Discord check-run/check_suite branch below can
+    # tell whether a passing check will be handled by the CI-pass debounce
+    # (see _dispatch_check_event) and skip its own immediate notification to
+    # avoid posting the same "CI passed" news twice.
+    dispatch, skip_reason = _should_dispatch_to_foreman(
+        event_type, action, payload, sender_login, task_id
+    )
+
     # Discord notifications for key GitHub events.
     _pr_label = f"{repo}#{pr_number}" if repo and pr_number else (repo or "")
     if event_type == "pull_request" and action == "opened":
@@ -1012,7 +1245,13 @@ async def github_webhook(
             if isinstance(node, dict)
             else "CI"
         )
-        if conclusion == "success":
+        if conclusion == "success" and not dispatch:
+            # When `dispatch` is True, this event goes through
+            # _dispatch_check_event → the CI-pass debounce queue, which
+            # posts one combined "Checks passed: a, b, c" Discord message
+            # once the window closes (see _deliver_ci_pass). Only send this
+            # immediate, single-check notification for the (rare) case where
+            # there's no context to debounce against, e.g. no matching task.
             spawn(
                 discord_notifier.notify_event(
                     "ci-pass",
@@ -1118,10 +1357,23 @@ async def github_webhook(
                 guild_owner_login,
             )
     else:
-        dispatch, skip_reason = _should_dispatch_to_foreman(
-            event_type, action, payload, sender_login, task_id
-        )
-        if dispatch:
+        if dispatch and event_type in {"check_run", "check_suite"}:
+            await _dispatch_check_event(
+                guild_id,
+                delivery_id,
+                event_type,
+                action,
+                payload,
+                repo,
+                pr_number,
+                pr_url,
+                task_id,
+                task_user_id,
+                sender_login,
+                linked_issue_repo,
+                linked_issue_number,
+            )
+        elif dispatch:
             summary = _build_foreman_summary(
                 event_type, action, payload, repo, pr_number, task_id or "", sender_login
             )

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -731,6 +731,201 @@ class TestDebounce:
 
 
 # ---------------------------------------------------------------------------
+# CI-pass debounce (issue #785): passing check_run/check_suite events coalesce
+# into one notification; failing checks bypass debounce entirely.
+# ---------------------------------------------------------------------------
+
+
+class TestCiPassDebounce:
+    """``_dispatch_check_event`` routing: pass → debounced, fail → immediate."""
+
+    @asynccontextmanager
+    async def _patched_env(self, wh):
+        """Fresh CI-pass DebounceQueue + captured foreman/Discord calls.
+
+        Mirrors ``TestDebounce._patched_env`` but swaps in
+        ``wh._ci_pass_debounce_queue`` (short window, CI-pass combine/deliver)
+        and also captures ``discord_notifier.notify_event`` calls so the
+        combined "Checks passed: a, b, c" post can be asserted on.
+        """
+        self._foreman_calls: list[tuple[str, str, str | None, str | None]] = []
+        self._discord_calls: list[dict] = []
+
+        async def fake_run_foreman(guild_id, summary, *, user_id=None, task_id=None, child=False):
+            self._foreman_calls.append((guild_id, summary, user_id, task_id))
+
+        async def fake_notify_event(event_type, **kwargs):
+            self._discord_calls.append({"event_type": event_type, **kwargs})
+
+        queue = wh.DebounceQueue(
+            window_seconds=0.05,
+            combine=wh._combine_ci_pass_items,
+            deliver=wh._deliver_ci_pass,
+        )
+        with (
+            patch.object(wh, "_ci_pass_debounce_queue", queue),
+            patch.object(wh, "run_foreman_ai", new=fake_run_foreman),
+            patch.object(wh, "reset_foreman_poll"),
+            patch.object(wh.discord_notifier, "notify_event", new=fake_notify_event),
+        ):
+            try:
+                yield
+            finally:
+                await queue.shutdown()
+
+    @staticmethod
+    def _check_payload(*, conclusion: str, name: str, repo: str, pr_number: int, head_sha: str):
+        return {
+            "action": "completed",
+            "repository": {"full_name": repo},
+            "check_run": {
+                "name": name,
+                "status": "completed",
+                "conclusion": conclusion,
+                "head_sha": head_sha,
+                "pull_requests": [
+                    {"number": pr_number, "html_url": f"https://github.com/{repo}/pull/{pr_number}"}
+                ],
+            },
+            "sender": {"login": "github-actions[bot]"},
+        }
+
+    async def test_multiple_passing_checks_coalesce(self):
+        """Several passing check_run events on the same PR/SHA fire one combined notification."""
+        import routes.webhooks as wh
+
+        async with self._patched_env(wh):
+            for name in ("rspec", "lint", "typecheck"):
+                await wh._dispatch_check_event(
+                    "g-ci1",
+                    f"d-{name}",
+                    "check_run",
+                    "completed",
+                    self._check_payload(
+                        conclusion="success", name=name, repo="o/r", pr_number=7, head_sha="sha1"
+                    ),
+                    "o/r",
+                    7,
+                    "https://github.com/o/r/pull/7",
+                    "t-ci1",
+                    "user-1",
+                    "github-actions[bot]",
+                    None,
+                    None,
+                )
+            await asyncio.sleep(0.2)
+
+        assert len(self._foreman_calls) == 1, f"expected 1 call, got {self._foreman_calls}"
+        guild_id, summary, user_id, task_id = self._foreman_calls[0]
+        assert guild_id == "g-ci1"
+        assert task_id == "t-ci1"
+        assert user_id == "user-1"
+        assert "rspec" in summary
+        assert "lint" in summary
+        assert "typecheck" in summary
+
+        assert len(self._discord_calls) == 1
+        assert self._discord_calls[0]["event_type"] == "ci-pass"
+        description = self._discord_calls[0]["description"]
+        assert "rspec" in description
+        assert "lint" in description
+        assert "typecheck" in description
+
+    async def test_failing_check_bypasses_debounce(self):
+        """A failing check_run reaches the foreman immediately, without waiting on any window."""
+        import routes.webhooks as wh
+
+        async with self._patched_env(wh):
+            await wh._dispatch_check_event(
+                "g-ci2",
+                "d-fail",
+                "check_run",
+                "completed",
+                self._check_payload(
+                    conclusion="failure", name="rspec", repo="o/r", pr_number=8, head_sha="sha2"
+                ),
+                "o/r",
+                8,
+                "https://github.com/o/r/pull/8",
+                "t-ci2",
+                "user-2",
+                "github-actions[bot]",
+                None,
+                None,
+            )
+            # No window wait — the failure must already have been dispatched
+            # (as a background task via spawn()); yield once so it can run.
+            await asyncio.sleep(0.05)
+
+        assert len(self._foreman_calls) == 1
+        guild_id, summary, _user_id, task_id = self._foreman_calls[0]
+        assert guild_id == "g-ci2"
+        assert task_id == "t-ci2"
+        assert "rspec" in summary
+        assert "failure" in summary
+        # No debounce notification is emitted for a failure.
+        assert self._discord_calls == []
+
+    async def test_mixed_batch_failure_immediate_pass_still_debounced(self):
+        """A failing check on a PR fires immediately; passing checks for the same
+        PR/SHA still coalesce into their own, separately-timed notification."""
+        import routes.webhooks as wh
+
+        async with self._patched_env(wh):
+            await wh._dispatch_check_event(
+                "g-ci3",
+                "d-mix-fail",
+                "check_run",
+                "completed",
+                self._check_payload(
+                    conclusion="failure", name="rspec", repo="o/r", pr_number=9, head_sha="sha3"
+                ),
+                "o/r",
+                9,
+                "https://github.com/o/r/pull/9",
+                "t-ci3",
+                "user-3",
+                "github-actions[bot]",
+                None,
+                None,
+            )
+            await asyncio.sleep(0.05)
+
+            # The failure must already be delivered before any passing check
+            # in the same batch is scheduled.
+            assert len(self._foreman_calls) == 1
+            assert "rspec" in self._foreman_calls[0][1]
+
+            for name in ("lint", "typecheck"):
+                await wh._dispatch_check_event(
+                    "g-ci3",
+                    f"d-mix-{name}",
+                    "check_run",
+                    "completed",
+                    self._check_payload(
+                        conclusion="success", name=name, repo="o/r", pr_number=9, head_sha="sha3"
+                    ),
+                    "o/r",
+                    9,
+                    "https://github.com/o/r/pull/9",
+                    "t-ci3",
+                    "user-3",
+                    "github-actions[bot]",
+                    None,
+                    None,
+                )
+            await asyncio.sleep(0.2)
+
+        assert len(self._foreman_calls) == 2
+        assert "rspec" in self._foreman_calls[0][1]
+        assert "lint" in self._foreman_calls[1][1]
+        assert "typecheck" in self._foreman_calls[1][1]
+        assert len(self._discord_calls) == 1
+        assert "lint" in self._discord_calls[0]["description"]
+        assert "typecheck" in self._discord_calls[0]["description"]
+
+
+# ---------------------------------------------------------------------------
 # get_pr_status tool
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -19,7 +19,7 @@ import os
 import sys
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -46,6 +46,7 @@ from models import (
 )
 from routes.webhooks import (  # noqa: E402
     _build_foreman_summary,
+    _ci_pass_key,
     _get_guild_owner_github_login,
     _linked_issue_number_from_body,
     _linked_issue_number_from_branch,
@@ -481,7 +482,7 @@ def test_webhook_dispatches_for_ci_bot_check_run(client):
     headers = _signed_headers("ssecret", body, event="check_run", delivery="d-ci-1")
     with (
         patch("routes.webhooks._debounce_queue") as mock_q,
-        patch("routes.webhooks._dispatch_immediately", new=AsyncMock()) as mock_immediate,
+        patch("routes.webhooks._dispatch_immediately", new=MagicMock()) as mock_immediate,
     ):
         mock_q.schedule = AsyncMock()
         resp = test_client.post("/webhooks/github/gd4", content=body, headers=headers)
@@ -493,6 +494,43 @@ def test_webhook_dispatches_for_ci_bot_check_run(client):
     assert "rspec" in summary_arg
     assert task_arg == "t-ci"
     assert user_arg is None
+
+
+def test_webhook_routes_no_task_ci_pass_through_debounce_queue(client):
+    """A passing check_run with no matching task must still be routed through
+    the CI-pass debounce queue (issue #785 review comment #3) instead of
+    posting an immediate, un-coalesced Discord notification."""
+    test_client, db_url = client
+    insert_guild(db_url, "gd5")
+    _set_webhook_secret(db_url, "gd5", "ssecret")
+    payload = {
+        "action": "completed",
+        "repository": {"full_name": "o/r"},
+        "check_run": {
+            "name": "rspec",
+            "status": "completed",
+            "conclusion": "success",
+            "head_sha": "shax",
+            "pull_requests": [{"number": 42, "html_url": "https://github.com/o/r/pull/42"}],
+        },
+        "sender": {"login": "github-actions[bot]"},
+    }
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("ssecret", body, event="check_run", delivery="d-no-task")
+    with (
+        patch("routes.webhooks._ci_pass_debounce_queue") as mock_q,
+        patch("routes.webhooks.discord_notifier.notify_event", new=AsyncMock()) as mock_notify,
+    ):
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd5", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 1
+    kwargs = mock_q.schedule.call_args.kwargs
+    assert kwargs["task_id"] is None
+    assert kwargs["label"] == "rspec"
+    # No immediate, per-check Discord post — the debounce queue's deliver
+    # function is responsible for the combined post once its window fires.
+    assert mock_notify.call_count == 0
 
 
 # ---------------------------------------------------------------------------
@@ -730,6 +768,22 @@ class TestDebounce:
         assert "event B" in summary
 
 
+class TestCiPassKey:
+    """``_ci_pass_key`` guards against a shared ``...:None`` collision key."""
+
+    def test_deterministic_with_head_sha(self):
+        assert _ci_pass_key("g1", "o/r#7", "sha1") == "g1:ci-pass:o/r#7:sha1"
+        assert _ci_pass_key("g1", "o/r#7", "sha1") == _ci_pass_key("g1", "o/r#7", "sha1")
+
+    def test_missing_head_sha_does_not_collide(self):
+        """Two events with no head_sha must not share a key (unlike a naive f-string
+        that would collapse both to '...:None')."""
+        key_a = _ci_pass_key("g1", "o/r#7", None)
+        key_b = _ci_pass_key("g1", "o/r#7", None)
+        assert key_a != key_b
+        assert "None" not in key_a
+
+
 # ---------------------------------------------------------------------------
 # CI-pass debounce (issue #785): passing check_run/check_suite events coalesce
 # into one notification; failing checks bypass debounce entirely.
@@ -923,6 +977,32 @@ class TestCiPassDebounce:
         assert len(self._discord_calls) == 1
         assert "lint" in self._discord_calls[0]["description"]
         assert "typecheck" in self._discord_calls[0]["description"]
+
+    async def test_no_task_batch_coalesces_without_foreman_call(self):
+        """A passing check batch with no task_id (no matching task) still
+        coalesces into one Discord post, but must not wake the foreman —
+        it has no task context to act on (see _should_dispatch_to_foreman)."""
+        import routes.webhooks as wh
+
+        async with self._patched_env(wh):
+            key = wh._ci_pass_key("g-ci4", "o/r#10", "sha4")
+            for name in ("lint", "typecheck"):
+                await wh._ci_pass_debounce_queue.schedule(
+                    key,
+                    "g-ci4",
+                    "[github-event] check_run/check_suite passed on o/r#10",
+                    None,
+                    task_id=None,
+                    label=name,
+                    context={"pr_label": "o/r#10", "repo": "o/r", "pr_number": 10},
+                )
+            await asyncio.sleep(0.2)
+
+        assert self._foreman_calls == []
+        assert len(self._discord_calls) == 1
+        description = self._discord_calls[0]["description"]
+        assert "lint" in description
+        assert "typecheck" in description
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -452,6 +452,8 @@ def test_webhook_skips_foreman_for_bot_on_non_ci(client):
 
 
 def test_webhook_dispatches_for_ci_bot_check_run(client):
+    """A failing check_run bypasses debounce entirely (issue #785) — it goes
+    through ``_dispatch_immediately``, not the buffered ``_debounce_queue``."""
     test_client, db_url = client
     insert_guild(db_url, "gd4")
     _set_webhook_secret(db_url, "gd4", "ssecret")
@@ -477,15 +479,20 @@ def test_webhook_dispatches_for_ci_bot_check_run(client):
     }
     body = json.dumps(payload).encode()
     headers = _signed_headers("ssecret", body, event="check_run", delivery="d-ci-1")
-    with patch("routes.webhooks._debounce_queue") as mock_q:
+    with (
+        patch("routes.webhooks._debounce_queue") as mock_q,
+        patch("routes.webhooks._dispatch_immediately", new=AsyncMock()) as mock_immediate,
+    ):
         mock_q.schedule = AsyncMock()
         resp = test_client.post("/webhooks/github/gd4", content=body, headers=headers)
     assert resp.status_code == 202
-    assert mock_q.schedule.call_count == 1
-    key_arg, guild_arg, summary_arg, _user_arg = mock_q.schedule.call_args.args
-    assert "gd4" in key_arg
+    assert mock_q.schedule.call_count == 0
+    assert mock_immediate.call_count == 1
+    guild_arg, summary_arg, user_arg, task_arg = mock_immediate.call_args.args
     assert guild_arg == "gd4"
     assert "rspec" in summary_arg
+    assert task_arg == "t-ci"
+    assert user_arg is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements debouncing of passing `check_run`/`check_suite` webhook events before they reach the Foreman, per #785.

- Passing (`conclusion=success`) `check_run`/`check_suite` events are now buffered on a short, configurable debounce window (`CI_PASS_DEBOUNCE_SECONDS`, default 7s) keyed on `guild + repo + PR number + head SHA`.
- Additional passing check events for the same key reset the window and accumulate; once the window expires with no new events, a single combined message listing every distinct check name that passed is sent to the Foreman, plus one combined Discord "CI passed" notification (replacing the previous per-event Discord post).
- Failing/erroring conclusions (`failure`, `action_required`, `timed_out`, `cancelled`) bypass the debounce entirely and are dispatched to the Foreman immediately via a new `_dispatch_immediately` path.
- Any other/unrecognized completed conclusion falls back to the existing generic per-task debounce queue so it still reaches the Foreman.
- The `DebounceQueue` class was generalized to accept pluggable `combine`/`deliver` callbacks so the new CI-pass queue can share the same generation-based race-safe scheduling/cancellation logic as the original per-task queue, rather than duplicating it.

## Tests

- Updated `test_webhook_dispatches_for_ci_bot_check_run` to assert a failing check_run now goes through `_dispatch_immediately` rather than the buffered debounce queue.
- Added `TestCiPassDebounce` covering:
  - Multiple passing checks on the same PR/SHA coalesce into one combined Foreman message and one Discord notification listing all check names.
  - A failing check reaches the Foreman immediately, with no debounce delay and no Discord "CI passed" notification.
  - A mixed batch: the failing check fires immediately while passing checks for the same PR/SHA still coalesce separately once their window expires.

All 60 tests in `backend/tests/test_github_webhooks_phase2.py` pass; `ruff check` / `ruff format` clean.

Fixes #785.