### PR TITLE
Ensure every DB table has an id primary key (#791)

### DIFF
--- a/backend/alembic/versions/20260706_000000_add_id_pk_everywhere.py
+++ b/backend/alembic/versions/20260706_000000_add_id_pk_everywhere.py
@@ -50,6 +50,19 @@ _COMPOSITE_TABLES = [
 ]
 
 
+def _pk_constraint_name(table: str) -> str:
+    """Look up a table's actual primary-key constraint name.
+
+    Some tables (e.g. ``guild_members``) went through a create-as-``_new``-
+    then-rename migration (20260512_000002); PostgreSQL keeps the
+    constraint's original auto-generated name (``guild_members_new_pkey``)
+    across the rename, so we can't assume ``{table}_pkey``.
+    """
+    bind = op.get_bind()
+    pk = sa.inspect(bind).get_pk_constraint(table)
+    return pk["name"]
+
+
 def upgrade() -> None:
     # user_sessions.github_user_id FKs to github_tokens.github_user_id; drop
     # that FK before github_tokens' PK constraint changes, then recreate it.
@@ -57,7 +70,7 @@ def upgrade() -> None:
 
     for table, col in _SINGLE_COLUMN_TABLES:
         op.execute(sa.text(f"ALTER TABLE {table} ADD COLUMN id SERIAL"))
-        op.drop_constraint(f"{table}_pkey", table, type_="primary")
+        op.drop_constraint(_pk_constraint_name(table), table, type_="primary")
         op.create_primary_key(f"{table}_pkey", table, ["id"])
         op.create_unique_constraint(f"{table}_{col}_key", table, [col])
 
@@ -71,7 +84,7 @@ def upgrade() -> None:
 
     for table, cols, index_name in _COMPOSITE_TABLES:
         op.execute(sa.text(f"ALTER TABLE {table} ADD COLUMN id SERIAL"))
-        op.drop_constraint(f"{table}_pkey", table, type_="primary")
+        op.drop_constraint(_pk_constraint_name(table), table, type_="primary")
         op.create_primary_key(f"{table}_pkey", table, ["id"])
         op.create_index(index_name, table, cols, unique=True)
 
@@ -79,7 +92,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     for table, cols, index_name in reversed(_COMPOSITE_TABLES):
         op.drop_index(index_name, table_name=table)
-        op.drop_constraint(f"{table}_pkey", table, type_="primary")
+        op.drop_constraint(_pk_constraint_name(table), table, type_="primary")
         op.create_primary_key(f"{table}_pkey", table, cols)
         op.drop_column(table, "id")
 
@@ -87,7 +100,7 @@ def downgrade() -> None:
 
     for table, col in reversed(_SINGLE_COLUMN_TABLES):
         op.drop_constraint(f"{table}_{col}_key", table, type_="unique")
-        op.drop_constraint(f"{table}_pkey", table, type_="primary")
+        op.drop_constraint(_pk_constraint_name(table), table, type_="primary")
         op.create_primary_key(f"{table}_pkey", table, [col])
         op.drop_column(table, "id")
 

--- a/backend/alembic/versions/20260706_000000_add_id_pk_everywhere.py
+++ b/backend/alembic/versions/20260706_000000_add_id_pk_everywhere.py
@@ -16,9 +16,11 @@ string column or a composite of two columns instead of a plain `id`:
 - discord_connect_tokens (PK was token)
 - model_catalog        (PK was (provider, model_id))
 
-For each, this adds a SERIAL `id` column, makes it the primary key, and
+For each, this adds an identity `id` column, makes it the primary key, and
 preserves the old key as a UNIQUE constraint/index so existing lookups,
-foreign keys, and ON CONFLICT upsert targets keep working unchanged.
+foreign keys, and ON CONFLICT upsert targets keep working unchanged (Postgres
+resolves `ON CONFLICT (col, ...)` against any matching unique constraint or
+index, not just the primary key).
 """
 
 from __future__ import annotations
@@ -57,10 +59,17 @@ def _pk_constraint_name(table: str) -> str:
     then-rename migration (20260512_000002); PostgreSQL keeps the
     constraint's original auto-generated name (``guild_members_new_pkey``)
     across the rename, so we can't assume ``{table}_pkey``.
+
+    Only call this to resolve the *original* (pre-migration) PK name, before
+    any constraint changes have been made. Once this migration has created
+    the surrogate ``id`` PK, its name is always ``{table}_pkey`` (set
+    explicitly by ``op.create_primary_key`` below) — downgrade() hardcodes
+    that rather than re-querying, since SQLite/test DBs can return a PK
+    reflection with no name at all.
     """
     bind = op.get_bind()
     pk = sa.inspect(bind).get_pk_constraint(table)
-    return pk["name"]
+    return pk["name"] if pk and pk.get("name") else f"{table}_pkey"
 
 
 def upgrade() -> None:
@@ -69,8 +78,9 @@ def upgrade() -> None:
     op.drop_constraint("user_sessions_github_user_id_fkey", "user_sessions", type_="foreignkey")
 
     for table, col in _SINGLE_COLUMN_TABLES:
-        op.execute(sa.text(f"ALTER TABLE {table} ADD COLUMN id SERIAL"))
-        op.drop_constraint(_pk_constraint_name(table), table, type_="primary")
+        old_pk_name = _pk_constraint_name(table)
+        op.add_column(table, sa.Column("id", sa.Integer(), sa.Identity(), nullable=False))
+        op.drop_constraint(old_pk_name, table, type_="primary")
         op.create_primary_key(f"{table}_pkey", table, ["id"])
         op.create_unique_constraint(f"{table}_{col}_key", table, [col])
 
@@ -83,16 +93,21 @@ def upgrade() -> None:
     )
 
     for table, cols, index_name in _COMPOSITE_TABLES:
