### PR TITLE
Parallelize Foreman tool calls with asyncio.gather (#555)

### DIFF
--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -520,6 +520,88 @@ class TestExecToolsDispatching:
             )
         assert task_tool == "pi"
 
+    async def test_two_assign_task_calls_same_worker_in_one_batch(self, db_session):
+        """Two assign_task calls to the same worker within a single foreman turn
+        (i.e. one exec_tools batch, dispatched concurrently via asyncio.gather)
+        must not both succeed — the per-worker assign_task:<worker_id> lock
+        forces exactly one to win, the other reports a clean error instead of
+        double-assigning the worker. Regression test for issue #555."""
+        insert_guild(db_session, "g-assign-batch-race")
+        _insert_worker(db_session, "g-assign-batch-race", "w-batchrace1")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-assign-batch-race",
+                [
+                    _fake_tool_use(
+                        "assign_task",
+                        {"worker_id": "w-batchrace1", "description": "Task A", "name": "Task A"},
+                        tool_id="tid-a",
+                    ),
+                    _fake_tool_use(
+                        "assign_task",
+                        {"worker_id": "w-batchrace1", "description": "Task B", "name": "Task B"},
+                        tool_id="tid-b",
+                    ),
+                ],
+            )
+
+        assert len(results) == 2
+        # Result order must match tool_use order regardless of which finished first.
+        assert results[0]["tool_use_id"] == "tid-a"
+        assert results[1]["tool_use_id"] == "tid-b"
+
+        successes = [r for r in results if not r.get("is_error")]
+        errors = [r for r in results if r.get("is_error")]
+        assert len(successes) == 1
+        assert len(errors) == 1
+        assert "queued" in successes[0]["content"].lower()
+        assert "already being assigned" in errors[0]["content"].lower()
+
+        # Exactly one task should have actually been persisted for this worker.
+        with _sync_session(db_session) as session:
+            count = session.scalar(
+                select(func.count()).select_from(Task).where(col(Task.worker_id) == "w-batchrace1")
+            )
+        assert count == 1
+
+    async def test_mixed_tool_types_in_one_batch(self, db_session):
+        """A single foreman turn mixing create_task, assign_task, and
+        message_worker must dispatch all of them concurrently and return
+        correctly matched, correctly ordered results for each."""
+        insert_guild(db_session, "g-mixed-batch")
+        _insert_worker(db_session, "g-mixed-batch", "w-mixed1")
+        with (
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+            patch("foreman.tools.emit_terminal_line", new=AsyncMock()),
+            patch("foreman.tools.broadcast_msg", new=AsyncMock()),
+        ):
+            results = await exec_tools(
+                "g-mixed-batch",
+                [
+                    _fake_tool_use(
+                        "create_task",
+                        {"name": "Standalone task", "description": "desc"},
+                        tool_id="tid-create",
+                    ),
+                    _fake_tool_use(
+                        "assign_task",
+                        {"worker_id": "w-mixed1", "description": "Do work", "name": "Do it"},
+                        tool_id="tid-assign",
+                    ),
+                    _fake_tool_use(
+                        "message_worker",
+                        {"worker_id": "w-mixed1", "message": "hello"},
+                        tool_id="tid-message",
+                    ),
+                ],
+            )
+
+        assert [r["tool_use_id"] for r in results] == ["tid-create", "tid-assign", "tid-message"]
+        assert not any(r.get("is_error") for r in results)
+        assert "t-" in results[0]["content"]
+        assert "queued" in results[1]["content"].lower()
+        assert "delivered" in results[2]["content"].lower()
+
     async def test_send_followup_defaults_to_first_worker_tool(self, db_session):
         insert_guild(db_session, "g-followup-tooldefault")
         insert_worker(

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import sys
 from datetime import UTC, datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -523,9 +524,24 @@ class TestExecToolsDispatching:
     async def test_two_assign_task_calls_same_worker_in_one_batch(self, db_session):
         """Two assign_task calls to the same worker within a single foreman turn
         (i.e. one exec_tools batch, dispatched concurrently via asyncio.gather)
-        must not both succeed — the per-worker assign_task:<worker_id> lock
-        forces exactly one to win, the other reports a clean error instead of
-        double-assigning the worker. Regression test for issue #555."""
+        must not both succeed.
+
+        Each concurrent call opens its *own* AsyncSession (see exec_tools'
+        docstring), so mutual exclusion can't come from an in-process
+        asyncio.Lock — there isn't one shared between the two coroutines, and
+        even if there were, holding it across the `await` points inside
+        assign_task wouldn't be guaranteed reentrant-safe. Instead assign_task
+        takes a **database-level** lock: LockService.acquire() INSERTs into the
+        `locks` table under a partial unique index on (key) for active rows
+        (`locks_key_active_unique`), and the loser gets an IntegrityError that
+        is converted into `acquired = False`. That uniqueness constraint is
+        enforced by Postgres itself, so exactly one of the two concurrent
+        inserts can ever succeed regardless of how the event loop interleaves
+        the two coroutines — this is what makes the test deterministic rather
+        than a race that happens to usually work.
+
+        Regression test for issue #555.
+        """
         insert_guild(db_session, "g-assign-batch-race")
         _insert_worker(db_session, "g-assign-batch-race", "w-batchrace1")
         with patch("foreman.tools.broadcast", new_callable=AsyncMock):
@@ -552,14 +568,23 @@ class TestExecToolsDispatching:
 
         successes = [r for r in results if not r.get("is_error")]
         errors = [r for r in results if r.get("is_error")]
+        # Exactly one success and one error — not >=1 of each — so the test
+        # fails loudly if the DB lock ever stops serializing the two calls
+        # (e.g. both succeed, or both get locked out).
         assert len(successes) == 1
         assert len(errors) == 1
         assert "queued" in successes[0]["content"].lower()
         assert "already being assigned" in errors[0]["content"].lower()
 
         # Exactly one task should have actually been persisted for this worker.
-        with _sync_session(db_session) as session:
-            count = session.scalar(
+        # assign_task commits its own AsyncSession before exec_tools returns
+        # (see the `await db.commit()` right after the lock acquire/recheck in
+        # foreman/tools.py), so a fresh session from the same AsyncSessionLocal
+        # used by the app — the same factory the db_session fixture points at
+        # database_module.AsyncSessionLocal — is guaranteed to observe the
+        # committed row(s), unlike a session opened before the commit lands.
+        async with database_module.AsyncSessionLocal() as db:
+            count = await db.scalar(
                 select(func.count()).select_from(Task).where(col(Task.worker_id) == "w-batchrace1")
             )
         assert count == 1
@@ -598,7 +623,10 @@ class TestExecToolsDispatching:
 
         assert [r["tool_use_id"] for r in results] == ["tid-create", "tid-assign", "tid-message"]
         assert not any(r.get("is_error") for r in results)
-        assert "t-" in results[0]["content"]
+        # Match the full "t-<6 lowercase alnum>" task id format (see the id
+        # generator in foreman/tools.py) rather than a bare "t-" substring,
+        # which would also match unrelated error text.
+        assert re.search(r"\bt-[a-z0-9]{6}\b", results[0]["content"])
         assert "queued" in results[1]["content"].lower()
         assert "delivered" in results[2]["content"].lower()
 


### PR DESCRIPTION
## Summary

Issue #555 asked for the Foreman's per-turn tool-dispatch loop to run independent tool calls concurrently with `asyncio.gather` instead of awaiting them one at a time, with per-worker locking to keep `assign_task`-style state transitions safe.

Investigation found this was already implemented in a prior commit (`0ac1a77`, "parallel foreman tools"): both `backend/foreman/tools.py::exec_tools` (embedded runner) and `foreman/pioneer_foreman/tools.py::exec_tools` (standalone runner) already fan out a turn's tool calls via `asyncio.gather`, preserve result order, and isolate per-tool failures (`_exec_one_tool` catches all exceptions internally, so one bad tool never drops the others). `assign_task` already guards worker-state transitions with a per-worker `assign_task:<worker_id>` DB lock (`LockService`), closing the TOCTOU window between worker selection and assignment.

What was missing was regression coverage for the exact scenarios called out in the issue. This PR adds:
- `test_two_assign_task_calls_same_worker_in_one_batch` — two `assign_task` calls targeting the same worker within a single `exec_tools` batch; asserts exactly one succeeds, the other fails cleanly with "already being assigned", and only one `Task` row is persisted.
- `test_mixed_tool_types_in_one_batch` — a batch mixing `create_task`, `assign_task`, and `message_worker`; asserts all three dispatch, results stay correctly ordered/matched to their `tool_use_id`.

No production code changes were needed — this closes out the remaining acceptance criterion (tests) for #555.

## Test plan
- [x] `pytest backend/tests/test_foreman.py backend/tests/test_foreman_runner.py backend/tests/test_assign_task_auto_model.py backend/tests/test_call_agent_tool.py` — 154 passed
- [x] `pytest foreman/tests/test_tools.py` — 12 passed

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)