### PR TITLE
Fix: worker with restricted tools never falls back to claude

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1088,15 +1088,8 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 desc = inp.get("description", "")
                 phase = inp.get("phase", "execute")
                 requested_tool: str | None = inp.get("tool")
-                tool = requested_tool or "claude"  # may be replaced below during tool validation
                 model = inp.get("model") or None
                 provider = inp.get("provider") or None
-                # Always compute the tier from phase+tool upfront so it can be
-                # persisted on the task row regardless of whether model is
-                # auto-selected or caller-specified.
-                from util.model_tiers import select_model_tier as _select_tier  # noqa: PLC0415
-
-                model_tier = _select_tier(phase, tool)
                 existing_task_id = inp.get("task_id")
                 guild_result = await db.exec(
                     select(col(Guild.primary_repo)).where(col(Guild.id) == guild_pk)
@@ -1119,6 +1112,30 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 else:
                     worker_tools: list[str] = json.loads(worker_row.tools or "[]")
                     worker_provider: str | None = worker_row.provider
+
+                    # Resolve the tool FIRST — before computing the model tier or
+                    # auto-selecting a model — so both are derived from the tool the
+                    # worker actually has, never from a "claude" placeholder. A worker
+                    # with tools=["pi"] must never end up with a claude model_tier.
+                    if requested_tool is None:
+                        tool = worker_tools[0] if worker_tools else "claude"
+                    elif worker_tools and requested_tool not in worker_tools:
+                        available = ", ".join(worker_tools)
+                        result_text = (
+                            f"Worker {wid} does not support tool {requested_tool!r}. "
+                            f"Available tools: {available}"
+                        )
+                        is_error = True
+                        tool = requested_tool
+                    else:
+                        # requested_tool is set and either matches worker_tools or the
+                        # worker is legacy (no tools registered) — accept it as-is.
+                        tool = requested_tool
+
+                    from util.model_tiers import select_model_tier as _select_tier  # noqa: PLC0415
+
+                    model_tier = _select_tier(phase, tool)
+
                     # Filter model selection to only provider-compatible models.
                     if worker_provider and not is_error:
                         from models import ModelCatalog  # noqa: PLC0415
@@ -1167,21 +1184,6 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 "— using short ID as fallback; worker may fail at inference time",
                                 model,
                             )
-
-                    if requested_tool is None:
-                        tool = worker_tools[0] if worker_tools else "claude"
-                    elif worker_tools and requested_tool not in worker_tools:
-                        available = ", ".join(worker_tools)
-                        result_text = (
-                            f"Worker {wid} does not support tool {requested_tool!r}. "
-                            f"Available tools: {available}"
-                        )
-                        is_error = True
-                    elif not worker_tools:
-                        # legacy worker: no tools registered, accept any requested tool
-                        tool = requested_tool
-                    else:
-                        tool = requested_tool
                     if not is_error and repos:
                         worker_repos: list[str] = json.loads(worker_row.repos or "[]")
                         worker_org: str | None = worker_row.org

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1890,6 +1890,35 @@ class Worker:
 
         emit = self._task_emit(task_id, agent)
 
+        # Resolve the tool to dispatch with. Never default to "claude" blindly —
+        # fall back to this worker's own detected/configured tools instead, and
+        # refuse outright if the foreman asked for a tool we don't actually have
+        # (e.g. a worker with tools=["pi"] must never end up invoking claude).
+        requested_tool = (task.get("tool") or "").lower()
+        if requested_tool:
+            tool = requested_tool
+        elif self._available_tools:
+            tool = self._available_tools[0]
+        else:
+            tool = (self.cfg.tool or "claude").lower()
+
+        if self._available_tools and tool not in self._available_tools:
+            logger.error(
+                "Task %s: tool %r is not among this worker's available tools %s — aborting",
+                task_id,
+                tool,
+                self._available_tools,
+            )
+            await emit(
+                f"✗ Tool {tool!r} is not available on this worker "
+                f"(available: {', '.join(self._available_tools)}) — aborting.",
+                level=LEVEL_WORKER,
+            )
+            await self._task_update(task_id, agent=agent, state="failed", finishedAt=_now_iso())
+            await self._set_state("error", agent)
+            await self._set_state("idle", agent)
+            return
+
         name = task.get("name") or desc
         if is_review and not is_followup:
             # Review tasks must operate on the PR's own branch — never a
@@ -2039,8 +2068,6 @@ class Worker:
         # Register worktrees for the deferred sweeper — touched again below in
         # finally so the timestamp reflects the most recent activity.
         self._register_worktrees(task_id, worktree_entries)
-
-        tool = (task.get("tool") or "claude").lower()
 
         # Tracks the last claude session ID so redirects can --resume with full context
         resume_session_id: str | None = None

