### PR TITLE
fix: omit tools/tool_choice when empty in llm.py

### DIFF
--- a/backend/foreman/llm.py
+++ b/backend/foreman/llm.py
@@ -364,6 +364,16 @@ def make_anthropic_client(
 # ---------------------------------------------------------------------------
 
 
+def _has_payload(value: dict[str, Any] | list[Any] | None) -> bool:
+    """True when `value` is a non-None, non-empty dict/list.
+
+    Explicit rather than a bare truthiness check so intent is clear and a
+    future falsy-but-meaningful value (e.g. `False`) wouldn't be silently
+    dropped the way an empty `tools`/`tool_choice` should be.
+    """
+    return value is not None and value != {} and value != []
+
+
 async def call_anthropic(
     client: Any,
     *,
@@ -400,9 +410,9 @@ async def call_anthropic(
         "system": system or [],
         "messages": messages or [],
     }
-    if tools:
+    if _has_payload(tools):
         kwargs["tools"] = tools
-    if tool_choice:
+    if _has_payload(tool_choice):
         kwargs["tool_choice"] = tool_choice
     raw = await client.messages.with_raw_response.create(**kwargs)
     return raw.parse(), raw.headers.get("request-id")
@@ -610,9 +620,9 @@ async def call_openai_compatible(
         "messages": anthropic_messages_to_openai(system or [], messages or []),
         "max_tokens": max_tokens,
     }
-    if tools:
+    if _has_payload(tools):
         body["tools"] = anthropic_tools_to_openai(tools)
-    if tool_choice:
+    if _has_payload(tool_choice):
         body["tool_choice"] = "none" if tool_choice.get("type") == "none" else tool_choice
 
     headers = {"Content-Type": "application/json"}

--- a/backend/foreman/llm.py
+++ b/backend/foreman/llm.py
@@ -388,10 +388,11 @@ async def call_anthropic(
     `.model_dump()` themselves; callers that stay in-process (the embedded
     foreman's local call path) can use it directly.
 
-    `tools` is only included in the request when non-empty: some Anthropic API
-    endpoints reject an explicit empty `tools` array, and omitting the param
-    (rather than defaulting a missing/None value to `[]`) also means a caller
-    that explicitly passes `tools=None` isn't silently overridden.
+    `tools` and `tool_choice` are only included in the request when non-empty:
+    some Anthropic API endpoints (e.g. Bedrock) reject an explicit empty
+    `tools` array or `tool_choice` object, and omitting the param (rather than
+    defaulting a missing/None value to `[]`/`{}`) also means a caller that
+    explicitly passes `tools=None`/`tool_choice=None` isn't silently overridden.
     """
     kwargs: dict[str, Any] = {
         "model": model,
@@ -401,7 +402,7 @@ async def call_anthropic(
     }
     if tools:
         kwargs["tools"] = tools
-    if tool_choice is not None:
+    if tool_choice:
         kwargs["tool_choice"] = tool_choice
     raw = await client.messages.with_raw_response.create(**kwargs)
     return raw.parse(), raw.headers.get("request-id")

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -670,6 +670,43 @@ class TestOpenAiTranslation:
 
         assert "tool_choice" not in captured["json"]
 
+    async def test_call_openai_compatible_includes_tool_choice_when_given(self):
+        """Complements test_call_openai_compatible_omits_empty_tool_choice: a
+        non-empty `tool_choice` is forwarded through to the POSTed body."""
+        import json
+
+        import httpx
+        from foreman.llm import call_openai_compatible
+
+        captured = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["json"] = json.loads(request.read())
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-5",
+                    "model": "llama3.1",
+                    "choices": [{"finish_reason": "stop", "message": {"content": "done"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                },
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            await call_openai_compatible(
+                client,
+                model="llama3.1",
+                max_tokens=32,
+                messages=[{"role": "user", "content": "Hi"}],
+                base_url="http://ollama.test/v1",
+                tool_choice={"type": "auto"},
+            )
+        finally:
+            await client.aclose()
+
+        assert captured["json"]["tool_choice"] == {"type": "auto"}
+
 
 # ---------------------------------------------------------------------------
 # call_anthropic — shared Anthropic Messages API call, used locally by the
@@ -781,13 +818,14 @@ class TestCallAnthropic:
     async def test_call_anthropic_omits_empty_tool_choice(self):
         """Regression for #850: an empty `tool_choice={}` must not be forwarded —
         some endpoints reject an empty tool_choice object just like empty tools."""
+        import httpx
         from foreman.llm import call_anthropic
 
         async def create(**kwargs):
             create.kwargs = kwargs
 
             class _RawResponse:
-                headers = {}
+                headers = httpx.Headers({})
 
                 def parse(self):
                     return SimpleNamespace(model_dump=lambda: {})
@@ -807,3 +845,34 @@ class TestCallAnthropic:
         )
 
         assert "tool_choice" not in create.kwargs
+
+    async def test_call_anthropic_includes_tool_choice_when_given(self):
+        """Complements test_call_anthropic_omits_empty_tool_choice: a non-empty
+        `tool_choice` is forwarded to the API as-is."""
+        import httpx
+        from foreman.llm import call_anthropic
+
+        async def create(**kwargs):
+            create.kwargs = kwargs
+
+            class _RawResponse:
+                headers = httpx.Headers({})
+
+                def parse(self):
+                    return SimpleNamespace(model_dump=lambda: {})
+
+            return _RawResponse()
+
+        client = SimpleNamespace(
+            messages=SimpleNamespace(with_raw_response=SimpleNamespace(create=create))
+        )
+
+        await call_anthropic(
+            client,
+            model="claude-sonnet-4-6",
+            max_tokens=256,
+            messages=[{"role": "user", "content": "hi"}],
+            tool_choice={"type": "auto"},
+        )
+
+        assert create.kwargs["tool_choice"] == {"type": "auto"}

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -633,6 +633,43 @@ class TestOpenAiTranslation:
 
         assert "tools" not in captured["json"]
 
+    async def test_call_openai_compatible_omits_empty_tool_choice(self):
+        """Regression for #850: an empty `tool_choice={}` must not be forwarded —
+        OpenAI (and compatible) APIs reject an empty tool_choice object."""
+        import httpx
+        from foreman.llm import call_openai_compatible
+
+        captured = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            captured["json"] = json.loads(request.read())
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-4",
+                    "model": "llama3.1",
+                    "choices": [{"finish_reason": "stop", "message": {"content": "done"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                },
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        try:
+            await call_openai_compatible(
+                client,
+                model="llama3.1",
+                max_tokens=32,
+                messages=[{"role": "user", "content": "Hi"}],
+                base_url="http://ollama.test/v1",
+                tool_choice={},
+            )
+        finally:
+            await client.aclose()
+
+        assert "tool_choice" not in captured["json"]
+
 
 # ---------------------------------------------------------------------------
 # call_anthropic — shared Anthropic Messages API call, used locally by the
@@ -740,3 +777,33 @@ class TestCallAnthropic:
         )
 
         assert create.kwargs["tools"] == tools
+
+    async def test_call_anthropic_omits_empty_tool_choice(self):
+        """Regression for #850: an empty `tool_choice={}` must not be forwarded —
+        some endpoints reject an empty tool_choice object just like empty tools."""
+        from foreman.llm import call_anthropic
+
+        async def create(**kwargs):
+            create.kwargs = kwargs
+
+            class _RawResponse:
+                headers = {}
+
+                def parse(self):
+                    return SimpleNamespace(model_dump=lambda: {})
+
+            return _RawResponse()
+
+        client = SimpleNamespace(
+            messages=SimpleNamespace(with_raw_response=SimpleNamespace(create=create))
+        )
+
+        await call_anthropic(
+            client,
+            model="claude-sonnet-4-6",
+            max_tokens=256,
+            messages=[{"role": "user", "content": "hi"}],
+            tool_choice={},
+        )
+
+        assert "tool_choice" not in create.kwargs


### PR DESCRIPTION
## Summary
- Guard `call_anthropic` so `tool_choice` is only included in the request when non-empty, matching the existing `tools` guard (some endpoints, e.g. Bedrock, reject an empty `tool_choice` object).
- Guard `call_openai_compatible` so an empty `tool_choice={}` is omitted from the payload instead of being forwarded verbatim (OpenAI-compatible APIs reject an empty `tool_choice` object).
- Added regression tests asserting `tool_choice` does not appear in the serialized request payload for both `call_anthropic` and `call_openai_compatible` when passed an empty dict.

Closes #850

## Test plan
- [x] `pytest backend/tests/test_foreman_llm.py` — 36 passed
- [x] `ruff check backend/foreman/llm.py backend/tests/test_foreman_llm.py` — clean