### PR TITLE
feat: periodic check preemptively fetches PR status (#844)

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -190,6 +190,23 @@ On every [periodic-check] event:
    c. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number and issue_repo so the worker's PR references the issue automatically.
 3. The label check must cover (case-insensitive): devReady, dev-ready, ready-for-dev, ready.
 4. Never pick up an issue that is already assigned to someone else.
+
+## Periodic PR status refresh
+Every [periodic-check] message that mentions open-PR tasks includes a "Fresh GitHub PR
+status" section — merge state, check-run conclusions, and submitted reviews fetched
+directly from GitHub this cycle for every non-terminal task with a pr_url. This closes
+the gap when a webhook was missed or never fired. Act on it immediately, per task:
+- **merged=True**: call finalize_task now — do not wait for a [github-event] webhook.
+- **CI failure** (any check with conclusion=failure): call send_followup with concrete
+  instructions to fix it.
+- **A review with state=changes_requested**: call send_followup with the requested changes.
+- **state=closed and merged=False**: read the reviews/checks for context, then either
+  send_followup with a fix or finalize_task with expires_in_seconds=86400 if abandoning.
+- **Approved (state=approved review, no failing checks) with nothing else pending**: no
+  action needed beyond noting it — a human or auto-merge will land it.
+This section is a snapshot fetched moments ago — you do not need to call get_pr_status
+again for these tasks unless you need detail beyond what's summarized (e.g. full review
+body or check output).
 """
 
 

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -421,6 +421,64 @@ async def _complete_api_request_log(
         await db.close()
 
 
+async def _fetch_pr_status_lines(guild_id: str, pr_tasks: list[dict]) -> list[str]:
+    """Fetch fresh GitHub PR status for each non-terminal task with an open PR.
+
+    Called on every periodic-check cycle so the foreman can detect merges, CI
+    failures, and review decisions without relying on webhook delivery. Best
+    effort: an individual PR fetch failure (rate limit, deleted PR, missing
+    token, etc.) is logged and skipped rather than aborting the whole poll.
+    """
+    if not pr_tasks:
+        return []
+
+    from foreman.tools import _PR_URL_RE, _guild_github_token, fetch_pr_status
+
+    creds = await _guild_github_token(guild_id)
+    if not creds:
+        return []
+    token, _username = creds
+
+    lines: list[str] = []
+    for t in pr_tasks:
+        pr_repo, pr_number = t.get("pr_repo"), t.get("pr_number")
+        if not pr_repo or not pr_number:
+            m = _PR_URL_RE.match((t.get("pr_url") or "").rstrip("/"))
+            if not m:
+                continue
+            pr_repo, pr_number = m.group(1), int(m.group(2))
+
+        try:
+            status = await fetch_pr_status(pr_repo, pr_number, token)
+        except Exception:
+            logger.warning(
+                "guild=%s task=%s failed to fetch PR status for %s#%s",
+                guild_id,
+                t["id"],
+                pr_repo,
+                pr_number,
+                exc_info=True,
+            )
+            continue
+
+        checks = status.get("checks") or []
+        check_summary = (
+            ", ".join(f"{c['name']}={c['conclusion'] or c['status']}" for c in checks)
+            if checks
+            else "none"
+        )
+        reviews = status.get("reviews") or []
+        review_summary = (
+            ", ".join(f"{r['user']}={r['state']}" for r in reviews) if reviews else "none"
+        )
+        lines.append(
+            f"- task {t['id']} PR {pr_repo}#{pr_number} ({t['pr_url']}): "
+            f"state={status['state']} merged={status['merged']} "
+            f"checks=[{check_summary}] reviews=[{review_summary}]"
+        )
+    return lines
+
+
 async def _poll_loop(guild_id: str) -> None:
     """Background loop: check non-terminal tasks and trigger the foreman if any are found.
 
