### PR TITLE
foreman: graceful soft-kill for spawned workers

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1665,6 +1665,18 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     )
                     await db.exec(update(Worker).where(col(Worker.id) == wid).values(disabled=True))
                     await db.commit()
+                    # Graceful signal only: give the worker a chance to finish any
+                    # in-progress task and exit on its own. Force-kill its container
+                    # only if it's still not offline after the timeout — see
+                    # worker_lifecycle.force_kill_worker_if_unresponsive.
+                    from worker_lifecycle import (  # noqa: PLC0415
+                        force_kill_worker_if_unresponsive as _force_kill_if_unresponsive,
+                    )
+
+                    spawn(
+                        _force_kill_if_unresponsive(wid),
+                        name=f"shutdown-escalate:{wid}",
+                    )
                     result_text = f"Shutdown signal sent to {wid}." + (
                         f" Reason: {reason}" if reason else ""
                     )

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -603,7 +603,7 @@ class _FakeStateDB:
 
 
 def test_shutdown_force_kill_timeout_default():
-    assert SHUTDOWN_FORCE_KILL_TIMEOUT == 30.0
+    assert SHUTDOWN_FORCE_KILL_TIMEOUT == 600.0
 
 
 def test_shutdown_force_kill_timeout_env_override(monkeypatch):

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -14,8 +14,10 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from worker_lifecycle import (  # noqa: E402
+    SHUTDOWN_FORCE_KILL_TIMEOUT,
     WORKER_DRAIN_TIMEOUT,
     drain_stale_workers_on_startup,
+    force_kill_worker_if_unresponsive,
     generate_worker_id,
     get_current_version,
     reconcile_stale_workers,
@@ -570,3 +572,87 @@ async def test_reconcile_only_respawns_workers_still_missing():
 
     mock_kill.assert_called_once_with({"w-b"})
     mock_spawn.assert_called_once_with(["w-b"])
+
+
+# ---------------------------------------------------------------------------
+# force_kill_worker_if_unresponsive
+# ---------------------------------------------------------------------------
+
+
+class _FakeStateDB:
+    """Fake session whose exec().one_or_none() returns states from a queue, in order."""
+
+    def __init__(self, states):
+        self._states = iter(states)
+        self.exec = AsyncMock(
+            side_effect=lambda *a, **k: MagicMock(one_or_none=lambda: next(self._states))
+        )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def test_shutdown_force_kill_timeout_default():
+    assert SHUTDOWN_FORCE_KILL_TIMEOUT == 30.0
+
+
+def test_shutdown_force_kill_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("PIONEER_SHUTDOWN_TIMEOUT", "45")
+    import importlib
+
+    import worker_lifecycle as wl
+
+    try:
+        importlib.reload(wl)
+        assert wl.SHUTDOWN_FORCE_KILL_TIMEOUT == 45.0
+    finally:
+        monkeypatch.delenv("PIONEER_SHUTDOWN_TIMEOUT", raising=False)
+        importlib.reload(wl)
+
+
+@pytest.mark.asyncio
+async def test_force_kill_if_unresponsive_noop_when_worker_goes_offline():
+    """A worker that reports offline within the timeout is never force-killed."""
+    session_iter = iter([_FakeStateDB(["offline"])])
+    mock_kill = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+    ):
+        await force_kill_worker_if_unresponsive("w-graceful", timeout=0.01)
+
+    mock_kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_force_kill_if_unresponsive_noop_when_worker_row_gone():
+    """A worker row that's disappeared (e.g. deleted) is treated as already gone."""
+    session_iter = iter([_FakeStateDB([None])])
+    mock_kill = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+    ):
+        await force_kill_worker_if_unresponsive("w-gone", timeout=0.01)
+
+    mock_kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_force_kill_if_unresponsive_escalates_after_timeout():
+    """A worker that never goes offline gets force-killed once the timeout elapses."""
+    session_iter = iter([_FakeStateDB(["working"])])
+    mock_kill = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+    ):
+        await force_kill_worker_if_unresponsive("w-wedged", timeout=0.01)
+
+    mock_kill.assert_called_once_with({"w-wedged"})

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -580,13 +580,20 @@ async def test_reconcile_only_respawns_workers_still_missing():
 
 
 class _FakeStateDB:
