### PR TITLE
fix: back off Discord gateway reconnects until session is healthy

### DIFF
--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -204,9 +204,15 @@ class GatewayClient:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.warning("discord gateway: connection error (%s)", exc)
+                # str(ConnectionClosed) carries Discord's close code + reason
+                # (e.g. 4014 disallowed intents, 4004 auth failed) — the key
+                # signal for why a session keeps ending. Include the type for
+                # non-close errors (DNS, TLS, timeouts).
+                logger.warning("discord gateway: connection error [%s] %s", type(exc).__name__, exc)
             finally:
                 await self._stop_heartbeat()
+
+            uptime = time.monotonic() - started
 
             # Reset the backoff only for a connection that reached READY/RESUMED
             # *and* stayed up a while. Resetting on mere socket-open (the
@@ -215,13 +221,21 @@ class GatewayClient:
             # ~3s forever, tripping Discord's abuse guard. The uptime floor also
             # covers a connection that reaches READY then drops instantly
             # (flapping): still a zero-delay storm without it.
-            if self._healthy and time.monotonic() - started >= _HEALTHY_MIN_SECONDS:
+            if self._healthy and uptime >= _HEALTHY_MIN_SECONDS:
                 attempt = 0
                 self._identify_count = 0
             else:
                 delay = _backoff_delay(attempt)
+                # "healthy but short" here == flapping: reached READY/RESUMED
+                # then dropped almost immediately. Distinguish it from a
+                # never-connected failure so the logs show which one is spinning.
                 logger.warning(
-                    "discord gateway: reconnecting in %.1fs (attempt %d)", delay, attempt + 1
+                    "discord gateway: %s after %.1fs — reconnecting in %.1fs (attempt %d, identifies=%d)",
+                    "flapping" if self._healthy else "connect failed",
+                    uptime,
+                    delay,
+                    attempt + 1,
+                    self._identify_count,
                 )
                 await asyncio.sleep(delay)
                 attempt += 1
@@ -240,8 +254,16 @@ class GatewayClient:
         )
 
         if self._session_id and self._seq is not None:
+            logger.info(
+                "discord gateway: RESUMEing session_id=%s seq=%s", self._session_id, self._seq
+            )
             await self._send_resume(ws)
         else:
+            logger.info(
+                "discord gateway: IDENTIFYing (no resumable session; session_id=%s seq=%s)",
+                self._session_id,
+                self._seq,
+            )
             await self._send_identify(ws)
 
         async for raw in ws:

--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -172,27 +172,38 @@ class GatewayClient:
         self._resume_url: str = _GATEWAY_URL
         self._heartbeat_task: asyncio.Task | None = None
         self._heartbeat_acked = True
+        self._healthy = False
 
     async def run(self) -> None:
         """Connect and process Gateway events forever. Never returns normally."""
         attempt = 0
         while True:
             url = self._resume_url if self._session_id else _GATEWAY_URL
+            self._healthy = False
             try:
                 async with websockets.connect(url, max_size=8 * 1024 * 1024) as ws:
-                    attempt = 0
                     await self._handle_connection(ws)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                delay = _backoff_delay(attempt)
-                logger.warning(
-                    "discord gateway: connection error (%s) — retrying in %.1fs", exc, delay
-                )
-                await asyncio.sleep(delay)
-                attempt += 1
+                logger.warning("discord gateway: connection error (%s)", exc)
             finally:
                 await self._stop_heartbeat()
+
+            # Reset the backoff only once a connection actually reached
+            # READY/RESUMED. Resetting on mere socket-open (the old behaviour)
+            # let a connect-then-immediately-closed failure — bad/expired token,
+            # or the privileged intents not being enabled (close 4014) — retry
+            # every ~3s forever: 1000+ connections in under an hour, which is
+            # what tripped Discord's abuse guard. An unhealthy connection now
+            # backs off exponentially instead.
+            if self._healthy:
+                attempt = 0
+            else:
+                delay = _backoff_delay(attempt)
+                logger.warning("discord gateway: reconnecting in %.1fs (attempt %d)", delay, attempt + 1)
+                await asyncio.sleep(delay)
+                attempt += 1
 
     async def _handle_connection(self, ws) -> None:
         """Run the HELLO handshake, then process frames until the socket closes."""
@@ -314,10 +325,12 @@ class GatewayClient:
         event_type = data.get("t")
         payload = data.get("d") or {}
         if event_type == "READY":
+            self._healthy = True
             self._session_id = payload.get("session_id")
             self._resume_url = payload.get("resume_gateway_url") or _GATEWAY_URL
             logger.info("discord gateway: READY session_id=%s", self._session_id)
         elif event_type == "RESUMED":
