### PR TITLE
Immediate devReady issue pickup on GitHub webhook events

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -130,6 +130,22 @@ Use the body to decide:
 Foreman events from bots on non-CI surfaces are filtered out before reaching you, so
 treat every `[github-event]` you see as something a human likely cares about.
 
+## Reacting to devReady issue webhooks
+`[github-event] issues/labeled` (with a devReady-family label just applied) or
+`[github-event] issues/opened` / `issues/reopened` (already carrying a devReady-family label)
+means an issue just became ready for pickup. Apply the devReady pickup flow immediately for
+this one issue — the same steps as "Periodic devReady issue pickup" below:
+1. Skip if the issue is already assigned to someone else.
+2. Skip if any existing non-terminal task already references this issue number (check the
+   current `<state>` task list).
+3. Call claim_github_issue to assign it.
+4. Call create_task(phase='issue', name="...", description="...") to create the issue-root
+   anchor task — skip this step if a phase='issue' task for this issue number already exists.
+5. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number,
+   issue_repo, and parent_task_id=<issue-root task_id from step 4>.
+The periodic sweep's own dedup checks (steps 1-2) make it safe if both the webhook and a
+same-cycle poll fire for the same issue — whichever runs first wins, the other no-ops.
+
 ## Reacting to worker lifecycle events
 Messages prefixed `[worker-online]` and `[worker-offline]` notify you when a worker
 process joins or leaves the guild.
@@ -181,6 +197,10 @@ Workers are configured with repos. Prefer workers whose repos cover the task.
 Be concise — one short paragraph maximum unless detail is requested.
 
 ## Periodic devReady issue pickup
+
+This is the polling safety net for the immediate webhook-triggered pickup described in
+"Reacting to devReady issue webhooks" above — it catches issues that became devReady while
+no webhook fired (e.g. label applied before the webhook was configured, or a missed delivery).
 
 On every [periodic-check] event:
 1. Call search_github_issues on the primary repo with query "label:devReady" (also try "label:dev-ready" and "label:ready-for-dev" as fallbacks).

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -72,6 +72,45 @@ _MAX_PAYLOAD_BYTES = 64 * 1024
 # events we want to react to.
 _BOT_OK_EVENTS = frozenset({"check_run", "check_suite", "status"})
 
