### PR TITLE
fix: drain+replace stale workers; wire shutdown button to real path

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -345,9 +345,10 @@ async def lifespan(app: FastAPI):
 
     await reset_connection_state()
 
-    # Phase 2: give stale workers the drain window to reconnect on their own
-    # before force-killing and replacing whichever ones don't come back. Runs
-    # in the background so it doesn't block startup or the first request.
+    # Phase 2: drain each stale worker (wait for it to reconnect, soft-kill it,
+    # let it finish its task and go offline) and spawn a fresh replacement once
+    # it's down. Runs in the background so it doesn't block startup or the first
+    # request.
     reconcile_bg = (
         spawn(reconcile_stale_workers(stale_ids), name="stale-worker-reconcile")
         if stale_ids

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -25,15 +25,20 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from util.tasks import spawn
 from utils import (
     build_spawn_worker_env,
     decode_claude_oauth_token,
     row_to_dict,
     worker_display_name,
 )
-from worker_lifecycle import generate_worker_id, record_worker_spawn
+from worker_lifecycle import (
+    force_kill_worker_if_unresponsive,
+    generate_worker_id,
+    record_worker_spawn,
+)
 from ws_handlers import _resolve_user_identifier
-from ws_types import TaskAssignedMsg, WorkerMessageMsg
+from ws_types import TaskAssignedMsg, WorkerMessageMsg, WorkerShutdownMsg
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -512,3 +517,52 @@ async def message_worker(
     await emit_terminal_line(guild_id, worker_id, f"[foreman → worker] {text_msg}")
     await broadcast_msg(guild_id, WorkerMessageMsg(workerId=worker_id, message=text_msg))
     return {"status": "delivered"}
+
+
+@router.post("/guilds/{guild_id}/workers/{worker_id}/shutdown")
+async def shutdown_worker_endpoint(
+    guild_id: str,
+    worker_id: str,
+    github_user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Gracefully shut down a worker process (operator-initiated).
+
+    Mirrors the foreman ``shutdown_worker`` tool so the frontend button drives the
+    real shutdown path instead of injecting an English message into a running
+    agent: broadcast the ``worker-shutdown`` signal (which the worker turns into a
+    graceful ``_initiate_shutdown`` — idle agents stop, busy agents finish their
+    current task, then the process exits), mark the worker ``disabled`` so it is
+    not respawned on the next backend restart, and schedule a force-kill backstop
+    in case the worker never goes offline on its own.
+    """
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+
+    worker = (
+        await db.exec(
+            select(col(Worker.id)).where(
+                col(Worker.id) == worker_id, col(Worker.guild_id) == guild_pk
+            )
+        )
+    ).one_or_none()
+    if worker is None:
+        raise HTTPException(status_code=404, detail="Worker not found")
+
+    await broadcast_msg(
+        guild_id,
+        WorkerShutdownMsg(workerId=worker_id, reason="operator-initiated shutdown"),
+    )
+    await db.exec(update(Worker).where(col(Worker.id) == worker_id).values(disabled=True))
+    await db.commit()
+    await emit_terminal_line(
+        guild_id, worker_id, "[operator] graceful shutdown signal sent"
+    )
+    # Force-kill the container only if it's still not offline after the timeout —
+    # see worker_lifecycle.force_kill_worker_if_unresponsive.
+    spawn(
+        force_kill_worker_if_unresponsive(worker_id),
+        name=f"shutdown-escalate:{worker_id}",
+    )
+    return {"status": "shutdown-signalled"}

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -556,9 +556,7 @@ async def shutdown_worker_endpoint(
     )
     await db.exec(update(Worker).where(col(Worker.id) == worker_id).values(disabled=True))
     await db.commit()
-    await emit_terminal_line(
-        guild_id, worker_id, "[operator] graceful shutdown signal sent"
-    )
+    await emit_terminal_line(guild_id, worker_id, "[operator] graceful shutdown signal sent")
     # Force-kill the container only if it's still not offline after the timeout —
     # see worker_lifecycle.force_kill_worker_if_unresponsive.
     spawn(

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -175,6 +175,63 @@ def test_assign_task_appears_in_list(client):
     assert descriptions == {"Task one", "Task two"}
 
 
+# ---------------------------------------------------------------------------
+# Worker shutdown
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_worker_signals_and_disables(client, monkeypatch):
+    """The shutdown endpoint broadcasts a worker-shutdown signal and disables the worker."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-shutdown")
+    worker_id = _create_worker(test_client, "guild-shutdown")
+
+    broadcasts: list = []
+
+    async def fake_broadcast(guild_id, msg, *a, **kw):
+        broadcasts.append((guild_id, msg))
+
+    # Don't schedule the real force-kill poll loop during the test — just close
+    # the coroutine so it isn't reported as never-awaited.
+    def fake_spawn(coro, **kw):
+        coro.close()
+        return None
+
+    monkeypatch.setattr("routes.workers.broadcast_msg", fake_broadcast)
+    monkeypatch.setattr("routes.workers.spawn", fake_spawn)
+
+    resp = test_client.post(
+        f"/guilds/guild-shutdown/workers/{worker_id}/shutdown",
+        headers=_auth(db_url),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "shutdown-signalled"
+
+    # A graceful worker-shutdown signal was broadcast to this worker.
+    assert any(
+        getattr(msg, "workerId", None) == worker_id
+        and getattr(msg, "type", None) == "worker-shutdown"
+        for _, msg in broadcasts
+    )
+
+    # The worker is now disabled so it isn't respawned on the next backend restart.
+    with _sync_session(db_url) as session:
+        disabled = session.execute(
+            select(col(Worker.disabled)).where(col(Worker.id) == worker_id)
+        ).scalar_one()
+    assert disabled is True
+
+
+def test_shutdown_unknown_worker_returns_404(client):
+    test_client, db_url = client
+    insert_guild(db_url, "guild-shutdown-404")
+    resp = test_client.post(
+        "/guilds/guild-shutdown-404/workers/w-nope/shutdown",
+        headers=_auth(db_url),
+    )
+    assert resp.status_code == 404
+
+
 def test_spawn_worker_env_forwards_claude_oauth_token():
     """CLAUDE_CODE_OAUTH_TOKEN must reach the spawned container so it skips setup-token."""
     from main import _build_spawn_worker_env

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import sys
 from datetime import UTC, datetime
@@ -16,6 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from worker_lifecycle import (  # noqa: E402
     SHUTDOWN_FORCE_KILL_TIMEOUT,
     WORKER_DRAIN_TIMEOUT,
+    WORKER_RECONNECT_GRACE,
     drain_stale_workers_on_startup,
     force_kill_worker_if_unresponsive,
     generate_worker_id,
@@ -244,7 +246,7 @@ async def test_drain_sends_shutdown_and_records_timestamp(monkeypatch):
 
 
 def test_drain_timeout_default():
-    assert WORKER_DRAIN_TIMEOUT == 60.0
+    assert WORKER_DRAIN_TIMEOUT == 1800.0
 
 
 def test_drain_timeout_env_override(monkeypatch):
@@ -301,6 +303,7 @@ async def test_spawn_replacement_workers_calls_spawn_for_each():
     fake_worker.id = "w-old1"
     fake_worker.guild_id = 42
     fake_worker.repos = '["owner/repo"]'
+    fake_worker.tools = '["bash"]'
     fake_worker.name = "old-worker"
 
     class FakeDB:
@@ -339,6 +342,9 @@ async def test_spawn_replacement_workers_calls_spawn_for_each():
     assert spawn_calls[0]["guild_id"] == "g-myguild"
     assert spawn_calls[0]["guild_pk"] == 42
     assert spawn_calls[0]["inp"]["repos"] == ["owner/repo"]
+    assert spawn_calls[0]["inp"]["tools"] == ["bash"]
+    # The replacement must get a fresh identity, never the drained worker's name.
+    assert "name" not in spawn_calls[0]["inp"]
 
 
 # ---------------------------------------------------------------------------
@@ -489,12 +495,11 @@ async def test_generate_worker_id_raises_after_max_attempts():
 # ---------------------------------------------------------------------------
 
 
-class _FakeReconcileDB:
-    def __init__(self, reconnected_ids):
-        self._reconnected_ids = reconnected_ids
-        self.exec = AsyncMock(
-            return_value=MagicMock(all=MagicMock(return_value=self._reconnected_ids))
-        )
+class _FakeExecDB:
+    """Fake session whose exec().all() returns a fixed row list."""
+
+    def __init__(self, rows):
+        self.exec = AsyncMock(return_value=MagicMock(all=MagicMock(return_value=rows)))
         self.commit = AsyncMock()
 
     async def __aenter__(self):
@@ -502,6 +507,33 @@ class _FakeReconcileDB:
 
     async def __aexit__(self, *a):
         return False
+
+
+@contextlib.contextmanager
+def _reconcile_patches(sessions, times, mock_kill, mock_spawn, broadcasts):
+    """Common patch set for driving reconcile_stale_workers deterministically.
+
+    ``sessions`` are consumed one AsyncSessionLocal() at a time: the first is the
+    guild-slug lookup, the rest are the per-poll online-worker queries. ``times``
+    feeds loop.time() (one call to seed phase_started, then one per poll). Real
+    sleeps are stubbed out so the loop runs instantly.
+    """
+    session_iter = iter(sessions)
+    fake_loop = MagicMock()
+    fake_loop.time = MagicMock(side_effect=times)
+
+    async def fake_broadcast(slug, msg, *a, **kw):
+        broadcasts.append((slug, msg))
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
+        patch("worker_lifecycle.asyncio.get_event_loop", return_value=fake_loop),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+        patch("worker_lifecycle.spawn_replacement_workers", mock_spawn),
+        patch("worker_lifecycle.broadcast_msg", fake_broadcast),
+    ):
+        yield
 
 
 @pytest.mark.asyncio
@@ -520,35 +552,43 @@ async def test_reconcile_noop_on_empty_ids():
 
 
 @pytest.mark.asyncio
-async def test_reconcile_skips_respawn_when_all_workers_reconnect():
-    """Workers that reconnect on their own during the drain window are not replaced."""
-    session_iter = iter([_FakeReconcileDB(["w-a", "w-b"])])
+async def test_reconcile_drains_then_replaces_reconnected_worker():
+    """A worker that reconnects then drains is soft-killed and replaced, never force-killed."""
+    sessions = [
+        _FakeExecDB([("w-a", "g-guild")]),  # guild-slug lookup
+        _FakeExecDB(["w-a"]),  # poll 1: back online → begin draining
+        _FakeExecDB([]),  # poll 2: gone offline → drained
+    ]
+    mock_kill = AsyncMock()
+    mock_spawn = AsyncMock()
+    broadcasts: list = []
+    # loop.time(): seed + poll1 + poll2. Well under the drain timeout.
+    times = [0.0, 10.0, 20.0]
 
-    with (
-        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.01),
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle._force_kill_containers") as mock_kill,
-        patch("worker_lifecycle.spawn_replacement_workers") as mock_spawn,
-    ):
-        await reconcile_stale_workers(["w-a", "w-b"])
+    with _reconcile_patches(sessions, times, mock_kill, mock_spawn, broadcasts):
+        await reconcile_stale_workers(["w-a"])
 
+    # Soft-kill delivered on reconnect; drained cleanly so no force-kill.
+    assert any(msg.workerId == "w-a" for _, msg in broadcasts)
     mock_kill.assert_not_called()
-    mock_spawn.assert_not_called()
+    mock_spawn.assert_called_once_with(["w-a"])
 
 
 @pytest.mark.asyncio
-async def test_reconcile_force_kills_and_respawns_workers_that_never_reconnect():
-    """Workers still offline once the drain window elapses get killed and replaced."""
-    session_iter = iter([_FakeReconcileDB([])])
+async def test_reconcile_force_kills_and_replaces_worker_that_never_reconnects():
+    """A worker that never comes back within the reconnect grace is killed and replaced."""
+    sessions = [
+        _FakeExecDB([("w-a", "g-guild")]),  # guild-slug lookup
+        _FakeExecDB([]),  # poll 1: still offline, within grace
+        _FakeExecDB([]),  # poll 2: still offline, grace exceeded → dead
+    ]
     mock_kill = AsyncMock()
     mock_spawn = AsyncMock()
+    broadcasts: list = []
+    # Seed at 0; poll1 within grace; poll2 past WORKER_RECONNECT_GRACE.
+    times = [0.0, 10.0, WORKER_RECONNECT_GRACE + 1.0]
 
-    with (
-        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.01),
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle._force_kill_containers", mock_kill),
-        patch("worker_lifecycle.spawn_replacement_workers", mock_spawn),
-    ):
+    with _reconcile_patches(sessions, times, mock_kill, mock_spawn, broadcasts):
         await reconcile_stale_workers(["w-a"])
 
     mock_kill.assert_called_once_with({"w-a"})
@@ -556,22 +596,24 @@ async def test_reconcile_force_kills_and_respawns_workers_that_never_reconnect()
 
 
 @pytest.mark.asyncio
-async def test_reconcile_only_respawns_workers_still_missing():
-    """A partial reconnect only triggers kill/respawn for the workers still missing."""
-    session_iter = iter([_FakeReconcileDB(["w-a"])])
+async def test_reconcile_force_kills_wedged_worker_that_never_drains():
+    """A worker that reconnects but never goes offline is force-killed after the drain timeout."""
+    sessions = [
+        _FakeExecDB([("w-a", "g-guild")]),  # guild-slug lookup
+        _FakeExecDB(["w-a"]),  # poll 1: online → begin draining
+        _FakeExecDB(["w-a"]),  # poll 2: still online past the drain timeout → wedged
+    ]
     mock_kill = AsyncMock()
     mock_spawn = AsyncMock()
+    broadcasts: list = []
+    # Seed=0; poll1 begins drain (phase_started=10); poll2 past drain timeout.
+    times = [0.0, 10.0, 10.0 + WORKER_DRAIN_TIMEOUT + 1.0]
 
-    with (
-        patch("worker_lifecycle.WORKER_DRAIN_TIMEOUT", 0.01),
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle._force_kill_containers", mock_kill),
-        patch("worker_lifecycle.spawn_replacement_workers", mock_spawn),
-    ):
-        await reconcile_stale_workers(["w-a", "w-b"])
+    with _reconcile_patches(sessions, times, mock_kill, mock_spawn, broadcasts):
+        await reconcile_stale_workers(["w-a"])
 
-    mock_kill.assert_called_once_with({"w-b"})
-    mock_spawn.assert_called_once_with(["w-b"])
+    mock_kill.assert_called_once_with({"w-a"})
+    mock_spawn.assert_called_once_with(["w-a"])
 
 
 # ---------------------------------------------------------------------------
@@ -603,7 +645,7 @@ class _FakeStateDB:
 
 
 def test_shutdown_force_kill_timeout_default():
-    assert SHUTDOWN_FORCE_KILL_TIMEOUT == 600.0
+    assert SHUTDOWN_FORCE_KILL_TIMEOUT == 1800.0
 
 
 def test_shutdown_force_kill_timeout_env_override(monkeypatch):

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -1,22 +1,37 @@
-"""Worker lifecycle: detect stale workers after a version change and drain/kill them.
+"""Worker lifecycle: detect stale workers after a version change and cycle them.
+
+A version bump means the running worker containers hold old code, so every stale
+worker must be drained (soft-killed, allowed to finish its in-progress task, then
+shut down) and replaced by a fresh container that picks up the new code. A stale
+worker reconnecting after the restart is *expected* (the backend restarts first,
+then the worker's reconnect loop brings its WebSocket back within seconds) — it is
+never a reason to spare the worker from replacement.
 
 Lifecycle steps on backend startup
 ───────────────────────────────────
-1. get_current_version()         — PIONEER_VERSION env var or git short SHA
+1. get_current_version()         — PIONEER_VERSION env var, or "<YYYYMMDD>-<sha>"
+   from the current commit (date is the deterministic committer date, never
+   wall-clock/build time — versions are compared for exact equality, so a
+   nondeterministic date would mark every worker perpetually stale).
 2. drain_stale_workers_on_startup() — find workers whose spawned_version differs
-   from current; send graceful WS shutdown signal; record drain_requested_at.
-   Returns list of stale worker IDs.
+   from current; record drain_requested_at (informational) and best-effort
+   broadcast a shutdown. Returns the list of stale worker IDs.
 3. reset_connection_state()      — called by main.py AFTER step 2, sets all
    workers offline in the DB.
-4. reconcile_stale_workers(ids)  — spawned as a background task AFTER step 3;
-   waits up to PIONEER_WORKER_DRAIN_TIMEOUT seconds, dropping any worker that
-   reconnects on its own from the replacement list (a cold restart drops every
-   WebSocket at once, so the shutdown broadcast in step 2 reaches no one — the
-   worker's own reconnect loop brings it back within seconds and it should
-   count against the desired worker total, not trigger a redundant spawn).
-   Workers that never come back within the window get their container
-   force-killed (via Docker SDK, using the stored container_id — skipped when
-   NULL) and a single replacement spawned via spawn_replacement_workers().
+4. reconcile_stale_workers(ids)  — spawned as a background task AFTER step 3.
+   Per worker, two phases:
+     • Reconnect: reset_connection_state() just marked everyone offline, so
+       "offline" now means "not yet reconnected", not "drained". Wait up to
+       PIONEER_WORKER_RECONNECT_GRACE for the worker to come back online. If it
+       never does, its container died during the deploy — force-kill (best
+       effort) and replace it immediately.
+     • Drain: once it is back online, send the soft-kill and wait for it to
+       finish its task and go offline (its ack), up to PIONEER_WORKER_DRAIN_TIMEOUT.
+       If it never goes offline it is wedged — force-kill its container.
+   Either way, once the worker is down a replacement with a brand-new worker ID
+   and name (never the drained worker's identity) is spawned via
+   spawn_replacement_workers(). Replacing only after the old worker is confirmed
+   down means there is never a moment with two live workers for the same slot.
 """
 
 from __future__ import annotations
@@ -38,33 +53,46 @@ from ws_types import WorkerShutdownMsg
 
 logger = logging.getLogger(__name__)
 
-# How long to wait for stale workers to exit gracefully before force-killing.
-WORKER_DRAIN_TIMEOUT = float(os.environ.get("PIONEER_WORKER_DRAIN_TIMEOUT", "60"))
+# How long to let a stale worker finish its in-progress task and exit gracefully
+# after the soft-kill before force-killing its container. Generous by default (30
+# min) because a busy worker may be mid-task when a deploy lands.
+WORKER_DRAIN_TIMEOUT = float(os.environ.get("PIONEER_WORKER_DRAIN_TIMEOUT", "1800"))
+
+# How long to wait for a stale worker to reconnect after a backend restart before
+# treating it as already dead (its container died during the deploy) and replacing
+# it without waiting for a drain. Workers normally reconnect within seconds.
+WORKER_RECONNECT_GRACE = float(os.environ.get("PIONEER_WORKER_RECONNECT_GRACE", "120"))
 
 # How long to wait after an explicit shutdown_worker request before force-killing
 # an unresponsive worker's container. Separate from WORKER_DRAIN_TIMEOUT (which
-# guards the much rarer startup version-mismatch drain) since this is the window
-# the foreman AI waits on every ordinary "stop this worker" request.
-SHUTDOWN_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_SHUTDOWN_TIMEOUT", "600"))
+# guards the startup version-mismatch drain) since this is the window the foreman
+# AI waits on every ordinary "stop this worker" request.
+SHUTDOWN_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_SHUTDOWN_TIMEOUT", "1800"))
 
 
 def get_current_version() -> str | None:
     """Return the running backend version.
 
-    Prefers the PIONEER_VERSION env var (set at image build time).  Falls back
-    to the short git SHA so local dev environments also get a version string.
-    Returns None if neither is available.
+    Prefers the PIONEER_VERSION env var (set at image build time). Falls back to
+    ``<YYYYMMDD>-<short-sha>`` from the current commit (e.g. ``20260709-1e1ae98``)
+    so local dev environments also get a version string that's easy to date at a
+    glance. Returns None if neither is available.
+
+    The date is the commit's committer date — deterministic per commit — never
+    the wall-clock/build time. Versions are compared for exact equality to decide
+    staleness, so a nondeterministic date would make every worker perpetually
+    version-mismatched and trigger endless recycling.
     """
     v = os.environ.get("PIONEER_VERSION")
     if v:
         return v.strip()
     try:
-        sha = subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"],
+        version = subprocess.check_output(
+            ["git", "show", "-s", "--format=%cd-%h", "--date=format:%Y%m%d", "HEAD"],
             stderr=subprocess.DEVNULL,
             text=True,
         ).strip()
-        return sha or None
+        return version or None
     except Exception:
         return None
 
@@ -102,7 +130,13 @@ async def record_worker_spawn(db, worker_id: str, container_id: str) -> None:
 
 
 async def spawn_replacement_workers(stale_ids: list[str]) -> None:
-    """Spawn one fresh replacement worker for each drained stale worker."""
+    """Spawn one fresh replacement worker for each drained stale worker.
+
+    The replacement carries the same repos and tools but gets a brand-new worker
+    ID and name — spawn_worker() mints a fresh ``w-…`` id and derives the display
+    name from it, so we deliberately omit ``name`` here rather than reuse the
+    drained worker's identity (its name embeds the now-dead worker id).
+    """
     if not stale_ids:
         return
 
@@ -121,7 +155,7 @@ async def spawn_replacement_workers(stale_ids: list[str]) -> None:
         try:
             inp = {
                 "repos": json.loads(worker.repos or "[]"),
-                "name": worker.name,
+                "tools": json.loads(worker.tools or "[]"),
             }
             async with AsyncSessionLocal() as db:
                 result_text, is_error = await _spawn_worker(
@@ -326,32 +360,73 @@ async def force_kill_worker_if_unresponsive(
     await _force_kill_containers({worker_id})
 
 
-async def reconcile_stale_workers(stale_ids: list[str]) -> None:
-    """Give drained workers a chance to reconnect on their own before replacing them.
+async def _guild_slugs_for_workers(worker_ids: set[str]) -> dict[str, str]:
+    """Map each worker id to its guild slug, for broadcasting shutdown messages."""
+    if not worker_ids:
+        return {}
+    async with AsyncSessionLocal() as db:
+        rows = (
+            await db.exec(
+                select(col(Worker.id), col(Guild.slug).label("guild_slug"))
+                .join(Guild, col(Guild.id) == col(Worker.guild_id))
+                .where(col(Worker.id).in_(worker_ids))
+            )
+        ).all()
+    return {wid: slug for wid, slug in rows}
 
-    Must be spawned as a background task *after* reset_connection_state() has
-    run.  Spawning a replacement immediately for every drained worker (the old
-    behaviour) overshoots the configured worker count on an ordinary restart:
-    the worker process's own reconnect loop brings it back within seconds —
-    it never saw the graceful-shutdown broadcast in the first place, since a
-    cold restart drops every WebSocket before that message can be sent — so
-    counting it as gone and spawning a full replacement leaves two workers
-    running under two different worker_ids. Waiting for the drain window and
-    checking who has already reconnected keeps replacement spawns limited to
-    workers that are actually still missing.
+
+async def reconcile_stale_workers(stale_ids: list[str]) -> None:
+    """Drain every stale worker and replace it with a fresh one.
+
+    Spawned as a background task *after* reset_connection_state() has run. On a
+    version bump every stale worker holds old code and must be cycled, so a
+    reconnect is never a reason to skip replacement — it is exactly what we wait
+    for so the soft-kill can be delivered. Replacing only after the old worker is
+    confirmed offline means there is never a moment with two live workers for the
+    same slot, which is the double-spawn the previous spare-on-reconnect logic was
+    guarding against.
+
+    Per worker, two phases (see module docstring):
+      • "reconnect" — wait up to WORKER_RECONNECT_GRACE for the worker to come
+        back online. reset_connection_state() just marked everyone offline, so
+        "offline" here means "not yet reconnected", not "drained". A worker that
+        never reconnects had its container die during the deploy; force-kill (best
+        effort) and replace it.
+      • "drain" — once online, (re)send the soft-kill and wait up to
+        WORKER_DRAIN_TIMEOUT for the worker to finish its task and go offline. If
+        it never does it is wedged; force-kill its container. Either way, replace
+        it once it is down.
     """
     if not stale_ids:
         return
 
-    # Poll every 5 s, dropping any worker that reconnects from the pending set.
     poll_interval = 5.0
-    elapsed = 0.0
+    guild_slugs = await _guild_slugs_for_workers(set(stale_ids))
+    loop = asyncio.get_event_loop()
+    # Per-worker phase and the monotonic time that phase began (for timeouts).
+    phase = {wid: "reconnect" for wid in stale_ids}
+    phase_started = {wid: loop.time() for wid in stale_ids}
     pending = set(stale_ids)
-    while pending and elapsed < WORKER_DRAIN_TIMEOUT:
-        await asyncio.sleep(min(poll_interval, WORKER_DRAIN_TIMEOUT - elapsed))
-        elapsed += poll_interval
+
+    async def _send_soft_kill(wid: str) -> None:
+        slug = guild_slugs.get(wid)
+        if not slug:
+            return
+        try:
+            await broadcast_msg(
+                slug,
+                WorkerShutdownMsg(workerId=wid, reason="backend restarted: version mismatch"),
+            )
+        except Exception:
+            logger.warning(
+                "worker_lifecycle: could not send soft-kill to worker %s", wid, exc_info=True
+            )
+
+    while pending:
+        await asyncio.sleep(poll_interval)
+        now = loop.time()
         async with AsyncSessionLocal() as db:
-            reconnected = set(
+            online = set(
                 (
                     await db.exec(
                         select(col(Worker.id)).where(
@@ -360,25 +435,46 @@ async def reconcile_stale_workers(stale_ids: list[str]) -> None:
                     )
                 ).all()
             )
-        if reconnected:
-            logger.info(
-                "worker_lifecycle: %d stale worker(s) reconnected on their own — "
-                "no replacement needed: %s",
-                len(reconnected),
-                sorted(reconnected),
+
+        drained: list[str] = []  # went offline after draining → replace
+        dead: list[str] = []  # never reconnected / wedged → force-kill + replace
+        to_signal: list[str] = []  # online & stale → (re)send soft-kill
+
+        for wid in list(pending):
+            if phase[wid] == "reconnect":
+                if wid in online:
+                    # Back online — begin draining and deliver the soft-kill.
+                    phase[wid] = "drain"
+                    phase_started[wid] = now
+                    to_signal.append(wid)
+                elif now - phase_started[wid] >= WORKER_RECONNECT_GRACE:
+                    dead.append(wid)  # container died during the deploy
+            else:  # draining
+                if wid not in online:
+                    drained.append(wid)  # ack: finished its task and exited
+                elif now - phase_started[wid] >= WORKER_DRAIN_TIMEOUT:
+                    dead.append(wid)  # wedged: force-kill below
+                else:
+                    to_signal.append(wid)  # still draining — re-send (idempotent)
+
+        for wid in to_signal:
+            await _send_soft_kill(wid)
+
+        if dead:
+            logger.warning(
+                "worker_lifecycle: %d stale worker(s) did not drain in time — "
+                "force-killing their containers: %s",
+                len(dead),
+                sorted(dead),
             )
-            pending -= reconnected
+            await _force_kill_containers(set(dead))
 
-    if not pending:
-        logger.info("worker_lifecycle: all stale workers reconnected within the drain window")
-        return
+        # Replace every worker now confirmed down (drained cleanly or force-killed).
+        for wid in (*drained, *dead):
+            await spawn_replacement_workers([wid])
+            logger.info(
+                "worker_lifecycle: stale worker %s cycled — replacement spawned", wid
+            )
+            pending.discard(wid)
 
-    logger.info(
-        "worker_lifecycle: %d stale worker(s) did not reconnect within %.0fs — "
-        "force-killing and spawning replacements: %s",
-        len(pending),
-        WORKER_DRAIN_TIMEOUT,
-        sorted(pending),
-    )
-    await _force_kill_containers(pending)
-    await spawn_replacement_workers(list(pending))
+    logger.info("worker_lifecycle: all stale workers drained and replaced")

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -472,9 +472,7 @@ async def reconcile_stale_workers(stale_ids: list[str]) -> None:
         # Replace every worker now confirmed down (drained cleanly or force-killed).
         for wid in (*drained, *dead):
             await spawn_replacement_workers([wid])
-            logger.info(
-                "worker_lifecycle: stale worker %s cycled — replacement spawned", wid
-            )
+            logger.info("worker_lifecycle: stale worker %s cycled — replacement spawned", wid)
             pending.discard(wid)
 
     logger.info("worker_lifecycle: all stale workers drained and replaced")

--- a/frontend/src/components/log-pane/WorkerActions.vue
+++ b/frontend/src/components/log-pane/WorkerActions.vue
@@ -246,10 +246,7 @@ async function handleShutdown() {
   shuttingDown.value = true
   actionError.value = ''
   try {
-    await agentsStore.messageWorker(
-      props.workerId,
-      'Please shut down cleanly: finish any in-flight work and exit the worker process.',
-    )
+    await agentsStore.shutdownWorker(props.workerId)
     _injectChat(`[Foreman] Sent shutdown signal to ${props.workerId} (operator-initiated).`)
   } catch (e: unknown) {
     actionError.value = e instanceof Error ? e.message : String(e)

--- a/frontend/src/stores/agents.ts
+++ b/frontend/src/stores/agents.ts
@@ -271,6 +271,13 @@ export const useAgentsStore = defineStore('agents', () => {
     })
   }
 
+  async function shutdownWorker(workerId: string) {
+    const guildId = _currentGuildId()
+    return api(`/guilds/${guildId}/workers/${workerId}/shutdown`, {
+      method: 'POST',
+    })
+  }
+
   function firstIdleWorker() {
     const workerAgents = agents.value.filter((a) => a.workerId && a.state !== 'offline')
     const pick =
@@ -384,6 +391,7 @@ export const useAgentsStore = defineStore('agents', () => {
     stopAgent,
     assignTask,
     messageWorker,
+    shutdownWorker,
     firstIdleWorker,
     workerDisplayName,
     clearAgents,


### PR DESCRIPTION
## Problem

Two related worker-lifecycle bugs, surfaced by a worker (`w-afe553`) sitting online with a `drain_requested_at` set but never actually being cycled:

1. **Version-mismatch drain never replaced anything.** On a cold restart the shutdown broadcast in `drain_stale_workers_on_startup` reached no connected worker, and `reconcile_stale_workers` then *spared* any worker that reconnected on its own. Stale workers kept running old code forever, got re-flagged on every restart, and were never replaced.

2. **The frontend shutdown button did nothing.** It posted an English sentence (`"Please shut down cleanly…"`) as a `worker-message`, which the worker either injected into a running agent's stdin or dropped (`"no claude running; dropping"`). It never called `_initiate_shutdown`, set `disabled`, or scheduled a force-kill.

## Changes

### Worker drain (`backend/worker_lifecycle.py`)
- **`reconcile_stale_workers` rewritten** to drain-then-replace, two-phase per worker. A reconnect is *expected* (backend restarts first) and is what we wait for so the soft-kill can be delivered — it's no longer a reason to skip replacement:
  - **Reconnect phase** — wait `WORKER_RECONNECT_GRACE` for the worker to come back online (`reset_connection_state` marks everyone offline at startup, so "offline" ≠ "drained"). Never reconnects → container died in the deploy → force-kill + replace.
  - **Drain phase** — once online, (re)send the soft-kill (`WorkerShutdownMsg` → the worker's `_initiate_shutdown`: idle agents stop, busy agents finish, process exits), wait `WORKER_DRAIN_TIMEOUT` for it to go offline. Wedged → force-kill.
  - Replacement spawns **only after the old worker is confirmed down**, so there's never a moment with two live workers for one slot (the double-spawn the old spare-on-reconnect logic was guarding against).
- **Replacements get a brand-new worker ID and name** (never the drained worker's identity, whose name embedded the dead id) and carry over `tools` as well as `repos`.
- **Timeouts:** `WORKER_DRAIN_TIMEOUT` 60s → **1800s (30 min)**, new `WORKER_RECONNECT_GRACE` (120s), `SHUTDOWN_FORCE_KILL_TIMEOUT` 600s → **1800s**.
- **Version strings** now embed the deterministic commit date, e.g. `20260709-1e1ae98`, so they're easy to date at a glance (committer date, never build/wall-clock time — versions are compared for exact equality).

### Shutdown button
- `backend/routes/workers.py`: new **`POST /guilds/{guild}/workers/{id}/shutdown`** mirroring the foreman `shutdown_worker` tool — broadcast `WorkerShutdownMsg`, set `disabled=True`, schedule the 30-min force-kill backstop.
- `frontend/src/stores/agents.ts`: new `shutdownWorker()`.
- `WorkerActions.vue`: button now calls `shutdownWorker()` instead of `messageWorker()`.

## Tests
- Rewrote the `reconcile_stale_workers` tests for the two-phase behavior (clean drain / never-reconnect / wedged); updated timeout-default and replacement (fresh identity + tools) assertions.
- Added two tests for the shutdown endpoint (signals + disables; 404 for unknown worker).
- **972 passed.** The only failures are 7 pre-existing `test_bedrock_enricher` tests that fail identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)