--- a/worker/tests/test_tool_dispatch_guard.py
+++ b/worker/tests/test_tool_dispatch_guard.py
@@ -1,0 +1,136 @@
+"""Tests for the worker's tool-dispatch guard (issue #827).
+
+A worker only ever runs the tool binaries it actually detected/was
+configured with (``self._available_tools``). ``_execute_task`` must never
+fall back to "claude" just because a task omits ``tool``, and must refuse
+outright rather than silently invoking a tool the worker doesn't have.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_cfg(**kwargs) -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="test-guild",
+        worker_id="w-test01",
+        max_agents=1,
+        pull_interval=3600.0,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pi_only_worker_never_invokes_claude_when_task_tool_omitted(tmp_path):
+    """A worker with only 'pi' available must dispatch to pi, not claude,
+    even when the task dict has no 'tool' field at all.
+    """
+    worker = Worker(_make_cfg(work_dir=str(tmp_path), repos=["org/myrepo"]))
+    worker._available_tools = ["pi"]
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+
+    task = {"id": "t-pi01", "description": "do something", "name": "do something"}
+    agent = worker.agents[0]
+
+    with (
+        patch(
+            "pioneer_worker.worker.git_ops.ensure_repo",
+            new=AsyncMock(return_value=str(tmp_path / "repo")),
+        ),
+        patch("pioneer_worker.worker.git_ops.create_worktree", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.pi_runner.run_pi_auto",
+            new=AsyncMock(return_value=(True, "done", "ok", None)),
+        ) as mock_pi,
+        patch(
+            "pioneer_worker.worker.claude_runner.run_claude_auto",
+            new=AsyncMock(side_effect=AssertionError("claude must not be invoked")),
+        ),
+        patch("pioneer_worker.worker.github_pr.push_branch", new=AsyncMock(return_value=False)),
+    ):
+        await worker._execute_task(task, agent)
+
+    mock_pi.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pi_only_worker_refuses_task_that_explicitly_requests_claude(tmp_path):
+    """If a task explicitly asks for a tool the worker doesn't have, the
+    worker must abort the task rather than silently running claude anyway.
+    """
+    worker = Worker(_make_cfg(work_dir=str(tmp_path), repos=["org/myrepo"]))
+    worker._available_tools = ["pi"]
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+
+    task = {
+        "id": "t-pi02",
+        "description": "do something",
+        "name": "do something",
+        "tool": "claude",
+    }
+    agent = worker.agents[0]
+
+    with (
+        patch(
+            "pioneer_worker.worker.git_ops.ensure_repo",
+            new=AsyncMock(return_value=str(tmp_path / "repo")),
+        ),
+        patch("pioneer_worker.worker.git_ops.create_worktree", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.claude_runner.run_claude_auto",
+            new=AsyncMock(side_effect=AssertionError("claude must not be invoked")),
+        ),
+        patch(
+            "pioneer_worker.worker.pi_runner.run_pi_auto",
+            new=AsyncMock(side_effect=AssertionError("pi must not be invoked either")),
+        ),
+    ):
+        await worker._execute_task(task, agent)
+
+    failed_calls = [
+        c for c in worker._task_update.await_args_list if c.kwargs.get("state") == "failed"
+    ]
+    assert failed_calls, "task must be marked failed when the requested tool is unavailable"
+    assert agent.state == "idle", "slot must return to idle after refusing the task"
+
+
+@pytest.mark.asyncio
+async def test_multi_tool_worker_dispatches_to_requested_pi_tool(tmp_path):
+    """A worker with both claude and pi available must honor an explicit
+    tool='pi' request rather than defaulting to claude.
+    """
+    worker = Worker(_make_cfg(work_dir=str(tmp_path), repos=["org/myrepo"]))
+    worker._available_tools = ["claude", "pi"]
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+
+    task = {"id": "t-multi01", "description": "do something", "name": "do something", "tool": "pi"}
+    agent = worker.agents[0]
+
+    with (
+        patch(
+            "pioneer_worker.worker.git_ops.ensure_repo",
+            new=AsyncMock(return_value=str(tmp_path / "repo")),
+        ),
+        patch("pioneer_worker.worker.git_ops.create_worktree", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.pi_runner.run_pi_auto",
+            new=AsyncMock(return_value=(True, "done", "ok", None)),
+        ) as mock_pi,
+        patch(
+            "pioneer_worker.worker.claude_runner.run_claude_auto",
+            new=AsyncMock(side_effect=AssertionError("claude must not be invoked")),
+        ),
+        patch("pioneer_worker.worker.github_pr.push_branch", new=AsyncMock(return_value=False)),
+    ):
+        await worker._execute_task(task, agent)
+
+    mock_pi.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Fixes #827 — a worker registered with a restricted `tools` list (e.g. `tools=["pi"]`) could still end up with a Claude-derived `model_tier` on the Foreman side, or have the worker itself default to `"claude"` when a task omitted the `tool` field.
- **Foreman** (`backend/foreman/tools.py`): the `tool` used to compute `model_tier` and drive model auto-selection is now resolved from `worker.tools` *before* `model_tier` is computed, instead of defaulting to `"claude"` up front. If the caller requests a tool the worker doesn't have, the call now returns an error instead of silently proceeding.
- **Worker** (`worker/pioneer_worker/worker.py`): `_execute_task` no longer defaults `tool = task.get("tool") or "claude"`. It resolves the dispatch tool from the task, falling back to `self._available_tools` (the tools the worker actually detected/was configured with), and aborts the task (marking it failed) if the requested tool isn't among the worker's available tools — rather than invoking it anyway.

## Test plan
- [x] `cd worker && python3 -m pytest tests/test_tool_dispatch_guard.py -v` — new tests covering: pi-only worker with no `tool` specified (dispatches to pi, never claude), pi-only worker explicitly asked for claude (refused, task marked failed), multi-tool worker honoring an explicit `tool="pi"` request.
- [x] `cd worker && python3 -m pytest tests/ -q` — full worker suite (259 tests) passes.
- [x] `cd backend && python3 -m pytest tests/test_assign_task_auto_model.py tests/test_model_tiers.py -q` — passes (other `test_foreman.py` failures are pre-existing local DB connectivity issues, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)