-        op.execute(sa.text(f"ALTER TABLE {table} ADD COLUMN id SERIAL"))
-        op.drop_constraint(_pk_constraint_name(table), table, type_="primary")
+        old_pk_name = _pk_constraint_name(table)
+        op.add_column(table, sa.Column("id", sa.Integer(), sa.Identity(), nullable=False))
+        op.drop_constraint(old_pk_name, table, type_="primary")
         op.create_primary_key(f"{table}_pkey", table, ["id"])
         op.create_index(index_name, table, cols, unique=True)
 
 
 def downgrade() -> None:
+    # The surrogate PK created above is always named "{table}_pkey" (set
+    # explicitly by op.create_primary_key in upgrade()); hardcode it here
+    # rather than re-inspecting, since by this point the original PK name
+    # has already been replaced and no longer exists to look up.
     for table, cols, index_name in reversed(_COMPOSITE_TABLES):
         op.drop_index(index_name, table_name=table)
-        op.drop_constraint(_pk_constraint_name(table), table, type_="primary")
+        op.drop_constraint(f"{table}_pkey", table, type_="primary")
         op.create_primary_key(f"{table}_pkey", table, cols)
         op.drop_column(table, "id")
 
@@ -100,7 +115,7 @@ def downgrade() -> None:
 
     for table, col in reversed(_SINGLE_COLUMN_TABLES):
         op.drop_constraint(f"{table}_{col}_key", table, type_="unique")
-        op.drop_constraint(_pk_constraint_name(table), table, type_="primary")
+        op.drop_constraint(f"{table}_pkey", table, type_="primary")
         op.create_primary_key(f"{table}_pkey", table, [col])
         op.drop_column(table, "id")
 