+            self._healthy = True
             logger.info("discord gateway: RESUMED session_id=%s", self._session_id)
         elif event_type == "MESSAGE_CREATE":
             await self._handle_message_create(payload)

--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -89,6 +89,19 @@ def _backoff_delay(attempt: int, base: float = 2.0, cap: float = 60.0) -> float:
     return min(cap, base * (2**attempt)) + random.uniform(0, base)
 
 
+# A connection must stay up at least this long to count as "healthy" and reset
+# the backoff. Without it, a socket that reaches READY then drops instantly
+# (flapping) would reconnect with zero delay — the same storm the backoff
+# prevents, just past the handshake.
+_HEALTHY_MIN_SECONDS = 30.0
+
+# Discord caps IDENTIFY (a fresh session, not a RESUME) at ~1000/day and closes
+# abusive reconnect loops. Cap consecutive IDENTIFYs and cool down hard past it
+# so an INVALID_SESSION loop can't quietly burn the daily identify budget.
+_MAX_IDENTIFIES = 5
+_IDENTIFY_COOLDOWN = 300.0  # fallback when READY didn't supply a reset window
+
+
 # Short-lived cache so a busy wired channel doesn't open a DB session on
 # every single message. Keyed on channel_id -> (wired, expires_at_monotonic).
 _CHANNEL_WIRED_CACHE_TTL = 30.0
@@ -173,6 +186,10 @@ class GatewayClient:
         self._heartbeat_task: asyncio.Task | None = None
         self._heartbeat_acked = True
         self._healthy = False
+        # #2: throttle fresh IDENTIFYs. Count resets when a connection proves
+        # healthy; reset_after is Discord's own identify-window from READY.
+        self._identify_count = 0
+        self._identify_reset_after = 0.0
 
     async def run(self) -> None:
         """Connect and process Gateway events forever. Never returns normally."""
@@ -180,6 +197,7 @@ class GatewayClient:
         while True:
             url = self._resume_url if self._session_id else _GATEWAY_URL
             self._healthy = False
+            started = time.monotonic()
             try:
                 async with websockets.connect(url, max_size=8 * 1024 * 1024) as ws:
                     await self._handle_connection(ws)
@@ -190,15 +208,16 @@ class GatewayClient:
             finally:
                 await self._stop_heartbeat()
 
-            # Reset the backoff only once a connection actually reached
-            # READY/RESUMED. Resetting on mere socket-open (the old behaviour)
-            # let a connect-then-immediately-closed failure — bad/expired token,
-            # or the privileged intents not being enabled (close 4014) — retry
-            # every ~3s forever: 1000+ connections in under an hour, which is
-            # what tripped Discord's abuse guard. An unhealthy connection now
-            # backs off exponentially instead.
-            if self._healthy:
+            # Reset the backoff only for a connection that reached READY/RESUMED
+            # *and* stayed up a while. Resetting on mere socket-open (the
+            # original bug) let a connect-then-immediately-closed failure — bad
+            # token, or privileged intents disabled (close 4014) — retry every
+            # ~3s forever, tripping Discord's abuse guard. The uptime floor also
+            # covers a connection that reaches READY then drops instantly
+            # (flapping): still a zero-delay storm without it.
+            if self._healthy and time.monotonic() - started >= _HEALTHY_MIN_SECONDS:
                 attempt = 0
