### PR TITLE
Consolidate LLM provider logic into shared module; make proxy a thin wrapper

### DIFF
--- a/backend/foreman/llm.py
+++ b/backend/foreman/llm.py
@@ -387,14 +387,20 @@ async def call_anthropic(
     plain dict (e.g. the proxy, to send the response back over the wire) call
     `.model_dump()` themselves; callers that stay in-process (the embedded
     foreman's local call path) can use it directly.
+
+    `tools` is only included in the request when non-empty: some Anthropic API
+    endpoints reject an explicit empty `tools` array, and omitting the param
+    (rather than defaulting a missing/None value to `[]`) also means a caller
+    that explicitly passes `tools=None` isn't silently overridden.
     """
     kwargs: dict[str, Any] = {
         "model": model,
         "max_tokens": max_tokens,
         "system": system or [],
         "messages": messages or [],
-        "tools": tools or [],
     }
+    if tools:
+        kwargs["tools"] = tools
     if tool_choice is not None:
         kwargs["tool_choice"] = tool_choice
     raw = await client.messages.with_raw_response.create(**kwargs)
@@ -574,30 +580,37 @@ def openai_response_to_anthropic(raw: dict[str, Any], model: str) -> dict[str, A
 
 async def call_openai_compatible(
     client: httpx.AsyncClient,
-    request: dict[str, Any],
     *,
     model: str,
+    max_tokens: int,
     base_url: str,
+    system: list[dict[str, Any]] | None = None,
+    messages: list[dict[str, Any]] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: dict[str, Any] | None = None,
     api_key: str | None = None,
 ) -> tuple[dict[str, Any], str | None]:
     """Execute one OpenAI-compatible POST /chat/completions call.
 
-    `request` is the same Anthropic-shaped request dict call_anthropic takes
-    (model/maxTokens/system/messages/tools/toolChoice); the request is
-    translated to OpenAI chat-completion format, POSTed, and the response is
-    translated back to an Anthropic Messages API response dict — so callers
-    (the standalone proxy today) don't need to know which wire format actually
+    Takes the same Anthropic-shaped, snake_case keyword arguments as
+    call_anthropic (model/max_tokens/system/messages/tools/tool_choice) rather
+    than a raw request dict, so the two provider call paths share one calling
+    convention. The caller (the standalone proxy) is responsible for
+    translating its own wire format (the backend's camelCase
+    maxTokens/toolChoice JSON) into these kwargs — that's the "which machine"
+    plumbing the proxy owns; everything below is the provider translation this
+    module owns. The request is converted to OpenAI chat-completion format,
+    POSTed, and the response is translated back to an Anthropic Messages API
+    response dict, so callers don't need to know which wire format actually
     served the request. Returns (response_dict, request_id).
     """
     body: dict[str, Any] = {
         "model": model,
-        "messages": anthropic_messages_to_openai(
-            request.get("system") or [], request.get("messages") or []
-        ),
-        "tools": anthropic_tools_to_openai(request.get("tools") or []),
-        "max_tokens": request.get("maxTokens") or 1024,
+        "messages": anthropic_messages_to_openai(system or [], messages or []),
+        "max_tokens": max_tokens,
     }
-    tool_choice = request.get("toolChoice")
+    if tools:
+        body["tools"] = anthropic_tools_to_openai(tools)
     if tool_choice:
         body["tool_choice"] = "none" if tool_choice.get("type") == "none" else tool_choice
 

--- a/backend/foreman/llm.py
+++ b/backend/foreman/llm.py
@@ -1,14 +1,33 @@
-"""Anthropic client factory supporting both the direct API and Amazon Bedrock.
+"""Shared LLM provider logic: client factory, the Anthropic call, and OpenAI-
+compatible request/response translation.
 
-Both the embedded foreman (backend) and standalone foreman import this to build
-their own module-level singleton — the factory is shared, the instance is not.
+Both the embedded foreman (backend/foreman/runner.py) and the standalone proxy
+(foreman/pioneer_foreman/runner.py) import this module for ALL provider
+normalization — this is the one place that knows the shape of each provider's
+wire format. Neither runner re-implements or duplicates any of it.
+
+Architecture boundary (see issue #826): the proxy exists only to decide *which
+machine* makes the outbound call — a different Bedrock region/profile, a
+locally-reachable OpenAI-compatible endpoint (e.g. Ollama), whatever the
+operator configured. It holds no provider-specific logic of its own; it just
+plumbs its own config into the helpers below. The embedded foreman calls
+`make_anthropic_client` + `call_anthropic` directly for the providers the
+Anthropic SDK can reach itself (`ANTHROPIC_SDK_PROVIDERS`); for anything else
+(currently just `"openai"`) it requires a connected foreman API proxy rather
+than calling `call_openai_compatible` locally — see the FOREMAN_PROVIDER check
+in `backend/foreman/runner.py`.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from collections.abc import Mapping
+from typing import Any
+from uuid import uuid4
+
+import httpx
 
 try:
     import anthropic as _anthropic_mod
@@ -19,6 +38,13 @@ except ImportError:
     HAS_ANTHROPIC = False
 
 logger = logging.getLogger(__name__)
+
+# Providers the Anthropic SDK (make_anthropic_client) can call directly, either
+# against the direct API or Amazon Bedrock. Any other provider value (e.g.
+# "openai") needs call_openai_compatible, which the embedded foreman never
+# calls locally — only the standalone proxy does, since that's the process an
+# operator points at their own OpenAI-compatible endpoint.
+ANTHROPIC_SDK_PROVIDERS = frozenset({"anthropic", "bedrock"})
 
 
 class BedrockModelNotConfiguredError(ValueError):
@@ -331,3 +357,256 @@ def make_anthropic_client(
         kwargs.get("base_url", "default"),
     )
     return _anthropic_mod.AsyncAnthropic(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic Messages API call
+# ---------------------------------------------------------------------------
+
+
+async def call_anthropic(
+    client: Any,
+    *,
+    model: str,
+    max_tokens: int,
+    system: list[dict[str, Any]] | None = None,
+    messages: list[dict[str, Any]] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: dict[str, Any] | None = None,
+) -> tuple[Any, str | None]:
+    """Execute one Anthropic Messages API call. Returns (parsed_response, request_id).
+
+    `client` is any Anthropic SDK async client from make_anthropic_client
+    (AsyncAnthropic or AsyncAnthropicBedrock — Bedrock speaks the same Messages
+    API shape, so one call path covers both). Both the embedded foreman and the
+    standalone proxy call this against whichever client their own config
+    selected, so the request/response shape only has to be gotten right here.
+
+    `parsed_response` is the SDK's own response model (exposing both attribute
+    access like `.content`/`.usage` and `.model_dump()`) — callers that need a
+    plain dict (e.g. the proxy, to send the response back over the wire) call
+    `.model_dump()` themselves; callers that stay in-process (the embedded
+    foreman's local call path) can use it directly.
+    """
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "system": system or [],
+        "messages": messages or [],
+        "tools": tools or [],
+    }
+    if tool_choice is not None:
+        kwargs["tool_choice"] = tool_choice
+    raw = await client.messages.with_raw_response.create(**kwargs)
+    return raw.parse(), raw.headers.get("request-id")
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible provider: translation to/from the Anthropic Messages API
+# shape that the rest of this codebase (history storage, tool-use parsing,
+# call_anthropic above) speaks natively.
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_content_to_text(blocks: Any) -> str:
+    """Flatten Anthropic content (a string, or a list of text/tool_result blocks)
+    into plain text — OpenAI chat messages take a single string, not blocks."""
+    if isinstance(blocks, str):
+        return blocks
+    if not isinstance(blocks, list):
+        return "" if blocks is None else str(blocks)
+    parts: list[str] = []
+    for block in blocks:
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict):
+            if block.get("type") == "text":
+                parts.append(str(block.get("text") or ""))
+            elif block.get("type") == "tool_result":
+                parts.append(str(block.get("content") or ""))
+    return "\n".join(p for p in parts if p)
+
+
+def anthropic_tools_to_openai(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert Anthropic tool schemas (name/description/input_schema) to OpenAI's
+    function-calling schema."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool["name"],
+                "description": tool.get("description", ""),
+                "parameters": tool.get("input_schema") or {},
+            },
+        }
+        for tool in tools
+    ]
+
+
+def _parse_openai_tool_arguments(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("OpenAI-compatible tool call returned invalid JSON arguments: %.200r", raw)
+        return {"_raw_arguments": raw}
+    return parsed if isinstance(parsed, dict) else {"value": parsed}
+
+
+def anthropic_messages_to_openai(
+    system: list[dict[str, Any]], messages: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Convert an Anthropic system+messages pair into an OpenAI chat `messages` list.
+
+    Anthropic `tool_use`/`tool_result` blocks become OpenAI `tool_calls` and
+    `role: "tool"` messages respectively; everything else is flattened to text.
+    """
+    converted: list[dict[str, Any]] = []
+    system_text = _anthropic_content_to_text(system)
+    if system_text:
+        converted.append({"role": "system", "content": system_text})
+
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+        if role == "assistant" and isinstance(content, list):
+            text = _anthropic_content_to_text(
+                [
+                    block
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ]
+            )
+            tool_calls = []
+            for block in content:
+                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    continue
+                tool_calls.append(
+                    {
+                        "id": block.get("id") or f"toolu_{uuid4().hex}",
+                        "type": "function",
+                        "function": {
+                            "name": block.get("name") or "",
+                            "arguments": json.dumps(block.get("input") or {}),
+                        },
+                    }
+                )
+            converted.append(
+                {
+                    "role": "assistant",
+                    "content": text or None,
+                    **({"tool_calls": tool_calls} if tool_calls else {}),
+                }
+            )
+            continue
+
+        if role == "user" and isinstance(content, list):
+            pending_text: list[str] = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    if pending_text:
+                        converted.append({"role": "user", "content": "\n".join(pending_text)})
+                        pending_text = []
+                    converted.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": block.get("tool_use_id") or "",
+                            "content": str(block.get("content") or ""),
+                        }
+                    )
+                else:
+                    text = _anthropic_content_to_text([block])
+                    if text:
+                        pending_text.append(text)
+            if pending_text:
+                converted.append({"role": "user", "content": "\n".join(pending_text)})
+            continue
+
+        converted.append({"role": role, "content": _anthropic_content_to_text(content)})
+
+    return converted
+
+
+def openai_response_to_anthropic(raw: dict[str, Any], model: str) -> dict[str, Any]:
+    """Convert an OpenAI chat-completion response into an Anthropic Messages API
+    response dict, so callers only ever handle one response shape."""
+    choice = (raw.get("choices") or [{}])[0]
+    message = choice.get("message") or {}
+    content_blocks: list[dict[str, Any]] = []
+    if message.get("content"):
+        content_blocks.append({"type": "text", "text": str(message["content"])})
+
+    for call in message.get("tool_calls") or []:
+        fn = call.get("function") or {}
+        content_blocks.append(
+            {
+                "type": "tool_use",
+                "id": call.get("id") or f"toolu_{uuid4().hex}",
+                "name": fn.get("name") or "",
+                "input": _parse_openai_tool_arguments(fn.get("arguments")),
+            }
+        )
+
+    finish_reason = choice.get("finish_reason")
+    stop_reason = {
+        "tool_calls": "tool_use",
+        "stop": "end_turn",
+        "length": "max_tokens",
+    }.get(finish_reason, finish_reason or "end_turn")
+    usage = raw.get("usage") or {}
+    return {
+        "id": raw.get("id") or f"msg_{uuid4().hex}",
+        "type": "message",
+        "role": "assistant",
+        "model": raw.get("model") or model,
+        "content": content_blocks,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens", 0) or 0,
+            "output_tokens": usage.get("completion_tokens", 0) or 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+        },
+    }
+
+
+async def call_openai_compatible(
+    client: httpx.AsyncClient,
+    request: dict[str, Any],
+    *,
+    model: str,
+    base_url: str,
+    api_key: str | None = None,
+) -> tuple[dict[str, Any], str | None]:
+    """Execute one OpenAI-compatible POST /chat/completions call.
+
+    `request` is the same Anthropic-shaped request dict call_anthropic takes
+    (model/maxTokens/system/messages/tools/toolChoice); the request is
+    translated to OpenAI chat-completion format, POSTed, and the response is
+    translated back to an Anthropic Messages API response dict — so callers
+    (the standalone proxy today) don't need to know which wire format actually
+    served the request. Returns (response_dict, request_id).
+    """
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": anthropic_messages_to_openai(
+            request.get("system") or [], request.get("messages") or []
+        ),
+        "tools": anthropic_tools_to_openai(request.get("tools") or []),
+        "max_tokens": request.get("maxTokens") or 1024,
+    }
+    tool_choice = request.get("toolChoice")
+    if tool_choice:
+        body["tool_choice"] = "none" if tool_choice.get("type") == "none" else tool_choice
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    url = f"{base_url.rstrip('/')}/chat/completions"
+    response = await client.post(url, json=body, headers=headers)
+    response.raise_for_status()
+    request_id = response.headers.get("x-request-id") or response.headers.get("request-id")
+    return openai_response_to_anthropic(response.json(), model), request_id

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -21,8 +21,10 @@ from foreman.constants import (
     MAX_FOREMAN_ROUNDS,
 )
 from foreman.llm import (
+    ANTHROPIC_SDK_PROVIDERS,
     HAS_ANTHROPIC,
     BedrockModelNotConfiguredError,
+    call_anthropic,
     get_foreman_model,
     make_anthropic_client,
 )
