### PR TITLE
Remove worker pre-truncation, cover all surfaces (#792)

### DIFF
--- a/frontend/src/components/IssueViewer.vue
+++ b/frontend/src/components/IssueViewer.vue
@@ -149,9 +149,9 @@
                 <div v-if="taskLogsFetching.has(task.id)" class="tl-logs-loading">
                   Fetching logs…
                 </div>
-                <pre v-else-if="taskLogsMap[task.id]?.length" class="tl-logs-pre"><code>{{
-                  taskLogsMap[task.id].slice(-50).map((l) => l.line).join('\n')
-                }}</code></pre>
+                <div v-else-if="taskLogsMap[task.id]?.length" class="tl-logs-body">
+                  <LogList :logs="taskLogsMap[task.id].slice(-50)" />
+                </div>
                 <div v-else class="tl-logs-empty">No log lines stored for this task.</div>
               </div>
             </div>
@@ -218,6 +218,7 @@ import { useGitHubStore } from '../stores/github'
 import type { GitHubIssueDetail, GitHubComment } from '../stores/github'
 import { useGuildStore } from '../stores/guild'
 import { useTasksStore } from '../stores/tasks'
+import LogList from './log-pane/LogList.vue'
 import type { Task, LogEntry } from '../types'
 import { api } from '../utils/api'
 import { renderMarkdown } from '../utils/markdown'
@@ -986,22 +987,10 @@ onMounted(loadIssue)
   padding: 8px 12px;
 }
 
-.tl-logs-pre {
-  margin: 0;
-  padding: 10px 12px;
+.tl-logs-body {
+  padding: 6px 12px;
   background: var(--color-bg);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  line-height: 1.5;
-  overflow-x: auto;
   max-height: 260px;
   overflow-y: auto;
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-
-.tl-logs-pre code {
-  background: none;
-  padding: 0;
 }
 </style>

--- a/frontend/src/components/IssueViewer.vue
+++ b/frontend/src/components/IssueViewer.vue
@@ -988,9 +988,9 @@ onMounted(loadIssue)
 }
 
 .tl-logs-body {
-  padding: 6px 12px;
+  display: flex;
+  flex-direction: column;
+  height: 260px;
   background: var(--color-bg);
-  max-height: 260px;
-  overflow-y: auto;
 }
 </style>

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -24,6 +24,9 @@ def _usage_tokens(usage: dict) -> dict:
     }
 
 
+# The task sidebar renders `line` in a narrow fixed-width column; 150 chars is
+# roughly 2-3 wrapped rows there before it starts pushing other tasks out of
+# view. Raise this only alongside a sidebar layout change.
 _LINE_PREVIEW_LEN = 150
 
 

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -24,16 +24,32 @@ def _usage_tokens(usage: dict) -> dict:
     }
 
 
+_LINE_PREVIEW_LEN = 150
+
+
+def _clip_line(line: str, limit: int = _LINE_PREVIEW_LEN) -> str:
+    """Clip a single display line to *limit* chars. The full text always lives
+    in the accompanying ``detail`` payload — this only shortens the sidebar
+    preview.
+    """
+    return line if len(line) <= limit else line[:limit] + "…"
+
+
 def _summarize_lines(lines: list[str], prefix: str = "  → ") -> str:
-    """Format a list of lines as a 2+ellipsis+1 summary."""
+    """Format a list of lines as a short 2+ellipsis+1 summary.
+
+    Each shown line is clipped to `_LINE_PREVIEW_LEN` chars so the summary
+    stays sidebar-sized; callers pair this with a ``detail`` dict carrying
+    the untruncated content for click-to-expand.
+    """
     if len(lines) <= 4:
-        return "\n".join(f"{prefix}{l}" for l in lines)
+        return "\n".join(f"{prefix}{_clip_line(l)}" for l in lines)
     middle = len(lines) - 3
     return (
-        f"{prefix}{lines[0]}\n"
-        f"{prefix}{lines[1]}\n"
+        f"{prefix}{_clip_line(lines[0])}\n"
+        f"{prefix}{_clip_line(lines[1])}\n"
         f"{prefix}… ({middle} more lines)\n"
-        f"{prefix}{lines[-1]}"
+        f"{prefix}{_clip_line(lines[-1])}"
     )
 
 

--- a/worker/tests/test_claude_runner.py
+++ b/worker/tests/test_claude_runner.py
@@ -53,9 +53,12 @@ def test_summarize_custom_prefix():
 
 def test_summarize_clips_long_lines():
     long_line = "x" * 500
