### PR TITLE
Auto-finalize phase='issue' root tasks when GitHub issue closes

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -479,6 +479,70 @@ async def _fetch_pr_status_lines(guild_id: str, pr_tasks: list[dict]) -> list[st
     return lines
 
 
+async def _sweep_closed_issue_tasks(guild_id: str, issue_tasks: list[dict]) -> None:
+    """Finalize ``phase='issue'`` root tasks whose linked GitHub issue has closed.
+
+    Called on every periodic-check cycle alongside the PR-status refresh above, for
+    every non-terminal ``phase='issue'`` root task that has both ``issue_repo`` and
+    ``issue_number`` set (backed by the ``ix_tasks_issue_repo_issue_number`` index
+    added in #836). This is a safety net for the ``issues`` webhook handler in
+    ``routes.webhooks`` — it catches issues closed before that handler existed, or
+    where a webhook delivery was missed — so it acts directly (no foreman/LLM
+    round-trip needed) rather than merely nudging the foreman like the PR-status
+    block does. Child tasks (plan/execute/review/followup) are never auto-closed;
+    a warning is logged if any remain non-terminal. Best effort: an individual
+    GitHub fetch failure is logged and skipped rather than aborting the sweep.
+    """
+    if not issue_tasks:
+        return
+
+    from foreman.tools import (
+        _guild_github_token,
+        fetch_issue_state,
+        finalize_issue_root_task,
+        warn_if_issue_task_has_open_children,
+    )
+
+    creds = await _guild_github_token(guild_id)
+    if not creds:
+        return
+    token, _username = creds
+
+    for t in issue_tasks:
+        repo, number = t["issue_repo"], t["issue_number"]
+        try:
+            state = await fetch_issue_state(repo, number, token)
+        except Exception:
+            logger.warning(
+                "guild=%s task=%s failed to fetch issue status for %s#%s",
+                guild_id,
+                t["id"],
+                repo,
+                number,
+                exc_info=True,
+            )
+            continue
+
+        if state != "closed":
+            continue
+
+        db = await get_db()
+        try:
+            guild_pk_val = await get_guild_pk(db, guild_id)
+            finalized = await finalize_issue_root_task(db, guild_pk_val, guild_id, t["id"])
+            if finalized:
+                logger.info(
+                    "guild=%s task=%s finalized (issue %s#%s closed)",
+                    guild_id,
+                    t["id"],
+                    repo,
+                    number,
+                )
+                await warn_if_issue_task_has_open_children(db, guild_id, t["id"])
+        finally:
+            await db.close()
+
+
 async def _poll_loop(guild_id: str) -> None:
     """Background loop: check non-terminal tasks and trigger the foreman if any are found.
 
@@ -517,6 +581,9 @@ async def _poll_loop(guild_id: str) -> None:
                         col(Task.pr_url),
                         col(Task.pr_number),
                         col(Task.pr_repo),
+                        col(Task.phase),
+                        col(Task.issue_repo),
+                        col(Task.issue_number),
                     ).where(
                         col(Task.guild_id) == guild_pk_val,
                         ~col(Task.state).in_(list(_TERMINAL_STATES)),
@@ -548,6 +615,13 @@ async def _poll_loop(guild_id: str) -> None:
                 task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active_tasks)
                 pr_tasks = [t for t in active_tasks if t.get("pr_url")]
                 pr_status_lines = await _fetch_pr_status_lines(guild_id, pr_tasks)
+
+                issue_tasks = [
+                    t
+                    for t in active_tasks
+                    if t.get("phase") == "issue" and t.get("issue_repo") and t.get("issue_number")
+                ]
+                await _sweep_closed_issue_tasks(guild_id, issue_tasks)
 
                 msg = (
                     f"[periodic-check] Automated status poll — {n} non-terminal "

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -508,27 +508,27 @@ async def _sweep_closed_issue_tasks(guild_id: str, issue_tasks: list[dict]) -> N
         return
     token, _username = creds
 
-    for t in issue_tasks:
-        repo, number = t["issue_repo"], t["issue_number"]
-        try:
-            state = await fetch_issue_state(repo, number, token)
-        except Exception:
-            logger.warning(
-                "guild=%s task=%s failed to fetch issue status for %s#%s",
-                guild_id,
-                t["id"],
-                repo,
-                number,
-                exc_info=True,
-            )
-            continue
+    db = await get_db()
+    try:
+        guild_pk_val = await get_guild_pk(db, guild_id)
+        for t in issue_tasks:
+            repo, number = t["issue_repo"], t["issue_number"]
+            try:
+                state = await fetch_issue_state(repo, number, token)
+            except Exception:
+                logger.warning(
+                    "guild=%s task=%s failed to fetch issue status for %s#%s",
+                    guild_id,
+                    t["id"],
+                    repo,
+                    number,
+                    exc_info=True,
+                )
+                continue
 
-        if state != "closed":
-            continue
+            if state != "closed":
+                continue
 
-        db = await get_db()
-        try:
-            guild_pk_val = await get_guild_pk(db, guild_id)
             finalized = await finalize_issue_root_task(db, guild_pk_val, guild_id, t["id"])
             if finalized:
                 logger.info(
@@ -539,8 +539,8 @@ async def _sweep_closed_issue_tasks(guild_id: str, issue_tasks: list[dict]) -> N
                     number,
                 )
                 await warn_if_issue_task_has_open_children(db, guild_id, t["id"])
-        finally:
-            await db.close()
+    finally:
+        await db.close()
 
 
 async def _poll_loop(guild_id: str) -> None:

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -169,20 +169,11 @@ async def finalize_issue_root_task(db, guild_pk: int, guild_id: str, task_id: st
     Shared by the periodic closed-issue sweep (``foreman.runner._sweep_closed_issue_tasks``)
     and the ``issues`` webhook handler (``routes.webhooks.github_webhook``) so both paths
     apply the same terminal-state guard and broadcast behaviour. Uses a single conditional
-    UPDATE (rather than SELECT-then-UPDATE) to avoid a TOCTOU race with a concurrent
-    finalize/follow-up on the same task. Does not touch child tasks — callers should warn
-    if any remain non-terminal. Returns True if finalization occurred.
+    ``UPDATE ... RETURNING`` (rather than SELECT-then-UPDATE) so ``worker_id`` is only ever
+    read off the winning update row — a separate prior SELECT would reopen the same TOCTOU
+    race with a concurrent finalize/follow-up on this task. Does not touch child tasks —
+    callers should warn if any remain non-terminal. Returns True if finalization occurred.
     """
-    row_result = await db.exec(
-        select(col(Task.id), col(Task.worker_id)).where(
-            col(Task.id) == task_id, col(Task.guild_id) == guild_pk
-        )
-    )
-    task_row = row_result.one_or_none()
-    if task_row is None:
-        return False
-    worker_id = task_row[1]
-
     deleted_at = datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS)
     upd = await db.exec(
         update(Task)
@@ -192,9 +183,12 @@ async def finalize_issue_root_task(db, guild_pk: int, guild_id: str, task_id: st
             ~col(Task.state).in_(list(_TERMINAL_STATES)),
         )
         .values(state="done", deleted_at=deleted_at)
+        .returning(col(Task.worker_id))
     )
