### PR TITLE
Add issue phase value and (issue_repo, issue_number) index on tasks

### DIFF
--- a/backend/alembic/versions/20260708_000000_add_issue_phase_and_index.py
+++ b/backend/alembic/versions/20260708_000000_add_issue_phase_and_index.py
@@ -1,0 +1,35 @@
+"""Add 'issue' phase value and index tasks(issue_repo, issue_number).
+
+Revision ID: 20260708_000000_add_issue_phase_and_index
+Revises: 20260706_000000_add_id_pk_everywhere
+Create Date: 2026-07-08
+
+Part of the issue-rooted task tree feature (#815). tasks.phase is a plain
+Text column (no DB-level enum type/CHECK constraint exists), so "issue" is
+simply a new value the application may write — no DDL is required for that
+part. The composite index supports looking up the task tree for a given
+GitHub issue by (issue_repo, issue_number) without a full table scan.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260708_000000_add_issue_phase_and_index"
+down_revision: str | Sequence[str] | None = "20260706_000000_add_id_pk_everywhere"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_tasks_issue_repo_issue_number",
+        "tasks",
+        ["issue_repo", "issue_number"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tasks_issue_repo_issue_number", table_name="tasks")

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -27,8 +27,13 @@ FOREMAN_TOOLS = [
                 },
                 "phase": {
                     "type": "string",
-                    "enum": ["plan", "execute", "review"],
-                    "description": "Starting phase. Default: execute.",
+                    "enum": ["issue", "plan", "execute", "review"],
+                    "description": (
+                        "Starting phase. Default: execute. Use 'issue' for the root task "
+                        "of an issue-rooted task tree — never assigned to a worker; has no "
+                        "branch or PR — created once per GitHub issue, with plan/execute "
+                        "tasks pointing at it via parent_task_id."
+                    ),
                 },
             },
             "required": ["name", "description"],

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -494,7 +494,7 @@ async def patch_task(
     - ``branch``: git branch name
     - ``pr_url``: GitHub PR URL
     - ``deleted_at``: ISO-8601 soft-delete / expiry timestamp
-    - ``phase``: task phase (plan / execute / review / followup)
+    - ``phase``: task phase (issue / plan / execute / review / followup)
 
     Broadcasts a ``task-update`` WS event with the changed fields so the
     frontend sidebar stays in sync.

--- a/backend/util/model_tiers.py
+++ b/backend/util/model_tiers.py
@@ -9,7 +9,7 @@ Priority order for ``select_model_tier()``:
   1. ``complexity_hint`` — explicit caller override, highest priority.
   2. Tool hard tier — tools like ``codex`` always require a specific tier
      regardless of phase.
-  3. Phase tier — plan/execute → standard, review → cheap.
+  3. Phase tier — plan/execute → standard, issue/review → cheap.
 """
 
 from __future__ import annotations
@@ -37,6 +37,7 @@ _TIER_ORDER: dict[str, int] = {TIER_CHEAP: 0, TIER_STANDARD: 1, TIER_POWERFUL: 2
 # ---------------------------------------------------------------------------
 
 _PHASE_TIERS: dict[str, str] = {
+    "issue": TIER_CHEAP,
     "plan": TIER_STANDARD,
     "execute": TIER_STANDARD,
     "review": TIER_CHEAP,
@@ -107,7 +108,7 @@ def select_model_tier(
     """Return the appropriate tier string for a task.
 
     Args:
-        phase: Task phase — ``"plan"``, ``"execute"``, or ``"review"``.
+        phase: Task phase — ``"issue"``, ``"plan"``, ``"execute"``, or ``"review"``.
                Unknown values fall back to ``TIER_STANDARD``.
         tool: Runner name — ``"claude"``, ``"codex"``, or ``"pi"``.
               Unknown values fall back to the phase tier.


### PR DESCRIPTION
## Summary
- Adds an Alembic migration creating a composite index on `tasks(issue_repo, issue_number)` for fast root-task lookup by GitHub issue.
- `tasks.phase` is a plain `Text` column with no DB-level enum/CHECK constraint (confirmed against the initial schema and every subsequent migration), so making `'issue'` a valid phase value requires no DDL — it's wired into the application-level "enum": the `create_task` foreman tool's JSON schema, the phase→tier mapping in `util/model_tiers.py` (mapped to the cheap tier, same as `review`), and the `patch_task` docstring.
- Part of the issue-rooted task tree work tracked in #815/#831: a root `phase='issue'` task will anchor each GitHub issue, with plan/execute/review/followup tasks as descendants via `parent_task_id`.

## Test plan
- [x] `python -m pytest tests/test_foreman.py tests/test_model_tiers.py -q` — 158 passed
- [x] Ran the new migration's `upgrade`/`downgrade` against a live Postgres test database (from the `postgres-test` docker-compose service) and confirmed the index is created/dropped correctly, with no impact on existing migrations.