-    result = _summarize_lines([long_line])
-    assert "…" in result
-    assert len(result.splitlines()[0]) < len(long_line)
+    prefix = "  → "
+    result = _summarize_lines([long_line], prefix=prefix)
+    first_line = result.splitlines()[0]
+    assert "…" in first_line
+    # +1 for the ellipsis character appended by _clip_line.
+    assert len(first_line) <= len(prefix) + _LINE_PREVIEW_LEN + 1
 
 
 def test_clip_line_short_unchanged():

--- a/worker/tests/test_claude_runner.py
+++ b/worker/tests/test_claude_runner.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pytest
 from pioneer_worker.claude_runner import (
+    _LINE_PREVIEW_LEN,
+    _clip_line,
     _summarize_lines,
     _truncate_at_word,
     _usage_tokens,
@@ -47,6 +49,24 @@ def test_summarize_custom_prefix():
     lines = ["alpha", "beta", "gamma", "delta", "epsilon"]
     result = _summarize_lines(lines, prefix=">> ")
     assert result.count(">> ") >= 3
+
+
+def test_summarize_clips_long_lines():
+    long_line = "x" * 500
+    result = _summarize_lines([long_line])
+    assert "…" in result
+    assert len(result.splitlines()[0]) < len(long_line)
+
+
+def test_clip_line_short_unchanged():
+    assert _clip_line("short") == "short"
+
+
+def test_clip_line_long_clipped():
+    long_line = "y" * 500
+    clipped = _clip_line(long_line)
+    assert clipped.endswith("…")
+    assert len(clipped) == _LINE_PREVIEW_LEN + 1
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +284,24 @@ def test_parse_user_tool_result_summarized_line_keeps_full_output_in_detail():
     assert "more lines" in text  # display line is elided
     assert text != full_output
     assert detail["output"] == full_output  # full content preserved untruncated
+
+
+def test_parse_user_tool_result_single_long_line_clipped_but_detail_full():
+    """A single line under the 4-line elision threshold can still be huge
+
+    (e.g. minified JSON); the display line must still be clipped for the
+    sidebar while ``detail['output']`` keeps the untruncated content.
+    """
+    full_output = "x" * 5000
+    event = {
+        "type": "user",
+        "message": {"content": [{"type": "tool_result", "content": full_output}]},
+    }
+    pairs = parse_claude_event(event)
+    assert len(pairs) == 1
+    text, detail = pairs[0]
+    assert len(text) < 200
+    assert detail["output"] == full_output
 
 
 def test_parse_user_tool_result_empty_skipped():


### PR DESCRIPTION
## Summary

Closes #792. Completes the pre-truncation removal started across #778, #781, #782, #783:

- `claude_runner._summarize_lines` was still writing full (unclipped) lines into the sidebar `line` summary for tool-result blocks with ≤4 lines. Long single-line output (e.g. minified JSON) could produce an oversized sidebar preview. Added `_clip_line` to cap each line shown in the sidebar summary at 150 chars, independent of the `detail`/`data` payload, which continues to carry the full untruncated content (as established in #781/#783 and consumed by `get_task_status` in #782).
- `codex_runner.py` / `pi_runner.py` already preview-clip their summaries while keeping `detail`/`data` full — no changes needed.
- `IssueViewer.vue`'s task-log panel rendered raw `<pre><code>{{ l.line }}</pre>` for each entry. Replaced with the existing `LogList` component (turn grouping + click-to-expand disclosure), matching the terminal pane's UX and giving task-log viewers the same fidelity.
- Discord notifier (`backend/discord_notifier.py`) already only ever forwards the short `line` field to Discord (`notify_task_stream` → `_StreamEntry.line`), never raw `TaskLog.data`, and chunks output to Discord's 2000-char limit at send time via `_chunk_content`. No changes needed there.
- `get_task_status` already returns full untruncated `TaskLog.data` (#782/#784, already on `main`). No changes needed there.

## Test plan
- [x] `pytest` (worker suite) — 259 passed, 1 pre-existing unrelated failure (`test_no_tools_flag_gives_none`, fails identically on a clean `main` in this sandbox because `claude`/`pi` CLIs are installed, causing auto-detection to return non-`None`)
- [x] `pytest tests/test_discord_notifier.py` (backend) — 80 passed
- [x] `npm run test` (frontend/vitest) — 111 passed, 4 skipped
- [x] `npm run type-check` (frontend/vue-tsc) — clean

Closes #792