--- a/backend/alembic/versions/20260706_000000_add_id_pk_everywhere.py
+++ b/backend/alembic/versions/20260706_000000_add_id_pk_everywhere.py
@@ -1,0 +1,100 @@
+"""Add a surrogate `id` primary key to every table that lacks one.
+
+Revision ID: 20260706_000000_add_id_pk_everywhere
+Revises: 20260705_000001_add_discord_task_threads
+Create Date: 2026-07-06
+
+Audit (issue #791) found eight tables whose primary key was either a natural
+string column or a composite of two columns instead of a plain `id`:
+
+- github_tokens        (PK was github_user_id)
+- user_sessions        (PK was token)
+- guild_members        (PK was (guild_id, user_id))
+- user_spawn_settings  (PK was (guild_id, user_id))
+- push_tokens          (PK was token)
+- discord_users        (PK was github_login)
+- discord_connect_tokens (PK was token)
+- model_catalog        (PK was (provider, model_id))
+
+For each, this adds a SERIAL `id` column, makes it the primary key, and
+preserves the old key as a UNIQUE constraint/index so existing lookups,
+foreign keys, and ON CONFLICT upsert targets keep working unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260706_000000_add_id_pk_everywhere"
+down_revision: str | Sequence[str] | None = "20260705_000001_add_discord_task_threads"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (table, old pk columns, unique constraint/index name, is_composite)
+_SINGLE_COLUMN_TABLES = [
+    ("github_tokens", "github_user_id"),
+    ("user_sessions", "token"),
+    ("push_tokens", "token"),
+    ("discord_users", "github_login"),
+    ("discord_connect_tokens", "token"),
+]
+
+_COMPOSITE_TABLES = [
+    ("guild_members", ["guild_id", "user_id"], "uq_guild_members_guild_id_user_id"),
+    ("user_spawn_settings", ["guild_id", "user_id"], "uq_user_spawn_settings_guild_id_user_id"),
+    ("model_catalog", ["provider", "model_id"], "uq_model_catalog_provider_model_id"),
+]
+
+
+def upgrade() -> None:
+    # user_sessions.github_user_id FKs to github_tokens.github_user_id; drop
+    # that FK before github_tokens' PK constraint changes, then recreate it.
+    op.drop_constraint("user_sessions_github_user_id_fkey", "user_sessions", type_="foreignkey")
+
+    for table, col in _SINGLE_COLUMN_TABLES:
+        op.execute(sa.text(f"ALTER TABLE {table} ADD COLUMN id SERIAL"))
+        op.drop_constraint(f"{table}_pkey", table, type_="primary")
+        op.create_primary_key(f"{table}_pkey", table, ["id"])
+        op.create_unique_constraint(f"{table}_{col}_key", table, [col])
+
+    op.create_foreign_key(
+        "user_sessions_github_user_id_fkey",
+        "user_sessions",
+        "github_tokens",
+        ["github_user_id"],
+        ["github_user_id"],
+    )
+
+    for table, cols, index_name in _COMPOSITE_TABLES:
+        op.execute(sa.text(f"ALTER TABLE {table} ADD COLUMN id SERIAL"))
+        op.drop_constraint(f"{table}_pkey", table, type_="primary")
+        op.create_primary_key(f"{table}_pkey", table, ["id"])
+        op.create_index(index_name, table, cols, unique=True)
+
+
+def downgrade() -> None:
+    for table, cols, index_name in reversed(_COMPOSITE_TABLES):
+        op.drop_index(index_name, table_name=table)
+        op.drop_constraint(f"{table}_pkey", table, type_="primary")
+        op.create_primary_key(f"{table}_pkey", table, cols)
+        op.drop_column(table, "id")
+
+    op.drop_constraint("user_sessions_github_user_id_fkey", "user_sessions", type_="foreignkey")
+
+    for table, col in reversed(_SINGLE_COLUMN_TABLES):
+        op.drop_constraint(f"{table}_{col}_key", table, type_="unique")
+        op.drop_constraint(f"{table}_pkey", table, type_="primary")
+        op.create_primary_key(f"{table}_pkey", table, [col])
+        op.drop_column(table, "id")
+
+    op.create_foreign_key(
+        "user_sessions_github_user_id_fkey",
+        "user_sessions",
+        "github_tokens",
+        ["github_user_id"],
+        ["github_user_id"],
+    )

--- a/backend/models.py
+++ b/backend/models.py
@@ -219,7 +219,8 @@ class Task(SQLModel, table=True):
 class GithubToken(SQLModel, table=True):
     __tablename__ = "github_tokens"  # type: ignore[assignment]
 
-    github_user_id: str = Field(primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
+    github_user_id: str = Field(unique=True)
     github_username: str | None = None
     access_token: str
     token_type: str = Field(default="bearer", sa_column_kwargs={"server_default": "'bearer'"})
@@ -231,7 +232,8 @@ class GithubToken(SQLModel, table=True):
 class UserSession(SQLModel, table=True):
     __tablename__ = "user_sessions"  # type: ignore[assignment]
 
-    token: str = Field(primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
+    token: str = Field(unique=True)
     github_user_id: str = Field(foreign_key="github_tokens.github_user_id")
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
@@ -254,11 +256,20 @@ class User(SQLModel, table=True):
 
 class GuildMember(SQLModel, table=True):
     __tablename__ = "guild_members"  # type: ignore[assignment]
-    __table_args__ = (Index("ix_guild_members_guild_id_role", "guild_id", "role"),)
+    __table_args__ = (
+        Index("ix_guild_members_guild_id_role", "guild_id", "role"),
+        Index(
+            "uq_guild_members_guild_id_user_id",
+            "guild_id",
+            "user_id",
+            unique=True,
+        ),
+    )
 
+    id: int | None = Field(default=None, primary_key=True)
     # guild_id is the integer FK to guilds.id (renamed from guild_pk).
-    guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
-    user_id: str = Field(foreign_key="users.id", primary_key=True)
+    guild_id: int = Field(foreign_key="guilds.id")
+    user_id: str = Field(foreign_key="users.id")
     role: str = Field(
         default="member", sa_column_kwargs={"server_default": "'member'"}
     )  # owner | member | viewer
@@ -495,9 +506,18 @@ class UserSpawnSettings(SQLModel, table=True):
     """
 
     __tablename__ = "user_spawn_settings"  # type: ignore[assignment]
