### PR TITLE
fix: carry pr_number/pr_repo through the REST assign-task endpoint

### DIFF
--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -90,6 +90,8 @@ class TaskCreate(BaseModel):
     provider: str | None = None
     issue_number: int | None = None
     issue_repo: str | None = None
+    pr_number: int | None = None
+    pr_repo: str | None = None
     repos: list[str] = []
     parent_task_id: str | None = None
     phase: str | None = "execute"
@@ -341,6 +343,8 @@ async def assign_task(
             provider=data.provider,
             issue_number=data.issue_number,
             issue_repo=data.issue_repo,
+            pr_number=data.pr_number,
+            pr_repo=data.pr_repo,
             state="pending",
             phase=data.phase or "execute",
             parent_task_id=data.parent_task_id,
@@ -363,6 +367,8 @@ async def assign_task(
             parentTaskId=data.parent_task_id,
             issueNumber=data.issue_number,
             issueRepo=data.issue_repo,
+            prNumber=data.pr_number,
+            prRepo=data.pr_repo,
             repos=data.repos,
         ),
     )


### PR DESCRIPTION
Follow-up to #865 (merged before this commit landed).

`POST /guilds/{g}/workers/{w}/tasks` (the `TaskCreate` REST path used for direct/UI/CLI task assignment) still lacked `pr_number`/`pr_repo`, so a `phase=review` task created through it would fall back to `issue_number` — the exact bug #865 fixed everywhere else. This closes the last task-creation path.

- `TaskCreate`: add `pr_number`/`pr_repo`
- persist them on the `Task` row and include them in the `TaskAssignedMsg` broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)