### PR TITLE
fix: sidebar renders duplicate root nodes when a phase='issue' root exists

### DIFF
--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -410,7 +410,13 @@ def _gh_fetch_pr_body(repo: str, pr_number: int, token: str) -> str | None:
 
 
 def _nest_tasks(tasks: list[dict]) -> list[dict]:
-    """Build a parent/child tree from a flat task list using parent_task_id."""
+    """Build a parent/child tree from a flat task list using parent_task_id.
+
+    A ``phase='issue'`` task is the canonical root of its issue-rooted subtree.
+    If it has no parent itself, any other parentless task in the same list
+    (e.g. a plan/execute task whose parent_task_id wasn't set) is nested under
+    it instead of surfacing as a second top-level root.
+    """
     by_id = {t["id"]: dict(t, children=[]) for t in tasks}
     roots: list[dict] = []
     for t in by_id.values():
@@ -419,6 +425,15 @@ def _nest_tasks(tasks: list[dict]) -> list[dict]:
             by_id[parent_id]["children"].append(t)
         else:
             roots.append(t)
+
+    issue_roots = [t for t in roots if t.get("phase") == "issue"]
+    if len(issue_roots) == 1:
+        issue_root = issue_roots[0]
+        other_roots = [t for t in roots if t is not issue_root]
+        if other_roots:
+            issue_root["children"].extend(other_roots)
+            roots = [issue_root]
+
     return roots
 
 

--- a/backend/tests/test_tasks_tree.py
+++ b/backend/tests/test_tasks_tree.py
@@ -194,6 +194,97 @@ def test_tree_open_and_closed_issues_sorted_correctly(client):
 
 
 # ---------------------------------------------------------------------------
+# Tree endpoint — phase='issue' root nesting (issue #861)
+# ---------------------------------------------------------------------------
+
+
+def test_tree_nests_execute_task_under_issue_root_via_parent_task_id(client):
+    """A phase='issue' root with a child (parent_task_id set) renders one root."""
+    test_client, db_url = client
+    guild_id = "tr-issroot1"
+    _guild_no_owner_token(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-issroot1", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-issroot1-root",
+        phase="issue",
+        state="pending",
+        issue_number=61,
+        issue_repo="org/repo",
+        issue_state="open",
+    )
+    insert_task(
+        db_url,
+        guild_id,
+        "task-issroot1-exec",
+        worker_id="w-issroot1",
+        phase="execute",
+        state="working",
+        issue_number=61,
+        issue_repo="org/repo",
+        issue_state="open",
+        parent_task_id="task-issroot1-root",
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()["nodes"]
+    assert len(nodes) == 1
+    tasks = nodes[0]["tasks"]
+    assert len(tasks) == 1, f"expected a single root task, got {len(tasks)}: {tasks}"
+    assert tasks[0]["id"] == "task-issroot1-root"
+    assert tasks[0]["phase"] == "issue"
+    assert len(tasks[0]["children"]) == 1
+    assert tasks[0]["children"][0]["id"] == "task-issroot1-exec"
+
+
+def test_tree_nests_orphan_task_under_issue_root_when_parent_unset(client):
+    """A task in the same issue group without parent_task_id is still nested
+    under the phase='issue' root rather than appearing as a second root."""
+    test_client, db_url = client
+    guild_id = "tr-issroot2"
+    _guild_no_owner_token(db_url, guild_id)
+
+    insert_worker(db_url, guild_id, "w-issroot2", state="online")
+    insert_task(
+        db_url,
+        guild_id,
+        "task-issroot2-root",
+        phase="issue",
+        state="pending",
+        issue_number=62,
+        issue_repo="org/repo",
+        issue_state="open",
+    )
+    # parent_task_id intentionally left unset — this is the bug scenario.
+    insert_task(
+        db_url,
+        guild_id,
+        "task-issroot2-exec",
+        worker_id="w-issroot2",
+        phase="execute",
+        state="working",
+        issue_number=62,
+        issue_repo="org/repo",
+        issue_state="open",
+    )
+
+    headers = _auth(db_url)
+    resp = test_client.get(f"/guilds/{guild_id}/tasks/tree", headers=headers)
+    assert resp.status_code == 200, resp.text
+    nodes = resp.json()["nodes"]
+    assert len(nodes) == 1
+    tasks = nodes[0]["tasks"]
+    assert len(tasks) == 1, f"expected a single root task, got {len(tasks)}: {tasks}"
+    assert tasks[0]["id"] == "task-issroot2-root"
+    child_ids = {c["id"] for c in tasks[0]["children"]}
+    assert child_ids == {"task-issroot2-exec"}
+
+
+# ---------------------------------------------------------------------------
 # Tree endpoint — GitHub API write-back
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `_nest_tasks` in `backend/routes/tasks.py` picked "root" purely from whether a task's `parent_task_id` was set/resolvable within its issue group. A `phase='issue'` root task and a plan/execute task that never got `parent_task_id` wired up (e.g. Foreman skipped that step, or the linked id fell outside the group) both landed in the group's top-level `tasks` array, so the sidebar rendered two root rows for the same issue.
- Fixed `_nest_tasks` so that when a group has exactly one `phase='issue'` root, any other parentless task is nested under it as a child instead of surfacing as a second root — matching the documented invariant that plan/execute/review/followup tasks nest under the issue-root via `parent_task_id`.
- Added two regression tests in `backend/tests/test_tasks_tree.py`: one covering the case where `parent_task_id` is correctly set, and one reproducing the bug (child task with `parent_task_id` unset) to confirm it now nests under the single issue root.

Closes #861

## Test plan
- [x] `cd backend && python -m pytest tests/test_tasks_tree.py -v` — 15/15 passed, including the 2 new tests
- [x] `cd backend && python -m pytest` — full suite: 974 passed, 2 skipped
- [x] `ruff check` / `ruff format --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)