### PR TITLE
fix: guild settings bedrock provider fails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,9 @@ ANTHROPIC_API_KEY=
 # FOREMAN_MODEL=claude-sonnet-4-6
 
 # Bedrock inference profile for the foreman AI when FOREMAN_PROVIDER=bedrock.
-# Must be a cross-region inference profile ID, not a plain model ID.
-# FOREMAN_BEDROCK_MODEL=arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6
+# Must be a cross-region inference profile ARN scoped to YOUR AWS account, not a
+# plain model ID and not someone else's account ID — there is no valid default.
+# FOREMAN_BEDROCK_MODEL=arn:aws:bedrock:us-east-1:<your-account-id>:inference-profile/us.anthropic.claude-sonnet-4-6
 
 # Claude OAuth token for the `claude` CLI inside workers. Generate with
 # `claude setup-token` on a machine where you've logged in. When set, workers

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -782,14 +782,19 @@ async def _run_foreman_ai(
         # supplies its own env vars (e.g. Bedrock AWS credentials/region from
         # the settings dialogue, which otherwise never reach this process).
         effective_provider = cfg_provider or os.environ.get("FOREMAN_PROVIDER", "anthropic").lower()
+        # Resolve the model before building the client (and before any task is
+        # dispatched) so a stale guild config — saved before the #817 fix added
+        # save-time validation, with no model or a placeholder ARN — fails here
+        # with a clear error instead of surfacing deep inside the API call.
+        foreman_model = cfg_model or get_foreman_model(provider=effective_provider)
         if cfg_provider or cfg_env_vars:
             client = make_anthropic_client(
                 provider=effective_provider,
                 extra_env=cfg_env_vars or None,
+                model=cfg_model,
             )
         else:
             client = _get_anthropic_client()
-        foreman_model = cfg_model or get_foreman_model(provider=effective_provider)
 
         text_parts = []
         for round_num in range(cfg_max_rounds):

--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -58,9 +58,15 @@ def get_foreman_model(provider: str | None = None) -> str:
         bedrock_model = os.environ.get("FOREMAN_BEDROCK_MODEL")
         if not bedrock_model:
             raise BedrockModelNotConfiguredError(
-                "Bedrock provider selected but no model is configured. Set a model "
-                "(inference-profile ARN or model ID) in the guild's foreman settings, "
-                "or set the FOREMAN_BEDROCK_MODEL environment variable."
+                "Bedrock provider selected but no model is configured. Unlike AWS "
+                "credentials, which boto3 can resolve on its own (IAM role, profile, "
+                "env vars) and report clearly if missing, there is no discoverable "
+                "default model or inference profile — the Bedrock API call itself "
+                "requires one to be passed explicitly, and an account-scoped ARN "
+                "guessed here could silently send requests to the wrong AWS account. "
+                "Set a model (inference-profile ARN or model ID) in the guild's "
+                "foreman settings, or set the FOREMAN_BEDROCK_MODEL environment "
+                "variable."
             )
         return bedrock_model
     return os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
@@ -224,9 +230,15 @@ def make_anthropic_client(
         resolved_model = model or env.get("FOREMAN_BEDROCK_MODEL")
         if not resolved_model:
             raise BedrockModelNotConfiguredError(
-                "Bedrock provider selected but no model is configured. Set a model "
-                "(inference-profile ARN or model ID) in the guild's foreman settings, "
-                "or set the FOREMAN_BEDROCK_MODEL environment variable."
+                "Bedrock provider selected but no model is configured. Unlike AWS "
+                "credentials, which boto3 can resolve on its own (IAM role, profile, "
+                "env vars) and report clearly if missing, there is no discoverable "
+                "default model or inference profile — the Bedrock API call itself "
+                "requires one to be passed explicitly, and an account-scoped ARN "
+                "guessed here could silently send requests to the wrong AWS account. "
+                "Set a model (inference-profile ARN or model ID) in the guild's "
+                "foreman settings, or set the FOREMAN_BEDROCK_MODEL environment "
+                "variable."
             )
         resolved_region = (
             region or env.get("AWS_DEFAULT_REGION") or env.get("AWS_REGION") or _BEDROCK_REGION

--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -20,15 +20,22 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_BEDROCK_MODEL = (
-    "arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6"
-)
+
+class BedrockModelNotConfiguredError(ValueError):
+    """Raised when provider=bedrock is selected but no model/inference-profile is configured.
+
+    Bedrock has no universal default model — inference profile ARNs are scoped to a
+    single AWS account — so there is no safe value to fall back to silently. Callers
+    must configure one explicitly (guild settings `model` field or FOREMAN_BEDROCK_MODEL).
+    """
+
 
 FOREMAN_MODEL = os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
-# Bedrock uses cross-region inference profiles, not plain model IDs.
-# Set this to the profile ARN/ID appropriate for your region, e.g.:
-#   arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6
-FOREMAN_BEDROCK_MODEL = os.environ.get("FOREMAN_BEDROCK_MODEL", _DEFAULT_BEDROCK_MODEL)
+# Bedrock uses cross-region inference profiles, not plain model IDs, and those
+# profiles are scoped to a single AWS account, so there is no valid cross-account
+# default. Set this to the profile ARN/ID appropriate for your account/region, e.g.:
+#   arn:aws:bedrock:us-east-1:<account-id>:inference-profile/us.anthropic.claude-sonnet-4-6
+FOREMAN_BEDROCK_MODEL = os.environ.get("FOREMAN_BEDROCK_MODEL")
 
 # Set FOREMAN_PROVIDER=bedrock to use Amazon Bedrock instead of the Anthropic API.
 # Requires: pip install "anthropic[bedrock]"  +  AWS credentials in env / IAM role.
@@ -40,13 +47,22 @@ def get_foreman_model(provider: str | None = None) -> str:
     """Return the model ID to use for the given provider.
 
     When provider is 'bedrock' (or FOREMAN_PROVIDER=bedrock), returns
-    FOREMAN_BEDROCK_MODEL; otherwise returns FOREMAN_MODEL.
+    FOREMAN_BEDROCK_MODEL, raising BedrockModelNotConfiguredError if it's unset —
+    Bedrock inference-profile ARNs are AWS-account-scoped, so there is no safe
+    default to fall back to. Otherwise returns FOREMAN_MODEL.
 
     Reads os.environ on every call so that tests can patch env vars directly.
     """
     resolved = (provider or os.environ.get("FOREMAN_PROVIDER", "anthropic")).lower()
     if resolved == "bedrock":
-        return os.environ.get("FOREMAN_BEDROCK_MODEL", _DEFAULT_BEDROCK_MODEL)
+        bedrock_model = os.environ.get("FOREMAN_BEDROCK_MODEL")
+        if not bedrock_model:
+            raise BedrockModelNotConfiguredError(
+                "Bedrock provider selected but no model is configured. Set a model "
+                "(inference-profile ARN or model ID) in the guild's foreman settings, "
+                "or set the FOREMAN_BEDROCK_MODEL environment variable."
+            )
+        return bedrock_model
     return os.environ.get("FOREMAN_MODEL", "claude-sonnet-4-6")
 
 
@@ -213,7 +229,7 @@ def make_anthropic_client(
             "bearer-token"
             if bearer_token
             else ("explicit-keys" if (access_key and secret_key) else "sigv4"),
-            get_foreman_model("bedrock"),
+            env.get("FOREMAN_BEDROCK_MODEL") or "<not configured>",
         )
         bedrock_kwargs: dict = {"aws_region": resolved_region}
         if bearer_token:

--- a/backend/foreman_core/llm.py
+++ b/backend/foreman_core/llm.py
@@ -185,6 +185,7 @@ def make_anthropic_client(
     region: str | None = None,
     aws_profile: str | None = None,
     extra_env: Mapping[str, str] | None = None,
+    model: str | None = None,
 ):
     """Create and return an Anthropic async client.
 
@@ -197,6 +198,12 @@ def make_anthropic_client(
                  ANTHROPIC_* for the direct API. These do NOT reach the foreman
                  process otherwise: the dialogue's env_vars are only injected
                  into spawned workers, never this process.
+    model:       Resolved model/inference-profile for Bedrock (e.g. the guild's
+                 configured model), checked against FOREMAN_BEDROCK_MODEL when
+                 absent. Ignored for the direct Anthropic API. Callers that
+                 build a client before resolving the model (see get_foreman_model)
+                 would otherwise only discover a missing Bedrock model deep
+                 inside the first API call; passing it here fails fast instead.
     """
     if not HAS_ANTHROPIC or _anthropic_mod is None:
         raise ImportError("anthropic package is not installed")
@@ -210,6 +217,17 @@ def make_anthropic_client(
     env: Mapping[str, str] = {**os.environ, **(extra_env or {})}
 
     if resolved_provider == "bedrock":
+        # Fail fast: a Bedrock client with no model would only surface this
+        # deep inside the first API call. Check it here, before the client
+        # (and any of its credential resolution) is even built — consistent
+        # with the same check in get_foreman_model().
+        resolved_model = model or env.get("FOREMAN_BEDROCK_MODEL")
+        if not resolved_model:
+            raise BedrockModelNotConfiguredError(
+                "Bedrock provider selected but no model is configured. Set a model "
+                "(inference-profile ARN or model ID) in the guild's foreman settings, "
+                "or set the FOREMAN_BEDROCK_MODEL environment variable."
+            )
         resolved_region = (
             region or env.get("AWS_DEFAULT_REGION") or env.get("AWS_REGION") or _BEDROCK_REGION
         )
@@ -229,7 +247,7 @@ def make_anthropic_client(
             "bearer-token"
             if bearer_token
             else ("explicit-keys" if (access_key and secret_key) else "sigv4"),
-            env.get("FOREMAN_BEDROCK_MODEL") or "<not configured>",
+            resolved_model,
         )
         bedrock_kwargs: dict = {"aws_region": resolved_region}
         if bearer_token:

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import secrets
 from datetime import UTC, datetime
@@ -482,6 +483,23 @@ async def update_foreman_config(
             config.pop(field, None)
         else:
             config[field] = value
+
+    # Bedrock inference-profile ARNs are AWS-account-scoped, so there is no safe
+    # default model to fall back to at run time (see #817). Reject the save now
+    # rather than let it fail opaquely against a placeholder/wrong-account ARN.
+    if (
+        config.get("provider") == "bedrock"
+        and not config.get("model")
+        and not os.environ.get("FOREMAN_BEDROCK_MODEL")
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Bedrock provider requires a model: set the Model field to an "
+                "inference-profile ARN or model ID for your AWS account."
+            ),
+        )
+
     guild.foreman_config = config
     await db.commit()
     return config

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -42,18 +42,24 @@ class TestGetForemanModel:
 
         assert get_foreman_model() == "claude-sonnet-4-6"
 
-    def test_bedrock_provider_env_returns_bedrock_model(self, monkeypatch):
+    def test_bedrock_provider_env_without_model_raises(self, monkeypatch):
+        """Regression for #817: Bedrock inference profiles are AWS-account-scoped, so
+        silently falling back to a hardcoded ARN sends requests to the wrong account.
+        Must raise a clear, actionable error instead."""
         monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
         monkeypatch.delenv("FOREMAN_BEDROCK_MODEL", raising=False)
-        from foreman_core.llm import _DEFAULT_BEDROCK_MODEL, get_foreman_model
+        from foreman_core.llm import BedrockModelNotConfiguredError, get_foreman_model
 
-        assert get_foreman_model() == _DEFAULT_BEDROCK_MODEL
+        with pytest.raises(BedrockModelNotConfiguredError):
+            get_foreman_model()
 
-    def test_explicit_provider_overrides_env(self, monkeypatch):
+    def test_explicit_provider_without_model_raises(self, monkeypatch):
         monkeypatch.setenv("FOREMAN_PROVIDER", "anthropic")
-        from foreman_core.llm import _DEFAULT_BEDROCK_MODEL, get_foreman_model
+        monkeypatch.delenv("FOREMAN_BEDROCK_MODEL", raising=False)
+        from foreman_core.llm import BedrockModelNotConfiguredError, get_foreman_model
 
-        assert get_foreman_model(provider="bedrock") == _DEFAULT_BEDROCK_MODEL
+        with pytest.raises(BedrockModelNotConfiguredError):
+            get_foreman_model(provider="bedrock")
 
     def test_custom_bedrock_model_env(self, monkeypatch):
         monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -128,7 +128,7 @@ class TestMakeAnthropicClient:
         mock_mod = _make_mock_anthropic()
         monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
         monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
-        llm_mod.make_anthropic_client()
+        llm_mod.make_anthropic_client(model="test-bedrock-model")
         mock_mod.AsyncAnthropicBedrock.assert_called_once()
         mock_mod.AsyncAnthropic.assert_not_called()
 
@@ -140,9 +140,36 @@ class TestMakeAnthropicClient:
         mock_mod = _make_mock_anthropic()
         monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
         monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
-        llm_mod.make_anthropic_client(provider="bedrock")
+        llm_mod.make_anthropic_client(provider="bedrock", model="test-bedrock-model")
         mock_mod.AsyncAnthropicBedrock.assert_called_once()
         mock_mod.AsyncAnthropic.assert_not_called()
+
+    def test_bedrock_no_model_raises_before_client_construction(self, monkeypatch):
+        """Regression for PR #818 review: a missing Bedrock model must raise
+        BedrockModelNotConfiguredError immediately, before AsyncAnthropicBedrock is
+        ever constructed — not fail later inside the first API call."""
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        monkeypatch.delenv("FOREMAN_BEDROCK_MODEL", raising=False)
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        with pytest.raises(llm_mod.BedrockModelNotConfiguredError):
+            llm_mod.make_anthropic_client()
+        mock_mod.AsyncAnthropicBedrock.assert_not_called()
+
+    def test_bedrock_model_falls_back_to_env(self, monkeypatch):
+        """When no model arg is passed, FOREMAN_BEDROCK_MODEL satisfies the check."""
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        monkeypatch.setenv("FOREMAN_BEDROCK_MODEL", "arn:aws:bedrock:us-west-2::my-profile")
+        import foreman_core.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client()
+        mock_mod.AsyncAnthropicBedrock.assert_called_once()
 
     def test_explicit_anthropic_provider_arg_overrides_bedrock_env(self, monkeypatch):
         """Passing provider='anthropic' must use AsyncAnthropic even if env says bedrock."""
@@ -167,7 +194,7 @@ class TestMakeAnthropicClient:
         monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
         # Patch the module-level constant directly rather than relying on env + reload.
         monkeypatch.setattr(llm_mod, "_BEDROCK_REGION", "eu-west-1")
-        llm_mod.make_anthropic_client()
+        llm_mod.make_anthropic_client(model="test-bedrock-model")
         mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="eu-west-1")
 
     def test_bedrock_region_explicit_arg_overrides_env(self, monkeypatch):
@@ -178,7 +205,9 @@ class TestMakeAnthropicClient:
         monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
         monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
         monkeypatch.setattr(llm_mod, "_BEDROCK_REGION", "us-east-1")
-        llm_mod.make_anthropic_client(provider="bedrock", region="ap-southeast-1")
+        llm_mod.make_anthropic_client(
+            provider="bedrock", region="ap-southeast-1", model="test-bedrock-model"
+        )
         mock_mod.AsyncAnthropicBedrock.assert_called_once_with(aws_region="ap-southeast-1")
 
     def test_bedrock_aws_env_explicit_keys_forwarded(self, monkeypatch):
@@ -195,6 +224,7 @@ class TestMakeAnthropicClient:
         monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
         llm_mod.make_anthropic_client(
             provider="bedrock",
+            model="test-bedrock-model",
             extra_env={
                 "AWS_ACCESS_KEY_ID": "AKIATEST",
                 "AWS_SECRET_ACCESS_KEY": "secret",
@@ -219,6 +249,7 @@ class TestMakeAnthropicClient:
         monkeypatch.setattr(llm_mod, "_BEDROCK_REGION", "us-east-1")
         llm_mod.make_anthropic_client(
             provider="bedrock",
+            model="test-bedrock-model",
             extra_env={"AWS_BEARER_TOKEN_BEDROCK": "bedrock-token-xyz"},
         )
         mock_mod.AsyncAnthropicBedrock.assert_called_once_with(
@@ -236,7 +267,9 @@ class TestMakeAnthropicClient:
         # Patch boto3 session probe so a missing real profile doesn't error the test.
         with patch.object(llm_mod, "_log_bedrock_credentials"):
             llm_mod.make_anthropic_client(
-                provider="bedrock", extra_env={"AWS_PROFILE": "my-sso-profile"}
+                provider="bedrock",
+                model="test-bedrock-model",
+                extra_env={"AWS_PROFILE": "my-sso-profile"},
             )
         mock_mod.AsyncAnthropicBedrock.assert_called_once_with(
             aws_region="us-east-1", aws_profile="my-sso-profile"
@@ -383,7 +416,7 @@ class TestMakeAnthropicClientDynamicEnv:
         mock_mod = _make_mock_anthropic()
         with patch.object(llm_mod, "_anthropic_mod", mock_mod):
             llm_mod.HAS_ANTHROPIC = True
-            llm_mod.make_anthropic_client()
+            llm_mod.make_anthropic_client(model="test-bedrock-model")
             mock_mod.AsyncAnthropicBedrock.assert_called_once()
             mock_mod.AsyncAnthropic.assert_not_called()
 

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -375,6 +375,7 @@ def test_foreman_config_env_vars_round_trip_in_clear(client):
         headers=headers,
         json={
             "provider": "bedrock",
+            "model": "arn:aws:bedrock:eu-west-1:111111111111:inference-profile/us.anthropic.claude-sonnet-4-6",
             "env_vars": [
                 {"key": "AWS_DEFAULT_REGION", "value": "eu-west-1"},
                 {"key": "AWS_ACCESS_KEY_ID", "value": "AKIASECRET"},
@@ -392,3 +393,43 @@ def test_foreman_config_env_vars_round_trip_in_clear(client):
         "AWS_ACCESS_KEY_ID": "AKIASECRET",
         "AWS_SECRET_ACCESS_KEY": "topsecret",  # secret returned in clear, not masked
     }
+
+
+def test_foreman_config_bedrock_without_model_rejected(client, monkeypatch):
+    """Regression for #817: saving provider=bedrock with no model configured must be
+    rejected up front — Bedrock inference profiles are AWS-account-scoped, so silently
+    accepting this would only fail later, opaquely, against a placeholder ARN."""
+    monkeypatch.delenv("FOREMAN_BEDROCK_MODEL", raising=False)
+    test_client, db_url = client
+    token = make_auth_token(db_url)
+    insert_guild(db_url, "g-fconf2")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    patch = test_client.patch(
+        "/api/guilds/g-fconf2/foreman-config",
+        headers=headers,
+        json={"provider": "bedrock"},
+    )
+    assert patch.status_code == 400
+
+    got = test_client.get("/api/guilds/g-fconf2/foreman-config", headers=headers)
+    assert got.json() == {}
+
+
+def test_foreman_config_bedrock_with_model_accepted(client, monkeypatch):
+    """A model supplied alongside provider=bedrock passes validation."""
+    monkeypatch.delenv("FOREMAN_BEDROCK_MODEL", raising=False)
+    test_client, db_url = client
+    token = make_auth_token(db_url)
+    insert_guild(db_url, "g-fconf3")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    patch = test_client.patch(
+        "/api/guilds/g-fconf3/foreman-config",
+        headers=headers,
+        json={
+            "provider": "bedrock",
+            "model": "arn:aws:bedrock:us-east-1:111111111111:inference-profile/us.anthropic.claude-sonnet-4-6",
+        },
+    )
+    assert patch.status_code == 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,11 +101,13 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       # Model and provider — set FOREMAN_PROVIDER=bedrock to use Amazon Bedrock.
       # Direct Anthropic API: FOREMAN_MODEL is a plain model ID (e.g. claude-sonnet-4-6).
-      # Amazon Bedrock: FOREMAN_BEDROCK_MODEL must be a cross-region inference profile, e.g.:
-      #   arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6
-      # When FOREMAN_PROVIDER=bedrock, FOREMAN_BEDROCK_MODEL is used; otherwise FOREMAN_MODEL.
+      # Amazon Bedrock: FOREMAN_BEDROCK_MODEL must be a cross-region inference profile
+      # ARN scoped to *your* AWS account, e.g.:
+      #   arn:aws:bedrock:us-east-1:<your-account-id>:inference-profile/us.anthropic.claude-sonnet-4-6
+      # There is no safe default (profiles are account-scoped) — it's required when
+      # FOREMAN_PROVIDER=bedrock; otherwise FOREMAN_MODEL is used.
       FOREMAN_MODEL: ${FOREMAN_MODEL:-claude-sonnet-4-6}
-      FOREMAN_BEDROCK_MODEL: ${FOREMAN_BEDROCK_MODEL:-arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6}
+      FOREMAN_BEDROCK_MODEL: ${FOREMAN_BEDROCK_MODEL:-}
       FOREMAN_PROVIDER: ${FOREMAN_PROVIDER:-anthropic}
       # Shared HMAC secret for JWT auth between the foreman and backend.
       PIONEER_FOREMAN_KEY: ${PIONEER_FOREMAN_KEY:-}

--- a/foreman/main.py
+++ b/foreman/main.py
@@ -18,7 +18,7 @@ Environment variables:
     DATABASE_URL     Full SQLAlchemy URL; overrides DB_PATH
     ANTHROPIC_API_KEY      Anthropic key for the AI loop
     FOREMAN_MODEL          Claude model for direct Anthropic API  (default: claude-sonnet-4-6)
-    FOREMAN_BEDROCK_MODEL  Bedrock inference profile ID           (default: arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6)
+    FOREMAN_BEDROCK_MODEL  Bedrock inference profile ARN/ID        (required for provider=bedrock; no default — profiles are AWS-account-scoped)
     LOG_LEVEL              Logging level                          (default: INFO)
 """
 

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
-from backend.foreman_core.llm import _DEFAULT_BEDROCK_MODEL
+from backend.foreman_core.llm import BedrockModelNotConfiguredError
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +31,10 @@ class Config:
     auth_token: str | None = None
     # Claude / AI provider settings
     model: str = "claude-sonnet-4-6"
-    # Bedrock uses cross-region inference profiles, not plain model IDs.
-    # Ignored when provider != "bedrock".
-    bedrock_model: str = _DEFAULT_BEDROCK_MODEL
+    # Bedrock uses cross-region inference profiles, not plain model IDs, and those
+    # profiles are scoped to a single AWS account, so there is no valid default.
+    # Ignored when provider != "bedrock"; required when it is (see effective_model).
+    bedrock_model: str | None = None
     api_key: str | None = None
     # Anthropic auth token (OAuth/claude.ai accounts).  Mutually exclusive with
     # api_key; when set it is forwarded as `auth_token` to AsyncAnthropic and
@@ -71,7 +72,15 @@ class Config:
         standalone foreman without the full backend env-var stack, so it needs
         its own copy operating on dataclass fields rather than os.environ.
         """
-        return self.bedrock_model if self.provider == "bedrock" else self.model
+        if self.provider == "bedrock":
+            if not self.bedrock_model:
+                raise BedrockModelNotConfiguredError(
+                    "Bedrock provider selected but no model is configured. Set "
+                    "[claude] bedrock_model in the config TOML or the "
+                    "FOREMAN_BEDROCK_MODEL environment variable."
+                )
+            return self.bedrock_model
+        return self.model
 
     @property
     def http_url(self) -> str:
@@ -190,8 +199,7 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         overrides.get("bedrock_model")
         or claude_block.get("bedrock_model")
         or os.environ.get("FOREMAN_BEDROCK_MODEL")
-        or _DEFAULT_BEDROCK_MODEL
-    )
+    ) or None
 
     provider = (
         overrides.get("provider")

--- a/foreman/pioneer_foreman/config.py
+++ b/foreman/pioneer_foreman/config.py
@@ -195,6 +195,10 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
         or "claude-sonnet-4-6"
     )
 
+    # Trailing `or None` normalises an empty string (e.g. an unset TOML/env
+    # value) to None rather than propagating it — an empty string is not a
+    # valid ARN/model, and `effective_model` treats None as "not configured"
+    # to raise BedrockModelNotConfiguredError instead of failing on empty.
     bedrock_model = (
         overrides.get("bedrock_model")
         or claude_block.get("bedrock_model")

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -64,6 +64,7 @@ def _get_anthropic_client(config: Config):
             region=region,
             aws_profile=profile,
             extra_env=extra_env or None,
+            model=getattr(config, "bedrock_model", None),
         )
     return _anthropic_clients[cache_key]
 
@@ -262,6 +263,11 @@ async def run_foreman_ai(
 
         _inject_state_preamble(messages, state_preamble)
 
+        # Resolve the model before building the client (and before any task is
+        # dispatched) so a stale config — saved before #817 added validation,
+        # with no bedrock_model — fails here with a clear error instead of
+        # surfacing deep inside the API call.
+        effective_model = config.effective_model
         client = _get_anthropic_client(config)
 
         text_parts = []
@@ -276,7 +282,7 @@ async def run_foreman_ai(
                 len(messages),
             )
             _raw = await client.messages.with_raw_response.create(
-                model=config.effective_model,
+                model=effective_model,
                 max_tokens=1024,
                 system=system_blocks,
                 messages=messages,


### PR DESCRIPTION
## Summary
- Removes the hardcoded Bedrock inference-profile ARN default (`arn:aws:bedrock:us-east-1:446872464738:inference-profile/...`) — inference profiles are AWS-account-scoped, so silently falling back to someone else's ARN made `provider=bedrock` always fail against the wrong account.
- `get_foreman_model(provider="bedrock")` now raises a clear `BedrockModelNotConfiguredError` when no model/ARN is configured, instead of returning a bogus cross-account default.
- `PATCH /api/guilds/{id}/foreman-config` now rejects saving `provider=bedrock` up front when no `model` is set (and no `FOREMAN_BEDROCK_MODEL` env fallback exists), so the guild settings UI surfaces the problem immediately rather than failing later inside the foreman run loop.
- `make_anthropic_client` correctly builds an `AsyncAnthropicBedrock` client for the bedrock provider (not a plain `Anthropic`/`AsyncAnthropic` client), and threads guild-configured AWS credentials (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`/`AWS_DEFAULT_REGION`/`AWS_PROFILE`/`AWS_BEARER_TOKEN_BEDROCK`) from the guild settings dialogue's `env_vars` through to the client via `extra_env`, since those never otherwise reach the foreman process.
- Adds a credential probe (`_log_bedrock_credentials`) that replicates boto3's credential resolution at client-creation time so missing/expired AWS credentials surface a clear log reason instead of the SDK's opaque "could not resolve credentials from session" error.
- Updates `.env.example`, `docker-compose.yml`, and standalone foreman config (`foreman/pioneer_foreman/config.py`) to drop the same bad hardcoded default and require explicit configuration for Bedrock.

Fixes #817

## Test plan
- [x] `pytest backend/tests/test_foreman_llm.py backend/tests/test_guild_api.py` — 47 passed, including new regression tests for the bedrock-without-model rejection (`test_foreman_config_bedrock_without_model_rejected`) and successful save with a model (`test_foreman_config_bedrock_with_model_accepted`), plus `test_bedrock_provider_env_without_model_raises`.
- [ ] Manual: set guild provider to `bedrock` with a valid inference-profile ARN + AWS credentials via the settings dialogue and confirm the foreman AI responds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)