### PR TITLE
fix: don't let thinking blocks break tool-call turn grouping

### DIFF
--- a/frontend/src/components/log-pane/LogList.vue
+++ b/frontend/src/components/log-pane/LogList.vue
@@ -66,13 +66,23 @@ interface TurnItem {
 }
 
 function isToolLine(log: LogEntry): boolean {
-  return log.detail?.toolType === 'tool_use' || log.detail?.toolType === 'tool_result'
+  // 'thinking' blocks routinely appear between tool calls in the same logical
+  // turn (Claude emits thinking → tool_use → tool_result per step), so they're
+  // treated as part of the run rather than a boundary — otherwise every
+  // tool call in a multi-step turn gets its own thinking-separated fragment
+  // and never accumulates past toolCallCount 1, defeating grouping entirely.
+  return (
+    log.detail?.toolType === 'tool_use' ||
+    log.detail?.toolType === 'tool_result' ||
+    log.detail?.toolType === 'thinking'
+  )
 }
 
-// Groups consecutive tool_use/tool_result entries into a single collapsible
-// "turn" (mirrors the Discord thread grouping in backend/discord_notifier.py's
-// _format_stream_entries). Non-tool lines (assistant text, thinking, status)
-// pass through individually and break the current turn.
+// Groups consecutive tool_use/tool_result/thinking entries into a single
+// collapsible "turn" (mirrors the Discord thread grouping in
+// backend/discord_notifier.py's _format_stream_entries). Non-tool lines
+// (assistant text, status) pass through individually and break the current
+// turn.
 const groupedLogs = computed<(LineItem | TurnItem)[]>(() => {
   const result: (LineItem | TurnItem)[] = []
   let turnNumber = 0

--- a/frontend/src/components/log-pane/__tests__/LogList.spec.ts
+++ b/frontend/src/components/log-pane/__tests__/LogList.spec.ts
@@ -15,6 +15,14 @@ function textLog(line: string): LogEntry {
   return { line, timestamp: '2026-01-01T00:00:00Z' }
 }
 
+function thinkingLog(text: string): LogEntry {
+  return {
+    line: `[thinking] ${text}`,
+    timestamp: '2026-01-01T00:00:00Z',
+    detail: { toolType: 'thinking', input: text, summary: text, fullText: text },
+  }
+}
+
 describe('LogList turn grouping', () => {
   it('renders plain lines normally when there are no tool calls', () => {
     const logs = [textLog('hello'), textLog('world')]
@@ -70,6 +78,26 @@ describe('LogList turn grouping', () => {
     // Both entries (tool_use + tool_result) should render inline, not be
     // swallowed by an accidental turn summary rendering alongside them.
     expect(wrapper.findAll('.log-line')).toHaveLength(2)
+  })
+
+  it('groups tool calls interleaved with thinking blocks into a single turn', () => {
+    // Mirrors real Claude transcripts: each tool call is preceded by its own
+    // thinking block, so a 5-bash-call turn looks like
+    // thinking, tool_use, tool_result, thinking, tool_use, tool_result, ...
+    const logs: LogEntry[] = []
+    for (let i = 0; i < 5; i++) {
+      logs.push(thinkingLog(`step ${i}`), toolLog('Bash', 'tool_use'), toolLog('Bash', 'tool_result'))
+    }
+    const wrapper = mount(LogList, { props: { logs } })
+
+    const summaries = wrapper.findAll('.turn-summary')
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0].text()).toContain('Turn 1')
+    expect(summaries[0].text()).toContain('bash × 5')
+    expect(summaries[0].text()).toContain('5 tool calls')
+
+    // Collapsed by default: none of the individual tool calls are visible.
+    expect(wrapper.find('.turn-body').exists()).toBe(false)
   })
 
   it('numbers multiple turns sequentially, separated by non-tool lines', () => {


### PR DESCRIPTION
## Summary

Follow-up to #802 / #803. In real Claude transcripts, each tool call in a multi-step turn is typically preceded by its own `thinking` block, so a run of 5 bash calls looks like:

```
thinking, tool_use, tool_result, thinking, tool_use, tool_result, ...
```

`LogList.vue`'s `isToolLine()` only recognized `tool_use`/`tool_result`, so every `thinking` entry broke the consecutive-tool-call run. Each bash call ended up isolated in its own single-call fragment (`toolCallCount === 1`), which bypasses turn grouping (per #803's "show a lone tool call inline" behavior) — so instead of one collapsible "Turn 1 — bash × 5 (5 tool calls)" summary, all 5 calls rendered individually and ungrouped, with no disclosure toggle to hide the detail.

## Fix

- `isToolLine()` now also treats `toolType: 'thinking'` as part of an in-progress tool-call run (it doesn't count toward `toolCallCount`, it just no longer forces a premature flush). Runs with 2+ actual tool calls now correctly collapse into a single "Turn N" summary, hidden by default until expanded — even when thinking blocks are interleaved. Genuinely isolated single tool calls (no siblings) still render inline per #803.

## Test plan

- [x] Added a regression test mirroring the real-world thinking-interleaved transcript shape (5 bash calls, each preceded by a thinking block) — verifies they collapse into one turn and stay collapsed by default.
- [x] `npx vitest run` — full frontend suite passes (112 passed, 4 skipped).
- [x] `npx vue-tsc --noEmit` — passes.

Closes #802