-    """Fake session whose exec().one_or_none() returns states from a queue, in order."""
+    """Fake session whose exec().one_or_none() returns states from a queue, in order.
+
+    Each call to exec() advances to the next queued state, so a single instance
+    can simulate a worker observed across several consecutive polls (e.g. online,
+    online, then offline) rather than always returning the same result.
+    """
 
     def __init__(self, states):
         self._states = iter(states)
-        self.exec = AsyncMock(
-            side_effect=lambda *a, **k: MagicMock(one_or_none=lambda: next(self._states))
-        )
+        self.call_count = 0
+
+    async def exec(self, *a, **k):
+        self.call_count += 1
+        return MagicMock(one_or_none=MagicMock(return_value=next(self._states)))
 
     async def __aenter__(self):
         return self
@@ -646,7 +653,9 @@ async def test_force_kill_if_unresponsive_noop_when_worker_row_gone():
 @pytest.mark.asyncio
 async def test_force_kill_if_unresponsive_escalates_after_timeout():
     """A worker that never goes offline gets force-killed once the timeout elapses."""
-    session_iter = iter([_FakeStateDB(["working"])])
+    # Second _FakeStateDB is consumed by the final re-check done immediately
+    # before force-killing.
+    session_iter = iter([_FakeStateDB(["working"]), _FakeStateDB(["working"])])
     mock_kill = AsyncMock()
 
     with (
@@ -656,3 +665,42 @@ async def test_force_kill_if_unresponsive_escalates_after_timeout():
         await force_kill_worker_if_unresponsive("w-wedged", timeout=0.01)
 
     mock_kill.assert_called_once_with({"w-wedged"})
+
+
+@pytest.mark.asyncio
+async def test_force_kill_if_unresponsive_skips_kill_when_offline_just_before_escalation():
+    """The final re-check catches a worker that went offline right after the last poll,
+    avoiding an unnecessary force-kill.
+    """
+    session_iter = iter([_FakeStateDB(["working"]), _FakeStateDB(["offline"])])
+    mock_kill = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+    ):
+        await force_kill_worker_if_unresponsive("w-just-in-time", timeout=0.01)
+
+    mock_kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_force_kill_if_unresponsive_polls_across_multiple_iterations():
+    """A worker seen online for two polls and offline on the third is neither
+    force-killed nor mistaken for offline early — each poll advances the state queue.
+    """
+    fake_db = _FakeStateDB(["working", "working", "offline"])
+    mock_kill = AsyncMock()
+    fake_loop = MagicMock()
+    fake_loop.time = MagicMock(side_effect=[0.0, 5.0, 10.0, 12.0])
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: fake_db),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
+        patch("worker_lifecycle.asyncio.get_event_loop", return_value=fake_loop),
+    ):
+        await force_kill_worker_if_unresponsive("w-slow-to-drain", timeout=12.0)
+
+    assert fake_db.call_count == 3
+    mock_kill.assert_not_called()

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -285,10 +285,11 @@ async def force_kill_worker_if_unresponsive(
     e.g. because it's wedged and never received/processed the shutdown signal.
     """
     poll_interval = 5.0
+    start = asyncio.get_event_loop().time()
     elapsed = 0.0
     while elapsed < timeout:
         await asyncio.sleep(min(poll_interval, timeout - elapsed))
-        elapsed += poll_interval
+        elapsed = asyncio.get_event_loop().time() - start
         async with AsyncSessionLocal() as db:
             state = (
                 await db.exec(select(col(Worker.state)).where(col(Worker.id) == worker_id))
@@ -300,6 +301,21 @@ async def force_kill_worker_if_unresponsive(
                 elapsed,
             )
             return
+
+    # Re-check right before escalating: the worker may have gone offline in the
+    # window between the last poll above and now, and we don't want to force-kill
+    # a container that already shut down gracefully.
+    async with AsyncSessionLocal() as db:
+        state = (
+            await db.exec(select(col(Worker.state)).where(col(Worker.id) == worker_id))
+        ).one_or_none()
+    if state is None or state == "offline":
+        logger.info(
+            "worker_lifecycle: worker %s shut down gracefully just before the force-kill "
+            "escalation — skipping container kill",
+            worker_id,
+        )
+        return
 
     logger.warning(
         "worker_lifecycle: worker %s did not shut down within %.0fs of the graceful "

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -41,6 +41,12 @@ logger = logging.getLogger(__name__)
 # How long to wait for stale workers to exit gracefully before force-killing.
 WORKER_DRAIN_TIMEOUT = float(os.environ.get("PIONEER_WORKER_DRAIN_TIMEOUT", "60"))
 
+# How long to wait after an explicit shutdown_worker request before force-killing
+# an unresponsive worker's container. Separate from WORKER_DRAIN_TIMEOUT (which
+# guards the much rarer startup version-mismatch drain) since this is the window
+# the foreman AI waits on every ordinary "stop this worker" request.
+SHUTDOWN_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_SHUTDOWN_TIMEOUT", "30"))
+
 
 def get_current_version() -> str | None:
     """Return the running backend version.
@@ -265,6 +271,43 @@ async def _force_kill_containers(worker_ids: set[str]) -> None:
                 "relying on graceful-shutdown signal only",
                 worker.id,
             )
