### PR TITLE
feat: DB cache for GitHub issues & PRs with webhook+backfill support

### DIFF
--- a/backend/alembic/versions/20260709_000000_add_github_issues_and_pull_requests.py
+++ b/backend/alembic/versions/20260709_000000_add_github_issues_and_pull_requests.py
@@ -1,0 +1,84 @@
+"""Add github_issues and github_pull_requests tables.
+
+Revision ID: 20260709_000000_add_github_issues_and_pull_requests
+Revises: 20260708_000001_add_discord_thread_id_to_tasks
+Create Date: 2026-07-09
+
+Local DB cache of GitHub issue/PR state (#864). Webhooks upsert on push;
+status/polling calls read from and update these tables. Both tables are
+keyed unique on (repo, number) so a repo/number pair maps to exactly one
+row and upserts from either the webhook receiver or
+scripts/backfill_github_cache.py are idempotent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "20260709_000000_add_github_issues_and_pull_requests"
+down_revision: str | Sequence[str] | None = "20260708_000001_add_discord_thread_id_to_tasks"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "github_issues",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("repo", sa.Text(), nullable=False),
+        sa.Column("number", sa.Integer(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("state", sa.Text(), nullable=False),
+        sa.Column("assignees", sa.JSON(), nullable=False),
+        sa.Column("labels", sa.JSON(), nullable=False),
+        sa.Column("milestone", sa.Text(), nullable=True),
+        sa.Column("author", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("raw", JSONB(), nullable=False),
+    )
+    op.create_index(
+        "uq_github_issues_repo_number", "github_issues", ["repo", "number"], unique=True
+    )
+
+    op.create_table(
+        "github_pull_requests",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("repo", sa.Text(), nullable=False),
+        sa.Column("number", sa.Integer(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("state", sa.Text(), nullable=False),
+        sa.Column("merged", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("draft", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("head_sha", sa.Text(), nullable=True),
+        sa.Column("head_ref", sa.Text(), nullable=True),
+        sa.Column("base_ref", sa.Text(), nullable=True),
+        sa.Column("author", sa.Text(), nullable=True),
+        sa.Column("assignees", sa.JSON(), nullable=False),
+        sa.Column("labels", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("merged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("raw", JSONB(), nullable=False),
+    )
+    op.create_index(
+        "uq_github_pull_requests_repo_number",
+        "github_pull_requests",
+        ["repo", "number"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_github_pull_requests_repo_number", table_name="github_pull_requests")
+    op.drop_table("github_pull_requests")
+    op.drop_index("uq_github_issues_repo_number", table_name="github_issues")
+    op.drop_table("github_issues")

--- a/backend/db/github_cache.py
+++ b/backend/db/github_cache.py
@@ -8,7 +8,7 @@ The full payload is retained in ``raw`` for future-proofing.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from models import GithubIssue, GithubPullRequest
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -20,6 +20,11 @@ def _parse_dt(value: str | None) -> datetime | None:
     if not value:
         return None
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _parse_dt_or_now(value: str | None) -> datetime:
+    """Parse a required timestamp, falling back to now() if GitHub omits it."""
+    return _parse_dt(value) or datetime.now(UTC)
 
 
 def _login(obj: dict | None) -> str | None:
@@ -49,8 +54,8 @@ async def upsert_issue(db: AsyncSession, repo: str, payload: dict) -> GithubIssu
         "labels": _label_names(payload),
         "milestone": milestone.get("title") if isinstance(milestone, dict) else None,
         "author": _login(payload.get("user")),
-        "created_at": _parse_dt(payload.get("created_at")),
-        "updated_at": _parse_dt(payload.get("updated_at")),
+        "created_at": _parse_dt_or_now(payload.get("created_at")),
+        "updated_at": _parse_dt_or_now(payload.get("updated_at")),
         "closed_at": _parse_dt(payload.get("closed_at")),
         "raw": payload,
     }
@@ -91,8 +96,8 @@ async def upsert_pr(db: AsyncSession, repo: str, payload: dict) -> GithubPullReq
         "author": _login(payload.get("user")),
         "assignees": _assignee_logins(payload),
         "labels": _label_names(payload),
-        "created_at": _parse_dt(payload.get("created_at")),
-        "updated_at": _parse_dt(payload.get("updated_at")),
+        "created_at": _parse_dt_or_now(payload.get("created_at")),
+        "updated_at": _parse_dt_or_now(payload.get("updated_at")),
         "closed_at": _parse_dt(payload.get("closed_at")),
         "merged_at": _parse_dt(payload.get("merged_at")),
         "raw": payload,

--- a/backend/db/github_cache.py
+++ b/backend/db/github_cache.py
@@ -1,0 +1,153 @@
+"""Local DB cache of GitHub issue/PR state (#864).
+
+Upsert helpers translate a raw GitHub REST/webhook payload into a row in
+``github_issues`` / ``github_pull_requests``, keyed unique on (repo, number)
+so repeated deliveries (webhook redelivery, backfill re-runs) are idempotent.
+The full payload is retained in ``raw`` for future-proofing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from models import GithubIssue, GithubPullRequest
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _login(obj: dict | None) -> str | None:
+    return obj.get("login") if isinstance(obj, dict) else None
+
+
+def _label_names(payload: dict) -> list[str]:
+    labels = payload.get("labels") or []
+    return [lb["name"] for lb in labels if isinstance(lb, dict) and lb.get("name")]
+
+
+def _assignee_logins(payload: dict) -> list[str]:
+    assignees = payload.get("assignees") or []
+    return [a["login"] for a in assignees if isinstance(a, dict) and a.get("login")]
+
+
+async def upsert_issue(db: AsyncSession, repo: str, payload: dict) -> GithubIssue:
+    """Insert or update the cached issue row for *repo* from a GitHub issue payload."""
+    milestone = payload.get("milestone")
+    values = {
+        "repo": repo,
+        "number": payload["number"],
+        "title": payload.get("title") or "",
+        "body": payload.get("body"),
+        "state": payload.get("state") or "open",
+        "assignees": _assignee_logins(payload),
+        "labels": _label_names(payload),
+        "milestone": milestone.get("title") if isinstance(milestone, dict) else None,
+        "author": _login(payload.get("user")),
+        "created_at": _parse_dt(payload.get("created_at")),
+        "updated_at": _parse_dt(payload.get("updated_at")),
+        "closed_at": _parse_dt(payload.get("closed_at")),
+        "raw": payload,
+    }
+    stmt = pg_insert(GithubIssue).values(**values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["repo", "number"],
+        set_={k: stmt.excluded[k] for k in values if k not in ("repo", "number")},
+    )
+    await db.exec(stmt)
+    await db.commit()
+    result = await db.exec(
+        select(GithubIssue).where(
+            col(GithubIssue.repo) == repo, col(GithubIssue.number) == payload["number"]
+        )
+    )
+    return result.one()
+
+
+async def upsert_pr(db: AsyncSession, repo: str, payload: dict) -> GithubPullRequest:
+    """Insert or update the cached PR row for *repo* from a GitHub pull_request payload."""
+    head = payload.get("head") or {}
+    base = payload.get("base") or {}
+    # The REST "list pull requests" endpoint omits the "merged" boolean present
+    # on webhook/single-PR payloads, so fall back to merged_at as the signal.
+    merged = bool(payload.get("merged")) or payload.get("merged_at") is not None
+    state = "merged" if merged else (payload.get("state") or "open")
+    values = {
+        "repo": repo,
+        "number": payload["number"],
+        "title": payload.get("title") or "",
+        "body": payload.get("body"),
+        "state": state,
+        "merged": merged,
+        "draft": bool(payload.get("draft")),
+        "head_sha": head.get("sha"),
+        "head_ref": head.get("ref"),
+        "base_ref": base.get("ref"),
+        "author": _login(payload.get("user")),
+        "assignees": _assignee_logins(payload),
+        "labels": _label_names(payload),
+        "created_at": _parse_dt(payload.get("created_at")),
+        "updated_at": _parse_dt(payload.get("updated_at")),
+        "closed_at": _parse_dt(payload.get("closed_at")),
+        "merged_at": _parse_dt(payload.get("merged_at")),
+        "raw": payload,
+    }
+    stmt = pg_insert(GithubPullRequest).values(**values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["repo", "number"],
+        set_={k: stmt.excluded[k] for k in values if k not in ("repo", "number")},
+    )
+    await db.exec(stmt)
+    await db.commit()
+    result = await db.exec(
+        select(GithubPullRequest).where(
+            col(GithubPullRequest.repo) == repo, col(GithubPullRequest.number) == payload["number"]
+        )
+    )
+    return result.one()
+
+
+async def get_issue(db: AsyncSession, repo: str, number: int) -> GithubIssue | None:
+    result = await db.exec(
+        select(GithubIssue).where(col(GithubIssue.repo) == repo, col(GithubIssue.number) == number)
+    )
+    return result.one_or_none()
+
+
+async def get_pr(db: AsyncSession, repo: str, number: int) -> GithubPullRequest | None:
+    result = await db.exec(
+        select(GithubPullRequest).where(
+            col(GithubPullRequest.repo) == repo, col(GithubPullRequest.number) == number
+        )
+    )
+    return result.one_or_none()
+
+
+async def list_issues(
+    db: AsyncSession, repo: str, state: str | None = None, label: str | None = None
+) -> list[GithubIssue]:
+    """List cached issues for *repo*, optionally filtered by state and/or label name."""
+    stmt = select(GithubIssue).where(col(GithubIssue.repo) == repo)
+    if state:
+        stmt = stmt.where(col(GithubIssue.state) == state)
+    result = await db.exec(stmt.order_by(col(GithubIssue.number).desc()))
+    issues = result.all()
+    if label:
+        issues = [i for i in issues if label in i.labels]
+    return issues
+
+
+async def list_prs(
+    db: AsyncSession, repo: str, state: str | None = None
+) -> list[GithubPullRequest]:
+    """List cached pull requests for *repo*, optionally filtered by state."""
+    stmt = select(GithubPullRequest).where(col(GithubPullRequest.repo) == repo)
+    if state:
+        stmt = stmt.where(col(GithubPullRequest.state) == state)
+    result = await db.exec(stmt.order_by(col(GithubPullRequest.number).desc()))
+    return result.all()

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 
 from sqlalchemy import JSON, Boolean, Column, DateTime, Index, Text, or_, text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel, col
 
 # Coding agent runners a worker can be configured with. Single source of
@@ -430,6 +431,75 @@ class GithubEvent(SQLModel, table=True):
     sender_login: str | None = None
     payload_json: str
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
+class GithubIssue(SQLModel, table=True):
+    """Local cache of a GitHub issue's state, upserted from webhooks and backfill.
+
+    Unique on (repo, number) so upserts are idempotent across both the
+    webhook receiver and scripts/backfill_github_cache.py. ``raw`` retains
+    the full GitHub payload so future fields don't require a migration.
+    """
+
+    __tablename__ = "github_issues"  # type: ignore[assignment]
+    __table_args__ = (Index("uq_github_issues_repo_number", "repo", "number", unique=True),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    repo: str  # "owner/repo"
+    number: int
+    title: str
+    body: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    state: str  # "open" | "closed"
+    assignees: list = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    labels: list = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    milestone: str | None = None
+    author: str | None = None
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    closed_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    raw: dict = Field(default_factory=dict, sa_column=Column(JSONB, nullable=False))
+
+
+class GithubPullRequest(SQLModel, table=True):
+    """Local cache of a GitHub pull request's state, upserted from webhooks and backfill.
+
+    Unique on (repo, number) so upserts are idempotent across both the
+    webhook receiver and scripts/backfill_github_cache.py. ``raw`` retains
+    the full GitHub payload so future fields don't require a migration.
+    """
+
+    __tablename__ = "github_pull_requests"  # type: ignore[assignment]
+    __table_args__ = (Index("uq_github_pull_requests_repo_number", "repo", "number", unique=True),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    repo: str  # "owner/repo"
+    number: int
+    title: str
+    body: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    state: str  # "open" | "closed" | "merged"
+    merged: bool = Field(
+        default=False, sa_column=Column(Boolean, nullable=False, server_default=text("false"))
+    )
+    draft: bool = Field(
+        default=False, sa_column=Column(Boolean, nullable=False, server_default=text("false"))
+    )
+    head_sha: str | None = None
+    head_ref: str | None = None
+    base_ref: str | None = None
+    author: str | None = None
+    assignees: list = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    labels: list = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    closed_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    merged_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    raw: dict = Field(default_factory=dict, sa_column=Column(JSONB, nullable=False))
 
 
 class Lock(SQLModel, table=True):

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -25,6 +25,7 @@ from datetime import UTC, datetime, timedelta
 
 import discord_notifier
 from database import get_db_dep
+from db import github_cache
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from foreman.runner import reset_foreman_poll, run_foreman_ai
@@ -883,6 +884,16 @@ async def github_webhook(
             event_type,
         )
         return Response(status_code=202)
+
+    # Keep the local github_issues/github_pull_requests cache current (#864).
+    if event_type == "issues" and repo:
+        issue_payload = payload.get("issue")
+        if isinstance(issue_payload, dict):
+            await github_cache.upsert_issue(db, repo, issue_payload)
+    elif event_type == "pull_request" and repo:
+        pr_payload = payload.get("pull_request")
+        if isinstance(pr_payload, dict):
+            await github_cache.upsert_pr(db, repo, pr_payload)
 
     # Back-fill pr_url on the task from the webhook payload when a
     # pull_request event arrives and the task doesn't already have it set.

--- a/scripts/backfill_github_cache.py
+++ b/scripts/backfill_github_cache.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Backfill the github_issues / github_pull_requests DB cache (#864).
+
+Paginates the GitHub REST API for issues and pull requests on one or more
+repos and upserts each into the local cache via backend/db/github_cache.py.
+Useful for seeding the cache for a repo that predates webhook coverage, or
+for re-syncing after downtime.
+
+Usage:
+    python scripts/backfill_github_cache.py --repo owner/repo [--repo owner/repo2] [--token ghp_...]
+
+GITHUB_TOKEN env var is used when --token is omitted. Requires DATABASE_URL
+to be set (same variable the backend reads).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+import httpx
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from database import AsyncSessionLocal  # noqa: E402
+from db import github_cache  # noqa: E402
+
+GH_API = "https://api.github.com"
+PER_PAGE = 100
+
+
+def _headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+async def _paginate(client: httpx.AsyncClient, url: str, params: dict) -> list[dict]:
+    items: list[dict] = []
+    page = 1
+    while True:
+        res = await client.get(url, params={**params, "page": page, "per_page": PER_PAGE})
+        res.raise_for_status()
+        batch = res.json()
+        if not batch:
+            break
+        items.extend(batch)
+        if len(batch) < PER_PAGE:
+            break
+        page += 1
+    return items
+
+
+async def backfill_repo(client: httpx.AsyncClient, repo: str) -> None:
+    # /issues returns both issues and PRs (PRs carry a "pull_request" key);
+    # filter those out since PRs are backfilled separately from /pulls.
+    print(f"[{repo}] fetching issues...")
+    raw_issues = await _paginate(client, f"{GH_API}/repos/{repo}/issues", {"state": "all"})
+    issues = [item for item in raw_issues if "pull_request" not in item]
+    print(f"[{repo}] fetched {len(issues)} issues ({len(raw_issues) - len(issues)} PRs excluded)")
+
+    print(f"[{repo}] fetching pull requests...")
+    prs = await _paginate(client, f"{GH_API}/repos/{repo}/pulls", {"state": "all"})
+    print(f"[{repo}] fetched {len(prs)} pull requests")
+
+    async with AsyncSessionLocal() as db:
+        for i, issue in enumerate(issues, start=1):
+            await github_cache.upsert_issue(db, repo, issue)
+            print(f"[{repo}] upserted issue #{issue['number']} ({i}/{len(issues)})")
+        for i, pr in enumerate(prs, start=1):
+            await github_cache.upsert_pr(db, repo, pr)
+            print(f"[{repo}] upserted PR #{pr['number']} ({i}/{len(prs)})")
+
+
+async def main(repos: list[str], token: str | None) -> None:
+    async with httpx.AsyncClient(headers=_headers(token), timeout=30) as client:
+        for repo in repos:
+            await backfill_repo(client, repo)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", action="append", required=True, dest="repos", help="owner/repo (repeatable)"
+    )
+    parser.add_argument(
+        "--token", default=None, help="GitHub token (defaults to GITHUB_TOKEN env var)"
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    token = args.token or os.environ.get("GITHUB_TOKEN")
+    asyncio.run(main(args.repos, token))


### PR DESCRIPTION
Closes #864

## Summary
- Add `github_issues` and `github_pull_requests` tables (migration `20260709_000000_add_github_issues_and_pull_requests.py`), each unique on `(repo, number)`, storing title/body/state/assignees/labels/timestamps plus a `raw` JSONB payload for future-proofing.
- Add `backend/db/github_cache.py` with `upsert_issue`/`upsert_pr` helpers (idempotent Postgres `ON CONFLICT` upserts) and `get_issue`/`get_pr`/`list_issues`/`list_prs` read helpers.
- Wire the `issues` and `pull_request` GitHub webhook events in `backend/routes/webhooks.py` to upsert into the cache as events arrive.
- Add `scripts/backfill_github_cache.py` to backfill the cache from the GitHub REST API for existing issues/PRs.

## Test plan
- [x] Lint checks pass
- [ ] Verify migration applies cleanly (`alembic upgrade head`)
- [ ] Verify webhook delivery upserts rows as expected
- [ ] Run backfill script against a repo and confirm cache is populated