### PR TITLE
feat: Discord debounce + combine PR messages, low notif priority (#843)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,7 +99,11 @@ GITHUB_TOKEN=
 
 # Seconds to buffer check_run/check_suite completions for the same PR before
 # flushing them as one combined, silent Discord message (e.g. "✅ 3 checks
-# passed: lint, test, build") instead of one message per check.
+# passed: lint, test, build") instead of one message per check. This is a
+# fixed-start window: the timer is armed on the *first* buffered check and is
+# NOT reset by later ones, so tune it above the longest expected gap between
+# checks in your CI matrix — a slower straggler that lands after the window
+# closes gets its own follow-up message instead of joining the summary.
 # DISCORD_PR_DEBOUNCE_SECONDS=15
 
 # Phase 4: enable the persistent Gateway websocket (backend/discord/gateway.py)

--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,11 @@ GITHUB_TOKEN=
 # never a flat channel post).
 # DISCORD_STREAM_TASKS=false
 
+# Seconds to buffer check_run/check_suite completions for the same PR before
+# flushing them as one combined, silent Discord message (e.g. "✅ 3 checks
+# passed: lint, test, build") instead of one message per check.
+# DISCORD_PR_DEBOUNCE_SECONDS=15
+
 # Phase 4: enable the persistent Gateway websocket (backend/discord/gateway.py)
 # for receiving inbound MESSAGE_CREATE events, instead of only the
 # /discord/interactions webhook. Requires DISCORD_BOT_TOKEN, and the bot's

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -60,6 +60,17 @@ Phase 6 — issue-rooted task tree thread routing
     routing below when *task_id* has no root, or the root predates this
     column and has no thread yet.
 
+Phase 7 — CI check debounce/combine
+    ``notify_ci_check`` buffers ``check_run``/``check_suite`` completions per
+    PR and flushes a single combined summary (e.g. ``"✅ 3 checks passed:
+    lint, test, build"``) after ``DISCORD_PR_DEBOUNCE_SECONDS`` (default 15)
+    of silence on that PR, instead of one Discord message per check — a CI
+    matrix routinely fires several of these within a few seconds of each
+    other. The combined message always carries ``SUPPRESS_NOTIFICATIONS``
+    (see ``_SILENT_FLAG``) so CI results don't page anyone; non-CI events
+    (PR opened/merged/closed, reviews) are unaffected and keep posting
+    immediately at normal priority.
+
 Required bot permissions: ``SEND_MESSAGES``, ``CREATE_PUBLIC_THREADS``, ``MANAGE_THREADS``.
 
 Usage::
@@ -164,6 +175,7 @@ async def notify(
     url: str | None = None,
     color: int | None = None,
     ps_guild_slug: str | None = None,
+    flags: int | None = None,
 ) -> None:
     """Post a Discord embed to the bot's configured channel.
 
@@ -180,7 +192,9 @@ async def notify(
     if not channel:
         return
 
-    await _post_to_thread(channel, event_type, title, description, url=url, color=color)
+    await _post_to_thread(
+        channel, event_type, title, description, url=url, color=color, flags=flags
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -524,15 +538,24 @@ async def _post_to_thread(
     url: str | None = None,
     color: int | None = None,
     fields: dict[str, str] | None = None,
+    flags: int | None = None,
 ) -> None:
-    """Post an embed to an existing Discord thread. Never raises."""
+    """Post an embed to an existing Discord thread. Never raises.
+
+    *flags* is the raw Discord message-flags bitmask (see ``_SILENT_FLAG``) —
+    passed through so callers like ``notify_ci_check`` can mark a message
+    silent without duplicating the request-building logic here.
+    """
     resolved_color = color if color is not None else _COLOURS.get(event_type, _DEFAULT_COLOUR)
     embed: dict = {"title": title, "description": description, "color": resolved_color}
     if url:
         embed["url"] = url
     if fields:
         embed["fields"] = [{"name": k, "value": v, "inline": True} for k, v in fields.items()]
-    await _bot_request("post", f"/channels/{thread_id}/messages", {"embeds": [embed]})
+    payload: dict = {"embeds": [embed]}
+    if flags:
+        payload["flags"] = flags
+    await _bot_request("post", f"/channels/{thread_id}/messages", payload)
 
 
 async def archive_thread(thread_id: str) -> None:
@@ -762,6 +785,7 @@ async def notify_event(
     linked_issue_repo: str | None = None,
     linked_issue_number: int | None = None,
     task_id: str | None = None,
+    flags: int | None = None,
 ) -> None:
     """Post a Discord notification, routing to a per-PR/issue thread when possible.
 
@@ -798,6 +822,11 @@ async def notify_event(
     When ``close=True`` the thread is archived after the message is posted
     (used for PR merge/close events).
 
+    *flags* is the raw Discord message-flags bitmask (see ``_SILENT_FLAG``),
+    passed straight through to whichever destination the message ends up at
+    — used by ``notify_ci_check`` to mark combined CI summaries silent
+    without affecting any other event type's priority.
+
     Falls back to a flat embed posted to the resolved channel when thread
     operations fail. Silent no-op when the bot token is not configured.
     Never raises.
@@ -813,6 +842,7 @@ async def notify_event(
                 url=url,
                 color=color,
                 fields=header_fields,
+                flags=flags,
             )
             return
 
@@ -832,6 +862,7 @@ async def notify_event(
                 url=url,
                 color=color,
                 fields=header_fields,
+                flags=flags,
             )
             return
 
@@ -848,13 +879,22 @@ async def notify_event(
                 url=url,
                 color=color,
                 fields=header_fields,
+                flags=flags,
             )
             if close:
                 await archive_thread(thread_id)
             return
 
     # Fallback: flat embed to the resolved channel
-    await notify(event_type, title, description, url=url, color=color, ps_guild_slug=ps_guild_slug)
+    await notify(
+        event_type,
+        title,
+        description,
+        url=url,
+        color=color,
+        ps_guild_slug=ps_guild_slug,
+        flags=flags,
+    )
 
 
 async def notify_existing_thread(
@@ -1222,3 +1262,150 @@ async def flush_task_stream(task_id: str) -> None:
         buf.flush_task.cancel()
         buf.flush_task = None
     await _drain_and_post(buf, task_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase 7: CI check debounce/combine
+# ---------------------------------------------------------------------------
+
+# Icon + verb used when rendering the combined CI summary line, keyed by
+# GitHub's check-run "conclusion" field.
+_CI_CONCLUSION_ICONS: dict[str, str] = {
+    "success": "✅",
+    "failure": "❌",
+    "cancelled": "⚠️",
+    "timed_out": "⚠️",
+    "action_required": "⚠️",
+}
+
+_CI_CONCLUSION_VERBS: dict[str, str] = {
+    "success": "passed",
+    "failure": "failed",
+    "cancelled": "cancelled",
+    "timed_out": "timed out",
+    "action_required": "need attention",
+}
+
+
+def _pr_debounce_seconds() -> float:
+    """Debounce window (seconds) before flushing a PR's buffered CI checks.
+
+    Read at call time (not cached) so ``DISCORD_PR_DEBOUNCE_SECONDS`` can be
+    tuned — or overridden in tests — without a restart. Defaults to 15s.
+    """
+    return float(os.environ.get("DISCORD_PR_DEBOUNCE_SECONDS", "15"))
+
+
+@dataclass
+class _CICheckEntry:
+    """One buffered check_run/check_suite completion pending combination."""
+
+    check_name: str
+    conclusion: str
+
+
+@dataclass
+class _CIBatch:
+    """Pending CI check completions for one PR, plus the shared notify_event routing kwargs."""
+
+    kwargs: dict
+    entries: list[_CICheckEntry] = field(default_factory=list)
+    flush_task: asyncio.Task | None = None
+
+
+# Keyed by "{issue_repo}#{issue_number}" (or the PR label when repo/number
+# aren't available). Holds only PRs with un-flushed CI entries.
+_ci_batches: dict[str, _CIBatch] = {}
+
+
+def _format_ci_summary(entries: list[_CICheckEntry]) -> str:
+    """Combine buffered check completions into a compact, multi-line summary.
+
+    Groups by conclusion so e.g. two passing checks plus one failing check
+    renders as two lines: ``"✅ 2 checks passed: lint, test"`` followed by
+    ``"❌ 1 check failed: build"`` — rather than one Discord message per check.
+    """
+    by_conclusion: dict[str, list[str]] = {}
+    for entry in entries:
+        by_conclusion.setdefault(entry.conclusion, []).append(entry.check_name)
+
+    lines = []
+    for conclusion, names in by_conclusion.items():
+        icon = _CI_CONCLUSION_ICONS.get(conclusion, "ℹ️")
+        noun = "check" if len(names) == 1 else "checks"
+        verb = _CI_CONCLUSION_VERBS.get(conclusion, conclusion.replace("_", " "))
+        lines.append(f"{icon} {len(names)} {noun} {verb}: {', '.join(names)}")
+    return "\n".join(lines)
+
+
+async def _flush_ci_batch(key: str) -> None:
+    """Post the combined summary for *key*'s buffered CI checks, then drop the batch."""
+    batch = _ci_batches.pop(key, None)
+    if batch is None or not batch.entries:
+        return
+    conclusions = {entry.conclusion for entry in batch.entries}
+    event_type = "ci-pass" if conclusions == {"success"} else "ci-fail"
+    description = _format_ci_summary(batch.entries)
+    await notify_event(event_type, description=description, flags=_SILENT_FLAG, **batch.kwargs)
+
+
+async def _delayed_ci_flush(key: str) -> None:
+    """Wait out the debounce window, then flush *key*'s buffered CI checks."""
+    try:
+        await asyncio.sleep(_pr_debounce_seconds())
+    except asyncio.CancelledError:
+        return
+    await _flush_ci_batch(key)
+
+
+async def notify_ci_check(
+    check_name: str,
+    conclusion: str,
+    *,
+    pr_label: str,
+    url: str | None = None,
+    issue_repo: str | None = None,
+    issue_number: int | None = None,
+    ps_guild_slug: str | None = None,
+    linked_issue_repo: str | None = None,
+    linked_issue_number: int | None = None,
+    task_id: str | None = None,
+) -> None:
+    """Buffer one CI check completion for *pr_label* and (re)arm a debounced flush.
+
+    Multiple ``check_run``/``check_suite`` completions for the same PR
+    arriving within ``DISCORD_PR_DEBOUNCE_SECONDS`` of each other (a CI
+    matrix routinely fires several within a few seconds) are combined into a
+    single Discord message — see ``_format_ci_summary`` — instead of one
+    message per check. The combined message always carries
+    ``SUPPRESS_NOTIFICATIONS`` (``_SILENT_FLAG``): a CI result is useful to
+    see in the thread but shouldn't page anyone. The timer starts on the
+    first buffered check for a PR and is not reset by later ones in the same
+    window — matching the existing task-stream buffer's batching behaviour
+    (see ``notify_task_stream``) rather than a sliding debounce, so a steady
+    trickle of checks can't indefinitely postpone the summary. Silent no-op
+    when the bot token is not configured. Never raises.
+    """
+    if not _bot_token():
+        return
+
+    key = f"{issue_repo}#{issue_number}" if issue_repo and issue_number is not None else pr_label
+    batch = _ci_batches.get(key)
+    if batch is None:
+        batch = _CIBatch(
+            kwargs={
+                "title": f"CI results: {pr_label}",
+                "url": url,
+                "issue_repo": issue_repo,
+                "issue_number": issue_number,
+                "ps_guild_slug": ps_guild_slug,
+                "linked_issue_repo": linked_issue_repo,
+                "linked_issue_number": linked_issue_number,
+                "task_id": task_id,
+            }
+        )
+        _ci_batches[key] = batch
+    batch.entries.append(_CICheckEntry(check_name=check_name, conclusion=conclusion))
+
+    if batch.flush_task is None:
+        batch.flush_task = asyncio.ensure_future(_delayed_ci_flush(key))

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -137,6 +137,12 @@ _COLOURS: dict[str, int] = {
 }
 _DEFAULT_COLOUR = 0x7289DA  # blurple
 
+# Discord message flag: SUPPRESS_NOTIFICATIONS. Marks a message "silent" so it
+# posts without pinging channel members or firing a push notification — used
+# for the streaming task-output firehose (Phase 4) and combined CI summaries
+# (Phase 7), both of which are high-volume/low-urgency by design.
+_SILENT_FLAG = 1 << 12  # 4096
+
 
 def _get_client() -> httpx.AsyncClient:
     global _client
@@ -963,11 +969,6 @@ async def notify_existing_thread(
 # Phase 4: live task-stream mirroring
 # ---------------------------------------------------------------------------
 
-# Discord message flag: SUPPRESS_NOTIFICATIONS. Marks a message "silent" so it
-# posts without pinging channel members or firing a push notification — exactly
-# the low-priority behaviour we want for a firehose of streaming task output.
-_SILENT_FLAG = 1 << 12  # 4096
-
 # How long to accumulate stream lines before flushing them as one Discord
 # message. Batching is essential: worker terminal output is line-per-event and
 # would blow past Discord's per-channel rate limit if each line were its own POST.
@@ -1286,6 +1287,17 @@ _CI_CONCLUSION_VERBS: dict[str, str] = {
     "action_required": "need attention",
 }
 
+# Rendering order for the combined summary: failures first (most actionable),
+# then warning-ish/neutral conclusions, then successes last. Unknown
+# conclusions are treated as neutral so they don't get buried below successes.
+_CI_CONCLUSION_PRIORITY: dict[str, int] = {
+    "failure": 0,
+    "timed_out": 1,
+    "action_required": 1,
+    "cancelled": 1,
+    "success": 2,
+}
+
 
 def _pr_debounce_seconds() -> float:
     """Debounce window (seconds) before flushing a PR's buffered CI checks.
@@ -1322,15 +1334,20 @@ def _format_ci_summary(entries: list[_CICheckEntry]) -> str:
     """Combine buffered check completions into a compact, multi-line summary.
 
     Groups by conclusion so e.g. two passing checks plus one failing check
-    renders as two lines: ``"✅ 2 checks passed: lint, test"`` followed by
-    ``"❌ 1 check failed: build"`` — rather than one Discord message per check.
+    renders as two lines: ``"❌ 1 check failed: build"`` followed by
+    ``"✅ 2 checks passed: lint, test"`` — rather than one Discord message per
+    check. Lines are ordered by ``_CI_CONCLUSION_PRIORITY`` (failures, then
+    warning-ish/neutral conclusions, then successes) rather than arrival
+    order, so the most actionable line is always first regardless of which
+    check happened to complete first.
     """
     by_conclusion: dict[str, list[str]] = {}
     for entry in entries:
         by_conclusion.setdefault(entry.conclusion, []).append(entry.check_name)
 
     lines = []
-    for conclusion, names in by_conclusion.items():
+    for conclusion in sorted(by_conclusion, key=lambda c: _CI_CONCLUSION_PRIORITY.get(c, 1)):
+        names = by_conclusion[conclusion]
         icon = _CI_CONCLUSION_ICONS.get(conclusion, "ℹ️")
         noun = "check" if len(names) == 1 else "checks"
         verb = _CI_CONCLUSION_VERBS.get(conclusion, conclusion.replace("_", " "))
@@ -1339,9 +1356,26 @@ def _format_ci_summary(entries: list[_CICheckEntry]) -> str:
 
 
 async def _flush_ci_batch(key: str) -> None:
-    """Post the combined summary for *key*'s buffered CI checks, then drop the batch."""
-    batch = _ci_batches.pop(key, None)
-    if batch is None or not batch.entries:
+    """Post the combined summary for *key*'s buffered CI checks, then drop the batch.
+
+    Cancels the batch's own pending debounce task before popping it (guarding
+    against self-cancellation when this runs from inside that very task via
+    ``_delayed_ci_flush``). Without this, an early/manual flush — as tests do
+    to avoid waiting out the real debounce window — leaves the original timer
+    running; if a new batch is later created for the same *key* before that
+    stale timer fires, it would wake up and flush the *new* batch prematurely.
+    """
+    batch = _ci_batches.get(key)
+    if batch is None:
+        return
+    if (
+        batch.flush_task is not None
+        and batch.flush_task is not asyncio.current_task()
+        and not batch.flush_task.done()
+    ):
+        batch.flush_task.cancel()
+    _ci_batches.pop(key, None)
+    if not batch.entries:
         return
     conclusions = {entry.conclusion for entry in batch.entries}
     event_type = "ci-pass" if conclusions == {"success"} else "ci-fail"
@@ -1385,6 +1419,16 @@ async def notify_ci_check(
     (see ``notify_task_stream``) rather than a sliding debounce, so a steady
     trickle of checks can't indefinitely postpone the summary. Silent no-op
     when the bot token is not configured. Never raises.
+
+    Guards against the batch being popped out from under it by a concurrent
+    ``_flush_ci_batch(key)``: since asyncio only switches tasks at ``await``
+    points and this function has none between reading and writing
+    ``_ci_batches[key]``, that can only happen across two separate calls —
+    e.g. a debounce timer flushes the batch this call just fetched a
+    reference to, in between our ``.get()`` and this point. If so, our entry
+    just landed on an object nothing will ever flush; re-registering it under
+    *key* and treating it as freshly created (forcing a new flush task) keeps
+    it from being silently dropped.
     """
     if not _bot_token():
         return
@@ -1407,5 +1451,9 @@ async def notify_ci_check(
         _ci_batches[key] = batch
     batch.entries.append(_CICheckEntry(check_name=check_name, conclusion=conclusion))
 
-    if batch.flush_task is None:
+    if _ci_batches.get(key) is not batch:
+        _ci_batches[key] = batch
+        batch.flush_task = None
+
+    if batch.flush_task is None or batch.flush_task.done():
         batch.flush_task = asyncio.ensure_future(_delayed_ci_flush(key))

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -1016,13 +1016,15 @@ async def github_webhook(
             if isinstance(node, dict)
             else "CI"
         )
-        if conclusion == "success":
+        # Buffered per-PR and combined into one Discord message (see
+        # discord_notifier.notify_ci_check) instead of one message per check —
+        # a CI matrix can complete several of these within seconds of each other.
+        if conclusion in {"success", "failure", "cancelled", "timed_out", "action_required"}:
             spawn(
-                discord_notifier.notify_event(
-                    "ci-pass",
-                    title=f"CI passed: {_pr_label}",
-                    description=f"`{check_name}` passed on `{_pr_label}`."
-                    + (f" Task: `{task_id}`." if task_id else ""),
+                discord_notifier.notify_ci_check(
+                    check_name,
+                    conclusion,
+                    pr_label=_pr_label,
                     url=pr_url or None,
                     issue_repo=repo,
                     issue_number=pr_number,
@@ -1031,24 +1033,7 @@ async def github_webhook(
                     linked_issue_number=linked_issue_number,
                     task_id=task_id,
                 ),
-                name=f"discord.ci-pass:{_pr_label}",
-            )
-        elif conclusion in {"failure", "cancelled", "timed_out", "action_required"}:
-            spawn(
-                discord_notifier.notify_event(
-                    "ci-fail",
-                    title=f"CI failed: {_pr_label}",
-                    description=f"`{check_name}` {conclusion} on `{_pr_label}`."
-                    + (f" Task: `{task_id}`." if task_id else ""),
-                    url=pr_url or None,
-                    issue_repo=repo,
-                    issue_number=pr_number,
-                    ps_guild_slug=guild_id,
-                    linked_issue_repo=linked_issue_repo,
-                    linked_issue_number=linked_issue_number,
-                    task_id=task_id,
-                ),
-                name=f"discord.ci-fail:{_pr_label}",
+                name=f"discord.ci-check:{_pr_label}:{check_name}",
             )
 
     await broadcast_msg(

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -48,6 +48,14 @@ def reset_stream_buffers():
     discord_notifier._stream_buffers.clear()
 
 
+@pytest.fixture(autouse=True)
+def reset_ci_batches():
+    """Clear the in-memory CI check batches between tests."""
+    discord_notifier._ci_batches.clear()
+    yield
+    discord_notifier._ci_batches.clear()
+
+
 def _make_mock_client(status_code: int = 204, side_effect=None, json_response: dict | None = None):
     """Return a mock httpx.AsyncClient with stubbed HTTP methods."""
     mock_response = MagicMock(spec=httpx.Response)
@@ -1416,3 +1424,219 @@ def test_chunk_content_prefers_newline_boundaries():
 
     assert chunks == ["aaaa", "bbbb", "cccc"]
     assert all(len(c) <= 7 for c in chunks)
+
+
+# ---------------------------------------------------------------------------
+# Phase 7: CI check debounce/combine (issue #843)
+# ---------------------------------------------------------------------------
+
+
+def test_pr_debounce_seconds_defaults_to_15(monkeypatch):
+    monkeypatch.delenv("DISCORD_PR_DEBOUNCE_SECONDS", raising=False)
+    assert discord_notifier._pr_debounce_seconds() == 15.0
+
+
+def test_pr_debounce_seconds_honours_env_override(monkeypatch):
+    monkeypatch.setenv("DISCORD_PR_DEBOUNCE_SECONDS", "5")
+    assert discord_notifier._pr_debounce_seconds() == 5.0
+
+
+def test_format_ci_summary_all_passed():
+    entries = [
+        discord_notifier._CICheckEntry(check_name="lint", conclusion="success"),
+        discord_notifier._CICheckEntry(check_name="test", conclusion="success"),
+        discord_notifier._CICheckEntry(check_name="build", conclusion="success"),
+    ]
+    summary = discord_notifier._format_ci_summary(entries)
+    assert summary == "✅ 3 checks passed: lint, test, build"
+
+
+def test_format_ci_summary_mixed_pass_and_fail():
+    entries = [
+        discord_notifier._CICheckEntry(check_name="lint", conclusion="success"),
+        discord_notifier._CICheckEntry(check_name="build", conclusion="failure"),
+    ]
+    summary = discord_notifier._format_ci_summary(entries)
+    assert "✅ 1 check passed: lint" in summary
+    assert "❌ 1 check failed: build" in summary
+
+
+def test_format_ci_summary_singular_wording():
+    entries = [discord_notifier._CICheckEntry(check_name="lint", conclusion="success")]
+    assert discord_notifier._format_ci_summary(entries) == "✅ 1 check passed: lint"
+
+
+@pytest.mark.asyncio
+async def test_notify_ci_check_noop_when_no_bot_token(monkeypatch):
+    """notify_ci_check must not buffer anything when the bot token is unset."""
+    await discord_notifier.notify_ci_check("lint", "success", pr_label="org/repo#1")
+
+    assert discord_notifier._ci_batches == {}
+
+
+@pytest.mark.asyncio
+async def test_notify_ci_check_buffers_without_posting_immediately(monkeypatch):
+    """A single CI check is buffered and a delayed flush armed — no immediate POST."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_delayed_ci_flush", AsyncMock()),
+    ):
+        await discord_notifier.notify_ci_check(
+            "lint", "success", pr_label="org/repo#1", issue_repo="org/repo", issue_number=1
+        )
+
+    mock_client.post.assert_not_called()
+    batch = discord_notifier._ci_batches["org/repo#1"]
+    assert batch.entries == [
+        discord_notifier._CICheckEntry(check_name="lint", conclusion="success")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_notify_ci_check_combines_multiple_checks_into_one_message(monkeypatch):
+    """Multiple rapid check completions for the same PR flush as one combined message."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        for name in ("lint", "test", "build"):
+            await discord_notifier.notify_ci_check(
+                name,
+                "success",
+                pr_label="org/repo#1",
+                issue_repo="org/repo",
+                issue_number=1,
+            )
+        # Flush directly instead of waiting out the real debounce window.
+        await discord_notifier._flush_ci_batch("org/repo#1")
+
+    mock_client.post.assert_called_once()
+    body = mock_client.post.call_args[1]["json"]
+    assert body["embeds"][0]["description"] == "✅ 3 checks passed: lint, test, build"
+    assert "org/repo#1" not in discord_notifier._ci_batches
+
+
+@pytest.mark.asyncio
+async def test_flush_ci_batch_uses_ci_pass_when_all_succeed(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_ci_check(
+            "lint", "success", pr_label="org/repo#1", issue_repo="org/repo", issue_number=1
+        )
+        await discord_notifier._flush_ci_batch("org/repo#1")
+
+    body = mock_client.post.call_args[1]["json"]
+    assert body["embeds"][0]["color"] == discord_notifier._COLOURS["ci-pass"]
+
+
+@pytest.mark.asyncio
+async def test_flush_ci_batch_uses_ci_fail_when_any_check_fails(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_ci_check(
+            "lint", "success", pr_label="org/repo#1", issue_repo="org/repo", issue_number=1
+        )
+        await discord_notifier.notify_ci_check(
+            "build", "failure", pr_label="org/repo#1", issue_repo="org/repo", issue_number=1
+        )
+        await discord_notifier._flush_ci_batch("org/repo#1")
+
+    body = mock_client.post.call_args[1]["json"]
+    assert body["embeds"][0]["color"] == discord_notifier._COLOURS["ci-fail"]
+
+
+@pytest.mark.asyncio
+async def test_flush_ci_batch_posts_with_suppress_notifications_flag(monkeypatch):
+    """Combined CI summaries must always carry SUPPRESS_NOTIFICATIONS (flags=4096)."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_ci_check(
+            "build", "failure", pr_label="org/repo#1", issue_repo="org/repo", issue_number=1
+        )
+        await discord_notifier._flush_ci_batch("org/repo#1")
+
+    body = mock_client.post.call_args[1]["json"]
+    assert body["flags"] == 4096 == discord_notifier._SILENT_FLAG
+
+
+@pytest.mark.asyncio
+async def test_flush_ci_batch_noop_when_batch_missing():
+    """Flushing an already-flushed / unknown key is a silent no-op."""
+    with patch.object(discord_notifier, "notify_event", AsyncMock()) as notify_mock:
+        await discord_notifier._flush_ci_batch("unknown-key")
+
+    notify_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_event_non_ci_has_no_suppress_flag(monkeypatch):
+    """Non-CI events (e.g. pr-merged) must post without the silent flag."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
+    mock_client = _make_mock_client()
+
+    with (
+        patch.object(discord_notifier, "_get_client", return_value=mock_client),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=THREAD_ID)),
+    ):
+        await discord_notifier.notify_event(
+            "pr-merged",
+            title="PR merged",
+            description="Merged!",
+            issue_repo="org/repo",
+            issue_number=1,
+        )
+
+    body = mock_client.post.call_args[1]["json"]
+    assert "flags" not in body
+
+
+@pytest.mark.asyncio
+async def test_post_to_thread_omits_flags_key_when_not_given(monkeypatch):
+    """_post_to_thread must not add a flags key to the payload when flags=None."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    mock_client = _make_mock_client()
+
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier._post_to_thread(THREAD_ID, "pr-opened", "t", "d")
+
+    body = mock_client.post.call_args[1]["json"]
+    assert "flags" not in body
+
+
+@pytest.mark.asyncio
+async def test_post_to_thread_includes_flags_when_given(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
+    mock_client = _make_mock_client()
+
+    with patch.object(discord_notifier, "_get_client", return_value=mock_client):
+        await discord_notifier._post_to_thread(THREAD_ID, "ci-pass", "t", "d", flags=4096)
+
+    body = mock_client.post.call_args[1]["json"]
+    assert body["flags"] == 4096

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -69,6 +69,7 @@ bot must already be a member of the guild that owns `DISCORD_CHANNEL_ID`.
 | `DISCORD_OPERATOR_ROLE_NAME` | No | Discord role name (in addition to the Manage Channels permission) allowed to run `/join-channel` and `/leave-channel`. Default `Pioneer Square Operator`. |
 | `DISCORD_DEV_GUILD_ID` | No (registration only) | Discord server ID. When set, `scripts/register_discord_commands.py` registers commands to that one server (near-instant) instead of globally (up to 1 hour to propagate). |
 | `DISCORD_STREAM_TASKS` | No | When truthy (`1`/`true`/`yes`/`on`), mirror each working task's live terminal output into a dedicated per-task Discord thread as silent, low-priority messages. Off by default (high-volume). Requires `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` — the feed always routes into a thread, never a flat channel post. |
+| `DISCORD_PR_DEBOUNCE_SECONDS` | No | Seconds to buffer `check_run`/`check_suite` completions for the same PR before flushing them as one combined, silent Discord message. Default `15`. |
 
 `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` must be set **together** — the bot needs both
 the credential and a destination channel to create threads.
@@ -148,6 +149,14 @@ call site — only the events listed below actually fire notifications today:
 - `pr-opened`, `pr-merged`, `pr-closed` — fired from the GitHub webhook handler.
 - `ci-pass`, `ci-fail` — fired from GitHub `check_run`/`check_suite` webhook events.
 - `task-complete` — fired when a worker reports a task finished.
+
+**CI check debounce/combine** — `check_run`/`check_suite` completions for the same PR are
+buffered per PR and flushed as a single combined message (e.g. `✅ 3 checks passed: lint, test,
+build`) after `DISCORD_PR_DEBOUNCE_SECONDS` (default 15) of silence on that PR, instead of one
+Discord message per check — a CI matrix routinely completes several checks within seconds of
+each other. The combined message always carries Discord's `SUPPRESS_NOTIFICATIONS` flag so CI
+results don't trigger a push notification. Non-CI events (PR opened/merged/closed, reviews) are
+unaffected — they post immediately, at normal notification priority.
 
 ### Per-PR/issue threads
 

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -158,6 +158,13 @@ each other. The combined message always carries Discord's `SUPPRESS_NOTIFICATION
 results don't trigger a push notification. Non-CI events (PR opened/merged/closed, reviews) are
 unaffected — they post immediately, at normal notification priority.
 
+`DISCORD_PR_DEBOUNCE_SECONDS` is a **fixed-start** window, not a sliding one: the timer arms on
+the first buffered check for a PR and is not reset by later checks arriving in the same window.
+A CI matrix with checks completing at t=0s, t=14s, and t=14.5s will flush at t=15s and catch all
+three, but one completing at t=16s misses the window and gets its own follow-up message instead
+of joining the summary. Set the value comfortably above the longest expected gap between checks
+in your CI matrix to avoid fragmenting a single CI run across two Discord messages.
+
 ### Per-PR/issue threads
 
 Add `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` to route PR/issue-related events into one


### PR DESCRIPTION
## Summary
- Buffer per-PR `check_run`/`check_suite` CI completions and flush a single combined Discord message (e.g. "✅ 3 checks passed: lint, test, build") after a debounce window, instead of one message per check.
- Debounce window configurable via `DISCORD_PR_DEBOUNCE_SECONDS` (default 15s).
- Combined CI messages carry Discord's `SUPPRESS_NOTIFICATIONS` flag (`1 << 12`) so they don't trigger push notifications.
- Non-CI events (PR opened/merged/closed, reviews) are unaffected — normal priority, immediate posting.

Closes #843

## Test plan
- [x] `pytest backend/tests/test_discord_notifier.py` — 95 passed
- [x] `ruff check` on changed files — clean