@@ -452,7 +510,14 @@ async def _poll_loop(guild_id: str) -> None:
             try:
                 guild_pk_val = await get_guild_pk(db, guild_id)
                 result = await db.exec(
-                    select(col(Task.id), col(Task.state), col(Task.name)).where(
+                    select(
+                        col(Task.id),
+                        col(Task.state),
+                        col(Task.name),
+                        col(Task.pr_url),
+                        col(Task.pr_number),
+                        col(Task.pr_repo),
+                    ).where(
                         col(Task.guild_id) == guild_pk_val,
                         ~col(Task.state).in_(list(_TERMINAL_STATES)),
                         live_tasks_filter(),
@@ -481,12 +546,27 @@ async def _poll_loop(guild_id: str) -> None:
 
             if active_tasks:
                 task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active_tasks)
+                pr_tasks = [t for t in active_tasks if t.get("pr_url")]
+                pr_status_lines = await _fetch_pr_status_lines(guild_id, pr_tasks)
+
                 msg = (
                     f"[periodic-check] Automated status poll — {n} non-terminal "
                     f"task(s): {task_summary}. Check whether any are stalled. "
-                    "Use get_task_status to inspect a task if it looks stuck. "
-                    "If everything looks healthy, no action is needed."
+                    "Use get_task_status to inspect a task if it looks stuck."
                 )
+                if pr_status_lines:
+                    msg += (
+                        "\n\nFresh GitHub PR status (fetched this cycle for each "
+                        "open-PR task):\n"
+                        + "\n".join(pr_status_lines)
+                        + "\nFor merged PRs, call finalize_task now. For CI failures or "
+                        "requested changes on these PRs, call send_followup with concrete "
+                        "fix instructions. Approved PRs with no open issues need no "
+                        "further action."
+                    )
+                else:
+                    msg += " If everything looks healthy, no action is needed."
+
                 # Deferred import: ws_handlers imports from the foreman package at
                 # module load time, so importing it back at module scope here would
                 # create a circular import.

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -294,6 +294,57 @@ async def _guild_github_token(guild_id: str) -> tuple[str, str] | None:
         await db.close()
 
 
+async def fetch_pr_status(repo: str, pr_number: int, token: str) -> dict:
+    """Fetch merge state, reviews, and check-runs for one PR.
+
+    Shared by the ``get_pr_status`` tool and the periodic-check poll loop
+    (foreman.runner._poll_loop), which proactively refreshes PR status for
+    every non-terminal task with an open PR on each poll cycle.
+    """
+    pr = await _to_thread(_gh_api, f"/repos/{repo}/pulls/{pr_number}", token)
+    reviews_raw = await _to_thread(
+        _gh_api,
+        f"/repos/{repo}/pulls/{pr_number}/reviews?per_page=20",
+        token,
+    )
+    head_sha = (pr.get("head") or {}).get("sha")
+    check_runs: list = []
+    if head_sha:
+        crs = await _to_thread(
+            _gh_api,
+            f"/repos/{repo}/commits/{head_sha}/check-runs?per_page=30",
+            token,
+        )
+        if isinstance(crs, dict):
+            check_runs = crs.get("check_runs", []) or []
+    return {
+        "number": pr["number"],
+        "state": pr["state"],
+        "merged": pr.get("merged", False),
+        "mergeable": pr.get("mergeable"),
+        "draft": pr.get("draft", False),
+        "head_sha": head_sha,
+        "reviews": [
+            {
+                "user": (r.get("user") or {}).get("login"),
+                "state": r.get("state"),
+                "body": (r.get("body") or "")[:300],
+                "submitted_at": r.get("submitted_at"),
+            }
+            for r in reviews_raw
+        ],
+        "checks": [
+            {
+                "name": cr.get("name"),
+                "status": cr.get("status"),
+                "conclusion": cr.get("conclusion"),
+                "summary": ((cr.get("output") or {}).get("summary") or "")[:300],
+            }
+            for cr in check_runs
+        ],
+    }
+
+
 async def _guild_private_key_pem(guild_id: str) -> str | None:
     """Return the Ed25519 private key PEM for the guild, or None if not found."""
     from auth_deps import get_guild_pk
@@ -1979,52 +2030,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     elif tu.name == "get_pr_status":
                         repo = inp["repo"]
                         num = int(inp["pr_number"])
-                        pr = await _to_thread(_gh_api, f"/repos/{repo}/pulls/{num}", token)
-                        reviews_raw = await _to_thread(
-                            _gh_api,
-                            f"/repos/{repo}/pulls/{num}/reviews?per_page=20",
-                            token,
-                        )
-                        head_sha = (pr.get("head") or {}).get("sha")
-                        check_runs: list = []
-                        if head_sha:
-                            crs = await _to_thread(
-                                _gh_api,
-                                f"/repos/{repo}/commits/{head_sha}/check-runs?per_page=30",
-                                token,
-                            )
-                            if isinstance(crs, dict):
-                                check_runs = crs.get("check_runs", []) or []
-                        result_text = json.dumps(
-                            {
-                                "number": pr["number"],
-                                "state": pr["state"],
-                                "merged": pr.get("merged", False),
-                                "mergeable": pr.get("mergeable"),
-                                "draft": pr.get("draft", False),
-                                "head_sha": head_sha,
-                                "reviews": [
-                                    {
-                                        "user": (r.get("user") or {}).get("login"),
-                                        "state": r.get("state"),
-                                        "body": (r.get("body") or "")[:300],
-                                        "submitted_at": r.get("submitted_at"),
-                                    }
-                                    for r in reviews_raw
-                                ],
-                                "checks": [
-                                    {
-                                        "name": cr.get("name"),
-                                        "status": cr.get("status"),
-                                        "conclusion": cr.get("conclusion"),
-                                        "summary": ((cr.get("output") or {}).get("summary") or "")[
-                                            :300
-                                        ],
-                                    }
-                                    for cr in check_runs
-                                ],
-                            }
-                        )
+                        result_text = json.dumps(await fetch_pr_status(repo, num, token))
 
                     elif tu.name == "search_github_issues":
                         repo = inp["repo"]


### PR DESCRIPTION
## Summary
- On every `[periodic-check]` poll, the backend now fetches fresh GitHub PR status (merge state, check-run conclusions, submitted reviews) for every non-terminal task with an open `pr_url`, and includes a summary in the message sent to the Foreman.
- Extracted the PR-status-fetching logic from the `get_pr_status` tool into a shared `fetch_pr_status()` helper in `backend/foreman/tools.py`, reused by both the tool and the new poll-loop enrichment in `backend/foreman/runner.py`.
- Updated the Foreman system prompt (`backend/foreman/prompt.py`) with explicit instructions for acting on the enriched PR data: finalize merged PRs immediately, send followups for CI failures or requested changes, and note approved PRs needing no action.
- Individual PR fetch failures (rate limits, deleted PRs, missing token) are logged and skipped rather than aborting the whole poll.

Closes #844

## Test plan
- [x] `python -m py_compile` on changed files
- [x] `ruff check` on changed files — clean
- [x] `pytest tests/test_foreman_runner.py tests/test_foreman_poll_backoff.py tests/test_foreman.py` — 153 passed