+
+
+async def force_kill_worker_if_unresponsive(
+    worker_id: str, timeout: float = SHUTDOWN_FORCE_KILL_TIMEOUT
+) -> None:
+    """Give a worker time to shut down gracefully; force-kill its container if it doesn't.
+
+    Spawned as a background task right after shutdown_worker broadcasts a graceful
+    WorkerShutdownMsg, so an in-progress task on that worker gets a chance to finish
+    before anything is force-killed. Only escalates to a hard Docker kill (last
+    resort) if the worker never reports going offline within *timeout* seconds —
+    e.g. because it's wedged and never received/processed the shutdown signal.
+    """
+    poll_interval = 5.0
+    elapsed = 0.0
+    while elapsed < timeout:
+        await asyncio.sleep(min(poll_interval, timeout - elapsed))
+        elapsed += poll_interval
+        async with AsyncSessionLocal() as db:
+            state = (
+                await db.exec(select(col(Worker.state)).where(col(Worker.id) == worker_id))
+            ).one_or_none()
+        if state is None or state == "offline":
+            logger.info(
+                "worker_lifecycle: worker %s shut down gracefully within %.0fs",
+                worker_id,
+                elapsed,
+            )
+            return
+
+    logger.warning(
+        "worker_lifecycle: worker %s did not shut down within %.0fs of the graceful "
+        "shutdown signal — force-killing its container",
+        worker_id,
+        timeout,
+    )
+    await _force_kill_containers({worker_id})
 
 
 async def reconcile_stale_workers(stale_ids: list[str]) -> None:

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -45,7 +45,7 @@ WORKER_DRAIN_TIMEOUT = float(os.environ.get("PIONEER_WORKER_DRAIN_TIMEOUT", "60"
 # an unresponsive worker's container. Separate from WORKER_DRAIN_TIMEOUT (which
 # guards the much rarer startup version-mismatch drain) since this is the window
 # the foreman AI waits on every ordinary "stop this worker" request.
-SHUTDOWN_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_SHUTDOWN_TIMEOUT", "30"))
+SHUTDOWN_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_SHUTDOWN_TIMEOUT", "600"))
 
 
 def get_current_version() -> str | None:


### PR DESCRIPTION
Implements graceful shutdown for spawned worker containers before escalating to force-kill. Adds a configurable timeout so the container has a chance to exit cleanly. Closes #835.