### PR TITLE
feat: single tool call shows tool name, not 'bash: 1 tool call' (#802)

### DIFF
--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -80,7 +80,6 @@ const groupedLogs = computed<(LineItem | TurnItem)[]>(() => {
 
   const flush = () => {
     if (current.length === 0) return
-    turnNumber += 1
     const counts: Record<string, number> = {}
     let toolCallCount = 0
     for (const { log } of current) {
@@ -90,6 +89,17 @@ const groupedLogs = computed<(LineItem | TurnItem)[]>(() => {
         toolCallCount += 1
       }
     }
+    // A single tool call carries no useful grouping information — showing its
+    // own line (e.g. "▶ bash: pytest") is more informative than collapsing it
+    // behind a generic "bash × 1 (1 tool call)" turn summary.
+    if (toolCallCount <= 1) {
+      for (const entry of current) {
+        result.push({ type: 'line', log: entry.log, index: entry.index })
+      }
+      current = []
+      return
+    }
+    turnNumber += 1
     result.push({ type: 'turn', turnNumber, entries: current, counts, toolCallCount })
     current = []
   }

--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -91,7 +91,9 @@ const groupedLogs = computed<(LineItem | TurnItem)[]>(() => {
     }
     // A single tool call carries no useful grouping information — showing its
     // own line (e.g. "▶ bash: pytest") is more informative than collapsing it
-    // behind a generic "bash × 1 (1 tool call)" turn summary.
+    // behind a generic "bash × 1 (1 tool call)" turn summary. toolCallCount can
+    // also be 0 here (a run of tool_result entries with no tool_use), which
+    // likewise needs no grouping and should just pass through as plain lines.
     if (toolCallCount <= 1) {
       for (const entry of current) {
         result.push({ type: 'line', log: entry.log, index: entry.index })

--- a/frontend/src/components/log-pane/__tests__/LogList.spec.ts
+++ b/frontend/src/components/log-pane/__tests__/LogList.spec.ts
@@ -48,7 +48,12 @@ describe('LogList turn grouping', () => {
   })
 
   it('expands a turn to reveal its full log lines on click', async () => {
-    const logs = [toolLog('Read', 'tool_use'), toolLog('Read', 'tool_result')]
+    const logs = [
+      toolLog('Read', 'tool_use'),
+      toolLog('Read', 'tool_result'),
+      toolLog('Bash', 'tool_use'),
+      toolLog('Bash', 'tool_result'),
+    ]
     const wrapper = mount(LogList, { props: { logs } })
 
     expect(wrapper.find('.turn-body').exists()).toBe(false)
@@ -56,13 +61,25 @@ describe('LogList turn grouping', () => {
     expect(wrapper.find('.turn-body').exists()).toBe(true)
   })
 
+  it('renders a single tool call directly instead of collapsing it into a turn', () => {
+    const logs = [toolLog('Read', 'tool_use'), toolLog('Read', 'tool_result')]
+    const wrapper = mount(LogList, { props: { logs } })
+
+    expect(wrapper.find('.turn-summary').exists()).toBe(false)
+    expect(wrapper.text()).toContain('▶ Read')
+  })
+
   it('numbers multiple turns sequentially, separated by non-tool lines', () => {
     const logs = [
       toolLog('Edit', 'tool_use'),
       toolLog('Edit', 'tool_result'),
+      toolLog('Write', 'tool_use'),
+      toolLog('Write', 'tool_result'),
       textLog('thinking about next step'),
       toolLog('Bash', 'tool_use'),
       toolLog('Bash', 'tool_result'),
+      toolLog('Read', 'tool_use'),
+      toolLog('Read', 'tool_result'),
     ]
     const wrapper = mount(LogList, { props: { logs } })
 

--- a/frontend/src/components/log-pane/__tests__/LogList.spec.ts
+++ b/frontend/src/components/log-pane/__tests__/LogList.spec.ts
@@ -67,6 +67,9 @@ describe('LogList turn grouping', () => {
 
     expect(wrapper.find('.turn-summary').exists()).toBe(false)
     expect(wrapper.text()).toContain('▶ Read')
+    // Both entries (tool_use + tool_result) should render inline, not be
+    // swallowed by an accidental turn summary rendering alongside them.
+    expect(wrapper.findAll('.log-line')).toHaveLength(2)
   })
 
   it('numbers multiple turns sequentially, separated by non-tool lines', () => {


### PR DESCRIPTION
## Summary

- The Task Log tab's turn-grouping collapsed *every* run of consecutive tool_use/tool_result entries into a "▸ Turn N — name × count (N tool calls)" summary — even when that run was a single tool call, hiding the actually useful detail (e.g. the bash command or file path) behind an extra click.
- `LogList.vue`'s grouping now only forms a collapsible "turn" when there are 2+ tool calls in a row. A lone tool call renders its own log line directly (e.g. `▶ bash: pytest`, `▶ read: src/foo.py`), which already carries the tool name and notable argument from the worker-side runners (`claude_runner.py` / `codex_runner.py` / `pi_runner.py`).
- Multiple tool calls in a row still collapse into the existing "Turn N — name × count (N tool calls)" summary, unchanged.

## Test plan

- [x] `npx vitest run src/components/log-pane/__tests__/LogList.spec.ts` — updated the single-tool-call turn test to assert it renders inline (no `.turn-summary`), adjusted the "expand" and "numbers multiple turns" tests to use 2+ tool calls per turn, all passing.
- [x] `npx vitest run` — full frontend suite passes (111 passed, 4 skipped).

Closes #802