### PR TITLE
Discord: DM new members with /connect-account instructions (#793)

### DIFF
--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -13,14 +13,16 @@ Enable with::
     DISCORD_BOT_TOKEN=...          # reused from Phase 2/3
 
 The bot's Discord application must have the privileged "Message Content
-Intent" turned on in the Developer Portal (Bot page) — without it Discord
-rejects the IDENTIFY payload's ``MESSAGE_CONTENT`` intent bit.
+Intent" and "Server Members Intent" turned on in the Developer Portal (Bot
+page) — without them Discord rejects the IDENTIFY payload's
+``MESSAGE_CONTENT``/``GUILD_MEMBERS`` intent bits.
 
 Protocol handled, per https://discord.com/developers/docs/topics/gateway:
     HELLO (op 10)            -> start the heartbeat loop, then IDENTIFY/RESUME
     HEARTBEAT_ACK (op 11)    -> mark the last heartbeat as acknowledged
     DISPATCH (op 0)          -> READY stores session_id/resume url; MESSAGE_CREATE
-                                 is filtered and queued
+                                 is filtered and queued; GUILD_MEMBER_ADD sends a
+                                 welcome DM (see ``discord_notifier.send_welcome_dm``)
     RECONNECT (op 7)         -> close and reconnect, attempting RESUME
     INVALID_SESSION (op 9)   -> RESUME if resumable, otherwise fresh IDENTIFY
 
@@ -55,8 +57,9 @@ logger = logging.getLogger(__name__)
 
 _GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
 
-# GUILDS (1 << 0) | GUILD_MESSAGES (1 << 9) | MESSAGE_CONTENT (1 << 15)
-_INTENTS = 33281
+# GUILDS (1 << 0) | GUILD_MEMBERS (1 << 1) | GUILD_MESSAGES (1 << 9)
+# | MESSAGE_CONTENT (1 << 15)
+_INTENTS = 33283
 
 # Gateway opcodes.
 _OP_DISPATCH = 0
@@ -317,6 +320,8 @@ class GatewayClient:
             logger.info("discord gateway: RESUMED session_id=%s", self._session_id)
         elif event_type == "MESSAGE_CREATE":
             await self._handle_message_create(payload)
+        elif event_type == "GUILD_MEMBER_ADD":
+            await self._handle_guild_member_add(payload)
 
     async def _handle_message_create(self, message: dict) -> None:
         author = message.get("author") or {}
@@ -328,6 +333,24 @@ class GatewayClient:
         if not channel_id or not await _is_channel_wired(channel_id):
             return
         await self._queue.put(message)
+
+    async def _handle_guild_member_add(self, member: dict) -> None:
+        """DM a newly-joined guild member onboarding instructions.
+
+        Skips bot accounts (they can't run slash commands anyway) and members
+        with no resolvable user id. Delegates the actual DM — including
+        swallowing "DMs disabled" failures — to
+        ``discord_notifier.send_welcome_dm``, so this method never raises.
+        """
+        user = member.get("user") or {}
+        user_id = user.get("id")
+        if not user_id or user.get("bot"):
+            return
+        username = user.get("global_name") or user.get("username")
+
+        from discord_notifier import send_welcome_dm  # noqa: PLC0415
+
+        await send_welcome_dm(user_id, username)
 
 
 _gateway_task: asyncio.Task | None = None

--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -52,6 +52,7 @@ import random
 import time
 
 import websockets
+from discord_notifier import send_welcome_dm
 
 logger = logging.getLogger(__name__)
 
@@ -347,8 +348,6 @@ class GatewayClient:
         if not user_id or user.get("bot"):
             return
         username = user.get("global_name") or user.get("username")
