### PR TITLE
fix: review tasks resolve PR branch from pr_number, not issue_number

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -59,8 +59,10 @@ Always create_task first and finalize_task after — whether you use a worker or
 
 **Full worker-driven review** (primary path — deeper analysis, runs tests/lint):
 1. create_task(name="Review PR #N: <title>", phase="review") → returns task_id
-2. assign_task(worker_id=..., task_id=<task_id>, parent_task_id=<foreman_task_id>, description="<review instructions>")
+2. assign_task(worker_id=..., task_id=<task_id>, parent_task_id=<foreman_task_id>, pr_number=N, pr_repo="owner/repo", description="<review instructions>")
    — parent_task_id links this review task to the parent work item so the hierarchy is visible.
+   pr_number/pr_repo are REQUIRED for reviews: the worker checks out that PR's branch. Pass the
+   PR number, not the issue number.
    Description must include: check out PR branch, run tests/lint, post via `gh pr review`,
    and explicitly forbid committing or opening a new PR.
 3. Worker posts findings as a GitHub PR review (APPROVE / REQUEST_CHANGES / COMMENT).
@@ -101,7 +103,8 @@ Use the body to decide:
   in the current `<state>` task list, automatically:
   1. `create_task(name="Review PR #N: <title>", phase="review")`
   2. `assign_task(worker_id=<any idle worker>, task_id=<task_id from step 1>,
-     description="<review instructions>")`
+     pr_number=<PR number>, pr_repo="<OWNER/REPO>", description="<review instructions>")`
+     — pr_number/pr_repo are REQUIRED so the worker checks out the right PR branch.
 
   The review instructions passed to the worker **must** include:
   - Check out the PR branch: `gh pr checkout <PR_NUMBER> --repo <OWNER/REPO>`

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1345,6 +1345,10 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     update_values["issue_number"] = inp["issue_number"]
                                 if inp.get("issue_repo"):
                                     update_values["issue_repo"] = inp["issue_repo"]
+                                if inp.get("pr_number") is not None:
+                                    update_values["pr_number"] = inp["pr_number"]
+                                if inp.get("pr_repo"):
+                                    update_values["pr_repo"] = inp["pr_repo"]
                                 if parent_task_id is not None:
                                     update_values["parent_task_id"] = parent_task_id
                                 await db.exec(
@@ -1385,6 +1389,8 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         parentTaskId=parent_task_id,
                                         issueNumber=inp.get("issue_number"),
                                         issueRepo=inp.get("issue_repo"),
+                                        prNumber=inp.get("pr_number"),
+                                        prRepo=inp.get("pr_repo"),
                                         repos=repos,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )
@@ -1415,6 +1421,8 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         provider=provider,
                                         issue_number=inp.get("issue_number"),
                                         issue_repo=inp.get("issue_repo"),
+                                        pr_number=inp.get("pr_number"),
+                                        pr_repo=inp.get("pr_repo"),
                                         state="pending",
                                         phase=phase,
                                         parent_task_id=parent_task_id,
@@ -1437,6 +1445,8 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         parentTaskId=parent_task_id,
                                         issueNumber=inp.get("issue_number"),
                                         issueRepo=inp.get("issue_repo"),
+                                        prNumber=inp.get("pr_number"),
+                                        prRepo=inp.get("pr_repo"),
                                         repos=repos,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -117,6 +117,19 @@ FOREMAN_TOOLS = [
                     "type": "string",
                     "description": "owner/repo for the issue (optional).",
                 },
+                "pr_number": {
+                    "type": "integer",
+                    "description": (
+                        "The pull request number this task acts on. REQUIRED for "
+                        "phase='review' — the worker checks out this PR's branch via "
+                        "`gh pr view <pr_number>`. This is the PR number, NOT the "
+                        "issue number."
+                    ),
+                },
+                "pr_repo": {
+                    "type": "string",
+                    "description": "owner/repo of the PR (for phase='review'; defaults to issue_repo).",
+                },
                 "repos": {
                     "type": "array",
                     "items": {"type": "string"},

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -128,6 +128,8 @@ class TaskAssignedMsg(_WS):
     parentTaskId: str | None = None
     issueNumber: int | None = None
     issueRepo: str | None = None
+    prNumber: int | None = None
+    prRepo: str | None = None
     repos: list[str] | None = None
 
 

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -875,6 +875,8 @@ class Worker:
             "phase": body.get("phase", "execute"),
             "issue_number": body.get("issueNumber"),
             "issue_repo": body.get("issueRepo"),
+            "pr_number": body.get("prNumber"),
+            "pr_repo": body.get("prRepo"),
             "repos": body.get("repos") or [],
         }
         if body.get("followupInstructions"):
@@ -1348,6 +1350,8 @@ class Worker:
                         "phase": msg.get("phase", "execute"),
                         "issue_number": msg.get("issueNumber"),
                         "issue_repo": msg.get("issueRepo"),
+                        "pr_number": msg.get("prNumber"),
+                        "pr_repo": msg.get("prRepo"),
                         "repos": msg.get("repos") or [],
                     }
                 )
@@ -1434,6 +1438,8 @@ class Worker:
                         "phase": msg.get("phase", "execute"),
                         "issue_number": msg.get("issueNumber"),
                         "issue_repo": msg.get("issueRepo"),
+                        "pr_number": msg.get("prNumber"),
+                        "pr_repo": msg.get("prRepo"),
                         "repos": msg.get("repos") or [],
                         "followup_instructions": instructions,
                         "followup_branch": msg.get("branch", ""),
@@ -1529,6 +1535,8 @@ class Worker:
                                 "phase": msg.get("phase", "execute"),
                                 "issue_number": msg.get("issueNumber"),
                                 "issue_repo": msg.get("issueRepo"),
+                                "pr_number": msg.get("prNumber"),
+                                "pr_repo": msg.get("prRepo"),
                                 "repos": msg.get("repos") or [],
                                 "followup_instructions": instructions,
                                 "followup_branch": msg.get("branch", ""),
@@ -1875,8 +1883,11 @@ class Worker:
         is_followup = bool(followup_instructions) or task.get("phase") == "followup"
         phase = (task.get("phase") or "execute").lower()
         is_review = phase == "review"
-        pr_repo = issue_repo
-        pr_number = task.get("issue_number")
+        # Review tasks act on a PR, identified by the dedicated pr_number/pr_repo
+        # fields. Fall back to issue_number/issue_repo for back-compat with the
+        # deterministic Discord path (which mirrors the PR number into both).
+        pr_repo = task.get("pr_repo") or issue_repo
+        pr_number = task.get("pr_number") or task.get("issue_number")
 
         logger.info(
             "Executing task %s (agent=%s, followup=%s): %s",

--- a/worker/tests/test_review_phase_guard.py
+++ b/worker/tests/test_review_phase_guard.py
@@ -266,3 +266,54 @@ async def test_review_phase_checks_out_pr_branch_via_gh(caplog: pytest.LogCaptur
     assert not any(
         m.args[0].get("branch", "").startswith("claude/") for m in worker._send.await_args_list
     ), "review tasks must never record a generated claude/... branch"
+
+
+async def test_review_prefers_pr_number_over_issue_number():
+    """When pr_number/pr_repo are present they identify the PR to check out —
+    issue_number is the GitHub issue to close, a different number (issue #843)."""
+    import os
+    import tempfile
+    from unittest.mock import patch
+
+    worker = Worker(_make_cfg(repos=["owner/repo"]))
+    worker._joined = True
+    worker._send = AsyncMock()
+    worker.cfg.worker_id = "w-test01"
+
+    task = {
+        "id": "t-revpr",
+        "name": "Review PR #99",
+        "description": "Review PR #99",
+        "phase": "review",
+        "tool": "claude",
+        "issue_number": 42,  # the GitHub issue — must NOT be used as the PR number
+        "issue_repo": "owner/other",
+        "pr_number": 99,
+        "pr_repo": "owner/repo",
+        "repos": ["owner/repo"],
+    }
+    slot = worker.agents[0]
+
+    async def fake_run_claude(desc, *args, **kwargs):
+        return True, "end_turn", "done", None
+
+    with (
+        patch("pioneer_worker.worker.git_ops.ensure_repo", return_value="/tmp/fake-repo"),
+        patch(
+            "pioneer_worker.worker.git_ops.get_pr_head_branch", return_value="feature/pr-99"
+        ) as mock_get_branch,
+        patch("pioneer_worker.worker.git_ops.checkout_pr_worktree", return_value=True) as mock_co,
+        patch("pioneer_worker.worker.git_ops.create_worktree") as mock_create_worktree,
+        patch("pioneer_worker.worker.github_pr.push_branch"),
+        patch("pioneer_worker.worker.github_pr.find_existing_pr", return_value=None),
+        patch("pioneer_worker.worker.claude_runner.run_claude_auto", side_effect=fake_run_claude),
+        tempfile.TemporaryDirectory() as tmp,
+    ):
+        worker.cfg.work_dir = tmp
+        worker.cfg.repos_dir = tmp
+        await worker._execute_task(task, slot)
+
+    expected_wt_path = os.path.join(tmp, "test-guild", "w-test01", "t-revpr", "repo")
+    mock_get_branch.assert_awaited_once_with("owner/repo", 99)
+    mock_co.assert_awaited_once_with("/tmp/fake-repo", expected_wt_path, 99, "owner/repo")
+    mock_create_worktree.assert_not_called()


### PR DESCRIPTION
## Problem

Starting ~yesterday, all internal (worker-driven) reviews failed with **"Could not resolve PR branch for review — aborting."**

The worker resolves the PR to check out from `task.issue_number` (`worker.py`), but `issue_number` means *"the GitHub issue to close"* (per the tool schema). The issue-root work (#836, #829) cemented `issue_number` = the GitHub issue across the whole task tree, so foreman-created review tasks now carry the issue number there. `gh pr view <issue_number>` then looks up the wrong number and returns nothing → abort.

The Task model already has dedicated `pr_number`/`pr_repo` columns (the deterministic Discord path sets them), but they were never plumbed to the worker.

## Fix

Reviews now resolve the PR from `pr_number`/`pr_repo`, falling back to `issue_number`/`issue_repo` for back-compat with the Discord path.

- **worker**: prefer `pr_number`/`pr_repo`; parse `prNumber`/`prRepo` from all WS task payloads (REST path already carried them via `row_to_dict`)
- **ws_types**: `TaskAssignedMsg` gains `prNumber`/`prRepo`
- **foreman/tools**: `assign_task` persists + broadcasts `pr_number`/`pr_repo` (both create and update paths)
- **foreman schema + prompt**: `pr_number`/`pr_repo` required for review assigns, with a note that it's the PR number, not the issue number
- **test**: locks in `pr_number`-wins-over-`issue_number` precedence

## Testing

- worker `test_review_phase_guard.py`: 7/7 pass
- backend `test_foreman.py`: 139/139 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)