+# Label names (case-insensitive) that mark a GitHub issue ready for the foreman
+# to pick up. Mirrors the "Periodic devReady issue pickup" label list in
+# foreman/prompt.py so a webhook-triggered claim and the periodic sweep agree
+# on what counts as devReady.
+_DEVREADY_LABELS = frozenset({"devready", "dev-ready", "ready-for-dev", "ready"})
+
+
+def _issue_label_names(issue_obj: dict) -> list[str]:
+    labels = issue_obj.get("labels") or []
+    return [lb["name"] for lb in labels if isinstance(lb, dict) and lb.get("name")]
+
+
+def _matching_devready_label(label_names: list[str]) -> str | None:
+    return next((name for name in label_names if name.lower() in _DEVREADY_LABELS), None)
+
+
+def _devready_issue_trigger(event_type: str, action: str | None, payload: dict) -> str | None:
+    """Return the matched devReady label name if this ``issues`` event should trigger
+    immediate pickup, else ``None``.
+
+    Triggers on ``action == "labeled"`` where the label just applied is a devReady
+    alias, or ``action in {"opened", "reopened"}`` where the issue already carries one
+    (e.g. it was created with the label already attached, or reopened after having it).
+    """
+    if event_type != "issues":
+        return None
+    issue_obj = payload.get("issue")
+    if not isinstance(issue_obj, dict):
+        return None
+    if action == "labeled":
+        label_obj = payload.get("label")
+        label_name = label_obj.get("name") if isinstance(label_obj, dict) else None
+        if label_name and label_name.lower() in _DEVREADY_LABELS:
+            return label_name
+        return None
+    if action in {"opened", "reopened"}:
+        return _matching_devready_label(_issue_label_names(issue_obj))
+    return None
+
 
 class DebounceQueue:
     """Per-PR debounce queue that coalesces rapid webhook events.
@@ -621,6 +660,28 @@ def _build_foreman_summary(
         context = payload.get("context") or "status"
         description = payload.get("description") or ""
         detail = f"{context}: {state}.{(' ' + description) if description else ''}"
+    elif event_type == "issues" and action in {"labeled", "opened", "reopened"}:
+        issue_obj = payload.get("issue") or {}
+        matched_label = _devready_issue_trigger(event_type, action, payload)
+        title = (issue_obj.get("title") or "")[:200]
+        issue_url = issue_obj.get("html_url") or ""
+        assignees = issue_obj.get("assignees") or []
+        assignee_logins = [a["login"] for a in assignees if isinstance(a, dict) and a.get("login")]
+        assignee_str = ", ".join(assignee_logins) or "none"
+        label_line = f"Label applied: {matched_label}\n" if matched_label else ""
+        detail = (
+            f"{label_line}"
+            f"Issue title: {title}\n"
+            f"Issue URL: {issue_url}\n"
+            f"Current assignees: {assignee_str}\n"
+            "This issue is devReady — run the devReady pickup flow now (same as "
+            "periodic-check): skip if already assigned to someone else, or if a "
+            "non-terminal task already references this issue number in the current "
+            "<state> task list; otherwise claim_github_issue, create the phase='issue' "
+            "root task (skip if one already exists for this issue number), then "
+            "create_task + assign_task as an atomic pair with issue_number, issue_repo, "
+            "and parent_task_id set."
+        )
 
     return f"{header}{sender_line}\n{detail}".strip() if detail else f"{header}{sender_line}"
 
@@ -1139,6 +1200,27 @@ async def github_webhook(
                 requested_reviewer,
                 guild_owner_login,
             )
+    elif (devready_label := _devready_issue_trigger(event_type, action, payload)) is not None:
+        # devReady issue pickup, same as review_requested above: no existing task/PR
+        # is required, so this bypasses _should_dispatch_to_foreman's task_id gate.
+        issue_obj = payload.get("issue") or {}
+        issue_num = issue_obj.get("number")
+        summary = _build_foreman_summary(
+            event_type, action, payload, repo, issue_num, task_id or "", sender_login
+        )
+        # Key is issue-scoped so rapid re-labeling of the same issue coalesces.
+        key = f"{guild_id}:issues-devready:{repo}#{issue_num}"
+        await _debounce_queue.schedule(key, guild_id, summary, task_user_id, task_id=task_id)
+        logger.info(
+            "github webhook issues devready dispatched guild=%s delivery=%s repo=%s issue=%s "
+            "action=%s label=%s",
+            guild_id,
+            delivery_id,
+            repo,
+            issue_num,
+            action,
+            devready_label,
+        )
     else:
         dispatch, skip_reason = _should_dispatch_to_foreman(
             event_type, action, payload, sender_login, task_id

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -46,6 +46,7 @@ from models import (
 )
 from routes.webhooks import (  # noqa: E402
     _build_foreman_summary,
+    _devready_issue_trigger,
     _get_guild_owner_github_login,
     _linked_issue_number_from_body,
     _linked_issue_number_from_branch,
@@ -1080,3 +1081,243 @@ def test_prompt_describes_review_requested_behavior():
     assert "--approve" in FOREMAN_SYSTEM
     assert "Do NOT commit" in FOREMAN_SYSTEM
     assert "duplicates" in FOREMAN_SYSTEM
+
+
+# ---------------------------------------------------------------------------
+# devReady issue pickup: _devready_issue_trigger
+# ---------------------------------------------------------------------------
+
+
+class TestDevReadyIssueTrigger:
+    def _issue_payload(self, *, labels: list[str], number: int = 1) -> dict:
+        return {"issue": {"number": number, "labels": [{"name": name} for name in labels]}}
+
+    def test_labeled_devready_triggers(self):
+        payload = {"issue": {"number": 1}, "label": {"name": "devReady"}}
+        assert _devready_issue_trigger("issues", "labeled", payload) == "devReady"
+
+    def test_labeled_non_devready_does_not_trigger(self):
+        payload = {"issue": {"number": 1}, "label": {"name": "bug"}}
+        assert _devready_issue_trigger("issues", "labeled", payload) is None
+
+    def test_labeled_case_insensitive(self):
+        payload = {"issue": {"number": 1}, "label": {"name": "DEV-READY"}}
+        assert _devready_issue_trigger("issues", "labeled", payload) == "DEV-READY"
+
+    def test_labeled_all_aliases(self):
+        for alias in ("devReady", "dev-ready", "ready-for-dev", "ready"):
+            payload = {"issue": {"number": 1}, "label": {"name": alias}}
+            assert _devready_issue_trigger("issues", "labeled", payload) == alias
+
+    def test_opened_with_devready_label_triggers(self):
+        payload = self._issue_payload(labels=["enhancement", "ready-for-dev"])
+        assert _devready_issue_trigger("issues", "opened", payload) == "ready-for-dev"
+
+    def test_opened_without_devready_label_does_not_trigger(self):
+        payload = self._issue_payload(labels=["enhancement"])
+        assert _devready_issue_trigger("issues", "opened", payload) is None
+
+    def test_reopened_with_devready_label_triggers(self):
+        payload = self._issue_payload(labels=["devReady"])
+        assert _devready_issue_trigger("issues", "reopened", payload) == "devReady"
+
+    def test_other_actions_do_not_trigger(self):
+        payload = self._issue_payload(labels=["devReady"])
+        assert _devready_issue_trigger("issues", "closed", payload) is None
+        assert _devready_issue_trigger("issues", "edited", payload) is None
+        assert _devready_issue_trigger("issues", "unlabeled", payload) is None
+
+    def test_non_issues_event_does_not_trigger(self):
+        payload = {"issue": {"number": 1}, "label": {"name": "devReady"}}
+        assert _devready_issue_trigger("issue_comment", "labeled", payload) is None
+
+    def test_missing_issue_object_does_not_trigger(self):
+        assert _devready_issue_trigger("issues", "opened", {}) is None
+
+
+# ---------------------------------------------------------------------------
+# devReady issue pickup: summary builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSummaryDevReadyIssue:
+    def test_labeled_summary_contains_key_fields(self):
+        payload = {
+            "issue": {
+                "number": 42,
+                "title": "Add dark mode",
+                "html_url": "https://github.com/o/r/issues/42",
+                "assignees": [],
+            },
+            "label": {"name": "devReady"},
+        }
+        s = _build_foreman_summary("issues", "labeled", payload, "o/r", 42, "", None)
+        assert "[github-event] issues/labeled on o/r#42 (new)" in s
+        assert "Label applied: devReady" in s
+        assert "Add dark mode" in s
+        assert "claim_github_issue" in s
+        assert "devReady pickup flow" in s
+
+    def test_opened_with_label_summary(self):
+        payload = {
+            "issue": {
+                "number": 7,
+                "title": "Fix flaky test",
+                "html_url": "https://github.com/o/r/issues/7",
+                "labels": [{"name": "ready"}],
+                "assignees": [{"login": "alice"}],
+            },
+        }
+        s = _build_foreman_summary("issues", "opened", payload, "o/r", 7, "", "alice")
+        assert "[github-event] issues/opened on o/r#7 (new)" in s
+        assert "Label applied: ready" in s
+        assert "Current assignees: alice" in s
+
+
+# ---------------------------------------------------------------------------
+# devReady issue pickup: end-to-end webhook -> foreman dispatch
+# ---------------------------------------------------------------------------
+
+
+def _issues_payload(*, action: str, repo: str, number: int, labels: list[str], **extra) -> dict:
+    return {
+        "action": action,
+        "repository": {"full_name": repo},
+        "issue": {
+            "number": number,
+            "title": extra.pop("title", "Some issue"),
+            "html_url": f"https://github.com/{repo}/issues/{number}",
+            "labels": [{"name": name} for name in labels],
+            "assignees": extra.pop("assignees", []),
+        },
+        "sender": {"login": extra.pop("sender_login", "octocat")},
+        **({"label": {"name": extra.pop("label_name")}} if "label_name" in extra else {}),
+        **extra,
+    }
+
+
+def test_issues_labeled_devready_dispatches_to_foreman(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gd-dr-1")
+    _set_webhook_secret(db_url, "gd-dr-1", "secret-dr-1")
+
+    payload = _issues_payload(
+        action="labeled", repo="o/r", number=100, labels=["devReady"], label_name="devReady"
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-dr-1", body, event="issues", delivery="d-dr-1")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-dr-1", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 1
+    key_arg, guild_arg, summary_arg, _user_arg = mock_q.schedule.call_args.args
+    assert "gd-dr-1" in key_arg
+    assert "issues-devready" in key_arg
+    assert "o/r#100" in key_arg
+    assert guild_arg == "gd-dr-1"
+    assert "devReady" in summary_arg
+    assert "claim_github_issue" in summary_arg
+
+
+def test_issues_labeled_non_devready_does_not_dispatch(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gd-dr-2")
+    _set_webhook_secret(db_url, "gd-dr-2", "secret-dr-2")
+
+    payload = _issues_payload(
+        action="labeled", repo="o/r", number=101, labels=["bug"], label_name="bug"
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-dr-2", body, event="issues", delivery="d-dr-2")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-dr-2", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 0
+
+
+def test_issues_opened_with_devready_label_dispatches(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gd-dr-3")
+    _set_webhook_secret(db_url, "gd-dr-3", "secret-dr-3")
+
+    payload = _issues_payload(
+        action="opened", repo="o/r", number=102, labels=["dev-ready", "enhancement"]
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-dr-3", body, event="issues", delivery="d-dr-3")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-dr-3", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 1
+    key_arg, *_ = mock_q.schedule.call_args.args
+    assert "o/r#102" in key_arg
+
+
+def test_issues_opened_without_devready_label_does_not_dispatch(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gd-dr-4")
+    _set_webhook_secret(db_url, "gd-dr-4", "secret-dr-4")
+
+    payload = _issues_payload(action="opened", repo="o/r", number=103, labels=["enhancement"])
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-dr-4", body, event="issues", delivery="d-dr-4")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-dr-4", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 0
+
+
+def test_issues_reopened_with_devready_label_dispatches(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gd-dr-5")
+    _set_webhook_secret(db_url, "gd-dr-5", "secret-dr-5")
+
+    payload = _issues_payload(action="reopened", repo="o/r", number=104, labels=["ready"])
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-dr-5", body, event="issues", delivery="d-dr-5")
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp = test_client.post("/webhooks/github/gd-dr-5", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert mock_q.schedule.call_count == 1
+
+
+def test_issues_devready_duplicate_delivery_is_idempotent(client):
+    test_client, db_url = client
+    insert_guild(db_url, "gd-dr-6")
+    _set_webhook_secret(db_url, "gd-dr-6", "secret-dr-6")
+
+    payload = _issues_payload(
+        action="labeled", repo="o/r", number=105, labels=["devReady"], label_name="devReady"
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers("secret-dr-6", body, event="issues", delivery="d-dr-6-dup")
+
+    with patch("routes.webhooks._debounce_queue") as mock_q:
+        mock_q.schedule = AsyncMock()
+        resp1 = test_client.post("/webhooks/github/gd-dr-6", content=body, headers=headers)
+        resp2 = test_client.post("/webhooks/github/gd-dr-6", content=body, headers=headers)
+
+    assert resp1.status_code == 202
+    assert resp2.status_code == 202
+    assert mock_q.schedule.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Prompt: devReady issue webhook section
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_describes_devready_issue_webhook_behavior():
+    """System prompt must document the immediate devReady webhook pickup flow."""
+    from foreman.prompt import FOREMAN_SYSTEM
+
+    assert "issues/labeled" in FOREMAN_SYSTEM
+    assert "issues/opened" in FOREMAN_SYSTEM
+    assert "issues/reopened" in FOREMAN_SYSTEM
+    assert "claim_github_issue" in FOREMAN_SYSTEM
+    assert "devReady pickup flow" in FOREMAN_SYSTEM


### PR DESCRIPTION
## Summary
- Forward `issues` webhook events to the Foreman when `action == "labeled"` and the applied label is a devReady alias (`devReady`, `dev-ready`, `ready-for-dev`, `ready`, case-insensitive), or when `action` is `opened`/`reopened` and the issue already carries one of those labels.
- Add a Foreman system prompt section ("Reacting to devReady issue webhooks") that runs the same claim/dedup flow as the existing periodic devReady sweep (skip if already assigned, skip if a non-terminal task already references the issue, `claim_github_issue`, create the `phase='issue'` root task if missing, then `create_task` + `assign_task` as an atomic pair) — triggered immediately by the webhook instead of waiting for the next periodic check.
- The periodic sweep's existing dedup logic makes concurrent webhook + poll pickups safe (whichever runs first wins).

Closes #858

## Test plan
- [x] `pytest backend/tests/test_github_webhooks_phase2.py` — added coverage for labeled/opened/reopened devReady dispatch, non-devready no-op, and duplicate-delivery idempotency (passes in an environment with the postgres-test container available)
- [x] Full backend suite (972 tests) passes per prior verification