### PR TITLE
Fix assign_task dropping parent_task_id on update path

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1241,6 +1241,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 is_error = True
                             elif existing_task_id:
                                 name_override = inp.get("name")
+                                parent_task_id = inp.get("parent_task_id")
                                 update_values: dict = {
                                     "worker_id": wid,
                                     "description": desc,
@@ -1257,6 +1258,8 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     update_values["issue_number"] = inp["issue_number"]
                                 if inp.get("issue_repo"):
                                     update_values["issue_repo"] = inp["issue_repo"]
+                                if parent_task_id is not None:
+                                    update_values["parent_task_id"] = parent_task_id
                                 await db.exec(
                                     update(Task)
                                     .where(
@@ -1282,6 +1285,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         model=model,
                                         provider=provider,
                                         phase=phase,
+                                        parentTaskId=parent_task_id,
                                         issueNumber=inp.get("issue_number"),
                                         issueRepo=inp.get("issue_repo"),
                                         repos=repos,

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1233,6 +1233,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 )
                                 .limit(1)
                             )
+                            parent_task_id = inp.get("parent_task_id")
                             if not worker_recheck.one_or_none():
                                 result_text = (
                                     f"Worker {wid} went offline — task NOT assigned. "
@@ -1241,7 +1242,6 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 is_error = True
                             elif existing_task_id:
                                 name_override = inp.get("name")
-                                parent_task_id = inp.get("parent_task_id")
                                 update_values: dict = {
                                     "worker_id": wid,
                                     "description": desc,
@@ -1295,7 +1295,6 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 result_text = f"Task {task_id} assigned to {wid}."
                             else:
                                 name = inp.get("name") or desc[:60]
-                                parent_task_id = inp.get("parent_task_id")
                                 task_id = "t-" + "".join(
                                     random.choices(string.ascii_lowercase + string.digits, k=6)
                                 )

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -481,6 +481,40 @@ class TestExecToolsDispatching:
         assert "assigned" in results[0]["content"].lower()
         assert "t-exist1" in results[0]["content"]
 
+    async def test_assign_task_update_path_persists_parent_task_id(self, db_session):
+        """create_task -> assign_task(task_id=..., parent_task_id=...) must persist
+        parent_task_id on the update path, not just on the create-new-row path (#830)."""
+        insert_guild(db_session, "g-assign-parent")
+        _insert_worker(db_session, "g-assign-parent", "w-wkr3")
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            create_results = await exec_tools(
+                "g-assign-parent",
+                [_fake_tool_use("create_task", {"name": "Sub Task", "description": "Do part"})],
+            )
+            task_id = create_results[0]["content"].split()[1]
+
+            results = await exec_tools(
+                "g-assign-parent",
+                [
+                    _fake_tool_use(
+                        "assign_task",
+                        {
+                            "worker_id": "w-wkr3",
+                            "description": "Updated description",
+                            "task_id": task_id,
+                            "parent_task_id": "t-parent1",
+                        },
+                    )
+                ],
+            )
+        assert "assigned" in results[0]["content"].lower()
+
+        with _sync_session(db_session) as session:
+            parent_task_id = session.scalar(
+                select(col(Task.parent_task_id)).where(col(Task.id) == task_id)
+            )
+        assert parent_task_id == "t-parent1"
+
     async def test_assign_task_unsupported_tool(self, db_session):
         insert_guild(db_session, "g-assign-toolcheck")
         insert_worker(db_session, "g-assign-toolcheck", "w-toolcheck", tools='["claude", "pi"]')

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -491,7 +491,16 @@ class TestExecToolsDispatching:
                 "g-assign-parent",
                 [_fake_tool_use("create_task", {"name": "Sub Task", "description": "Do part"})],
             )
-            task_id = create_results[0]["content"].split()[1]
+            create_content = create_results[0]["content"]
+            assert create_content.startswith("Task t-"), create_content
+            assert "created" in create_content
+            task_id = create_content.split()[1]
+
+            with _sync_session(db_session) as session:
+                parent_task_id_before = session.scalar(
+                    select(col(Task.parent_task_id)).where(col(Task.id) == task_id)
+                )
+            assert parent_task_id_before is None
 
             results = await exec_tools(
                 "g-assign-parent",


### PR DESCRIPTION
## Summary
- `assign_task`'s update path (called when `task_id` is provided, e.g. via `create_task` → `assign_task(task_id=...)`) silently dropped `parent_task_id` — it was never included in the SET clause of the UPDATE, unlike the create-new-row path which did persist it.
- Fixed by reading `parent_task_id` from the tool input and including it in `update_values` when present, so it's written to the DB on the update path too.
- Added a regression test that creates a task, then calls `assign_task(task_id=..., parent_task_id=...)` and asserts the stored row has the correct `parent_task_id`.

Closes #830

## Test plan
- [x] `backend/tests/test_foreman.py::TestExecToolsDispatching::test_assign_task_update_path_persists_parent_task_id` passes
- [x] Existing `assign_task` tests still pass