### PR TITLE
foreman: add proxy-role banner comments + fix stale docs (#810)

### DIFF
--- a/docs/foreman-split-plan.md
+++ b/docs/foreman-split-plan.md
@@ -46,8 +46,9 @@ foreman/
   pioneer_foreman/
     cli.py           – argument parser + entry point
     config.py        – Config dataclass; reads TOML + env vars + CLI overrides
-    foreman.py       – Foreman class: WS lifecycle, trigger dispatch
+    foreman.py       – Foreman class: WS lifecycle, trigger dispatch, per-task locks
     runner.py        – Claude API loop (thin wrapper around foreman_core)
+    prompt.py        – system prompt / state preamble builders (parent + child)
     tools.py         – tool definitions; all execution delegated to /exec_tool
     http_client.py   – ForemanHTTPClient: typed methods for every backend endpoint
     jwt_auth.py      – JWTTokenManager: mints short-lived HS256 tokens from backend_key

--- a/foreman/pioneer_foreman/__init__.py
+++ b/foreman/pioneer_foreman/__init__.py
@@ -4,6 +4,7 @@ This process is a thin proxy: it holds no durable state and makes no product
 decisions of its own. Its only job is to run the LLM call and relay tool
 execution across the network/firewall boundary that the backend can't
 otherwise cross — all state lives in the backend's database, and all tool
-logic lives in the backend. See docs/foreman-split-plan.md for the full
-protocol.
+logic lives in the backend. See
+https://github.com/jmelloy/pioneer-square/blob/main/docs/foreman-split-plan.md
+for the full protocol.
 """

--- a/foreman/pioneer_foreman/__init__.py
+++ b/foreman/pioneer_foreman/__init__.py
@@ -1,1 +1,9 @@
-"""Pioneer Square standalone foreman agent."""
+"""Pioneer Square standalone foreman agent.
+
+This process is a thin proxy: it holds no durable state and makes no product
+decisions of its own. Its only job is to run the LLM call and relay tool
+execution across the network/firewall boundary that the backend can't
+otherwise cross — all state lives in the backend's database, and all tool
+logic lives in the backend. See docs/foreman-split-plan.md for the full
+protocol.
+"""

--- a/foreman/pioneer_foreman/foreman.py
+++ b/foreman/pioneer_foreman/foreman.py
@@ -1,10 +1,13 @@
-"""Standalone Foreman process: WebSocket connection, trigger handling.
+"""Standalone Foreman process: WebSocket connection, trigger dispatch.
 
-Periodic task-health polling is scheduled by the backend (see
-backend/foreman/runner.py's ``_poll_loop``), which dispatches each tick as a
-``foreman-trigger`` to whichever foreman — embedded or external — currently
-owns the guild. This process only reacts to triggers it receives over the WS
-connection; it does not run its own poll timer.
+Connects to the backend over WebSocket, registers as the external foreman for
+one guild, and dispatches each incoming ``foreman-trigger`` 1:1 to
+``run_foreman_ai`` (task-scoped triggers go through a per-task lock instead of
+the whole-guild queue; see docs/foreman-per-task-context.md). Any broadcast
+the run produces is relayed back to the backend as a ``foreman-broadcast``
+message for it to fan out. This process holds no state of its own beyond what
+is needed to serialize concurrent runs — see docs/foreman-split-plan.md for
+the full protocol.
 """
 
 from __future__ import annotations
@@ -33,6 +36,8 @@ class Foreman:
 
     def __init__(self, config: Config):
         self._config = config
+        # REST client back to the backend — the only storage this process can reach;
+        # it never holds its own copy of guild/task state.
         self._http: ForemanHTTPClient | None = None
         # True while a foreman run (including its queue drain) is executing.
         self._processing: bool = False
@@ -160,6 +165,9 @@ class Foreman:
             logger.info("WebSocket connected to %s", ws_url)
 
             async def _ws_send(message: dict) -> None:
+                # Wraps `message` in a foreman-broadcast envelope for the backend to fan
+                # out to the guild's connections — this process never talks to end-user
+                # clients directly, only to the backend over this one WS connection.
                 try:
                     await ws.send(
                         json.dumps(

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -137,8 +137,10 @@ async def run_foreman_ai(
     user_id: str | None = None,
     task_id: str | None = None,
     *,
-    http: ForemanHTTPClient,
-    ws_send: Callable[[dict], Awaitable[None]],
+    http: ForemanHTTPClient,  # only path to storage; all state lives in the backend's DB
+    ws_send: Callable[
+        [dict], Awaitable[None]
+    ],  # relays to the backend for fan-out, not to the user
     config: Config,
     child: bool = False,
     tool_observer: ToolObserver | None = None,

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -137,10 +137,8 @@ async def run_foreman_ai(
     user_id: str | None = None,
     task_id: str | None = None,
     *,
-    http: ForemanHTTPClient,  # only path to storage; all state lives in the backend's DB
-    ws_send: Callable[
-        [dict], Awaitable[None]
-    ],  # relays to the backend for fan-out, not to the user
+    http: ForemanHTTPClient,
+    ws_send: Callable[[dict], Awaitable[None]],
     config: Config,
     child: bool = False,
     tool_observer: ToolObserver | None = None,
@@ -150,6 +148,10 @@ async def run_foreman_ai(
     Standalone version — uses REST for state/history, WS for broadcasts.
     ``task_id`` must be passed explicitly by the caller; it is not inferred from
     guild state so there is no ambiguity when multiple tasks are active.
+
+    ``http`` is the only path to storage this process has — all state lives in
+    the backend's DB. ``ws_send`` relays a message to the backend for fan-out;
+    it does not deliver directly to the end user.
 
     When ``child`` is True the run is scoped to a single task (``task_id`` is
     required): history, system prompt, state preamble, and tool set are all


### PR DESCRIPTION
## Summary
- `foreman/pioneer_foreman/__init__.py`: added a module-level banner stating the standalone foreman holds no durable state and makes no product decisions — its only job is running the LLM call and relaying tool execution across the network/firewall boundary the backend can't otherwise cross. Points to `docs/foreman-split-plan.md`.
- `foreman/pioneer_foreman/foreman.py`: trimmed the module docstring (dropped the now-stale "poll loop" framing removed in #809) to describe the current shape — connect, register, dispatch triggers 1:1 to `run_foreman_ai`, relay broadcasts.
- Added clarifying inline comments at the definition sites of `ws_send` (relays to the backend for fan-out, not to the end user) and `http` (the only path this process has to storage) in `runner.py` and `foreman.py`.
- `docs/foreman-split-plan.md`: added the missing `prompt.py` entry to the file listing and noted `foreman.py` now also owns per-task locks.

Investigated `docs/foreman-per-task-context.md` and `AGENTS.md`'s "Standalone Foreman" section per the issue — both were already updated for the #806–#809 cleanup (no `task_context.py`, poll-config, or `foreman/main.py` references remain), so no changes were needed there.

Closes #810

## Test plan
- [x] `cd foreman && python -m pytest` — 84 passed
- [x] `ruff check` / `ruff format --check` on all modified Python files