-    if (getattr(upd, "rowcount", 0) or 0) == 0:
+    row = upd.one_or_none()
+    if row is None:
         return False
+    worker_id = row[0]
 
     await LockService(db).release(f"task:{task_id}")
     await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -23,6 +23,7 @@ from typing import Any
 import discord_notifier
 from database import get_db
 from events import broadcast, broadcast_msg, emit_terminal_line
+from foreman.constants import _TERMINAL_STATES
 from foreman.llm import get_foreman_model, make_anthropic_client
 from foreman.message_utils import _json_default, truncate_tool_result
 from foreman.tools_schema import (
@@ -40,6 +41,7 @@ from models import (
     TaskEvent,
     TaskLog,
     Worker,
+    live_tasks_filter,
 )
 from sqlalchemy import delete, update
 from sqlmodel import col, select
@@ -159,6 +161,76 @@ def _resolve_finalize_deleted_at(inp: dict) -> tuple[datetime | None, str | None
             return None, "expires_in_seconds must be >= 0"
         return datetime.now(UTC) + timedelta(seconds=secs), None
     return datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS), None
+
+
+async def finalize_issue_root_task(db, guild_pk: int, guild_id: str, task_id: str) -> bool:
+    """Directly finalize a ``phase='issue'`` root task once its GitHub issue closes.
+
+    Shared by the periodic closed-issue sweep (``foreman.runner._sweep_closed_issue_tasks``)
+    and the ``issues`` webhook handler (``routes.webhooks.github_webhook``) so both paths
+    apply the same terminal-state guard and broadcast behaviour. Uses a single conditional
+    UPDATE (rather than SELECT-then-UPDATE) to avoid a TOCTOU race with a concurrent
+    finalize/follow-up on the same task. Does not touch child tasks — callers should warn
+    if any remain non-terminal. Returns True if finalization occurred.
+    """
+    row_result = await db.exec(
+        select(col(Task.id), col(Task.worker_id)).where(
+            col(Task.id) == task_id, col(Task.guild_id) == guild_pk
+        )
+    )
+    task_row = row_result.one_or_none()
+    if task_row is None:
+        return False
+    worker_id = task_row[1]
+
+    deleted_at = datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS)
+    upd = await db.exec(
+        update(Task)
+        .where(
+            col(Task.id) == task_id,
+            col(Task.guild_id) == guild_pk,
+            ~col(Task.state).in_(list(_TERMINAL_STATES)),
+        )
+        .values(state="done", deleted_at=deleted_at)
+    )
+    if (getattr(upd, "rowcount", 0) or 0) == 0:
+        return False
+
+    await LockService(db).release(f"task:{task_id}")
+    await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
+    await db.commit()
+
+    await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=task_id))
+    await broadcast_msg(
+        guild_id,
+        TaskUpdateMsg(taskId=task_id, state="done", deletedAt=deleted_at.isoformat()),
+    )
+    return True
+
+
+async def warn_if_issue_task_has_open_children(db, guild_id: str, root_task_id: str) -> None:
+    """Log a warning if an issue-root task still has non-terminal child tasks.
+
+    Child tasks (plan/execute/review/followup) are never auto-closed when the parent
+    GitHub issue closes — a human should decide whether to cancel in-flight work.
+    """
+    result = await db.exec(
+        select(col(Task.id)).where(
+            col(Task.parent_task_id) == root_task_id,
+            ~col(Task.state).in_(list(_TERMINAL_STATES)),
+            live_tasks_filter(),
+        )
+    )
+    open_children = [row[0] for row in result.all()]
+    if open_children:
+        logger.warning(
+            "guild=%s task=%s issue closed but %d non-terminal child task(s) remain "
+            "open: %s — leaving them as-is",
+            guild_id,
+            root_task_id,
+            len(open_children),
+            ", ".join(open_children),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -292,6 +364,16 @@ async def _guild_github_token(guild_id: str) -> tuple[str, str] | None:
         return (row.access_token, row.github_username) if row else None
     finally:
         await db.close()
+
+
+async def fetch_issue_state(repo: str, issue_number: int, token: str) -> str:
+    """Return the current lifecycle state (``"open"`` or ``"closed"``) of a GitHub issue.
+
+    Used by the periodic closed-issue sweep (foreman.runner._sweep_closed_issue_tasks)
+    to detect issues closed outside the webhook path (e.g. a missed delivery).
+    """
+    issue = await _to_thread(_gh_api, f"/repos/{repo}/issues/{issue_number}", token)
+    return issue.get("state", "open")
 
 
 async def fetch_pr_status(repo: str, pr_number: int, token: str) -> dict:

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -882,6 +882,7 @@ async def github_webhook(
                         col(Task.issue_repo) == repo,
                         col(Task.issue_number) == issue_num,
                         col(Task.phase) == "issue",
+                        col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
                     )
                 )
                 for row in root_result.all():

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -865,6 +865,37 @@ async def github_webhook(
                 guild_id,
             )
 
