### PR TITLE
feat: remove worker pre-truncation, move to backend/UI (#792)

### DIFF
--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -24,16 +24,32 @@ def _usage_tokens(usage: dict) -> dict:
     }
 
 
+_LINE_PREVIEW_LEN = 150
+
+
+def _clip_line(line: str, limit: int = _LINE_PREVIEW_LEN) -> str:
+    """Clip a single display line to *limit* chars. The full text always lives
+    in the accompanying ``detail`` payload — this only shortens the sidebar
+    preview.
+    """
+    return line if len(line) <= limit else line[:limit] + "…"
+
+
 def _summarize_lines(lines: list[str], prefix: str = "  → ") -> str:
-    """Format a list of lines as a 2+ellipsis+1 summary."""
+    """Format a list of lines as a short 2+ellipsis+1 summary.
+
+    Each shown line is clipped to `_LINE_PREVIEW_LEN` chars so the summary
+    stays sidebar-sized; callers pair this with a ``detail`` dict carrying
+    the untruncated content for click-to-expand.
+    """
     if len(lines) <= 4:
-        return "\n".join(f"{prefix}{l}" for l in lines)
+        return "\n".join(f"{prefix}{_clip_line(l)}" for l in lines)
     middle = len(lines) - 3
     return (
-        f"{prefix}{lines[0]}\n"
-        f"{prefix}{lines[1]}\n"
+        f"{prefix}{_clip_line(lines[0])}\n"
+        f"{prefix}{_clip_line(lines[1])}\n"
         f"{prefix}… ({middle} more lines)\n"
-        f"{prefix}{lines[-1]}"
+        f"{prefix}{_clip_line(lines[-1])}"
     )
 
 

--- a/worker/tests/test_claude_runner.py
+++ b/worker/tests/test_claude_runner.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pytest
 from pioneer_worker.claude_runner import (
+    _LINE_PREVIEW_LEN,
+    _clip_line,
     _summarize_lines,
     _truncate_at_word,
     _usage_tokens,
@@ -47,6 +49,24 @@ def test_summarize_custom_prefix():
     lines = ["alpha", "beta", "gamma", "delta", "epsilon"]
     result = _summarize_lines(lines, prefix=">> ")
     assert result.count(">> ") >= 3
+
+
+def test_summarize_clips_long_lines():
+    long_line = "x" * 500
+    result = _summarize_lines([long_line])
+    assert "…" in result
+    assert len(result.splitlines()[0]) < len(long_line)
+
+
+def test_clip_line_short_unchanged():
+    assert _clip_line("short") == "short"
+
+
+def test_clip_line_long_clipped():
+    long_line = "y" * 500
+    clipped = _clip_line(long_line)
+    assert clipped.endswith("…")
+    assert len(clipped) == _LINE_PREVIEW_LEN + 1
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +284,24 @@ def test_parse_user_tool_result_summarized_line_keeps_full_output_in_detail():
     assert "more lines" in text  # display line is elided
     assert text != full_output
     assert detail["output"] == full_output  # full content preserved untruncated
+
+
+def test_parse_user_tool_result_single_long_line_clipped_but_detail_full():
+    """A single line under the 4-line elision threshold can still be huge
+
+    (e.g. minified JSON); the display line must still be clipped for the
+    sidebar while ``detail['output']`` keeps the untruncated content.
+    """
+    full_output = "x" * 5000
+    event = {
+        "type": "user",
+        "message": {"content": [{"type": "tool_result", "content": full_output}]},
+    }
+    pairs = parse_claude_event(event)
+    assert len(pairs) == 1
+    text, detail = pairs[0]
+    assert len(text) < 200
+    assert detail["output"] == full_output
 
 
 def test_parse_user_tool_result_empty_skipped():


### PR DESCRIPTION
## Summary

Closes #792. Completes the last piece of the pre-truncation removal that was started across #778, #781, and #782:

- `claude_runner._summarize_lines` was still writing full (unclipped) lines into the sidebar `line` summary for tool-result blocks with ≤4 lines. Long single-line output (e.g. minified JSON) could produce an oversized sidebar preview.
- Added `_clip_line` to cap each line shown in the sidebar summary at 150 chars, independent of the `detail`/`data` payload, which continues to carry the full untruncated content (as established in #781/#783 and consumed by `get_task_status` in #782).

`codex_runner.py` and `pi_runner.py` already preserve full untruncated content in `detail`/`data` from prior work and needed no changes here.

## Test plan
- [x] `pytest tests/test_claude_runner.py` — 35 passed
- [x] Full worker suite: `pytest` — 257 passed, 1 pre-existing unrelated failure

Note: `tests/test_tools_detection.py::TestToolsCLIFlag::test_no_tools_flag_gives_none` fails on this branch, but it also fails on a clean stash of `main` in this environment (it asserts tool auto-detection returns `None`, but the sandbox has `claude`/`pi` CLIs installed, so auto-detect finds them). This is unrelated to the truncation changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)