-
-        from discord_notifier import send_welcome_dm  # noqa: PLC0415
 
         await send_welcome_dm(user_id, username)
 

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -175,6 +175,33 @@ async def notify(
 # ---------------------------------------------------------------------------
 
 
+async def _bot_request_raw(
+    method: str,
+    path: str,
+    json_body: dict | None = None,
+) -> dict:
+    """Make an authenticated Discord bot API request, raising on failure.
+
+    Returns the parsed JSON response dict, or an empty dict for 204/empty
+    bodies. Unlike ``_bot_request``, this does not swallow errors — callers
+    that need to distinguish an expected API failure (``httpx.HTTPError``)
+    from a genuine bug use this directly (see ``send_welcome_dm``).
+    """
+    token = _bot_token()
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+    }
+    client = _get_client()
+    resp = await getattr(client, method)(
+        f"{_DISCORD_API_BASE}{path}",
+        json=json_body,
+        headers=headers,
+    )
+    resp.raise_for_status()
+    return resp.json() if resp.content else {}
+
+
 async def _bot_request(
     method: str,
     path: str,
@@ -185,24 +212,10 @@ async def _bot_request(
     Returns the parsed JSON response dict, an empty dict for 204/empty bodies,
     or None on error.  Never raises.
     """
-    token = _bot_token()
-    if not token:
+    if not _bot_token():
         return None
-    headers = {
-        "Authorization": f"Bot {token}",
-        "Content-Type": "application/json",
-    }
     try:
-        client = _get_client()
-        resp = await getattr(client, method)(
-            f"{_DISCORD_API_BASE}{path}",
-            json=json_body,
-            headers=headers,
-        )
-        resp.raise_for_status()
-        if resp.content:
-            return resp.json()
-        return {}
+        return await _bot_request_raw(method, path, json_body)
     except Exception:
         logger.warning(
             "Discord bot API request failed method=%s path=%s", method, path, exc_info=True
@@ -411,7 +424,8 @@ def _welcome_dm_text(username: str) -> str:
     template = os.environ.get("DISCORD_WELCOME_DM_TEXT") or _DEFAULT_WELCOME_DM_TEXT
     try:
         return template.format(username=username)
-    except (KeyError, IndexError):
+    except (KeyError, IndexError) as e:
+        logger.warning("DISCORD_WELCOME_DM_TEXT render failed, using raw template: %s", e)
         return template
 
 
@@ -420,17 +434,17 @@ async def send_welcome_dm(discord_user_id: str, username: str | None = None) -> 
 
     Opens a DM channel with the bot (``POST /users/@me/channels``), then posts
     the welcome message there. Some users have DMs disabled for non-friends —
-    Discord's API returns an error opening the channel or sending the message
-    in that case, which is caught and logged at WARNING. Silent no-op when the
-    bot token is not configured. Never raises.
+    Discord's API returns an HTTP error opening the channel or sending the
+    message in that case, which is caught and logged at WARNING. Silent
+    no-op when the bot token is not configured. Never raises.
     """
     if not _bot_token():
         return
     try:
-        dm_channel = await _bot_request(
+        dm_channel = await _bot_request_raw(
             "post", "/users/@me/channels", {"recipient_id": discord_user_id}
         )
-        channel_id = dm_channel.get("id") if dm_channel else None
+        channel_id = dm_channel.get("id")
         if not channel_id:
             logger.warning(
                 "discord: could not open DM channel for new member user=%s", discord_user_id
@@ -438,18 +452,12 @@ async def send_welcome_dm(discord_user_id: str, username: str | None = None) -> 
             return
 
         content = _welcome_dm_text(username or "there")
-        sent = await _bot_request(
+        await _bot_request_raw(
             "post", f"/channels/{channel_id}/messages", {"content": content[:_MAX_MESSAGE_LENGTH]}
         )
-        if sent is None:
-            logger.warning(
-                "discord: failed to send welcome DM to new member user=%s", discord_user_id
-            )
-    except Exception:
+    except httpx.HTTPError as e:
         logger.warning(
-            "discord: unexpected error sending welcome DM to user=%s",
-            discord_user_id,
-            exc_info=True,
+            "discord: welcome DM failed for new member user=%s: %s", discord_user_id, e
         )
 
 

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -38,6 +38,15 @@ Phase 4 — live task-stream mirroring
     bot token, since the feed always routes into a thread — never a flat channel
     post). The per-task thread mapping persists in ``discord_task_threads``.
 
+Phase 5 — new-member welcome DM
+    ``send_welcome_dm`` is called by the Gateway client (``discord.gateway``)
+    when a ``GUILD_MEMBER_ADD`` event arrives, and DMs the new member
+    onboarding instructions pointing them at ``/connect-account``. Requires
+    ``DISCORD_GATEWAY_ENABLED`` plus the privileged Server Members intent (see
+    ``discord.gateway``). Message text is configurable via
+    ``DISCORD_WELCOME_DM_TEXT``. DM failures (e.g. DMs disabled) are logged at
+    WARNING and never raised.
+
 Required bot permissions: ``SEND_MESSAGES``, ``CREATE_PUBLIC_THREADS``, ``MANAGE_THREADS``.
 
 Usage::
@@ -376,6 +385,72 @@ async def _post_to_thread(
 async def archive_thread(thread_id: str) -> None:
     """Archive a Discord thread. Never raises."""
     await _bot_request("patch", f"/channels/{thread_id}", {"archived": True})
+
+
+# ---------------------------------------------------------------------------
+# New-member welcome DM
+# ---------------------------------------------------------------------------
+
+_DEFAULT_WELCOME_DM_TEXT = (
+    "Welcome, {username}! 👋\n\n"
+    "Pioneer Square is an AI-assisted engineering system: a Foreman AI turns GitHub "
+    "issues into shipped pull requests using a fleet of coding workers.\n\n"
+    "Run `/connect-account` here to link your Discord identity to Pioneer Square — "
+    "that unlocks personal login keys and lets you chat directly with the Foreman."
+)
+
+
+def _welcome_dm_text(username: str) -> str:
+    """Return the welcome DM body, filling in *username* if the template uses it.
+
+    Reads ``DISCORD_WELCOME_DM_TEXT`` on every call (rather than caching) so an
+    operator's env var change takes effect without a restart. Falls back to the
+    literal template when it doesn't reference ``{username}`` — or references an
+    unknown placeholder — so a misconfigured env var never blocks the DM.
+    """
+    template = os.environ.get("DISCORD_WELCOME_DM_TEXT") or _DEFAULT_WELCOME_DM_TEXT
+    try:
+        return template.format(username=username)
+    except (KeyError, IndexError):
+        return template
+
+
+async def send_welcome_dm(discord_user_id: str, username: str | None = None) -> None:
+    """DM a newly-joined guild member with onboarding instructions.
+
+    Opens a DM channel with the bot (``POST /users/@me/channels``), then posts
+    the welcome message there. Some users have DMs disabled for non-friends —
+    Discord's API returns an error opening the channel or sending the message
+    in that case, which is caught and logged at WARNING. Silent no-op when the
+    bot token is not configured. Never raises.
+    """
+    if not _bot_token():
+        return
+    try:
+        dm_channel = await _bot_request(
+            "post", "/users/@me/channels", {"recipient_id": discord_user_id}
+        )
+        channel_id = dm_channel.get("id") if dm_channel else None
+        if not channel_id:
+            logger.warning(
+                "discord: could not open DM channel for new member user=%s", discord_user_id
+            )
+            return
+
+        content = _welcome_dm_text(username or "there")
+        sent = await _bot_request(
+            "post", f"/channels/{channel_id}/messages", {"content": content[:_MAX_MESSAGE_LENGTH]}
+        )
+        if sent is None:
+            logger.warning(
+                "discord: failed to send welcome DM to new member user=%s", discord_user_id
+            )
+    except Exception:
+        logger.warning(
+            "discord: unexpected error sending welcome DM to user=%s",
+            discord_user_id,
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -456,9 +456,7 @@ async def send_welcome_dm(discord_user_id: str, username: str | None = None) -> 
             "post", f"/channels/{channel_id}/messages", {"content": content[:_MAX_MESSAGE_LENGTH]}
         )
     except httpx.HTTPError as e:
-        logger.warning(
-            "discord: welcome DM failed for new member user=%s: %s", discord_user_id, e
-        )
+        logger.warning("discord: welcome DM failed for new member user=%s: %s", discord_user_id, e)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -94,7 +94,7 @@ async def test_identify_sent_after_hello_with_no_prior_session():
     identify = [m for m in ws.sent if m["op"] == gateway._OP_IDENTIFY]
     assert len(identify) == 1
     assert identify[0]["d"]["token"] == "test-token"
-    assert identify[0]["d"]["intents"] == 33281
+    assert identify[0]["d"]["intents"] == 33283
 
 
 @pytest.mark.asyncio
@@ -236,6 +236,60 @@ async def test_message_create_dispatch_reaches_queue_end_to_end():
 
     assert q.qsize() == 1
     assert (await q.get())["content"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# GUILD_MEMBER_ADD -> welcome DM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_guild_member_add_sends_welcome_dm():
+    client = gateway.GatewayClient("token")
+    member = {"user": {"id": "u1", "username": "newperson", "bot": False}}
+    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+        await client._handle_guild_member_add(member)
+    mock_send.assert_awaited_once_with("u1", "newperson")
+
+
+@pytest.mark.asyncio
+async def test_guild_member_add_prefers_global_name():
+    client = gateway.GatewayClient("token")
+    member = {"user": {"id": "u1", "username": "newperson", "global_name": "New Person", "bot": False}}
+    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+        await client._handle_guild_member_add(member)
+    mock_send.assert_awaited_once_with("u1", "New Person")
+
+
+@pytest.mark.asyncio
+async def test_guild_member_add_skips_bot_accounts():
+    client = gateway.GatewayClient("token")
+    member = {"user": {"id": "u1", "username": "some-bot", "bot": True}}
+    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+        await client._handle_guild_member_add(member)
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_guild_member_add_skips_missing_user_id():
+    client = gateway.GatewayClient("token")
+    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+        await client._handle_guild_member_add({"user": {}})
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_guild_member_add_dispatch_end_to_end():
+    """A full GUILD_MEMBER_ADD dispatch frame triggers the welcome DM."""
+    member = {"user": {"id": "u1", "username": "newperson", "bot": False}}
+    frame = _dispatch("GUILD_MEMBER_ADD", member)
+    ws = FakeGatewayWebSocket([_hello(), frame, _CLOSE])
+    client = gateway.GatewayClient("test-token")
+
+    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+        await _run_briefly(client, ws)
+
+    mock_send.assert_awaited_once_with("u1", "newperson")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -255,7 +255,9 @@ async def test_guild_member_add_sends_welcome_dm():
 @pytest.mark.asyncio
 async def test_guild_member_add_prefers_global_name():
     client = gateway.GatewayClient("token")
-    member = {"user": {"id": "u1", "username": "newperson", "global_name": "New Person", "bot": False}}
+    member = {
+        "user": {"id": "u1", "username": "newperson", "global_name": "New Person", "bot": False}
+    }
     with patch("discord.gateway.send_welcome_dm", new=AsyncMock()) as mock_send:
         await client._handle_guild_member_add(member)
     mock_send.assert_awaited_once_with("u1", "New Person")

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -247,7 +247,7 @@ async def test_message_create_dispatch_reaches_queue_end_to_end():
 async def test_guild_member_add_sends_welcome_dm():
     client = gateway.GatewayClient("token")
     member = {"user": {"id": "u1", "username": "newperson", "bot": False}}
-    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+    with patch("discord.gateway.send_welcome_dm", new=AsyncMock()) as mock_send:
         await client._handle_guild_member_add(member)
     mock_send.assert_awaited_once_with("u1", "newperson")
 
@@ -256,7 +256,7 @@ async def test_guild_member_add_sends_welcome_dm():
 async def test_guild_member_add_prefers_global_name():
     client = gateway.GatewayClient("token")
     member = {"user": {"id": "u1", "username": "newperson", "global_name": "New Person", "bot": False}}
-    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+    with patch("discord.gateway.send_welcome_dm", new=AsyncMock()) as mock_send:
         await client._handle_guild_member_add(member)
     mock_send.assert_awaited_once_with("u1", "New Person")
 
@@ -265,7 +265,7 @@ async def test_guild_member_add_prefers_global_name():
 async def test_guild_member_add_skips_bot_accounts():
     client = gateway.GatewayClient("token")
     member = {"user": {"id": "u1", "username": "some-bot", "bot": True}}
-    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+    with patch("discord.gateway.send_welcome_dm", new=AsyncMock()) as mock_send:
         await client._handle_guild_member_add(member)
     mock_send.assert_not_called()
 
@@ -273,7 +273,7 @@ async def test_guild_member_add_skips_bot_accounts():
 @pytest.mark.asyncio
 async def test_guild_member_add_skips_missing_user_id():
     client = gateway.GatewayClient("token")
-    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+    with patch("discord.gateway.send_welcome_dm", new=AsyncMock()) as mock_send:
         await client._handle_guild_member_add({"user": {}})
     mock_send.assert_not_called()
 
@@ -286,7 +286,7 @@ async def test_guild_member_add_dispatch_end_to_end():
     ws = FakeGatewayWebSocket([_hello(), frame, _CLOSE])
     client = gateway.GatewayClient("test-token")
 
-    with patch("discord_notifier.send_welcome_dm", new=AsyncMock()) as mock_send:
+    with patch("discord.gateway.send_welcome_dm", new=AsyncMock()) as mock_send:
         await _run_briefly(client, ws)
 
     mock_send.assert_awaited_once_with("u1", "newperson")

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -841,6 +841,125 @@ async def test_archive_thread_http_error_does_not_raise(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# New-member welcome DM
+# ---------------------------------------------------------------------------
+
+
+def _json_response(payload: dict, status_code: int = 200):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.content = json.dumps(payload).encode()
+    resp.json = MagicMock(return_value=payload)
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_send_welcome_dm_opens_channel_and_posts_message(monkeypatch):
+    """send_welcome_dm opens a DM channel then posts the welcome text there."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    DM_CHANNEL_ID = "dm-channel-999"
+
+    channel_response = _json_response({"id": DM_CHANNEL_ID})
+    message_response = _json_response({"id": "msg-1"})
+
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    mock_client.post = AsyncMock(side_effect=[channel_response, message_response])
+
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier.send_welcome_dm("u123", "newperson")
+
+    assert mock_client.post.call_count == 2
+
+    open_call = mock_client.post.call_args_list[0]
+    assert "/users/@me/channels" in open_call[0][0]
+    assert open_call[1]["json"] == {"recipient_id": "u123"}
+
+    send_call = mock_client.post.call_args_list[1]
+    assert f"/channels/{DM_CHANNEL_ID}/messages" in send_call[0][0]
+    assert "/connect-account" in send_call[1]["json"]["content"]
+    assert "newperson" in send_call[1]["json"]["content"]
+
+
+@pytest.mark.asyncio
+async def test_send_welcome_dm_no_op_when_bot_token_unset():
+    """send_welcome_dm makes no HTTP call when DISCORD_BOT_TOKEN is unset."""
+    mock_client = _make_mock_client()
+
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier.send_welcome_dm("u123", "newperson")
+
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_welcome_dm_swallows_dm_disabled_error(monkeypatch):
+    """A user with DMs disabled makes channel-open fail; never raises."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    mock_client = _make_mock_client(status_code=403)
+
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier.send_welcome_dm("u123", "newperson")  # must not raise
+
+    mock_client.post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_welcome_dm_swallows_send_failure(monkeypatch):
+    """Channel opens fine but the message POST fails; never raises."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    channel_response = _json_response({"id": "dm-channel-999"})
+    failure_response = _json_response({}, status_code=500)
+
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    mock_client.post = AsyncMock(side_effect=[channel_response, failure_response])
+
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier.send_welcome_dm("u123", "newperson")  # must not raise
+
+    assert mock_client.post.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_send_welcome_dm_defaults_username_when_missing(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    channel_response = _json_response({"id": "dm-channel-999"})
+    message_response = _json_response({"id": "msg-1"})
+
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    mock_client.post = AsyncMock(side_effect=[channel_response, message_response])
+
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier.send_welcome_dm("u123", None)
+
+    send_call = mock_client.post.call_args_list[1]
+    assert "there" in send_call[1]["json"]["content"]
+
+
+def test_welcome_dm_text_uses_default_template(monkeypatch):
+    monkeypatch.delenv("DISCORD_WELCOME_DM_TEXT", raising=False)
+    text = discord_notifier._welcome_dm_text("alice")
+    assert "alice" in text
+    assert "/connect-account" in text
+
+
+def test_welcome_dm_text_honours_env_override(monkeypatch):
+    monkeypatch.setenv("DISCORD_WELCOME_DM_TEXT", "Hey {username}, welcome aboard!")
+    assert discord_notifier._welcome_dm_text("alice") == "Hey alice, welcome aboard!"
+
+
+def test_welcome_dm_text_env_override_without_placeholder(monkeypatch):
+    """A custom template with no {username} placeholder is used verbatim."""
+    monkeypatch.setenv("DISCORD_WELCOME_DM_TEXT", "Welcome! Run /connect-account.")
+    assert discord_notifier._welcome_dm_text("alice") == "Welcome! Run /connect-account."
+
+
+# ---------------------------------------------------------------------------
 # Phase 3: Foreman chat threads
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Gateway client now handles `GUILD_MEMBER_ADD` dispatch events (requires the privileged **Server Members Intent**, added alongside the existing Message Content intent bit) and DMs new guild members with onboarding instructions pointing them at `/connect-account`.
- `discord_notifier.send_welcome_dm()` opens a DM channel via the bot API (`POST /users/@me/channels`) and posts the welcome text; failures (DMs disabled, API errors) are caught and logged at WARNING — never raised.
- Welcome text is configurable via `DISCORD_WELCOME_DM_TEXT` (supports a `{username}` placeholder), with a sensible default.
- Bot accounts and members with no resolvable user id are skipped.

## Test plan
- [x] `pytest backend/tests/test_discord_gateway.py backend/tests/test_discord_notifier.py -q` — 101 passed, including new `GUILD_MEMBER_ADD` and `send_welcome_dm` tests covering: DM sent with correct content, `{username}` substitution, missing-username fallback, bot-account skip, DM-disabled failure swallowed, message-send failure swallowed, env var override of welcome text.
- [x] Full backend suite: `pytest -q` — 892 passed, 2 skipped (pre-existing).
- [x] `ruff check` — clean.

Closes #793