+            # A closed issue finalizes its phase='issue' root task directly — no
+            # foreman/LLM round-trip needed, since the issue's own state is the
+            # only signal that matters here. The periodic sweep in
+            # foreman.runner._sweep_closed_issue_tasks is a safety net for
+            # missed deliveries; this is the primary (near-instant) path.
+            if action == "closed":
+                from foreman.tools import (
+                    finalize_issue_root_task,
+                    warn_if_issue_task_has_open_children,
+                )
+
+                root_result = await db.exec(
+                    select(col(Task.id)).where(
+                        col(Task.guild_id) == guild_pk,
+                        col(Task.issue_repo) == repo,
+                        col(Task.issue_number) == issue_num,
+                        col(Task.phase) == "issue",
+                    )
+                )
+                for row in root_result.all():
+                    root_task_id = row[0]
+                    finalized = await finalize_issue_root_task(db, guild_pk, guild_id, root_task_id)
+                    if finalized:
+                        logger.info(
+                            "github webhook auto-finalized issue-root task=%s on issue "
+                            "close guild=%s",
+                            root_task_id,
+                            guild_id,
+                        )
+                        await warn_if_issue_task_has_open_children(db, guild_id, root_task_id)
+
     # Deterministic lifecycle transitions: finalize on merge, fail on close-without-merge.
     # These happen directly — no AI decision needed for these clear-cut outcomes.
     if task_id and event_type == "pull_request" and action == "closed":


### PR DESCRIPTION
## Summary
- Add a periodic sweep (`foreman.runner._sweep_closed_issue_tasks`) that checks every non-terminal `phase='issue'` root task with `issue_repo`/`issue_number` set against the GitHub issue's current state, finalizing (state=done, deleted_at=+3d) any whose issue has closed.
- Add a shared `finalize_issue_root_task` helper in `foreman/tools.py` used by both the sweep and the webhook path, using a single conditional UPDATE to avoid a TOCTOU race with concurrent finalization.
- Add an `issues` webhook handler (`action=closed`) in `routes/webhooks.py` that finalizes the matching issue-root task immediately, with the periodic sweep as a safety net for missed deliveries.
- Log a warning (never auto-close) if a finalized issue-root task still has non-terminal child tasks.

Closes #847.

## Test plan
- [x] `python -m pytest tests/` — 932 passed, 2 skipped, 0 failed
- [x] Reviewed diff vs `main` to confirm sweep, webhook handler, and shared finalize/child-warning helpers are wired consistently with the existing PR-status sweep pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)