### PR TITLE
feat: queue human messages when Foreman busy (#855)

### DIFF
--- a/backend/foreman/classify.py
+++ b/backend/foreman/classify.py
@@ -1,0 +1,24 @@
+"""Shared classification of foreman trigger events by origin (human vs. automated).
+
+Human-originated triggers (Discord/web UI chat, user-requested follow-ups) are
+queued rather than dropped when the foreman is busy — see
+``foreman.runner.run_foreman_ai``'s ``is_human`` param. Two call sites need to
+agree on this classification, so it lives here as a single source of truth:
+
+- ``ws_handlers._trigger_foreman`` — event-driven dispatch (websocket-origin
+  triggers: ``chat``, ``task-complete``, ``periodic-check``, etc).
+- ``routes.tasks.create_task_followup`` — the REST follow-up endpoint, which
+  has no dispatch ``event`` string of its own but tags its call with the
+  synthetic event name ``"user-followup"`` purely to share this classifier.
+
+If you add a new human-originated trigger path, add its event name to
+``_HUMAN_FOREMAN_EVENTS`` below and route it through ``is_human_event`` rather
+than hand-rolling the check.
+"""
+
+_HUMAN_FOREMAN_EVENTS = frozenset({"chat", "user-followup"})
+
+
+def is_human_event(event: str) -> bool:
+    """Return True if *event* originates from a human, not an automated trigger."""
+    return event in _HUMAN_FOREMAN_EVENTS

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -77,17 +77,37 @@ _HISTORY_FETCH_LIMIT = 100
 # Per-guild background poll task registry
 _poll_tasks: dict[str, "asyncio.Task[None]"] = {}
 
-# Per-guild locks to serialise foreman runs.  If a run is already in progress
-# for a (guild, user) pair, new invocations are dropped rather than queued —
-# the poll loop will re-trigger on the next tick.  Dropping (vs. queuing) keeps
-# memory bounded and avoids stale snapshots piling up under load.
+# Per-guild run state, used to serialise foreman runs.  If a run is already in
+# progress for a (guild, user) pair, new invocations are dropped rather than
+# queued — the poll loop will re-trigger on the next tick.  Dropping (vs.
+# queuing) keeps memory bounded and avoids stale snapshots piling up under load.
 # Entries are popped in the finally block after each run so the dict stays small.
 #
 # Human-originated messages (Discord/web UI chat, user-requested follow-ups)
-# are the one exception: they are never silently dropped. When the lock for
-# their key is held, they are appended to ``_human_queues`` instead, and
+# are the one exception: they are never silently dropped. When the entry for
+# their key is busy, they are appended to ``_human_queues`` instead, and
 # drained (FIFO) once the in-flight run finishes — see ``run_foreman_ai``.
-_guild_locks: dict[tuple[str, str | None], asyncio.Lock] = {}
+@dataclass
+class _GuildRunLock:
+    """Tracks whether a foreman run currently owns a given (guild, key) slot.
+
+    ``busy`` is checked and flipped to True in the same synchronous step (no
+    ``await`` in between) inside ``run_foreman_ai``, so two concurrent
+    invocations can never both observe ``busy=False`` and both proceed:
+    asyncio's single-threaded, cooperative scheduler only switches between
+    coroutines at an ``await`` point, so nothing can interleave between the
+    check and the claim. This is deliberately a plain flag rather than
+    ``asyncio.Lock.locked()`` + ``await lock.acquire()`` — that pattern is
+    *currently* just as atomic (acquiring an uncontended ``asyncio.Lock``
+    never suspends), but it relies on ``Lock`` internals that a future edit
+    could silently break (e.g. adding an ``await`` between the check and the
+    acquire). A dedicated flag makes the invariant self-evident.
+    """
+
+    busy: bool = False
+
+
+_guild_locks: dict[tuple[str, str | None], _GuildRunLock] = {}
 
 # Max number of queued human messages per (guild, user)/(guild, task) key.
 # Bounded so a guild nobody is watching can't grow this without limit; the
@@ -720,7 +740,7 @@ def reset_foreman_poll(guild_id: str) -> None:
     # Debounce: any in-flight run for this guild (regardless of user_id) means we
     # skip the reset entirely.  The run was already dispatched; another timer reset
     # would be wasteful and could mask the first run's backoff contribution.
-    in_flight = any(k[0] == guild_id and lock.locked() for k, lock in _guild_locks.items())
+    in_flight = any(k[0] == guild_id and state.busy for k, state in _guild_locks.items())
     if in_flight:
         logger.debug("guild=%s reset_foreman_poll: run in-flight, skipping timer reset", guild_id)
         return
@@ -822,16 +842,17 @@ async def run_foreman_ai(
 ) -> None:
     """Serialise per-context and delegate to ``_run_foreman_ai``.
 
-    Uses an ``asyncio.Lock`` stored in ``_guild_locks``.  If the lock is already
-    held, automated invocations (``is_human=False`` — periodic-check, GitHub
-    webhook events, worker lifecycle, task review escalations) are dropped;
-    the poll loop re-triggers on the next tick. Dropping is preferred over
-    queuing for these to avoid unbounded build-up of stale automated snapshots.
+    Uses the ``busy`` flag on the ``_GuildRunLock`` stored in ``_guild_locks``.
+    If a run is already in progress, automated invocations (``is_human=False``
+    — periodic-check, GitHub webhook events, worker lifecycle, task review
+    escalations) are dropped; the poll loop re-triggers on the next tick.
+    Dropping is preferred over queuing for these to avoid unbounded build-up
+    of stale automated snapshots.
 
     Human-originated invocations (``is_human=True`` — Discord/web UI chat,
     user-requested follow-ups) are never dropped: when busy, they are appended
     to a small bounded FIFO queue (``_human_queues``) and drained in order once
-    the in-flight run for that key finishes, before the lock is released.
+    the in-flight run for that key finishes, before the slot is freed.
 
     Whole-guild (parent) runs key the lock on ``(guild_id, user_id)``.  Per-task
     child runs (``child=True`` with a ``task_id``, gated by FOREMAN_CHILD_CONTEXTS)
@@ -839,9 +860,7 @@ async def run_foreman_ai(
     single task's review loop still serialises against itself.  See
     docs/foreman-per-task-context.md.
 
-    lock.locked() + lock.acquire() is atomic here: asyncio is single-threaded
-    and cooperative, so no other coroutine can run between the check and the
-    acquire (there is no ``await`` between them).
+    See ``_GuildRunLock`` for why the busy-check and claim below are atomic.
     """
     use_child = child and bool(task_id) and _child_contexts_enabled()
     # When user_id is None (system-triggered/poll runs), all such invocations
@@ -849,8 +868,8 @@ async def run_foreman_ai(
     # each other.  This is intentional — system runs are per-guild work and
     # should not overlap with themselves.
     lock_key = (guild_id, f"task:{task_id}") if use_child else (guild_id, user_id)
-    lock = _guild_locks.setdefault(lock_key, asyncio.Lock())
-    if lock.locked():
+    state = _guild_locks.setdefault(lock_key, _GuildRunLock())
+    if state.busy:
         if is_human:
             _enqueue_human_turn(
                 lock_key, guild_id, human_message, extra_context, user_id, task_id, use_child
@@ -862,7 +881,7 @@ async def run_foreman_ai(
                 lock_key[1],
             )
         return
-    await lock.acquire()
+    state.busy = True
     try:
         await _run_foreman_ai(
             guild_id, human_message, extra_context, user_id, task_id=task_id, child=use_child
@@ -872,7 +891,7 @@ async def run_foreman_ai(
         # loop until the queue for this key is empty.
         await _drain_human_queue(lock_key)
     finally:
-        lock.release()
+        state.busy = False
         _guild_locks.pop(lock_key, None)
 
 
@@ -962,15 +981,44 @@ async def _drain_human_queue(lock_key: tuple[str, str | None]) -> None:
                     task_id=turn.task_id,
                     child=turn.child,
                 )
-            except Exception:
+            except Exception as exc:
                 logger.exception(
                     "guild=%s key=%s error processing queued human message",
                     turn.guild_id,
                     lock_key[1],
                 )
+                await _notify_queued_turn_failure(lock_key, turn, exc)
         if not _human_queues.get(lock_key):
             _human_queues.pop(lock_key, None)
             return
+
+
+async def _notify_queued_turn_failure(
+    lock_key: tuple[str, str | None], turn: "_QueuedHumanTurn", exc: Exception
+) -> None:
+    """Best-effort error reply to the human whose queued message failed to process.
+
+    ``_drain_human_queue`` swallows exceptions from ``_run_foreman_ai`` so one
+    bad queued turn doesn't abort the rest of the drain; without this, the
+    human whose message failed would see no reply at all. Routed through
+    ``_emit_foreman_chat`` so it reaches both the WS chat stream and, when the
+    queued turn concerned a task, that task's Discord thread. Failures here
+    are only logged — a broken notification path must not crash the drain.
+    """
+    try:
+        await _emit_foreman_chat(
+            turn.guild_id,
+            f"Sorry, something went wrong processing your message: {exc}",
+            datetime.now(UTC).isoformat(),
+            child_task_id=turn.task_id if turn.child else None,
+            discord_task_id=turn.task_id,
+        )
+    except Exception:
+        logger.exception(
+            "guild=%s key=%s failed to send error feedback for queued human message",
+            turn.guild_id,
+            lock_key[1],
+        )
 
 
 async def _run_foreman_ai(

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -77,6 +77,7 @@ _HISTORY_FETCH_LIMIT = 100
 # Per-guild background poll task registry
 _poll_tasks: dict[str, "asyncio.Task[None]"] = {}
 
+
 # Per-guild run state, used to serialise foreman runs.  If a run is already in
 # progress for a (guild, user) pair, new invocations are dropped rather than
 # queued — the poll loop will re-trigger on the next tick.  Dropping (vs.

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -926,40 +926,51 @@ async def _drain_human_queue(lock_key: tuple[str, str | None]) -> None:
 
     Called while the caller still holds the lock for *lock_key*, so queued
     turns run back-to-back without an automated trigger (periodic-check,
-    github-event) sneaking in between them. Any message that queues up while
-    a queued turn is itself running is picked up by the same loop.
+    github-event) sneaking in between them.
+
+    Each pass snapshots the current queue by swapping in a fresh deque before
+    processing it, rather than popping from the live deque while iterating.
+    Messages enqueued by ``_enqueue_human_turn`` while a snapshot is being
+    processed (e.g. because a queued turn's own side effects send another
+    human message) land in the new deque and are left for the next pass, so
+    the drain never consumes a message that arrived after this pass started.
     """
-    queue = _human_queues.get(lock_key)
-    if not queue:
-        return
-    while queue:
-        turn = queue.popleft()
-        logger.info(
-            "guild=%s key=%s draining queued human message (queued_at=%s, remaining=%d)",
-            turn.guild_id,
-            lock_key[1],
-            turn.queued_at,
-            len(queue),
-        )
-        annotated_message = (
-            f"[queued at {turn.queued_at} while Foreman was busy]\n{turn.human_message}"
-        )
-        try:
-            await _run_foreman_ai(
-                turn.guild_id,
-                annotated_message,
-                turn.extra_context,
-                turn.user_id,
-                task_id=turn.task_id,
-                child=turn.child,
-            )
-        except Exception:
-            logger.exception(
-                "guild=%s key=%s error processing queued human message",
+    while True:
+        queue = _human_queues.get(lock_key)
+        if not queue:
+            return
+        pending = queue
+        _human_queues[lock_key] = deque()
+        while pending:
+            turn = pending.popleft()
+            logger.info(
+                "guild=%s key=%s draining queued human message (queued_at=%s, remaining=%d)",
                 turn.guild_id,
                 lock_key[1],
+                turn.queued_at,
+                len(pending),
             )
-    _human_queues.pop(lock_key, None)
+            annotated_message = (
+                f"[queued at {turn.queued_at} while Foreman was busy]\n{turn.human_message}"
+            )
+            try:
+                await _run_foreman_ai(
+                    turn.guild_id,
+                    annotated_message,
+                    turn.extra_context,
+                    turn.user_id,
+                    task_id=turn.task_id,
+                    child=turn.child,
+                )
+            except Exception:
+                logger.exception(
+                    "guild=%s key=%s error processing queued human message",
+                    turn.guild_id,
+                    lock_key[1],
+                )
+        if not _human_queues.get(lock_key):
+            _human_queues.pop(lock_key, None)
+            return
 
 
 async def _run_foreman_ai(

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import time
+from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -81,7 +82,35 @@ _poll_tasks: dict[str, "asyncio.Task[None]"] = {}
 # the poll loop will re-trigger on the next tick.  Dropping (vs. queuing) keeps
 # memory bounded and avoids stale snapshots piling up under load.
 # Entries are popped in the finally block after each run so the dict stays small.
+#
+# Human-originated messages (Discord/web UI chat, user-requested follow-ups)
+# are the one exception: they are never silently dropped. When the lock for
+# their key is held, they are appended to ``_human_queues`` instead, and
+# drained (FIFO) once the in-flight run finishes — see ``run_foreman_ai``.
 _guild_locks: dict[tuple[str, str | None], asyncio.Lock] = {}
+
+# Max number of queued human messages per (guild, user)/(guild, task) key.
+# Bounded so a guild nobody is watching can't grow this without limit; the
+# oldest entry is dropped (with a warning) once the cap is hit.
+_HUMAN_QUEUE_MAX = 50
+
+# FIFO queues of human messages that arrived while the foreman was busy,
+# keyed by the same lock key used for ``_guild_locks``.
+_human_queues: dict[tuple[str, str | None], "deque[_QueuedHumanTurn]"] = {}
+
+
+@dataclass
+class _QueuedHumanTurn:
+    """One human message waiting for the busy foreman lock to free up."""
+
+    guild_id: str
+    human_message: str
+    extra_context: str
+    user_id: str | None
+    task_id: str | None
+    child: bool
+    queued_at: str
+
 
 # Monotonic timestamp (time.monotonic()) of the last foreman run that made at
 # least one tool call, keyed by guild_id.  Used by reset_foreman_poll to decide
@@ -789,12 +818,20 @@ async def run_foreman_ai(
     task_id: str | None = None,
     *,
     child: bool = False,
+    is_human: bool = False,
 ) -> None:
     """Serialise per-context and delegate to ``_run_foreman_ai``.
 
     Uses an ``asyncio.Lock`` stored in ``_guild_locks``.  If the lock is already
-    held the invocation is dropped; the poll loop re-triggers on the next tick.
-    Dropping is preferred over queuing to avoid unbounded build-up.
+    held, automated invocations (``is_human=False`` — periodic-check, GitHub
+    webhook events, worker lifecycle, task review escalations) are dropped;
+    the poll loop re-triggers on the next tick. Dropping is preferred over
+    queuing for these to avoid unbounded build-up of stale automated snapshots.
+
+    Human-originated invocations (``is_human=True`` — Discord/web UI chat,
+    user-requested follow-ups) are never dropped: when busy, they are appended
+    to a small bounded FIFO queue (``_human_queues``) and drained in order once
+    the in-flight run for that key finishes, before the lock is released.
 
     Whole-guild (parent) runs key the lock on ``(guild_id, user_id)``.  Per-task
     child runs (``child=True`` with a ``task_id``, gated by FOREMAN_CHILD_CONTEXTS)
@@ -814,20 +851,115 @@ async def run_foreman_ai(
     lock_key = (guild_id, f"task:{task_id}") if use_child else (guild_id, user_id)
     lock = _guild_locks.setdefault(lock_key, asyncio.Lock())
     if lock.locked():
-        logger.info(
-            "guild=%s key=%s run_foreman_ai: dropping concurrent invocation (already running)",
-            guild_id,
-            lock_key[1],
-        )
+        if is_human:
+            _enqueue_human_turn(
+                lock_key, guild_id, human_message, extra_context, user_id, task_id, use_child
+            )
+        else:
+            logger.info(
+                "guild=%s key=%s run_foreman_ai: dropping concurrent invocation (already running)",
+                guild_id,
+                lock_key[1],
+            )
         return
     await lock.acquire()
     try:
         await _run_foreman_ai(
             guild_id, human_message, extra_context, user_id, task_id=task_id, child=use_child
         )
+        # Drain any human messages that queued up while this turn ran, before
+        # going idle — each drained turn can itself queue further messages, so
+        # loop until the queue for this key is empty.
+        await _drain_human_queue(lock_key)
     finally:
         lock.release()
         _guild_locks.pop(lock_key, None)
+
+
+def _enqueue_human_turn(
+    lock_key: tuple[str, str | None],
+    guild_id: str,
+    human_message: str,
+    extra_context: str,
+    user_id: str | None,
+    task_id: str | None,
+    child: bool,
+) -> None:
+    """Append a human message to the busy queue for *lock_key*, bounded and FIFO.
+
+    When the queue is already at capacity, the oldest queued message is
+    dropped (with a warning) to make room — better to lose the stalest queued
+    turn than to grow memory without bound or drop the newest arrival.
+    """
+    queue = _human_queues.setdefault(lock_key, deque())
+    if len(queue) >= _HUMAN_QUEUE_MAX:
+        dropped = queue.popleft()
+        logger.warning(
+            "guild=%s key=%s human message queue full (max=%d); dropping oldest "
+            "queued message (queued_at=%s)",
+            guild_id,
+            lock_key[1],
+            _HUMAN_QUEUE_MAX,
+            dropped.queued_at,
+        )
+    queue.append(
+        _QueuedHumanTurn(
+            guild_id=guild_id,
+            human_message=human_message,
+            extra_context=extra_context,
+            user_id=user_id,
+            task_id=task_id,
+            child=child,
+            queued_at=datetime.now(UTC).isoformat(),
+        )
+    )
+    logger.info(
+        "guild=%s key=%s run_foreman_ai: foreman busy, queued human message (queue_len=%d)",
+        guild_id,
+        lock_key[1],
+        len(queue),
+    )
+
+
+async def _drain_human_queue(lock_key: tuple[str, str | None]) -> None:
+    """Process every human message queued for *lock_key*, in FIFO order.
+
+    Called while the caller still holds the lock for *lock_key*, so queued
+    turns run back-to-back without an automated trigger (periodic-check,
+    github-event) sneaking in between them. Any message that queues up while
+    a queued turn is itself running is picked up by the same loop.
+    """
+    queue = _human_queues.get(lock_key)
+    if not queue:
+        return
+    while queue:
+        turn = queue.popleft()
+        logger.info(
+            "guild=%s key=%s draining queued human message (queued_at=%s, remaining=%d)",
+            turn.guild_id,
+            lock_key[1],
+            turn.queued_at,
+            len(queue),
+        )
+        annotated_message = (
+            f"[queued at {turn.queued_at} while Foreman was busy]\n{turn.human_message}"
+        )
+        try:
+            await _run_foreman_ai(
+                turn.guild_id,
+                annotated_message,
+                turn.extra_context,
+                turn.user_id,
+                task_id=turn.task_id,
+                child=turn.child,
+            )
+        except Exception:
+            logger.exception(
+                "guild=%s key=%s error processing queued human message",
+                turn.guild_id,
+                lock_key[1],
+            )
+    _human_queues.pop(lock_key, None)
 
 
 async def _run_foreman_ai(

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -19,6 +19,7 @@ from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException
+from foreman.classify import is_human_event
 from foreman.runner import run_foreman_ai
 from lock_service import LockService
 from models import GithubToken, Guild, GuildMember, Task, TaskLog, live_tasks_filter
@@ -247,7 +248,10 @@ async def create_task_followup(
             user_id=github_user_id,
             task_id=task_id,
             child=True,
-            is_human=True,
+            # See foreman.classify — REST follow-ups have no dispatch "event"
+            # string of their own, so they tag "user-followup" purely to
+            # share the same human/automated classifier as ws_handlers.
+            is_human=is_human_event("user-followup"),
         ),
         name=f"foreman.user-followup:{task_id}",
     )

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -247,6 +247,7 @@ async def create_task_followup(
             user_id=github_user_id,
             task_id=task_id,
             child=True,
+            is_human=True,
         ),
         name=f"foreman.user-followup:{task_id}",
     )

--- a/backend/tests/test_foreman_guild_lock.py
+++ b/backend/tests/test_foreman_guild_lock.py
@@ -1,4 +1,4 @@
-"""Tests for per-guild asyncio.Lock in run_foreman_ai.
+"""Tests for per-guild run serialisation in run_foreman_ai.
 
 Verifies that concurrent invocations for the same guild are dropped (not
 queued) while invocations for different guilds proceed independently.
@@ -7,7 +7,7 @@ queued) while invocations for different guilds proceed independently.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 
 async def _run_foreman_ai_patched(guild_id: str, impl_event: asyncio.Event | None = None):

--- a/backend/tests/test_foreman_guild_lock.py
+++ b/backend/tests/test_foreman_guild_lock.py
@@ -147,3 +147,112 @@ def test_lock_released_after_impl_exception():
         assert call_count == 2
 
     _run(_test())
+
+
+def test_human_message_queued_when_busy_then_drained():
+    """A human message arriving while busy is queued, not dropped, and runs after."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        runner._guild_locks.clear()
+        runner._human_queues.clear()
+
+        call_log: list[str] = []
+        hold = asyncio.Event()
+
+        async def _impl(gid, msg, extra="", uid=None, task_id=None, child=False):
+            call_log.append(msg)
+            if len(call_log) == 1:
+                await hold.wait()
+
+        with patch.object(runner, "_run_foreman_ai", side_effect=_impl):
+            first = asyncio.create_task(runner.run_foreman_ai("g4", "first", is_human=True))
+            await asyncio.sleep(0)
+
+            # Second human message while busy: queued, not dropped.
+            await runner.run_foreman_ai("g4", "second", is_human=True)
+            assert call_log == ["first"], "queued message must not run until the lock frees up"
+            assert len(runner._human_queues[("g4", None)]) == 1
+
+            hold.set()
+            await first
+
+        assert len(call_log) == 2
+        assert "second" in call_log[1]
+        # Queue is drained (and its entry removed) once processed.
+        assert ("g4", None) not in runner._human_queues
+
+    _run(_test())
+
+
+def test_automated_still_drops_while_human_queue_exists():
+    """is_human=False keeps drop-if-busy even though human messages now queue."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        runner._guild_locks.clear()
+        runner._human_queues.clear()
+
+        call_log: list[str] = []
+        hold = asyncio.Event()
+
+        async def _impl(gid, msg, extra="", uid=None, task_id=None, child=False):
+            call_log.append(msg)
+            if len(call_log) == 1:
+                await hold.wait()
+
+        with patch.object(runner, "_run_foreman_ai", side_effect=_impl):
+            first = asyncio.create_task(runner.run_foreman_ai("g5", "first", is_human=True))
+            await asyncio.sleep(0)
+
+            # An automated trigger (e.g. periodic-check) while busy: dropped, not queued.
+            await runner.run_foreman_ai("g5", "periodic", is_human=False)
+            assert call_log == ["first"]
+            assert ("g5", None) not in runner._human_queues
+
+            hold.set()
+            await first
+
+        assert call_log == ["first"], "dropped automated trigger must never run"
+
+    _run(_test())
+
+
+def test_human_queue_bounded_drops_oldest():
+    """The human queue is capped; overflow drops the oldest queued entry."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        runner._guild_locks.clear()
+        runner._human_queues.clear()
+
+        hold = asyncio.Event()
+
+        async def _impl(gid, msg, extra="", uid=None, task_id=None, child=False):
+            await hold.wait()
+
+        with patch.object(runner, "_run_foreman_ai", side_effect=_impl):
+            first = asyncio.create_task(runner.run_foreman_ai("g6", "first", is_human=True))
+            await asyncio.sleep(0)
+
+            max_queue = runner._HUMAN_QUEUE_MAX
+            for i in range(max_queue + 1):
+                await runner.run_foreman_ai("g6", f"queued-{i}", is_human=True)
+
+            queue = runner._human_queues[("g6", None)]
+            assert len(queue) == max_queue, "queue must not grow past the configured max"
+            # The oldest entry (queued-0) was dropped to make room for the newest.
+            assert queue[0].human_message == "queued-1"
+            assert queue[-1].human_message == f"queued-{max_queue}"
+
+            # Unblocking lets "first" finish and the drain loop process (and
+            # empty) the whole backlog, since hold is already set by then.
+            hold.set()
+            await first
+
+        assert ("g6", None) not in runner._human_queues
+
+    _run(_test())

--- a/backend/tests/test_foreman_guild_lock.py
+++ b/backend/tests/test_foreman_guild_lock.py
@@ -256,3 +256,75 @@ def test_human_queue_bounded_drops_oldest():
         assert ("g6", None) not in runner._human_queues
 
     _run(_test())
+
+
+def test_drain_snapshots_queue_before_processing():
+    """Messages enqueued mid-drain don't get spliced into the in-flight pass.
+
+    Regression test for a re-entrancy bug where ``_drain_human_queue`` popped
+    directly from the live ``_human_queues`` deque. If a message arrives while
+    a queued turn is being processed, it must land in a fresh deque for the
+    *next* drain pass rather than mutating the deque the current pass is
+    iterating over.
+    """
+
+    async def _test():
+        import foreman.runner as runner
+
+        runner._guild_locks.clear()
+        runner._human_queues.clear()
+
+        call_log: list[str] = []
+        hold_first = asyncio.Event()
+        hold_second = asyncio.Event()
+        key = ("g7", None)
+
+        async def _impl(gid, msg, extra="", uid=None, task_id=None, child=False):
+            call_log.append(msg)
+            if msg == "first":
+                await hold_first.wait()
+            elif "second" in msg:
+                await hold_second.wait()
+
+        with patch.object(runner, "_run_foreman_ai", side_effect=_impl):
+            first = asyncio.create_task(runner.run_foreman_ai("g7", "first", is_human=True))
+            await asyncio.sleep(0)
+
+            # Two messages queue up before the drain starts.
+            await runner.run_foreman_ai("g7", "second", is_human=True)
+            await runner.run_foreman_ai("g7", "extra", is_human=True)
+            assert len(runner._human_queues[key]) == 2
+
+            # Let "first" finish; the drain snapshots ["second", "extra"] and
+            # starts processing "second".
+            hold_first.set()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert len(call_log) == 2
+            assert call_log[0] == "first"
+            assert "second" in call_log[1]
+
+            # While "second" is in flight, the live queue must already be a
+            # fresh, empty deque — "extra" lives only in the drain's local
+            # snapshot, not in _human_queues.
+            assert len(runner._human_queues[key]) == 0
+
+            # A message arriving now must not be spliced into the pass
+            # currently processing "second"/"extra".
+            await runner.run_foreman_ai("g7", "third", is_human=True)
+            assert len(runner._human_queues[key]) == 1
+            assert runner._human_queues[key][0].human_message == "third"
+
+            # Unblock "second"; the current pass should finish "extra" next,
+            # not "third".
+            hold_second.set()
+            await first
+
+        assert len(call_log) == 4
+        assert call_log[0] == "first"
+        assert "second" in call_log[1]
+        assert "extra" in call_log[2]
+        assert "third" in call_log[3]
+        assert key not in runner._human_queues
+
+    _run(_test())

--- a/backend/tests/test_foreman_poll_backoff.py
+++ b/backend/tests/test_foreman_poll_backoff.py
@@ -64,7 +64,7 @@ def test_guild_active_recently_false_for_unknown_guild():
 
 
 def test_reset_poll_skips_when_run_in_flight():
-    """reset_foreman_poll must not restart the loop when a run holds the lock."""
+    """reset_foreman_poll must not restart the loop when a run is in-flight."""
 
     async def _test():
         import foreman.runner as runner
@@ -74,16 +74,13 @@ def test_reset_poll_skips_when_run_in_flight():
         runner._poll_tasks.pop(guild, None)
         runner._guild_last_action_at[guild] = time.monotonic()  # recently active
 
-        # Acquire the lock as if a run is in progress.
-        lock = asyncio.Lock()
-        await lock.acquire()
-        runner._guild_locks[(guild, None)] = lock
+        # Mark the slot busy, as if a run is in progress.
+        runner._guild_locks[(guild, None)] = runner._GuildRunLock(busy=True)
 
         spawned = []
         with patch.object(runner, "spawn", side_effect=lambda c, **kw: spawned.append(c)):
             runner.reset_foreman_poll(guild)
 
-        lock.release()
         assert spawned == [], "spawn must not be called while a run is in-flight"
 
     _run(_test())

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -177,6 +177,7 @@ async def _task_user_id(db, task_id: str | None) -> str | None:
 # context. See docs/foreman-per-task-context.md.
 _CHILD_FOREMAN_EVENTS = frozenset({"task-complete", "followup-done", "needs-input", "task-error"})
 
+
 async def _trigger_foreman(
     guild_id: str,
     event: str,

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -30,6 +30,7 @@ from events import (
     send_ws_message,
 )
 from fastapi import WebSocket
+from foreman.classify import is_human_event
 from foreman.proxy import fail_pending_for_websocket, resolve_foreman_api_response
 from foreman.runner import reset_foreman_poll, run_foreman_ai
 from foreman.tools import maybe_post_plan_comment
@@ -176,13 +177,6 @@ async def _task_user_id(db, task_id: str | None) -> str | None:
 # context. See docs/foreman-per-task-context.md.
 _CHILD_FOREMAN_EVENTS = frozenset({"task-complete", "followup-done", "needs-input", "task-error"})
 
-# Events that originate from a human (Discord message, web UI chat input) as
-# opposed to automated triggers (periodic-check, worker lifecycle, github-event
-# webhooks, task review escalations). Human events are queued rather than
-# dropped when the foreman is busy — see ``run_foreman_ai``'s ``is_human`` param.
-_HUMAN_FOREMAN_EVENTS = frozenset({"chat"})
-
-
 async def _trigger_foreman(
     guild_id: str,
     event: str,
@@ -207,7 +201,9 @@ async def _trigger_foreman(
     # lifecycle, periodic-check, claude-auth) stay on the parent whole-guild
     # context.
     child = bool(task_id) and event in _CHILD_FOREMAN_EVENTS
-    is_human = event in _HUMAN_FOREMAN_EVENTS
+    # See foreman.classify for the human/automated event classification shared
+    # with routes.tasks.create_task_followup's REST follow-up path.
+    is_human = is_human_event(event)
     spawn(
         run_foreman_ai(
             guild_id,

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -176,6 +176,12 @@ async def _task_user_id(db, task_id: str | None) -> str | None:
 # context. See docs/foreman-per-task-context.md.
 _CHILD_FOREMAN_EVENTS = frozenset({"task-complete", "followup-done", "needs-input", "task-error"})
 
+# Events that originate from a human (Discord message, web UI chat input) as
+# opposed to automated triggers (periodic-check, worker lifecycle, github-event
+# webhooks, task review escalations). Human events are queued rather than
+# dropped when the foreman is busy — see ``run_foreman_ai``'s ``is_human`` param.
+_HUMAN_FOREMAN_EVENTS = frozenset({"chat"})
+
 
 async def _trigger_foreman(
     guild_id: str,
@@ -201,8 +207,16 @@ async def _trigger_foreman(
     # lifecycle, periodic-check, claude-auth) stay on the parent whole-guild
     # context.
     child = bool(task_id) and event in _CHILD_FOREMAN_EVENTS
+    is_human = event in _HUMAN_FOREMAN_EVENTS
     spawn(
-        run_foreman_ai(guild_id, human_message, user_id=user_id, task_id=task_id, child=child),
+        run_foreman_ai(
+            guild_id,
+            human_message,
+            user_id=user_id,
+            task_id=task_id,
+            child=child,
+            is_human=is_human,
+        ),
         name=task_name,
     )
 

--- a/docs/foreman-per-task-context.md
+++ b/docs/foreman-per-task-context.md
@@ -43,8 +43,13 @@ single Foreman turn with three pieces of isolation:
 3. A per-task `asyncio.Lock` keyed as `(guild_id, "task:<id>")` in `_guild_locks`.
 
 If a task-scoped run is already active for the same task, the new invocation is
-dropped instead of queued. The backend poll/re-trigger mechanism recovers stale
-or missed work on a later tick. Different tasks may run concurrently.
+dropped instead of queued — unless it's human-originated (e.g. a user-requested
+follow-up posted from the web UI), in which case it's appended to a small FIFO
+queue and drained once the in-flight run for that task finishes. See
+"Human message queueing" below. Automated child-context triggers (task-complete,
+followup-done, needs-input) keep the drop-if-busy behavior; the backend
+poll/re-trigger mechanism recovers stale or missed work on a later tick.
+Different tasks may run concurrently.
 
 Parent runs are keyed by `(guild_id, user_id)` and never read task-tagged child
 history, even if the incoming parent trigger includes a `task_id` for Discord


### PR DESCRIPTION
Implements a small FIFO queue for human-originated messages so they are never dropped when the Foreman is busy. Automated events (periodic-check, github-event) keep the existing drop-if-busy behaviour. Closes #855