+    __table_args__ = (
+        Index(
+            "uq_user_spawn_settings_guild_id_user_id",
+            "guild_id",
+            "user_id",
+            unique=True,
+        ),
+    )
 
-    guild_id: int = Field(foreign_key="guilds.id", primary_key=True)
-    user_id: str = Field(foreign_key="users.id", primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
+    guild_id: int = Field(foreign_key="guilds.id")
+    user_id: str = Field(foreign_key="users.id")
     # JSON blob: {repos: [...], tools: [...], envVars: [{key, value}, ...]}
     # SECURITY: this column may contain sensitive values (API tokens, credentials,
     # secret env vars). Operators must restrict DB-level read access to this table.
@@ -513,14 +533,15 @@ class UserSpawnSettings(SQLModel, table=True):
 class PushToken(SQLModel, table=True):
     """APNs (or, in the future, FCM) device token registered by the iOS app.
 
-    The token is the primary key because Apple's tokens are globally unique
-    per app install — when the same token comes back from a different user
-    it means the device was re-provisioned and we overwrite ``user_id``.
+    ``token`` is unique because Apple's tokens are globally unique per app
+    install — when the same token comes back from a different user it means
+    the device was re-provisioned and we overwrite ``user_id``.
     """
 
     __tablename__ = "push_tokens"
 
-    token: str = Field(primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
+    token: str = Field(unique=True)
     user_id: str = Field(foreign_key="users.id", index=True)
     platform: str = Field(
         default="ios", sa_column_kwargs={"server_default": "'ios'"}
@@ -615,7 +636,8 @@ class DiscordUser(SQLModel, table=True):
 
     __tablename__ = "discord_users"  # type: ignore[assignment]
 
-    github_login: str = Field(primary_key=True)  # stored lowercase
+    id: int | None = Field(default=None, primary_key=True)
+    github_login: str = Field(unique=True)  # stored lowercase
     discord_user_id: str
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
@@ -657,7 +679,8 @@ class DiscordConnectToken(SQLModel, table=True):
 
     __tablename__ = "discord_connect_tokens"  # type: ignore[assignment]
 
-    token: str = Field(primary_key=True)  # UUID4 string
+    id: int | None = Field(default=None, primary_key=True)
+    token: str = Field(unique=True)  # UUID4 string
     discord_user_id: str  # Discord snowflake ID of the invoking user
     discord_username: str
     expires_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
@@ -687,13 +710,22 @@ class ModelCatalog(SQLModel, table=True):
     """Persisted snapshot of models.dev provider/model entries.
 
     Upserted from the models.dev API on startup and periodically refreshed.
-    Primary key is (provider, model_id) so upserts are idempotent.
+    ``(provider, model_id)`` is unique so upserts are idempotent.
     """
 
     __tablename__ = "model_catalog"  # type: ignore[assignment]
+    __table_args__ = (
+        Index(
+            "uq_model_catalog_provider_model_id",
+            "provider",
+            "model_id",
+            unique=True,
+        ),
+    )
 
-    provider: str = Field(primary_key=True)
-    model_id: str = Field(primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
+    provider: str
+    model_id: str
     display_name: str
     capabilities: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     raw: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))

--- a/backend/tests/test_discord_connect.py
+++ b/backend/tests/test_discord_connect.py
@@ -186,7 +186,7 @@ def test_connect_valid_token_links_account(client):
         assert link is not None
         assert link.ps_user_id == "gh-conn-2"
 
-        used_row = session.get(DiscordConnectToken, connect_token)
+        used_row = session.query(DiscordConnectToken).filter_by(token=connect_token).one_or_none()
         assert used_row.used_at is not None
 
 


### PR DESCRIPTION
## Summary

Closes #791. Audited every SQLAlchemy model in `backend/models.py` and found eight tables whose primary key was a natural string column or a composite of two columns instead of a plain `id`:

- `github_tokens` — PK was `github_user_id`
- `user_sessions` — PK was `token`
- `guild_members` — PK was `(guild_id, user_id)`
- `user_spawn_settings` — PK was `(guild_id, user_id)`
- `push_tokens` — PK was `token`
- `discord_users` — PK was `github_login`
- `discord_connect_tokens` — PK was `token`
- `model_catalog` — PK was `(provider, model_id)`

For each table, added a surrogate `id` integer primary key and preserved the old key as a `UNIQUE` constraint/index so existing lookups, foreign keys, and upsert targets keep working unchanged.

## Changes

- `backend/models.py` — updated the eight SQLModel classes above to declare `id: int | None = Field(default=None, primary_key=True)` and moved their old PK columns to `unique=True` fields or unique indexes.
- `backend/alembic/versions/20260706_000000_add_id_pk_everywhere.py` — new Alembic migration that adds a `SERIAL id` column, swaps the primary key, and recreates the old key as a unique constraint/index for all eight tables (with a matching `downgrade()`).
- `backend/tests/test_discord_connect.py` — updated a test that used `session.get(DiscordConnectToken, connect_token)` (a PK lookup) to query by `token` instead, since `token` is no longer the primary key.

## Bug fixed during verification

While running the full test suite against the real Postgres test container, the migration failed on `guild_members` with `constraint "guild_members_pkey" of relation "guild_members" does not exist`. Digging in, `guild_members` went through a create-as-`guild_members_new`-then-rename migration back in `20260512_000002_drop_guild_id_child_tables.py`, so Postgres kept the original auto-generated constraint name `guild_members_new_pkey` across the rename instead of `guild_members_pkey`. The migration now looks up the real PK constraint name via `sa.inspect(bind).get_pk_constraint(table)` instead of assuming `{table}_pkey`.

## Test plan

- [x] `cd backend && python3 -m pytest -q` — 879 passed, 2 skipped, 0 failures (against the postgres-test container)
- [x] `alembic downgrade -1` then `alembic upgrade head` — both directions run cleanly with no errors