### PR TITLE
fix: address PR #800 review comments on review-branch checkout

### DIFF
--- a/worker/pioneer_worker/git_ops.py
+++ b/worker/pioneer_worker/git_ops.py
@@ -166,7 +166,8 @@ async def checkout_pr_worktree(
     (including cross-fork PRs) and checks it out in place.
     """
     logger.info("Checking out PR #%s (%s) into worktree %s", pr_number, repo_full, wt_path)
-    os.makedirs(os.path.dirname(wt_path), exist_ok=True)
+    if parent := os.path.dirname(wt_path):
+        os.makedirs(parent, exist_ok=True)
     await run_git(["fetch", "origin"], cwd=repo_path)
     rc, _, _ = await run_git(["worktree", "add", "--detach", wt_path, "origin/HEAD"], cwd=repo_path)
     if rc != 0:
@@ -175,6 +176,9 @@ async def checkout_pr_worktree(
     rc, _, _ = await run_gh(["pr", "checkout", str(pr_number), "--repo", repo_full], cwd=wt_path)
     if rc != 0:
         logger.error("gh pr checkout failed for PR #%s (%s) in %s", pr_number, repo_full, wt_path)
+        # Detached worktree add succeeded but the checkout didn't — remove the
+        # orphaned worktree so it doesn't linger as a dangling checkout.
+        await run_git(["worktree", "remove", "--force", wt_path], cwd=repo_path)
         return False
     return True
 

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1913,6 +1913,7 @@ class Worker:
                 )
                 await self._task_update(task_id, agent=agent, state="failed", finishedAt=_now_iso())
                 await self._set_state("error", agent)
+                await self._set_state("idle", agent)
                 return
         else:
             # On follow-ups we must continue on the existing branch — the original
@@ -1993,10 +1994,11 @@ class Worker:
                         level=LEVEL_WORKER,
                     )
                     ok = await git_ops.create_worktree(repo_path, wt_path, branch)
-            elif is_review and repo_full == pr_repo:
+            elif is_review and pr_repo and repo_full.lower() == pr_repo.lower():
                 # Check out the PR's own branch via `gh pr checkout` instead of
                 # `git checkout -b` — review tasks read an existing PR, they
-                # never create a new branch.
+                # never create a new branch. Compared case-insensitively since
+                # GitHub repo slugs are case-insensitive.
                 logger.info(
                     "Task %s: checking out PR #%s (%s) into worktree %s",
                     task_id,
@@ -2006,6 +2008,14 @@ class Worker:
                 )
                 ok = await git_ops.checkout_pr_worktree(repo_path, wt_path, pr_number, repo_full)
             else:
+                if is_review:
+                    logger.warning(
+                        "Task %s: repo %s does not match PR repo %s (case-insensitive) — "
+                        "falling back to create_worktree instead of gh pr checkout",
+                        task_id,
+                        repo_full,
+                        pr_repo,
+                    )
                 logger.info("Task %s: creating worktree %s on branch %s", task_id, wt_path, branch)
                 ok = await git_ops.create_worktree(repo_path, wt_path, branch)
             if ok:


### PR DESCRIPTION
## Summary
Follow-up to #800 (merged) addressing review comments left on that PR:

- Compare repo names case-insensitively (`repo_full.lower() == pr_repo.lower()`) when matching a review task's repo to its PR repo, with a warning log when a review-phase repo falls through to `create_worktree` instead of `gh pr checkout`.
- Guard `os.makedirs(os.path.dirname(wt_path), ...)` in `checkout_pr_worktree` against a `FileNotFoundError` when `wt_path` has no directory separator.
- Release the agent slot back to `idle` after the early-return error path taken when a PR branch can't be resolved for a review task (previously left the slot stuck in `error`).
- Clean up the orphaned detached worktree via `git worktree remove --force` if `gh pr checkout` fails after `git worktree add` succeeded.

Refs #799.

## Test plan
- [x] `uv run pytest -q` in `worker/` — 255 passed, 1 pre-existing unrelated failure (`test_no_tools_flag_gives_none`, fails on `origin/main` too because `claude`/`pi` binaries are present on this sandbox's `PATH`).