+                self._identify_count = 0
             else:
                 delay = _backoff_delay(attempt)
                 logger.warning(
@@ -257,6 +276,20 @@ class GatewayClient:
         self._heartbeat_task = None
 
     async def _send_identify(self, ws) -> None:
+        # #2: a runaway INVALID_SESSION loop re-IDENTIFYs every 1–5s; cap it so
+        # it can't burn Discord's ~1000/day identify budget. RESUME is exempt
+        # (Discord doesn't rate-limit it), so only this path is counted.
+        if self._identify_count >= _MAX_IDENTIFIES:
+            wait = self._identify_reset_after or _IDENTIFY_COOLDOWN
+            logger.warning(
+                "discord gateway: %d consecutive IDENTIFYs — cooling down %.0fs "
+                "to stay under Discord's identify limit",
+                self._identify_count,
+                wait,
+            )
+            await asyncio.sleep(wait)
+            self._identify_count = 0
+        self._identify_count += 1
         await ws.send(
             json.dumps(
                 {
@@ -328,6 +361,11 @@ class GatewayClient:
         payload = data.get("d") or {}
         if event_type == "READY":
             self._healthy = True
+            # Remember Discord's identify-window so the #2 throttle cools down
+            # for exactly as long as Discord says, not a guessed fallback.
+            reset_after = (payload.get("session_start_limit") or {}).get("reset_after")
+            if reset_after:
+                self._identify_reset_after = reset_after / 1000.0
             self._session_id = payload.get("session_id")
             self._resume_url = payload.get("resume_gateway_url") or _GATEWAY_URL
             logger.info("discord gateway: READY session_id=%s", self._session_id)

--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -201,7 +201,9 @@ class GatewayClient:
                 attempt = 0
             else:
                 delay = _backoff_delay(attempt)
-                logger.warning("discord gateway: reconnecting in %.1fs (attempt %d)", delay, attempt + 1)
+                logger.warning(
+                    "discord gateway: reconnecting in %.1fs (attempt %d)", delay, attempt + 1
+                )
                 await asyncio.sleep(delay)
                 attempt += 1
 

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -205,23 +205,20 @@ async def test_healthy_longlived_connection_does_not_back_off():
     """A connection that reaches READY and stays up past the uptime floor
     reconnects promptly without ever computing a backoff delay."""
     ready = _dispatch("READY", {"session_id": "s", "resume_gateway_url": "wss://r/"})
-
-    def fresh_ws(*_a, **_kw):
-        return FakeGatewayWebSocket([_hello(), ready, _CLOSE])
+    # First connect reaches READY (floor patched to 0 -> counts as long-lived);
+    # the second aborts the loop so the test terminates deterministically.
+    connects = [FakeGatewayWebSocket([_hello(), ready, _CLOSE]), asyncio.CancelledError]
 
     client = gateway.GatewayClient("test-token")
     with (
-        patch("discord.gateway.websockets.connect", side_effect=fresh_ws),
+        patch("discord.gateway.websockets.connect", side_effect=connects),
         patch("discord.gateway._HEALTHY_MIN_SECONDS", 0.0),  # count as long-lived
         patch("discord.gateway._backoff_delay") as backoff,
     ):
-        task = asyncio.create_task(client.run())
-        await asyncio.sleep(0.05)
-        task.cancel()
         with pytest.raises(asyncio.CancelledError):
-            await task
+            await client.run()
 
-    assert client._healthy is True
+    assert client._session_id == "s"  # READY was processed (healthy path)
     backoff.assert_not_called()  # never hit the unhealthy backoff branch
 
 

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -169,6 +169,62 @@ async def test_invalid_session_resumable_sends_resume_and_keeps_state():
 
 
 # ---------------------------------------------------------------------------
+# Reconnect backoff (regression: connect-then-immediately-closed loop)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_connection_backs_off():
+    """A connection that opens but never reaches READY must go through the
+    backoff branch — not reconnect immediately every cycle (the bug that opened
+    1000+ connections and got the bot token reset)."""
+    attempts: list[int] = []
+
+    def fake_backoff(attempt, *a, **k):
+        attempts.append(attempt)
+        raise asyncio.CancelledError  # stop the loop after the first backoff
+
+    # Socket opens, HELLO arrives, then closes before READY — the failure mode.
+    def fresh_ws(*_a, **_kw):
+        return FakeGatewayWebSocket([_hello(), _CLOSE])
+
+    client = gateway.GatewayClient("test-token")
+    with (
+        patch("discord.gateway.websockets.connect", side_effect=fresh_ws),
+        patch("discord.gateway._backoff_delay", side_effect=fake_backoff),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await client.run()
+
+    assert client._healthy is False
+    assert attempts == [0]  # entered the backoff branch on the first failure
+
+
+@pytest.mark.asyncio
+async def test_healthy_connection_does_not_back_off():
+    """Once READY is seen, a clean close (e.g. server RECONNECT) reconnects
+    promptly without ever computing a backoff delay."""
+    ready = _dispatch("READY", {"session_id": "s", "resume_gateway_url": "wss://r/"})
+
+    def fresh_ws(*_a, **_kw):
+        return FakeGatewayWebSocket([_hello(), ready, _CLOSE])
+
+    client = gateway.GatewayClient("test-token")
+    with (
+        patch("discord.gateway.websockets.connect", side_effect=fresh_ws),
+        patch("discord.gateway._backoff_delay") as backoff,
+    ):
+        task = asyncio.create_task(client.run())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert client._healthy is True
+    backoff.assert_not_called()  # never hit the unhealthy backoff branch
+
+
+# ---------------------------------------------------------------------------
 # MESSAGE_CREATE filtering
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -201,9 +201,9 @@ async def test_unhealthy_connection_backs_off():
 
 
 @pytest.mark.asyncio
-async def test_healthy_connection_does_not_back_off():
-    """Once READY is seen, a clean close (e.g. server RECONNECT) reconnects
-    promptly without ever computing a backoff delay."""
+async def test_healthy_longlived_connection_does_not_back_off():
+    """A connection that reaches READY and stays up past the uptime floor
+    reconnects promptly without ever computing a backoff delay."""
     ready = _dispatch("READY", {"session_id": "s", "resume_gateway_url": "wss://r/"})
 
     def fresh_ws(*_a, **_kw):
@@ -212,6 +212,7 @@ async def test_healthy_connection_does_not_back_off():
     client = gateway.GatewayClient("test-token")
     with (
         patch("discord.gateway.websockets.connect", side_effect=fresh_ws),
+        patch("discord.gateway._HEALTHY_MIN_SECONDS", 0.0),  # count as long-lived
         patch("discord.gateway._backoff_delay") as backoff,
     ):
         task = asyncio.create_task(client.run())
@@ -222,6 +223,71 @@ async def test_healthy_connection_does_not_back_off():
 
     assert client._healthy is True
     backoff.assert_not_called()  # never hit the unhealthy backoff branch
+
+
+@pytest.mark.asyncio
+async def test_healthy_but_flapping_connection_backs_off():
+    """A connection that reaches READY but drops before the uptime floor must
+    still back off — otherwise it's a zero-delay storm past the handshake."""
+    ready = _dispatch("READY", {"session_id": "s", "resume_gateway_url": "wss://r/"})
+    attempts: list[int] = []
+
+    def fake_backoff(attempt, *a, **k):
+        attempts.append(attempt)
+        raise asyncio.CancelledError
+
+    def fresh_ws(*_a, **_kw):
+        return FakeGatewayWebSocket([_hello(), ready, _CLOSE])
+
+    client = gateway.GatewayClient("test-token")
+    # Default _HEALTHY_MIN_SECONDS (30s) — the ~0s connection is "flapping".
+    with (
+        patch("discord.gateway.websockets.connect", side_effect=fresh_ws),
+        patch("discord.gateway._backoff_delay", side_effect=fake_backoff),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await client.run()
+
+    assert client._healthy is True  # it did reach READY...
+    assert attempts == [0]  # ...but still backed off because it dropped instantly
+
+
+@pytest.mark.asyncio
+async def test_identify_throttled_after_max_consecutive():
+    """Once _MAX_IDENTIFIES fresh IDENTIFYs pile up, the next one cools down
+    (Discord caps identifies ~1000/day) rather than firing immediately."""
+    ws = FakeGatewayWebSocket([])
+    client = gateway.GatewayClient("test-token")
+    client._identify_count = gateway._MAX_IDENTIFIES
+    client._identify_reset_after = 123.0  # from a prior READY
+
+    sleep = AsyncMock()
+    with patch("discord.gateway.asyncio.sleep", new=sleep):
+        await client._send_identify(ws)
+
+    sleep.assert_awaited_once_with(123.0)  # waited Discord's window, not a guess
+    assert client._identify_count == 1  # counter reset, then this identify counted
+    assert [m for m in ws.sent if m["op"] == gateway._OP_IDENTIFY]
+
+
+@pytest.mark.asyncio
+async def test_ready_captures_identify_reset_window():
+    ready = _dispatch(
+        "READY",
+        {"session_id": "s", "session_start_limit": {"remaining": 3, "reset_after": 5000}},
+    )
+    ws = FakeGatewayWebSocket([_hello(), ready, _CLOSE])
+    client = gateway.GatewayClient("test-token")
+
+    def stop(*_a, **_k):
+        raise asyncio.CancelledError  # break the reconnect loop after one pass
+
+    with patch("discord.gateway.websockets.connect", return_value=ws):
+        with patch("discord.gateway._backoff_delay", side_effect=stop):
+            with pytest.raises(asyncio.CancelledError):
+                await client.run()
+
+    assert client._identify_reset_after == 5.0  # 5000ms -> seconds
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`GatewayClient.run()` reset its backoff counter (`attempt = 0`) the moment the websocket *opened* — before Discord's IDENTIFY handshake. If Discord closed the socket right after IDENTIFY (bad/expired token, or the privileged **Message Content / Server Members** intents not enabled → close code 4014), the loop reconnected every ~3s indefinitely because the backoff never escalated.

At ~3s per connection that's **1000+ connections in under an hour** — exactly what tripped Discord's abuse guard and got the bot token reset.

## Fix

Track `_healthy`, set it only on `READY`/`RESUMED`. Reset the backoff counter only for a connection that actually became healthy; otherwise back off exponentially. A clean server `RECONNECT` (already healthy) still reconnects promptly.

## Tests

- `test_unhealthy_connection_backs_off` — a connect-then-close-before-READY loop goes through the backoff branch instead of hammering.
- `test_healthy_connection_does_not_back_off` — once READY is seen, a clean close reconnects without computing a backoff delay.

## Note

This is the code fix. The bot token still needs to be regenerated at the Developer Portal and updated in `DISCORD_BOT_TOKEN` for the bot to reconnect. Also worth double-checking the privileged intents are enabled, since a 4014 close is one of the failure modes this loop was spinning on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)