@@ -120,6 +122,14 @@ class _LLMCallResult:
 
 
 class _ProxyContentBlock(SimpleNamespace):
+    """Attribute-access view of one content-block dict from a proxied response.
+
+    The foreman API proxy returns plain JSON (dicts), not SDK model instances,
+    so this mimics the Anthropic SDK's content-block attribute access
+    (`.type`/`.text`/`.input`/...) for code shared with the local call path
+    below, which gets real SDK objects from foreman.llm.call_anthropic.
+    """
+
     def __init__(self, raw: dict[str, Any]):
         super().__init__(**raw)
         self._raw = raw
@@ -162,7 +172,15 @@ async def _call_llm(
     tools: list[dict[str, Any]],
     tool_choice: dict[str, Any] | None = None,
 ) -> _LLMCallResult:
-    """Execute one LLM request, either locally or through the external proxy."""
+    """Execute one LLM request.
+
+    Either locally, via foreman.llm.call_anthropic against our own client (for
+    providers in ANTHROPIC_SDK_PROVIDERS), or through the connected foreman API
+    proxy — which can reach any provider, including OpenAI-compatible ones this
+    embedded foreman never calls directly. Request/response translation for
+    every provider lives in foreman.llm, shared with the proxy; this function
+    only picks which of those two call paths to use.
+    """
     if has_foreman_proxy(guild_id):
         data = await call_foreman_api_proxy(
             guild_id,
@@ -187,21 +205,19 @@ async def _call_llm(
     if client is None:
         raise RuntimeError("No Anthropic client available and no external foreman proxy connected")
 
-    kwargs: dict[str, Any] = {
-        "model": model,
-        "max_tokens": max_tokens,
-        "system": system_blocks,
-        "messages": messages,
-        "tools": tools,
-    }
-    if tool_choice is not None:
-        kwargs["tool_choice"] = tool_choice
-    raw = await client.messages.with_raw_response.create(**kwargs)
-    response = raw.parse()
+    response, request_id = await call_anthropic(
+        client,
+        model=model,
+        max_tokens=max_tokens,
+        system=system_blocks,
+        messages=messages,
+        tools=tools,
+        tool_choice=tool_choice,
+    )
     return _LLMCallResult(
         response=response,
         response_dict=response.model_dump(),
-        request_id=raw.headers.get("request-id"),
+        request_id=request_id,
         provider=provider,
         model=model,
     )
@@ -1033,9 +1049,15 @@ async def _run_foreman_ai(
             foreman_model = cfg_model or os.environ.get("FOREMAN_MODEL", "external-proxy")
 
         client = None
-        if not proxy_available and effective_provider not in {"anthropic", "bedrock"}:
+        if not proxy_available and effective_provider not in ANTHROPIC_SDK_PROVIDERS:
+            # This embedded foreman only calls the Anthropic SDK directly
+            # (ANTHROPIC_SDK_PROVIDERS); any other provider — e.g. an
+            # OpenAI-compatible endpoint — is only reachable through a
+            # connected foreman API proxy, which owns that provider's
+            # request/response translation (foreman.llm.call_openai_compatible).
             raise RuntimeError(
-                f"FOREMAN_PROVIDER={effective_provider!r} requires a connected foreman API proxy"
+                f"FOREMAN_PROVIDER={effective_provider!r} is not an embedded provider "
+                f"({sorted(ANTHROPIC_SDK_PROVIDERS)}) and no foreman API proxy is connected"
             )
         if not proxy_available and (cfg_provider or cfg_env_vars):
             client = make_anthropic_client(

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -580,14 +580,10 @@ class TestOpenAiTranslation:
         try:
             response, request_id = await call_openai_compatible(
                 client,
-                {
-                    "model": "backend-model",
-                    "maxTokens": 32,
-                    "system": [{"type": "text", "text": "System"}],
-                    "messages": [{"role": "user", "content": "Hi"}],
-                    "tools": [],
-                },
                 model="llama3.1",
+                max_tokens=32,
+                system=[{"type": "text", "text": "System"}],
+                messages=[{"role": "user", "content": "Hi"}],
                 base_url="http://ollama.test/v1",
                 api_key="key",
             )
@@ -596,9 +592,46 @@ class TestOpenAiTranslation:
 
         assert captured["url"] == "http://ollama.test/v1/chat/completions"
         assert captured["json"]["model"] == "llama3.1"
+        assert "tools" not in captured["json"]
         assert captured["headers"]["authorization"] == "Bearer key"
         assert request_id == "req-openai"
         assert response["content"] == [{"type": "text", "text": "done"}]
+
+    async def test_call_openai_compatible_omits_tools_when_none_given(self):
+        """No tools passed → no `tools` key in the POSTed body, matching
+        call_anthropic — some OpenAI-compatible endpoints reject an empty list."""
+        import httpx
+        from foreman.llm import call_openai_compatible
+
+        captured = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            captured["json"] = json.loads(request.read())
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-3",
+                    "model": "llama3.1",
+                    "choices": [{"finish_reason": "stop", "message": {"content": "done"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                },
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            await call_openai_compatible(
+                client,
+                model="llama3.1",
+                max_tokens=32,
+                messages=[{"role": "user", "content": "Hi"}],
+                base_url="http://ollama.test/v1",
+            )
+        finally:
+            await client.aclose()
+
+        assert "tools" not in captured["json"]
 
 
 # ---------------------------------------------------------------------------
@@ -645,3 +678,65 @@ class TestCallAnthropic:
         assert response.model_dump() == response_payload
         assert request_id == "req-1"
         assert create.kwargs["tool_choice"] == {"type": "auto"}
+        assert "tools" not in create.kwargs
+
+    async def test_call_anthropic_omits_tools_when_none_given(self):
+        """Regression for PR #849 review: an empty `tools` array is not sent to
+        the Anthropic API — some endpoints reject it — and an explicit
+        `tools=None` from the caller isn't silently coerced into `[]` either."""
+        from foreman.llm import call_anthropic
+
+        async def create(**kwargs):
+            create.kwargs = kwargs
+
+            class _RawResponse:
+                headers = {}
+
+                def parse(self):
+                    return SimpleNamespace(model_dump=lambda: {})
+
+            return _RawResponse()
+
+        client = SimpleNamespace(
+            messages=SimpleNamespace(with_raw_response=SimpleNamespace(create=create))
+        )
+
+        await call_anthropic(
+            client,
+            model="claude-sonnet-4-6",
+            max_tokens=256,
+            system=[{"type": "text", "text": "sys"}],
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+        )
+
+        assert "tools" not in create.kwargs
+
+    async def test_call_anthropic_includes_tools_when_given(self):
+        from foreman.llm import call_anthropic
+
+        async def create(**kwargs):
+            create.kwargs = kwargs
+
+            class _RawResponse:
+                headers = {}
+
+                def parse(self):
+                    return SimpleNamespace(model_dump=lambda: {})
+
+            return _RawResponse()
+
+        client = SimpleNamespace(
+            messages=SimpleNamespace(with_raw_response=SimpleNamespace(create=create))
+        )
+
+        tools = [{"name": "assign_task", "input_schema": {}}]
+        await call_anthropic(
+            client,
+            model="claude-sonnet-4-6",
+            max_tokens=256,
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+        )
+
+        assert create.kwargs["tools"] == tools

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -433,3 +433,215 @@ class TestMakeAnthropicClientDynamicEnv:
             llm_mod.make_anthropic_client()
             mock_mod.AsyncAnthropic.assert_called_once()
             mock_mod.AsyncAnthropicBedrock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible translation (issue #826: shared with the standalone proxy,
+# which has no translation logic of its own — see foreman/tests/test_runner.py)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAiTranslation:
+    def test_anthropic_tools_to_openai_wrap_schema(self):
+        from foreman.llm import anthropic_tools_to_openai
+
+        tools = [
+            {
+                "name": "assign_task",
+                "description": "Assign a task.",
+                "input_schema": {"type": "object", "properties": {"task_id": {"type": "string"}}},
+            }
+        ]
+
+        assert anthropic_tools_to_openai(tools) == [
+            {
+                "type": "function",
+                "function": {
+                    "name": "assign_task",
+                    "description": "Assign a task.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"task_id": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+    def test_anthropic_messages_to_openai_convert_tool_exchange(self):
+        from foreman.llm import anthropic_messages_to_openai
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Create it"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I'll do that."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu-1",
+                        "name": "create_task",
+                        "input": {"name": "Build"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu-1", "content": "created"}
+                ],
+            },
+        ]
+
+        converted = anthropic_messages_to_openai([{"type": "text", "text": "System"}], messages)
+
+        assert converted == [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "Create it"},
+            {
+                "role": "assistant",
+                "content": "I'll do that.",
+                "tool_calls": [
+                    {
+                        "id": "toolu-1",
+                        "type": "function",
+                        "function": {"name": "create_task", "arguments": '{"name": "Build"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu-1", "content": "created"},
+        ]
+
+    def test_openai_response_to_anthropic_maps_tool_calls(self):
+        from foreman.llm import openai_response_to_anthropic
+
+        raw = {
+            "id": "chatcmpl-1",
+            "model": "llama3.1",
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "content": "Checking.",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_task_status",
+                                    "arguments": '{"task_id": "t-1"}',
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 3},
+        }
+
+        normalised = openai_response_to_anthropic(raw, "llama3.1")
+
+        assert normalised["stop_reason"] == "tool_use"
+        assert normalised["usage"]["input_tokens"] == 12
+        assert normalised["usage"]["output_tokens"] == 3
+        assert normalised["content"] == [
+            {"type": "text", "text": "Checking."},
+            {
+                "type": "tool_use",
+                "id": "call-1",
+                "name": "get_task_status",
+                "input": {"task_id": "t-1"},
+            },
+        ]
+
+    async def test_call_openai_compatible_posts_chat_completion(self):
+        import json
+
+        import httpx
+        from foreman.llm import call_openai_compatible
+
+        captured = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["headers"] = dict(request.headers)
+            captured["json"] = json.loads(request.read())
+            return httpx.Response(
+                200,
+                headers={"x-request-id": "req-openai"},
+                json={
+                    "id": "chatcmpl-2",
+                    "model": "llama3.1",
+                    "choices": [{"finish_reason": "stop", "message": {"content": "done"}}],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+                },
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            response, request_id = await call_openai_compatible(
+                client,
+                {
+                    "model": "backend-model",
+                    "maxTokens": 32,
+                    "system": [{"type": "text", "text": "System"}],
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "tools": [],
+                },
+                model="llama3.1",
+                base_url="http://ollama.test/v1",
+                api_key="key",
+            )
+        finally:
+            await client.aclose()
+
+        assert captured["url"] == "http://ollama.test/v1/chat/completions"
+        assert captured["json"]["model"] == "llama3.1"
+        assert captured["headers"]["authorization"] == "Bearer key"
+        assert request_id == "req-openai"
+        assert response["content"] == [{"type": "text", "text": "done"}]
+
+
+# ---------------------------------------------------------------------------
+# call_anthropic — shared Anthropic Messages API call, used locally by the
+# embedded foreman and by the standalone proxy against its own client.
+# ---------------------------------------------------------------------------
+
+
+class TestCallAnthropic:
+    async def test_call_anthropic_returns_parsed_response_and_request_id(self):
+        """call_anthropic returns the SDK's own parsed response object (not a
+        pre-dumped dict) so local callers keep full attribute access; callers
+        that need JSON (the proxy) call .model_dump() themselves."""
+        from foreman.llm import call_anthropic
+
+        response_payload = {"id": "msg_1", "type": "message", "content": []}
+        parsed_response = SimpleNamespace(model_dump=lambda: response_payload)
+
+        class _RawResponse:
+            headers = {"request-id": "req-1"}
+
+            def parse(self):
+                return parsed_response
+
+        async def create(**kwargs):
+            create.kwargs = kwargs
+            return _RawResponse()
+
+        client = SimpleNamespace(
+            messages=SimpleNamespace(with_raw_response=SimpleNamespace(create=create))
+        )
+
+        response, request_id = await call_anthropic(
+            client,
+            model="claude-sonnet-4-6",
+            max_tokens=256,
+            system=[{"type": "text", "text": "sys"}],
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            tool_choice={"type": "auto"},
+        )
+
+        assert response is parsed_response
+        assert response.model_dump() == response_payload
+        assert request_id == "req-1"
+        assert create.kwargs["tool_choice"] == {"type": "auto"}

--- a/docs/foreman-split-plan.md
+++ b/docs/foreman-split-plan.md
@@ -153,10 +153,13 @@ provider call per `foreman-api-request`.
 
 ### Provider normalization
 
-Anthropic and Bedrock are called with the Anthropic SDK. OpenAI-compatible
-providers are called with `POST /chat/completions`; tools and messages are
-translated at the proxy boundary, and responses are normalized back to
-Anthropic content blocks for the backend.
+All provider request/response translation — the Anthropic SDK client factory
+and call, and OpenAI-compatible `POST /chat/completions` translation — lives in
+`backend/foreman/llm.py`, shared by the embedded foreman and this proxy (issue
+#826). The proxy holds no provider-specific logic of its own: it only decides
+*which machine* makes the call (its own config selects the client/credentials)
+and forwards the shared module's already Anthropic-shaped response back to the
+backend.
 
 ### Single-proxy enforcement
 

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -63,6 +63,12 @@ def _get_http_client(config: Config) -> httpx.AsyncClient:
 
 
 async def _call_anthropic(request: dict[str, Any], config: Config) -> dict[str, Any]:
+    """Translate the backend's camelCase wire request into call_anthropic's kwargs.
+
+    This camelCase-to-snake_case translation is the proxy's own "which machine"
+    plumbing (the WebSocket wire format), not provider logic — the provider
+    request/response shape itself is entirely owned by backend.foreman.llm.
+    """
     if not HAS_ANTHROPIC:
         raise RuntimeError("anthropic package is not installed")
     model = config.effective_model or request["model"]
@@ -73,7 +79,7 @@ async def _call_anthropic(request: dict[str, Any], config: Config) -> dict[str, 
         max_tokens=request.get("maxTokens") or 1024,
         system=request.get("system") or [],
         messages=request.get("messages") or [],
-        tools=request.get("tools") or [],
+        tools=request.get("tools"),
         tool_choice=request.get("toolChoice"),
     )
     return {
@@ -85,12 +91,22 @@ async def _call_anthropic(request: dict[str, Any], config: Config) -> dict[str, 
 
 
 async def _call_openai_compatible(request: dict[str, Any], config: Config) -> dict[str, Any]:
+    """Translate the backend's camelCase wire request into call_openai_compatible's kwargs.
+
+    Same boundary as _call_anthropic above: the wire format is this proxy's own
+    concern, the provider translation it feeds into is shared with the
+    embedded foreman.
+    """
     model = config.effective_model or request["model"]
     client = _get_http_client(config)
     response, request_id = await call_openai_compatible(
         client,
-        request,
         model=model,
+        max_tokens=request.get("maxTokens") or 1024,
+        system=request.get("system"),
+        messages=request.get("messages"),
+        tools=request.get("tools"),
+        tool_choice=request.get("toolChoice"),
         base_url=config.openai_base_url,
         api_key=config.api_key,
     )

--- a/foreman/pioneer_foreman/runner.py
+++ b/foreman/pioneer_foreman/runner.py
@@ -1,21 +1,28 @@
 """LLM API execution for the standalone Foreman proxy.
 
 The backend sends complete Anthropic-shaped Messages API requests over the
-WebSocket. This module executes that one request against the operator-selected
-provider and returns an Anthropic-shaped response. It does not read or mutate
-Pioneer Square state.
+WebSocket. This module is a thin wrapper: it only decides *which machine* (and
+which client/credentials) executes that request — a Bedrock region/profile, an
+OpenAI-compatible endpoint the operator configured (e.g. Ollama), whatever this
+process's config selects. All provider-specific request/response translation
+lives in backend.foreman.llm, shared with the embedded foreman; this module
+holds none of its own. It does not read or mutate Pioneer Square state.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING, Any
-from uuid import uuid4
 
 import httpx
 
-from backend.foreman.llm import HAS_ANTHROPIC, make_anthropic_client
+from backend.foreman.llm import (
+    ANTHROPIC_SDK_PROVIDERS,
+    HAS_ANTHROPIC,
+    call_anthropic,
+    call_openai_compatible,
+    make_anthropic_client,
+)
 
 if TYPE_CHECKING:
     from .config import Config
@@ -55,219 +62,49 @@ def _get_http_client(config: Config) -> httpx.AsyncClient:
     return _http_clients[key]
 
 
-def _text_from_blocks(blocks: Any) -> str:
-    if isinstance(blocks, str):
-        return blocks
-    if not isinstance(blocks, list):
-        return "" if blocks is None else str(blocks)
-    parts: list[str] = []
-    for block in blocks:
-        if isinstance(block, str):
-            parts.append(block)
-        elif isinstance(block, dict):
-            if block.get("type") == "text":
-                parts.append(str(block.get("text") or ""))
-            elif block.get("type") == "tool_result":
-                parts.append(str(block.get("content") or ""))
-    return "\n".join(p for p in parts if p)
-
-
-def _openai_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        {
-            "type": "function",
-            "function": {
-                "name": tool["name"],
-                "description": tool.get("description", ""),
-                "parameters": tool.get("input_schema") or {},
-            },
-        }
-        for tool in tools
-    ]
-
-
-def _parse_tool_arguments(raw: str | None) -> dict[str, Any]:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        logger.warning("OpenAI-compatible tool call returned invalid JSON arguments: %.200r", raw)
-        return {"_raw_arguments": raw}
-    return parsed if isinstance(parsed, dict) else {"value": parsed}
-
-
-def _openai_messages(
-    system: list[dict[str, Any]], messages: list[dict[str, Any]]
-) -> list[dict[str, Any]]:
-    converted: list[dict[str, Any]] = []
-    system_text = _text_from_blocks(system)
-    if system_text:
-        converted.append({"role": "system", "content": system_text})
-
-    for msg in messages:
-        role = msg.get("role")
-        content = msg.get("content")
-        if role == "assistant" and isinstance(content, list):
-            text = _text_from_blocks(
-                [
-                    block
-                    for block in content
-                    if isinstance(block, dict) and block.get("type") == "text"
-                ]
-            )
-            tool_calls = []
-            for block in content:
-                if not isinstance(block, dict) or block.get("type") != "tool_use":
-                    continue
-                tool_calls.append(
-                    {
-                        "id": block.get("id") or f"toolu_{uuid4().hex}",
-                        "type": "function",
-                        "function": {
-                            "name": block.get("name") or "",
-                            "arguments": json.dumps(block.get("input") or {}),
-                        },
-                    }
-                )
-            converted.append(
-                {
-                    "role": "assistant",
-                    "content": text or None,
-                    **({"tool_calls": tool_calls} if tool_calls else {}),
-                }
-            )
-            continue
-
-        if role == "user" and isinstance(content, list):
-            pending_text: list[str] = []
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "tool_result":
-                    if pending_text:
-                        converted.append({"role": "user", "content": "\n".join(pending_text)})
-                        pending_text = []
-                    converted.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": block.get("tool_use_id") or "",
-                            "content": str(block.get("content") or ""),
-                        }
-                    )
-                else:
-                    text = _text_from_blocks([block])
-                    if text:
-                        pending_text.append(text)
-            if pending_text:
-                converted.append({"role": "user", "content": "\n".join(pending_text)})
-            continue
-
-        converted.append({"role": role, "content": _text_from_blocks(content)})
-
-    return converted
-
-
-def _normalise_openai_response(raw: dict[str, Any], model: str) -> dict[str, Any]:
-    choice = (raw.get("choices") or [{}])[0]
-    message = choice.get("message") or {}
-    content_blocks: list[dict[str, Any]] = []
-    if message.get("content"):
-        content_blocks.append({"type": "text", "text": str(message["content"])})
-
-    for call in message.get("tool_calls") or []:
-        fn = call.get("function") or {}
-        content_blocks.append(
-            {
-                "type": "tool_use",
-                "id": call.get("id") or f"toolu_{uuid4().hex}",
-                "name": fn.get("name") or "",
-                "input": _parse_tool_arguments(fn.get("arguments")),
-            }
-        )
-
-    finish_reason = choice.get("finish_reason")
-    stop_reason = {
-        "tool_calls": "tool_use",
-        "stop": "end_turn",
-        "length": "max_tokens",
-    }.get(finish_reason, finish_reason or "end_turn")
-    usage = raw.get("usage") or {}
-    return {
-        "id": raw.get("id") or f"msg_{uuid4().hex}",
-        "type": "message",
-        "role": "assistant",
-        "model": raw.get("model") or model,
-        "content": content_blocks,
-        "stop_reason": stop_reason,
-        "stop_sequence": None,
-        "usage": {
-            "input_tokens": usage.get("prompt_tokens", 0) or 0,
-            "output_tokens": usage.get("completion_tokens", 0) or 0,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
-        },
-    }
-
-
-async def _call_openai_compatible(request: dict[str, Any], config: Config) -> dict[str, Any]:
-    model = config.effective_model or request["model"]
-    body: dict[str, Any] = {
-        "model": model,
-        "messages": _openai_messages(request.get("system") or [], request.get("messages") or []),
-        "tools": _openai_tools(request.get("tools") or []),
-        "max_tokens": request.get("maxTokens") or 1024,
-    }
-    tool_choice = request.get("toolChoice")
-    if tool_choice:
-        body["tool_choice"] = "none" if tool_choice.get("type") == "none" else tool_choice
-
-    headers = {"Content-Type": "application/json"}
-    if config.api_key:
-        headers["Authorization"] = f"Bearer {config.api_key}"
-
-    client = _get_http_client(config)
-    url = f"{config.openai_base_url.rstrip('/')}/chat/completions"
-    response = await client.post(url, json=body, headers=headers)
-    response.raise_for_status()
-    return {
-        "response": _normalise_openai_response(response.json(), model),
-        "apiRequestId": response.headers.get("x-request-id") or response.headers.get("request-id"),
-        "provider": "openai",
-        "model": model,
-    }
-
-
 async def _call_anthropic(request: dict[str, Any], config: Config) -> dict[str, Any]:
     if not HAS_ANTHROPIC:
         raise RuntimeError("anthropic package is not installed")
     model = config.effective_model or request["model"]
     client = _get_anthropic_client(config)
-    kwargs: dict[str, Any] = {
-        "model": model,
-        "max_tokens": request.get("maxTokens") or 1024,
-        "system": request.get("system") or [],
-        "messages": request.get("messages") or [],
-        "tools": request.get("tools") or [],
-    }
-    if request.get("toolChoice") is not None:
-        kwargs["tool_choice"] = request["toolChoice"]
-    raw = await client.messages.with_raw_response.create(**kwargs)
-    parsed = raw.parse()
+    parsed, request_id = await call_anthropic(
+        client,
+        model=model,
+        max_tokens=request.get("maxTokens") or 1024,
+        system=request.get("system") or [],
+        messages=request.get("messages") or [],
+        tools=request.get("tools") or [],
+        tool_choice=request.get("toolChoice"),
+    )
     return {
         "response": parsed.model_dump(),
-        "apiRequestId": raw.headers.get("request-id"),
+        "apiRequestId": request_id,
         "provider": config.provider,
         "model": model,
     }
 
 
+async def _call_openai_compatible(request: dict[str, Any], config: Config) -> dict[str, Any]:
+    model = config.effective_model or request["model"]
+    client = _get_http_client(config)
+    response, request_id = await call_openai_compatible(
+        client,
+        request,
+        model=model,
+        base_url=config.openai_base_url,
+        api_key=config.api_key,
+    )
+    return {"response": response, "apiRequestId": request_id, "provider": "openai", "model": model}
+
+
 async def run_api_request(request: dict[str, Any], config: Config) -> dict[str, Any]:
     """Execute one backend-supplied LLM API request and return a response envelope."""
     provider = (config.provider or "anthropic").lower()
+    if provider in ANTHROPIC_SDK_PROVIDERS:
+        return await _call_anthropic(request, config)
     if provider == "openai":
         return await _call_openai_compatible(request, config)
-    if provider in {"anthropic", "bedrock"}:
-        return await _call_anthropic(request, config)
-    raise ValueError(f"Unsupported foreman proxy provider: {provider}")
+    raise ValueError(f"Unsupported foreman proxy provider: {provider!r}")
 
 
 async def close_clients() -> None:

--- a/foreman/tests/test_runner.py
+++ b/foreman/tests/test_runner.py
@@ -1,4 +1,10 @@
-"""Tests for the standalone proxy LLM request executor."""
+"""Tests for the standalone proxy LLM request executor.
+
+The OpenAI-compatible request/response translation itself lives in and is
+tested by backend/tests/test_foreman_llm.py (shared with the embedded
+foreman). These tests cover only what's local to the proxy: dispatching to the
+right provider and wiring config into the shared helpers.
+"""
 
 from __future__ import annotations
 
@@ -7,118 +13,7 @@ import json
 import httpx
 import pioneer_foreman.runner as runner
 from pioneer_foreman.config import Config
-from pioneer_foreman.runner import (
-    _normalise_openai_response,
-    _openai_messages,
-    _openai_tools,
-    run_api_request,
-)
-
-
-def test_openai_tools_wrap_anthropic_schema():
-    tools = [
-        {
-            "name": "assign_task",
-            "description": "Assign a task.",
-            "input_schema": {"type": "object", "properties": {"task_id": {"type": "string"}}},
-        }
-    ]
-
-    assert _openai_tools(tools) == [
-        {
-            "type": "function",
-            "function": {
-                "name": "assign_task",
-                "description": "Assign a task.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"task_id": {"type": "string"}},
-                },
-            },
-        }
-    ]
-
-
-def test_openai_messages_convert_tool_exchange():
-    messages = [
-        {"role": "user", "content": [{"type": "text", "text": "Create it"}]},
-        {
-            "role": "assistant",
-            "content": [
-                {"type": "text", "text": "I'll do that."},
-                {
-                    "type": "tool_use",
-                    "id": "toolu-1",
-                    "name": "create_task",
-                    "input": {"name": "Build"},
-                },
-            ],
-        },
-        {
-            "role": "user",
-            "content": [{"type": "tool_result", "tool_use_id": "toolu-1", "content": "created"}],
-        },
-    ]
-
-    converted = _openai_messages([{"type": "text", "text": "System"}], messages)
-
-    assert converted == [
-        {"role": "system", "content": "System"},
-        {"role": "user", "content": "Create it"},
-        {
-            "role": "assistant",
-            "content": "I'll do that.",
-            "tool_calls": [
-                {
-                    "id": "toolu-1",
-                    "type": "function",
-                    "function": {"name": "create_task", "arguments": '{"name": "Build"}'},
-                }
-            ],
-        },
-        {"role": "tool", "tool_call_id": "toolu-1", "content": "created"},
-    ]
-
-
-def test_normalise_openai_response_maps_tool_calls():
-    raw = {
-        "id": "chatcmpl-1",
-        "model": "llama3.1",
-        "choices": [
-            {
-                "finish_reason": "tool_calls",
-                "message": {
-                    "content": "Checking.",
-                    "tool_calls": [
-                        {
-                            "id": "call-1",
-                            "type": "function",
-                            "function": {
-                                "name": "get_task_status",
-                                "arguments": '{"task_id": "t-1"}',
-                            },
-                        }
-                    ],
-                },
-            }
-        ],
-        "usage": {"prompt_tokens": 12, "completion_tokens": 3},
-    }
-
-    normalised = _normalise_openai_response(raw, "llama3.1")
-
-    assert normalised["stop_reason"] == "tool_use"
-    assert normalised["usage"]["input_tokens"] == 12
-    assert normalised["usage"]["output_tokens"] == 3
-    assert normalised["content"] == [
-        {"type": "text", "text": "Checking."},
-        {
-            "type": "tool_use",
-            "id": "call-1",
-            "name": "get_task_status",
-            "input": {"task_id": "t-1"},
-        },
-    ]
+from pioneer_foreman.runner import run_api_request
 
 
 async def test_run_api_request_openai_posts_chat_completion(monkeypatch):
@@ -169,3 +64,14 @@ async def test_run_api_request_openai_posts_chat_completion(monkeypatch):
     assert result["response"]["content"] == [{"type": "text", "text": "done"}]
 
     await client.aclose()
+
+
+async def test_run_api_request_unsupported_provider_raises():
+    cfg = Config(backend_url="ws://x:1", guild_id="g", provider="unsupported")
+
+    try:
+        await run_api_request({"model": "m"}, cfg)
+    except ValueError as exc:
+        assert "unsupported" in str(exc).lower()
+    else:
+        raise AssertionError("expected ValueError for an unsupported provider")


### PR DESCRIPTION
## Summary
- Moves all provider normalization/conversion logic — Anthropic calls, OpenAI-compatible request/response translation — into `backend/foreman/llm.py`, the single shared module already used for the Anthropic/Bedrock client factory.
- `foreman/pioneer_foreman/runner.py` (the standalone proxy) no longer duplicates any translation logic; it now imports `call_anthropic`, `call_openai_compatible`, and `ANTHROPIC_SDK_PROVIDERS` from the shared module and only decides which client/machine executes the request.
- `backend/foreman/runner.py` (embedded foreman) now calls the same shared `call_anthropic` helper instead of building the Anthropic SDK request inline, and its error message for unsupported providers now references `ANTHROPIC_SDK_PROVIDERS` for consistent proxy/embedded provider wording.
- Added a module-level docstring in `backend/foreman/llm.py` spelling out the architecture boundary from issue #826: the proxy exists only to pick *which machine* calls the provider endpoint; it holds no provider-specific logic of its own.
- Added `backend/tests/test_foreman_llm.py` covering the moved OpenAI-compatible translation helpers; trimmed the now-redundant duplicate tests out of `foreman/tests/test_runner.py`.

Closes #826.

## Test plan
- [x] `ruff check .` — clean
- [x] `ruff format . --check` — clean
- [x] `cd foreman && python -m pytest` — 40 passed
- [x] `cd backend && python -m pytest tests/test_foreman_llm.py` — 31 passed
- [x] `cd backend && python -m pytest -k "foreman or llm or runner"` — 270 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)