### PR TITLE
refactor: canonical Discord thread keyspace, retire phase='issue' root tasks

### DIFF
--- a/backend/alembic/versions/20260709_000001_fold_issue_root_threads_into_discord_threads.py
+++ b/backend/alembic/versions/20260709_000001_fold_issue_root_threads_into_discord_threads.py
@@ -1,0 +1,53 @@
+"""Fold issue-root Discord threads into discord_threads; drop tasks.discord_thread_id.
+
+Revision ID: 20260709_000001_fold_issue_root_threads_into_discord_threads
+Revises: 20260709_000000_add_github_issues_and_pull_requests
+Create Date: 2026-07-09
+
+The issue-rooted task tree (phase='issue' root tasks, #832) is retired:
+Discord threads are now keyed canonically by (issue_repo, issue_number) in
+``discord_threads`` (see discord_notifier._canonical_coords, #866). Copy each
+legacy root's thread into that table under its issue coordinates so in-flight
+issues keep routing to their existing thread, then drop the per-task column.
+
+Roots without issue linkage (created before create_task accepted
+issue_number/issue_repo and not yet backfilled by
+scripts/backfill_task_linkage.py) can't be migrated — their threads are
+orphaned and future notifications for those issues start a fresh thread. Run
+the backfill before deploying this migration to minimise that set.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260709_000001_fold_issue_root_threads_into_discord_threads"
+down_revision: str | Sequence[str] | None = "20260709_000000_add_github_issues_and_pull_requests"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO discord_threads (issue_repo, issue_number, thread_id, created_at)
+            SELECT issue_repo, issue_number, discord_thread_id, now()
+            FROM tasks
+            WHERE discord_thread_id IS NOT NULL
+              AND issue_repo IS NOT NULL
+              AND issue_number IS NOT NULL
+            ON CONFLICT (issue_repo, issue_number) DO NOTHING
+            """
+        )
+    )
+    op.drop_column("tasks", "discord_thread_id")
+
+
+def downgrade() -> None:
+    # The thread-id copies in discord_threads are left in place — they are
+    # valid rows under the old model too.
+    op.add_column("tasks", sa.Column("discord_thread_id", sa.Text(), nullable=True))

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -47,18 +47,17 @@ Phase 5 — new-member welcome DM
     ``DISCORD_WELCOME_DM_TEXT``. DM failures (e.g. DMs disabled) are logged at
     WARNING and never raised.
 
-Phase 6 — issue-rooted task tree thread routing
+Phase 6 — canonical thread keyspace (#866)
     Every thread-aware entry point (``notify_event``, ``notify_existing_thread``,
-    ``notify_foreman_chat``) accepts a *task_id* and, before anything else,
-    calls ``_resolve_root_thread_id`` to walk ``parent_task_id`` up to that
-    task's root (the phase='issue' task created via ``create_task``). When the
-    root has a ``discord_thread_id`` — set once, immediately, by
-    ``ensure_issue_root_thread`` when the root task is minted — the
-    notification posts there, so every plan/execute/review/followup task
-    parented to the same issue lands in one stable thread for the issue's
-    whole lifetime. Falls back to the legacy ``issue_repo``/``issue_number``
-    routing below when *task_id* has no root, or the root predates this
-    column and has no thread yet.
+    ``notify_foreman_chat``) resolves its subject to ONE canonical
+    ``(repo, number)`` key via ``_canonical_coords`` before touching
+    ``discord_threads``: the linked GitHub *issue* number when one can be
+    determined (task linkage columns, the branch name's ``-<N>-t-<id>``
+    suffix, or a ``Closes #N`` body reference in the ``github_pull_requests``
+    cache), the PR number otherwise. GitHub issues and PRs share a number
+    sequence per repo, so the key never collides across kinds — canonical
+    resolution exists to stop *fragmentation*, where a PR's events and its
+    linked issue's events used to land in two different threads.
 
 Phase 7 — CI check debounce/combine
     ``notify_ci_check`` buffers ``check_run``/``check_suite`` completions per
@@ -105,6 +104,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -410,128 +410,139 @@ async def _ensure_thread(
 
 
 # ---------------------------------------------------------------------------
-# Issue-rooted task tree: stable thread anchored to the phase='issue' root task
+# Canonical thread key: one work item -> one (repo, number) -> one thread
 # ---------------------------------------------------------------------------
 
-# Guards _resolve_root_thread_id against an (expected-impossible) cyclic
-# parent_task_id chain so a bad row can never spin the lookup forever.
-_MAX_PARENT_CHAIN_DEPTH = 20
+# A PR's linked issue, from the branch name's "-<N>-t-<id>" suffix (always
+# set by the system) or a "Closes #N"-style reference in the PR body.
+# routes/webhooks.py imports these for its own linkage bookkeeping.
+CLOSES_ISSUE_RE = re.compile(r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE)
+_BRANCH_ISSUE_RE = re.compile(r"-(\d+)-t-[a-z0-9]+$")
 
 
-async def _resolve_root_thread_id(task_id: str) -> str | None:
-    """Walk ``parent_task_id`` up from *task_id* to its root and return the root's thread.
+def linked_issue_number_from_body(body: str | None) -> int | None:
+    """Return the issue number a PR body closes ("Closes #N" etc.), or None."""
+    if not body:
+        return None
+    match = CLOSES_ISSUE_RE.search(body)
+    return int(match.group(1)) if match else None
 
-    The root is the top of the chain (``parent_task_id IS NULL``), normally the
-    phase='issue' task created via ``create_task``. Fetches the whole ancestor
-    chain (up to ``_MAX_PARENT_CHAIN_DEPTH`` levels) in a single recursive-CTE
-    query rather than one round-trip per level. Returns None when the chain
-    has no root with a ``discord_thread_id`` set — callers should fall back to
-    the legacy issue_repo/issue_number thread lookup (unrooted or
-    pre-migration tasks). Never raises.
+
+def linked_issue_number_from_branch(branch: str | None) -> int | None:
+    """Return the issue number encoded in a system branch name suffix, or None."""
+    if not branch:
+        return None
+    match = _BRANCH_ISSUE_RE.search(branch)
+    return int(match.group(1)) if match else None
+
+
+async def _canonical_coords(
+    repo: str | None,
+    number: int | None,
+    *,
+    kind: str = "issue",
+    task_id: str | None = None,
+) -> tuple[str, int] | None:
+    """Resolve the canonical ``(repo, number)`` thread key for a work item.
+
+    One work item gets one thread, keyed by the GitHub *issue* number when an
+    issue is linked and by the PR number otherwise. GitHub issues and PRs
+    share a single number sequence per repo, so the pair never collides
+    across kinds — the failure mode this prevents is *fragmentation*: the
+    same work item keyed once under its PR number and once under its issue
+    number (#866).
+
+    Resolution order:
+      1. the task's own issue linkage (``Task.issue_repo``/``issue_number``)
+      2. for PRs (``kind='pr'``): any task linked to the PR that knows its
+         issue, then the cached PR's branch-name suffix or ``Closes #N``
+         body reference (``github_pull_requests``, webhook-fed)
+      3. the subject ``(repo, number)`` as given
+
+    Never raises; returns None when no coordinates can be determined at all.
     """
+    pr_repo, pr_number = (repo, number) if kind == "pr" else (None, None)
     try:
-        from database import AsyncSessionLocal  # noqa: PLC0415
-        from models import Task  # noqa: PLC0415
-        from sqlalchemy import literal  # noqa: PLC0415
-        from sqlalchemy import select as sa_select  # noqa: PLC0415
+        from database import AsyncSessionLocal  # noqa: PLC0415 — lazy to avoid circular import
+        from models import GithubPullRequest, Task  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
 
         async with AsyncSessionLocal() as db:
-            anchor = sa_select(
-                Task.id.label("id"),
-                Task.parent_task_id.label("parent_task_id"),
-                Task.discord_thread_id.label("discord_thread_id"),
-                literal(0).label("depth"),
-            ).where(Task.id == task_id)
-            chain = anchor.cte(name="parent_chain", recursive=True)
-            parent = (
-                sa_select(
-                    Task.id.label("id"),
-                    Task.parent_task_id.label("parent_task_id"),
-                    Task.discord_thread_id.label("discord_thread_id"),
-                    (chain.c.depth + 1).label("depth"),
+            if task_id:
+                result = await db.exec(
+                    select(Task.issue_repo, Task.issue_number, Task.pr_repo, Task.pr_number).where(
+                        col(Task.id) == task_id
+                    )
                 )
-                .join(chain, Task.id == chain.c.parent_task_id)
-                .where(chain.c.depth < _MAX_PARENT_CHAIN_DEPTH - 1)
-            )
-            chain = chain.union_all(parent)
+                row = result.one_or_none()
+                if row:
+                    if row[0] and row[1] is not None:
+                        return row[0], row[1]
+                    if pr_repo is None and row[2] and row[3] is not None:
+                        pr_repo, pr_number = row[2], row[3]
 
-            result = await db.execute(
-                sa_select(chain.c.parent_task_id, chain.c.discord_thread_id).order_by(
-                    chain.c.depth.asc()
+            if pr_repo and pr_number is not None:
+                result = await db.exec(
+                    select(Task.issue_repo, Task.issue_number)
+                    .where(
+                        col(Task.pr_repo) == pr_repo,
+                        col(Task.pr_number) == pr_number,
+                        col(Task.issue_number).is_not(None),
+                    )
+                    .limit(1)
                 )
-            )
-            rows = result.all()
-            if not rows:
-                return None
-            for parent_id, thread_id in rows:
-                if parent_id is None:
-                    return thread_id
-            logger.warning(
-                "discord: parent_task_id chain exceeded depth=%d starting task=%s",
-                _MAX_PARENT_CHAIN_DEPTH,
-                task_id,
-            )
-            return None
+                linked = result.first()
+                if linked and linked[0]:
+                    return linked[0], linked[1]
+
+                result = await db.exec(
+                    select(GithubPullRequest.head_ref, GithubPullRequest.body).where(
+                        col(GithubPullRequest.repo) == pr_repo,
+                        col(GithubPullRequest.number) == pr_number,
+                    )
+                )
+                pr_row = result.one_or_none()
+                if pr_row:
+                    issue_num = linked_issue_number_from_branch(
+                        pr_row[0]
+                    ) or linked_issue_number_from_body(pr_row[1])
+                    if issue_num is not None:
+                        return pr_repo, issue_num
+                return pr_repo, pr_number
     except Exception:
-        logger.warning("discord: root-thread resolution failed task=%s", task_id, exc_info=True)
-        return None
+        logger.warning(
+            "discord: canonical coords resolution failed repo=%s number=%s task=%s",
+            repo,
+            number,
+            task_id,
+            exc_info=True,
+        )
+    return (repo, number) if repo and number is not None else None
 
 
-async def ensure_issue_root_thread(
-    task_id: str, thread_name: str, ps_guild_slug: str | None = None
-) -> str | None:
-    """Create and persist the stable Discord thread for a new issue-root task.
+async def _issue_thread_name(repo: str, number: int) -> str | None:
+    """Return "#N: <title>" from the github_issues cache, or None on a miss.
 
-    Called once, when a phase='issue' root task is minted (see
-    ``create_task`` in ``foreman/tools.py``) — not lazily on first child
-    post — so every task parented to *task_id* via ``parent_task_id``
-    resolves the same thread through ``_resolve_root_thread_id`` for the
-    rest of the issue's lifetime. Returns the new thread_id, or None when
-    Discord isn't configured or thread creation fails. Never raises.
-
-    ``create_task`` can be invoked through two independent paths — the REST
-    endpoint in ``routes/foreman.py`` and the ``create_task`` tool in
-    ``foreman/tools.py`` — that could race each other for the same task_id.
-    To avoid both creating a Discord thread and one silently losing the DB
-    write, this locks the task row (``SELECT ... FOR UPDATE``) and re-checks
-    ``discord_thread_id`` before creating anything: a racing caller blocks on
-    the lock until the winner commits, then observes the already-persisted
-    thread and returns it instead of creating a duplicate.
+    Used when a PR event resolves to its linked issue and has to create that
+    issue's thread — naming it after the issue rather than the transient PR
+    event title.
     """
-    if not _bot_token():
-        return None
-    channel = await _resolve_channel_for_guild(ps_guild_slug)
-    if not channel:
-        return None
-
     try:
         from database import AsyncSessionLocal  # noqa: PLC0415
-        from models import Task  # noqa: PLC0415
-        from sqlalchemy import update  # noqa: PLC0415
+        from models import GithubIssue  # noqa: PLC0415
         from sqlmodel import col, select  # noqa: PLC0415
 
         async with AsyncSessionLocal() as db:
             result = await db.exec(
-                select(Task.discord_thread_id).where(col(Task.id) == task_id).with_for_update()
+                select(GithubIssue.title).where(
+                    col(GithubIssue.repo) == repo, col(GithubIssue.number) == number
+                )
             )
-            existing = result.one_or_none()
-            if existing:
-                return existing
-
-            thread_id = await _create_thread_in_channel(channel, thread_name)
-            if not thread_id:
-                return None
-
-            await db.execute(
-                update(Task).where(col(Task.id) == task_id).values(discord_thread_id=thread_id)
-            )
-            await db.commit()
-            return thread_id
+            title = result.one_or_none()
+            return f"#{number}: {title}" if title else None
     except Exception:
         logger.warning(
-            "discord: ensure_issue_root_thread failed task=%s",
-            task_id,
-            exc_info=True,
+            "discord: issue thread name lookup failed %s#%s", repo, number, exc_info=True
         )
         return None
 
@@ -633,43 +644,6 @@ async def send_welcome_dm(discord_user_id: str, username: str | None = None) -> 
 # ---------------------------------------------------------------------------
 
 
-async def _lookup_task_issue_coords(task_id: str) -> tuple[str, int] | None:
-    """Return the ``(issue_repo, issue_number)`` linked to *task_id*, or None.
-
-    Used to route task-scoped Foreman chat into the same thread as that
-    task's PR/issue notifications (see ``_lookup_thread``), instead of the
-    daily guild thread. None when the task has no linked issue/PR, doesn't
-    exist, or the lookup fails.
-    """
-    try:
-        from database import AsyncSessionLocal  # noqa: PLC0415
-        from models import Task  # noqa: PLC0415
-        from sqlalchemy.exc import NoResultFound  # noqa: PLC0415
-        from sqlmodel import col, select  # noqa: PLC0415
-
-        try:
-            async with AsyncSessionLocal() as db:
-                result = await db.exec(
-                    select(Task.issue_repo, Task.issue_number).where(col(Task.id) == task_id)
-                )
-                row = result.one_or_none()
-                if row and row[0] and row[1] is not None:
-                    return row[0], row[1]
-                return None
-        except NoResultFound:
-            # Expected when the task has no linked issue/PR (or no thread) yet.
-            logger.debug("discord: no issue coords for task=%s", task_id)
-            return None
-    except Exception as exc:
-        logger.warning(
-            "discord: task issue-coords lookup failed task=%s error_type=%s: %s",
-            task_id,
-            type(exc).__name__,
-            exc,
-        )
-        return None
-
-
 # Discord's hard cap on a single message's content length.
 _MAX_MESSAGE_LENGTH = 2000
 
@@ -695,14 +669,11 @@ async def notify_foreman_chat(
 ) -> None:
     """Mirror a Foreman → user chat line into Discord.
 
-    When *task_id* is given, its issue-rooted task tree takes priority: if
-    walking ``parent_task_id`` up to the root task finds a
-    ``discord_thread_id``, the line posts there. Otherwise, when *task_id*
-    resolves (via ``discord_threads``) to a per-task thread already created
-    for that task's linked PR/issue, the line is posted there. In every other
-    case — no *task_id*, or a *task_id* with no root or linked thread yet —
-    the line is posted directly to the guild's main configured Discord
-    channel; there is no dated/daily fallback thread.
+    When *task_id* is given and its canonical issue/PR (see
+    ``_canonical_coords``) already has a thread in ``discord_threads``, the
+    line is posted there. In every other case — no *task_id*, or no linked
+    thread yet — the line is posted directly to the guild's main configured
+    Discord channel; there is no dated/daily fallback thread.
 
     The message is only ever posted to one destination. Silent no-op when
     the bot token or channel are not configured, or when *content* is
@@ -718,15 +689,9 @@ async def notify_foreman_chat(
         return
 
     if task_id:
-        root_thread_id = await _resolve_root_thread_id(task_id)
-        if root_thread_id:
-            await _post_foreman_chat_line(root_thread_id, content)
-            return
-
-        coords = await _lookup_task_issue_coords(task_id)
+        coords = await _canonical_coords(None, None, task_id=task_id)
         if coords:
-            issue_repo, issue_number = coords
-            task_thread_id = await _lookup_thread(issue_repo, issue_number)
+            task_thread_id = await _lookup_thread(coords[0], coords[1])
             if task_thread_id:
                 await _post_foreman_chat_line(task_thread_id, content)
                 return
@@ -784,41 +749,24 @@ async def notify_event(
     color: int | None = None,
     issue_repo: str | None = None,
     issue_number: int | None = None,
+    kind: str = "issue",
     thread_name: str | None = None,
     header_fields: dict[str, str] | None = None,
     close: bool = False,
     ps_guild_slug: str | None = None,
-    linked_issue_repo: str | None = None,
-    linked_issue_number: int | None = None,
     task_id: str | None = None,
     flags: int | None = None,
 ) -> None:
-    """Post a Discord notification, routing to a per-PR/issue thread when possible.
+    """Post a Discord notification, routing to the work item's one thread.
 
-    Thread routing is attempted when ``DISCORD_BOT_TOKEN`` is set **and** both
-    ``issue_repo`` and ``issue_number`` are provided.  The thread is lazily
-    created on first use and its ID cached in the ``discord_threads`` table.
-
-    When *task_id* is given, resolving its issue-rooted task tree takes
-    priority over everything else: ``_resolve_root_thread_id`` walks
-    ``parent_task_id`` up to the phase='issue' root task and, if that root has
-    a ``discord_thread_id``, posts there directly (*close* is ignored — the
-    root thread outlives any single child task). Falls back to the behaviour
-    below when *task_id* has no root, or its root has no thread yet (legacy
-    tasks predating the issue-rooted tree).
-
-    When *linked_issue_repo*/*linked_issue_number* are given (a PR's linked
-    GitHub issue, e.g. via ``Closes #N`` or the task's ``issue_number``) and
-    that issue already has a Discord thread on record, the message is posted
-    there instead — no new PR-numbered thread is created, and *close* is
-    ignored (the issue's thread outlives any single PR closing/merging into
-    it). Falls back to the ``issue_repo``/``issue_number`` (PR-keyed) behaviour
-    below when the linked issue has no thread yet.
-
-    When *linked_issue_repo*/*linked_issue_number* are omitted but *task_id*
-    is given, the linked issue is resolved from ``Task.issue_repo``/
-    ``Task.issue_number`` (same lookup ``notify_foreman_chat`` uses) — a
-    convenience for callers that only have a task_id on hand.
+    ``issue_repo``/``issue_number`` are the event subject's coordinates —
+    pass ``kind="pr"`` when that number is a PR number. The destination is
+    the *canonical* thread key resolved by ``_canonical_coords``: the linked
+    GitHub issue when one can be determined (task linkage, branch suffix, or
+    ``Closes #N``), the PR itself otherwise. The thread is lazily created on
+    first use and its ID cached in the ``discord_threads`` table; when a PR
+    event has to create its linked issue's thread, the thread is named after
+    the issue (``github_issues`` cache) rather than this event's title.
 
     When *ps_guild_slug* is provided, the destination channel is resolved via
     the ``discord_channel_guilds`` binding table (populated by
@@ -826,7 +774,8 @@ async def notify_event(
     env var.
 
     When ``close=True`` the thread is archived after the message is posted
-    (used for PR merge/close events).
+    (used for PR merge/close events) — unless the message landed in a linked
+    issue's thread, which outlives any single PR closing/merging into it.
 
     *flags* is the raw Discord message-flags bitmask (see ``_SILENT_FLAG``),
     passed straight through to whichever destination the message ends up at
@@ -837,59 +786,31 @@ async def notify_event(
     operations fail. Silent no-op when the bot token is not configured.
     Never raises.
     """
-    if _bot_token() and task_id:
-        root_thread_id = await _resolve_root_thread_id(task_id)
-        if root_thread_id:
-            await _post_to_thread(
-                root_thread_id,
-                event_type,
-                title,
-                description,
-                url=url,
-                color=color,
-                fields=header_fields,
-                flags=flags,
-            )
-            return
-
-    if _bot_token() and not (linked_issue_repo and linked_issue_number is not None) and task_id:
-        coords = await _lookup_task_issue_coords(task_id)
+    if _bot_token():
+        coords = await _canonical_coords(issue_repo, issue_number, kind=kind, task_id=task_id)
         if coords:
-            linked_issue_repo, linked_issue_number = coords
-
-    if _bot_token() and linked_issue_repo and linked_issue_number is not None:
-        linked_thread_id = await _lookup_thread(linked_issue_repo, linked_issue_number)
-        if linked_thread_id:
-            await _post_to_thread(
-                linked_thread_id,
-                event_type,
-                title,
-                description,
-                url=url,
-                color=color,
-                fields=header_fields,
-                flags=flags,
-            )
-            return
-
-    if _bot_token() and issue_repo and issue_number is not None:
-        tn = thread_name or f"#{issue_number}: {title}"
-        channel = await _resolve_channel_for_guild(ps_guild_slug)
-        thread_id = await _ensure_thread(issue_repo, issue_number, tn, channel=channel)
-        if thread_id:
-            await _post_to_thread(
-                thread_id,
-                event_type,
-                title,
-                description,
-                url=url,
-                color=color,
-                fields=header_fields,
-                flags=flags,
-            )
-            if close:
-                await archive_thread(thread_id)
-            return
+            repo, number = coords
+            resolved_to_issue = kind == "pr" and (repo, number) != (issue_repo, issue_number)
+            if resolved_to_issue:
+                tn = await _issue_thread_name(repo, number) or f"#{number}"
+            else:
+                tn = thread_name or f"#{number}: {title}"
+            channel = await _resolve_channel_for_guild(ps_guild_slug)
+            thread_id = await _ensure_thread(repo, number, tn, channel=channel)
+            if thread_id:
+                await _post_to_thread(
+                    thread_id,
+                    event_type,
+                    title,
+                    description,
+                    url=url,
+                    color=color,
+                    fields=header_fields,
+                    flags=flags,
+                )
+                if close and not resolved_to_issue:
+                    await archive_thread(thread_id)
+                return
 
     # Fallback: flat embed to the resolved channel
     await notify(
@@ -909,11 +830,12 @@ async def notify_existing_thread(
     description: str,
     issue_repo: str | None = None,
     issue_number: int | None = None,
+    kind: str = "issue",
     url: str | None = None,
     color: int | None = None,
     task_id: str | None = None,
 ) -> None:
-    """Post to an issue/PR's Discord thread only if one already exists.
+    """Post to a work item's Discord thread only if one already exists.
 
     This is deliberately **not** a thin wrapper around ``notify_event``:
     ``notify_event`` always creates a thread when none exists yet, naming it
@@ -927,35 +849,26 @@ async def notify_existing_thread(
     would then be scattered across that wrong thread.
 
     ``notify_existing_thread`` avoids that by only ever looking up the thread
-    persisted in ``discord_threads``; when there isn't one, it falls back to a
-    flat embed on the configured channel instead of creating anything. Silent
+    persisted in ``discord_threads`` — under the same canonical key
+    ``notify_event`` posts to (see ``_canonical_coords``) — and falling back
+    to a flat embed on the configured channel when there isn't one. Silent
     no-op / never raises, same guarantees as ``notify_event``.
-
-    When *task_id* is given, its issue-rooted task tree takes priority: if
-    walking ``parent_task_id`` up to the root task finds a
-    ``discord_thread_id``, the message posts there and nothing else runs.
-    Falls back to the ``issue_repo``/``issue_number`` lookup (and its flat-
-    channel fallback) exactly as before when there's no root or the root has
-    no thread yet.
     """
-    if _bot_token() and task_id:
-        root_thread_id = await _resolve_root_thread_id(task_id)
-        if root_thread_id:
-            await _post_to_thread(
-                root_thread_id, event_type, title, description, url=url, color=color
+    if _bot_token():
+        coords = await _canonical_coords(issue_repo, issue_number, kind=kind, task_id=task_id)
+        if coords:
+            thread_id = await _lookup_thread(coords[0], coords[1])
+            if thread_id:
+                await _post_to_thread(
+                    thread_id, event_type, title, description, url=url, color=color
+                )
+                return
+            logger.debug(
+                "notify_existing_thread: no thread on record for %s#%s, "
+                "falling back to flat channel",
+                coords[0],
+                coords[1],
             )
-            return
-
-    if _bot_token() and issue_repo and issue_number is not None:
-        thread_id = await _lookup_thread(issue_repo, issue_number)
-        if thread_id:
-            await _post_to_thread(thread_id, event_type, title, description, url=url, color=color)
-            return
-        logger.debug(
-            "notify_existing_thread: no thread on record for %s#%s, falling back to flat channel",
-            issue_repo,
-            issue_number,
-        )
     elif not is_configured():
         logger.debug(
             "notify_existing_thread: Discord not configured, skipping event=%s",
@@ -1401,8 +1314,6 @@ async def notify_ci_check(
     issue_repo: str | None = None,
     issue_number: int | None = None,
     ps_guild_slug: str | None = None,
-    linked_issue_repo: str | None = None,
-    linked_issue_number: int | None = None,
     task_id: str | None = None,
 ) -> None:
     """Buffer one CI check completion for *pr_label* and (re)arm a debounced flush.
@@ -1442,9 +1353,8 @@ async def notify_ci_check(
                 "url": url,
                 "issue_repo": issue_repo,
                 "issue_number": issue_number,
+                "kind": "pr",
                 "ps_guild_slug": ps_guild_slug,
-                "linked_issue_repo": linked_issue_repo,
-                "linked_issue_number": linked_issue_number,
                 "task_id": task_id,
             }
         )

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -143,11 +143,9 @@ this one issue — the same steps as "Periodic devReady issue pickup" below:
 2. Skip if any existing non-terminal task already references this issue number (check the
    current `<state>` task list).
 3. Call claim_github_issue to assign it.
-4. Call create_task(phase='issue', name="...", description="...", issue_number=N,
-   issue_repo="owner/repo") to create the issue-root anchor task — skip this step if a
-   phase='issue' task for this issue number already exists.
-5. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number,
-   issue_repo on both calls, and parent_task_id=<issue-root task_id from step 4>.
+4. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number
+   and issue_repo on both calls — the linkage groups the task under its issue in the
+   sidebar and routes notifications into the issue's Discord thread.
 The periodic sweep's own dedup checks (steps 1-2) make it safe if both the webhook and a
 same-cycle poll fire for the same issue — whichever runs first wins, the other no-ops.
 
@@ -213,17 +211,9 @@ On every [periodic-check] event:
 2. For each returned issue that has no assignee:
    a. Skip it if any existing non-terminal task already references this issue number (check the current <state> task list).
    b. Call claim_github_issue to assign it.
-   c. Call create_task(phase='issue', name="...", description="...", issue_number=N,
-      issue_repo="owner/repo") FIRST, before any plan/execute
-      task — this creates the issue-root task, the sidebar anchor for all work on this issue. It is
-      never assigned to a worker and carries no branch or PR; create exactly one per issue. Skip
-      this step if a phase='issue' task for this issue number already exists in the current
-      <state> task list (e.g. from a retry after step c succeeded but before step d completed) —
-      reuse that existing task_id as the parent in step d instead of creating a duplicate root.
-   d. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number and
-      issue_repo so the worker's PR references the issue automatically, and
-      parent_task_id=<issue-root task_id from step c> so the plan/execute task nests under the
-      issue root in the hierarchy.
+   c. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number and
+      issue_repo on both calls so the worker's PR references the issue automatically and the
+      task groups under its issue in the sidebar.
 3. The label check must cover (case-insensitive): devReady, dev-ready, ready-for-dev, ready.
 4. Never pick up an issue that is already assigned to someone else.
 

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -545,29 +545,25 @@ async def _fetch_pr_status_lines(guild_id: str, pr_tasks: list[dict]) -> list[st
     return lines
 
 
-async def _sweep_closed_issue_tasks(guild_id: str, issue_tasks: list[dict]) -> None:
-    """Finalize ``phase='issue'`` root tasks whose linked GitHub issue has closed.
+async def _sweep_closed_issues(guild_id: str, linked_issues: set[tuple[str, int]]) -> None:
+    """Sweep tasks whose linked GitHub issue has closed.
 
-    Called on every periodic-check cycle alongside the PR-status refresh above, for
-    every non-terminal ``phase='issue'`` root task that has both ``issue_repo`` and
-    ``issue_number`` set (backed by the ``ix_tasks_issue_repo_issue_number`` index
-    added in #836). This is a safety net for the ``issues`` webhook handler in
-    ``routes.webhooks`` — it catches issues closed before that handler existed, or
-    where a webhook delivery was missed — so it acts directly (no foreman/LLM
-    round-trip needed) rather than merely nudging the foreman like the PR-status
-    block does. Child tasks (plan/execute/review/followup) are never auto-closed;
-    a warning is logged if any remain non-terminal. Best effort: an individual
-    GitHub fetch failure is logged and skipped rather than aborting the sweep.
+    Called on every periodic-check cycle alongside the PR-status refresh above,
+    for every distinct ``(issue_repo, issue_number)`` linked by a non-terminal
+    task (backed by the ``ix_tasks_issue_repo_issue_number`` index). This is a
+    safety net for the ``issues`` webhook handler in ``routes.webhooks`` — it
+    catches issues closed while a webhook delivery was missed — so it acts
+    directly via ``finalize_closed_issue`` (no foreman/LLM round-trip needed)
+    rather than merely nudging the foreman like the PR-status block does.
+    Non-terminal linked tasks are never auto-closed; only legacy phase='issue'
+    rows are finalized and already-terminal tasks swept. Best effort: an
+    individual GitHub fetch failure is logged and skipped rather than aborting
+    the sweep.
     """
-    if not issue_tasks:
+    if not linked_issues:
         return
 
-    from foreman.tools import (
-        _guild_github_token,
-        fetch_issue_state,
-        finalize_issue_root_task,
-        warn_if_issue_task_has_open_children,
-    )
+    from foreman.tools import _guild_github_token, fetch_issue_state, finalize_closed_issue
 
     creds = await _guild_github_token(guild_id)
     if not creds:
@@ -577,15 +573,13 @@ async def _sweep_closed_issue_tasks(guild_id: str, issue_tasks: list[dict]) -> N
     db = await get_db()
     try:
         guild_pk_val = await get_guild_pk(db, guild_id)
-        for t in issue_tasks:
-            repo, number = t["issue_repo"], t["issue_number"]
+        for repo, number in sorted(linked_issues):
             try:
                 state = await fetch_issue_state(repo, number, token)
             except Exception:
                 logger.warning(
-                    "guild=%s task=%s failed to fetch issue status for %s#%s",
+                    "guild=%s failed to fetch issue status for %s#%s",
                     guild_id,
-                    t["id"],
                     repo,
                     number,
                     exc_info=True,
@@ -595,16 +589,15 @@ async def _sweep_closed_issue_tasks(guild_id: str, issue_tasks: list[dict]) -> N
             if state != "closed":
                 continue
 
-            finalized = await finalize_issue_root_task(db, guild_pk_val, guild_id, t["id"])
+            finalized = await finalize_closed_issue(db, guild_pk_val, guild_id, repo, number)
             if finalized:
                 logger.info(
-                    "guild=%s task=%s finalized (issue %s#%s closed)",
+                    "guild=%s finalized %d task(s) for closed issue %s#%s",
                     guild_id,
-                    t["id"],
+                    len(finalized),
                     repo,
                     number,
                 )
-                await warn_if_issue_task_has_open_children(db, guild_id, t["id"])
     finally:
         await db.close()
 
@@ -682,12 +675,12 @@ async def _poll_loop(guild_id: str) -> None:
                 pr_tasks = [t for t in active_tasks if t.get("pr_url")]
                 pr_status_lines = await _fetch_pr_status_lines(guild_id, pr_tasks)
 
-                issue_tasks = [
-                    t
+                linked_issues = {
+                    (t["issue_repo"], t["issue_number"])
                     for t in active_tasks
-                    if t.get("phase") == "issue" and t.get("issue_repo") and t.get("issue_number")
-                ]
-                await _sweep_closed_issue_tasks(guild_id, issue_tasks)
+                    if t.get("issue_repo") and t.get("issue_number")
+                }
+                await _sweep_closed_issues(guild_id, linked_issues)
 
                 msg = (
                     f"[periodic-check] Automated status poll — {n} non-terminal "

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -41,7 +41,6 @@ from models import (
     TaskEvent,
     TaskLog,
     Worker,
-    live_tasks_filter,
 )
 from sqlalchemy import delete, literal, update
 from sqlmodel import col, select
@@ -163,76 +162,70 @@ def _resolve_finalize_deleted_at(inp: dict) -> tuple[datetime | None, str | None
     return datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS), None
 
 
-async def finalize_issue_root_task(db, guild_pk: int, guild_id: str, task_id: str) -> bool:
-    """Directly finalize a ``phase='issue'`` root task once its GitHub issue closes.
+async def finalize_closed_issue(
+    db, guild_pk: int, guild_id: str, issue_repo: str, issue_number: int
+) -> list[str]:
+    """Clean up tasks linked to a GitHub issue that just closed.
 
-    Shared by the periodic closed-issue sweep (``foreman.runner._sweep_closed_issue_tasks``)
-    and the ``issues`` webhook handler (``routes.webhooks.github_webhook``) so both paths
-    apply the same terminal-state guard and broadcast behaviour. Uses a single conditional
-    ``UPDATE ... RETURNING`` (rather than SELECT-then-UPDATE) so ``worker_id`` is only ever
-    read off the winning update row — a separate prior SELECT would reopen the same TOCTOU
-    race with a concurrent finalize/follow-up on this task. Cascades ``deleted_at`` to any
-    already-terminal descendant tasks and posts a pre-close verification comment
-    summarising child-PR merge status — see ``cascade_soft_delete_terminal_descendants``
-    and ``post_issue_close_summary_comment``. Returns True if finalization occurred.
+    Shared by the periodic closed-issue sweep (``foreman.runner._sweep_closed_issues``)
+    and the ``issues`` webhook handler (``routes.webhooks.github_webhook``). Legacy
+    ``phase='issue'`` root rows are finalized outright — a single conditional
+    ``UPDATE ... RETURNING`` keeps the terminal-state guard TOCTOU-safe against a
+    concurrent finalize. Every already-terminal task linked to the issue gets its
+    soft-delete stamped; non-terminal linked tasks are never force-closed (a human
+    decides whether to cancel in-flight work) and only logged. Posts one pre-close
+    verification comment summarising linked-PR merge status when anything was
+    finalized. Returns the ids of the tasks that were finalized or swept.
     """
     deleted_at = datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS)
+    issue_filter = (
+        col(Task.guild_id) == guild_pk,
+        col(Task.issue_repo) == issue_repo,
+        col(Task.issue_number) == issue_number,
+    )
+
+    # Legacy phase='issue' roots: synthetic rows owned by the issue itself.
     upd = await db.exec(
         update(Task)
         .where(
-            col(Task.id) == task_id,
-            col(Task.guild_id) == guild_pk,
-            ~col(Task.state).in_(list(_TERMINAL_STATES)),
+            *issue_filter, col(Task.phase) == "issue", ~col(Task.state).in_(list(_TERMINAL_STATES))
         )
         .values(state="done", deleted_at=deleted_at)
-        .returning(col(Task.worker_id), col(Task.issue_repo), col(Task.issue_number))
+        .returning(col(Task.id), col(Task.worker_id))
     )
-    row = upd.one_or_none()
-    if row is None:
-        return False
-    worker_id, issue_repo, issue_number = row
+    roots = list(upd.all())
+    for root_id, _ in roots:
+        await LockService(db).release(f"task:{root_id}")
+        await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == root_id))
 
-    descendants = await find_descendant_tasks(db, task_id)
-    await cascade_soft_delete_terminal_descendants(db, descendants, deleted_at)
-
-    await LockService(db).release(f"task:{task_id}")
-    await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
+    linked_result = await db.exec(select(Task).where(*issue_filter))
+    linked = list(linked_result.all())
+    swept_ids = await cascade_soft_delete_terminal_descendants(db, linked, deleted_at)
     await db.commit()
 
-    await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=task_id))
-    await broadcast_msg(
-        guild_id,
-        TaskUpdateMsg(taskId=task_id, state="done", deletedAt=deleted_at.isoformat()),
-    )
-
-    if issue_repo and issue_number is not None:
-        await post_issue_close_summary_comment(guild_id, issue_repo, issue_number, descendants)
-    return True
-
-
-async def warn_if_issue_task_has_open_children(db, guild_id: str, root_task_id: str) -> None:
-    """Log a warning if an issue-root task still has non-terminal child tasks.
-
-    Child tasks (plan/execute/review/followup) are never auto-closed when the parent
-    GitHub issue closes — a human should decide whether to cancel in-flight work.
-    """
-    result = await db.exec(
-        select(col(Task.id)).where(
-            col(Task.parent_task_id) == root_task_id,
-            ~col(Task.state).in_(list(_TERMINAL_STATES)),
-            live_tasks_filter(),
+    for root_id, worker_id in roots:
+        await broadcast_msg(guild_id, TaskFinalizeMsg(workerId=worker_id, taskId=root_id))
+        await broadcast_msg(
+            guild_id,
+            TaskUpdateMsg(taskId=root_id, state="done", deletedAt=deleted_at.isoformat()),
         )
-    )
-    open_children = [row[0] for row in result.all()]
-    if open_children:
+
+    open_tasks = [t.id for t in linked if t.state not in _TERMINAL_STATES and t.phase != "issue"]
+    if open_tasks:
         logger.warning(
-            "guild=%s task=%s issue closed but %d non-terminal child task(s) remain "
+            "guild=%s issue %s#%s closed but %d non-terminal linked task(s) remain "
             "open: %s — leaving them as-is",
             guild_id,
-            root_task_id,
-            len(open_children),
-            ", ".join(open_children),
+            issue_repo,
+            issue_number,
+            len(open_tasks),
+            ", ".join(open_tasks),
         )
+
+    finalized = [root_id for root_id, _ in roots] + swept_ids
+    if finalized:
+        await post_issue_close_summary_comment(guild_id, issue_repo, issue_number, linked)
+    return finalized
 
 
 # Guards find_descendant_tasks against an (expected-impossible) cyclic
@@ -274,7 +267,7 @@ async def cascade_soft_delete_terminal_descendants(
     Only tasks already in a terminal state (done/failed/cancelled/error — see
     ``_TERMINAL_STATES``) and not yet soft-deleted are touched. In-progress or
     pending descendants are never force-closed here; a human decides whether to
-    cancel in-flight work (see ``warn_if_issue_task_has_open_children``). Returns
+    cancel in-flight work — ``finalize_closed_issue`` logs them instead). Returns
     the ids that were updated.
     """
     terminal_ids = [
@@ -489,7 +482,7 @@ async def _guild_github_token(guild_id: str) -> tuple[str, str] | None:
 async def fetch_issue_state(repo: str, issue_number: int, token: str) -> str:
     """Return the current lifecycle state (``"open"`` or ``"closed"``) of a GitHub issue.
 
-    Used by the periodic closed-issue sweep (foreman.runner._sweep_closed_issue_tasks)
+    Used by the periodic closed-issue sweep (foreman.runner._sweep_closed_issues)
     to detect issues closed outside the webhook path (e.g. a missed delivery).
     """
     issue = await _to_thread(_gh_api, f"/repos/{repo}/issues/{issue_number}", token)
@@ -695,18 +688,17 @@ async def notify_discord_task_assigned(
     """Notify Discord that a task was assigned, routing to the right thread.
 
     When *issue_repo*/*issue_number* are given, resolves (or creates) the
-    issue's legacy per-issue Discord thread as soon as a task is assigned —
-    this is what moves thread creation earlier in the lifecycle; previously
-    the first per-issue Discord thread only appeared when a PR was opened.
-    This whole coroutine (including the GitHub title lookup) only ever runs
-    via ``spawn``, which schedules it with ``asyncio.create_task`` and never
-    awaits it in the caller's context — so a slow GitHub API call delays this
-    background task, not the tool call that triggered it.
+    issue's Discord thread as soon as a task is assigned — this is what moves
+    thread creation earlier in the lifecycle; previously the first per-issue
+    Discord thread only appeared when a PR was opened. This whole coroutine
+    (including the GitHub title lookup) only ever runs via ``spawn``, which
+    schedules it with ``asyncio.create_task`` and never awaits it in the
+    caller's context — so a slow GitHub API call delays this background task,
+    not the tool call that triggered it.
 
-    When they're omitted — a child task of an issue-rooted tree, linked to
-    its root only via ``parent_task_id`` — the GitHub title lookup is
-    skipped and ``notify_event``'s task_id-based root-thread resolution finds
-    the destination instead (see ``_resolve_root_thread_id``).
+    When they're omitted, the GitHub title lookup is skipped and
+    ``notify_event`` resolves the destination from the task's own linkage
+    (see ``discord_notifier._canonical_coords``).
 
     Skips entirely when Discord notifications aren't configured.
     """
@@ -777,7 +769,9 @@ async def notify_discord_followup(
 
     Uses ``notify_existing_thread`` rather than ``notify_event``: the thread
     should already exist from ``assign_task``, so a missing thread here
-    falls back to the flat channel instead of spawning a new one.
+    falls back to the flat channel instead of spawning a new one. *task_id*
+    lets the notifier resolve the canonical thread even when the task has no
+    issue linkage (PR-only work).
     """
     if not discord_notifier.is_configured():
         return
@@ -787,6 +781,7 @@ async def notify_discord_followup(
         description=f"Follow-up dispatched for task `{task_id}`: {instructions[:500]}",
         issue_repo=issue_repo,
         issue_number=issue_number,
+        task_id=task_id,
     )
 
 
@@ -808,6 +803,7 @@ async def notify_discord_redirect(
         description=f"Redirect sent for task `{task_id}`: {instructions[:500]}",
         issue_repo=issue_repo,
         issue_number=issue_number,
+        task_id=task_id,
     )
 
 
@@ -1365,16 +1361,6 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 result_text = (
                     f"Task {task_id} created: '{name}'. Reference this task_id in assign_task."
                 )
-                if phase == "issue" and discord_notifier.is_configured():
-                    # Create the issue's stable Discord thread now, at root-task
-                    # mint time, rather than lazily on the first child post — see
-                    # discord_notifier.ensure_issue_root_thread.
-                    spawn(
-                        discord_notifier.ensure_issue_root_thread(
-                            task_id, name, ps_guild_slug=guild_id
-                        ),
-                        name=f"discord.issue-root-thread:{task_id}",
-                    )
 
             elif tu.name == "assign_task":
                 wid = inp["worker_id"]
@@ -1867,16 +1853,15 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         issueRepo=task_issue_repo,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )
-                                if task_issue_number is not None and task_issue_repo:
-                                    spawn(
-                                        notify_discord_followup(
-                                            task_issue_repo,
-                                            task_issue_number,
-                                            task_id,
-                                            instructions,
-                                        ),
-                                        name=f"discord.followup:{task_id}",
-                                    )
+                                spawn(
+                                    notify_discord_followup(
+                                        task_issue_repo,
+                                        task_issue_number,
+                                        task_id,
+                                        instructions,
+                                    ),
+                                    name=f"discord.followup:{task_id}",
+                                )
                                 if target_worker_id != original_worker_id and original_worker_id:
                                     result_text = (
                                         f"Follow-up reassigned from {original_worker_id} "

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -27,20 +27,16 @@ FOREMAN_TOOLS = [
                 },
                 "phase": {
                     "type": "string",
-                    "enum": ["issue", "plan", "execute", "review"],
-                    "description": (
-                        "Starting phase. Default: execute. Use 'issue' for the root task "
-                        "of an issue-rooted task tree — never assigned to a worker; has no "
-                        "branch or PR — created once per GitHub issue, with plan/execute "
-                        "tasks pointing at it via parent_task_id."
-                    ),
+                    "enum": ["plan", "execute", "review"],
+                    "description": "Starting phase. Default: execute.",
                 },
                 "issue_number": {
                     "type": "integer",
                     "description": (
                         "GitHub issue this task belongs to. ALWAYS set this (with "
-                        "issue_repo) when the work relates to an issue — required for "
-                        "phase='issue' — so the task groups under the issue in the sidebar."
+                        "issue_repo) when the work relates to an issue — it groups the "
+                        "task under the issue in the sidebar and routes its Discord "
+                        "notifications into the issue's thread."
                     ),
                 },
                 "issue_repo": {

--- a/backend/models.py
+++ b/backend/models.py
@@ -220,12 +220,6 @@ class Task(SQLModel, table=True):
     # "powerful". Derived from phase+tool at assign_task time. NULL on legacy
     # tasks created before this column existed.
     model_tier: str | None = None
-    # Discord thread ID for this task's issue-rooted task tree, set only on the
-    # phase="issue" root task at creation time. Child tasks (plan/execute/review/
-    # followup) resolve their Discord thread by walking parent_task_id up to this
-    # root rather than carrying their own thread ID. NULL on every non-root task
-    # and on roots created before Discord routing was configured.
-    discord_thread_id: str | None = None
 
 
 class GithubToken(SQLModel, table=True):

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -508,8 +508,6 @@ async def _cmd_review(interaction_token: str, guild_slug: str, pr_url: str) -> N
                 tool="claude",
                 state="pending",
                 phase="review",
-                issue_repo=pr_repo,
-                issue_number=pr_number,
                 pr_url=pr_url,
                 pr_number=pr_number,
                 pr_repo=pr_repo,

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -32,7 +32,6 @@ import string
 from datetime import UTC, datetime
 from typing import Literal
 
-import discord_notifier
 from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
 from database import get_db_dep
 from events import broadcast_msg
@@ -51,7 +50,6 @@ from pydantic import BaseModel
 from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
-from util.tasks import spawn
 from ws_types import ChatMsg, TaskCreatedMsg, TaskUpdateMsg
 
 router = APIRouter()
@@ -458,15 +456,6 @@ async def create_foreman_task(
             createdAt=created_at.isoformat(),
         ),
     )
-
-    if body.phase == "issue" and discord_notifier.is_configured():
-        # Create the issue's stable Discord thread now, at root-task mint
-        # time, rather than lazily on the first child post — see
-        # discord_notifier.ensure_issue_root_thread.
-        spawn(
-            discord_notifier.ensure_issue_root_thread(task_id, name, ps_guild_slug=guild_id),
-            name=f"discord.issue-root-thread:{task_id}",
-        )
 
     return {"task_id": task_id, "created_at": created_at}
 

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -20,7 +20,6 @@ import hmac
 import json
 import logging
 import os
-import re
 from datetime import UTC, datetime, timedelta
 
 import discord_notifier
@@ -416,37 +415,6 @@ def _verify_signature(secret: str, body: bytes, signature_header: str | None) ->
     return hmac.compare_digest(expected, provided)
 
 
-# Matches "Closes #123", "Fixes #123", "Resolves #123" (and closed/fixed/
-# resolved variants) in a PR body — GitHub's own auto-close syntax. Used to
-# find the issue a PR is linked to when the task record has no issue_number
-# set (mirrors the same pattern used for task-tree grouping in routes/tasks.py).
-_CLOSES_ISSUE_RE = re.compile(r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE)
-
-
-def _linked_issue_number_from_body(body: str | None) -> int | None:
-    """Return the issue number referenced by a "Closes #N"-style line in *body*."""
-    if not body:
-        return None
-    match = _CLOSES_ISSUE_RE.search(body)
-    return int(match.group(1)) if match else None
-
-
-# Matches the issue number embedded in a task branch name, e.g.
-# "claude/discord-associate-pr-threads-773-t-0jlq" -> 773. The branch is
-# always set by the system when a task is created (unlike a "Closes #N" line,
-# which depends on the PR author remembering to write one), so this is
-# preferred over _linked_issue_number_from_body when both are available.
-_BRANCH_ISSUE_RE = re.compile(r"-(\d+)-t-[a-z0-9]+$")
-
-
-def _linked_issue_number_from_branch(branch: str | None) -> int | None:
-    """Return the issue number embedded in *branch*'s "-<N>-t-<id>" suffix."""
-    if not branch:
-        return None
-    match = _BRANCH_ISSUE_RE.search(branch)
-    return int(match.group(1)) if match else None
-
-
 def _extract_pr_info(payload: dict) -> tuple[int | None, str | None, str | None]:
     """Pull (pr_number, pr_url, repo) out of a webhook payload.
 
@@ -678,10 +646,8 @@ def _build_foreman_summary(
             "This issue is devReady — run the devReady pickup flow now (same as "
             "periodic-check): skip if already assigned to someone else, or if a "
             "non-terminal task already references this issue number in the current "
-            "<state> task list; otherwise claim_github_issue, create the phase='issue' "
-            "root task (skip if one already exists for this issue number), then "
-            "create_task + assign_task as an atomic pair with issue_number, issue_repo, "
-            "and parent_task_id set."
+            "<state> task list; otherwise claim_github_issue, then create_task + "
+            "assign_task as an atomic pair with issue_number and issue_repo set on both."
         )
 
     return f"{header}{sender_line}\n{detail}".strip() if detail else f"{header}{sender_line}"
@@ -811,36 +777,6 @@ async def github_webhook(
     task_row = await _find_task(db, guild_pk, repo, pr_number)
     task_id = task_row.id if task_row else None
     task_user_id = task_row.user_id if task_row else None
-
-    # The issue this PR is linked to, if any — used to route PR Discord
-    # notifications into the issue's existing thread rather than a new one.
-    # Prefer the task's own issue_number (set by the foreman at assign_task
-    # time); then the branch name's "-<N>-t-<id>" suffix (always set by the
-    # system, whether the branch comes from the PR payload itself or the
-    # task record); fall back to a "Closes #N"-style reference in the PR
-    # body last, since that depends on the author remembering to write one.
-    linked_issue_repo: str | None = None
-    linked_issue_number: int | None = None
-    if task_row and task_row.issue_repo and task_row.issue_number is not None:
-        linked_issue_repo, linked_issue_number = task_row.issue_repo, task_row.issue_number
-    elif repo:
-        pr_obj_for_link = payload.get("pull_request")
-        head_ref = (
-            (pr_obj_for_link.get("head") or {}).get("ref")
-            if isinstance(pr_obj_for_link, dict)
-            else None
-        )
-        branch_issue_number = _linked_issue_number_from_branch(
-            head_ref or (task_row.branch if task_row else None)
-        )
-        if branch_issue_number is not None:
-            linked_issue_repo, linked_issue_number = repo, branch_issue_number
-        else:
-            body_issue_number = _linked_issue_number_from_body(
-                pr_obj_for_link.get("body") if isinstance(pr_obj_for_link, dict) else None
-            )
-            if body_issue_number is not None:
-                linked_issue_repo, linked_issue_number = repo, body_issue_number
 
     # Trim the persisted payload so a runaway diff hunk can't balloon the DB.
     body_text = body.decode("utf-8", errors="replace")
@@ -974,36 +910,23 @@ async def github_webhook(
                 guild_id,
             )
 
-            # A closed issue finalizes its phase='issue' root task directly — no
-            # foreman/LLM round-trip needed, since the issue's own state is the
-            # only signal that matters here. The periodic sweep in
-            # foreman.runner._sweep_closed_issue_tasks is a safety net for
-            # missed deliveries; this is the primary (near-instant) path.
+            # A closed issue sweeps its linked tasks directly — no foreman/LLM
+            # round-trip needed, since the issue's own state is the only signal
+            # that matters here. The periodic sweep in
+            # foreman.runner._sweep_closed_issues is a safety net for missed
+            # deliveries; this is the primary (near-instant) path.
             if action == "closed":
-                from foreman.tools import (
-                    finalize_issue_root_task,
-                    warn_if_issue_task_has_open_children,
-                )
+                from foreman.tools import finalize_closed_issue
 
-                root_result = await db.exec(
-                    select(col(Task.id)).where(
-                        col(Task.guild_id) == guild_pk,
-                        col(Task.issue_repo) == repo,
-                        col(Task.issue_number) == issue_num,
-                        col(Task.phase) == "issue",
-                        col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
+                finalized_ids = await finalize_closed_issue(db, guild_pk, guild_id, repo, issue_num)
+                if finalized_ids:
+                    logger.info(
+                        "github webhook finalized %d task(s) on issue %s#%s close guild=%s",
+                        len(finalized_ids),
+                        repo,
+                        issue_num,
+                        guild_id,
                     )
-                )
-                for root_task_id in root_result.all():
-                    finalized = await finalize_issue_root_task(db, guild_pk, guild_id, root_task_id)
-                    if finalized:
-                        logger.info(
-                            "github webhook auto-finalized issue-root task=%s on issue "
-                            "close guild=%s",
-                            root_task_id,
-                            guild_id,
-                        )
-                        await warn_if_issue_task_has_open_children(db, guild_id, root_task_id)
 
     # Deterministic lifecycle transitions: finalize on merge, fail on close-without-merge.
     # These happen directly — no AI decision needed for these clear-cut outcomes.
@@ -1062,11 +985,10 @@ async def github_webhook(
                 url=pr_url or None,
                 issue_repo=repo,
                 issue_number=pr_number,
+                kind="pr",
                 thread_name=f"#{pr_number}: {pr_title}" if pr_title else f"#{pr_number}",
                 header_fields={"Assignee": assignee_str, "Labels": labels_str},
                 ps_guild_slug=guild_id,
-                linked_issue_repo=linked_issue_repo,
-                linked_issue_number=linked_issue_number,
                 task_id=task_id,
             ),
             name=f"discord.pr-opened:{_pr_label}",
@@ -1083,10 +1005,9 @@ async def github_webhook(
                     url=pr_url or None,
                     issue_repo=repo,
                     issue_number=pr_number,
+                    kind="pr",
                     close=True,
                     ps_guild_slug=guild_id,
-                    linked_issue_repo=linked_issue_repo,
-                    linked_issue_number=linked_issue_number,
                     task_id=task_id,
                 ),
                 name=f"discord.pr-merged:{_pr_label}",
@@ -1101,10 +1022,9 @@ async def github_webhook(
                     url=pr_url or None,
                     issue_repo=repo,
                     issue_number=pr_number,
+                    kind="pr",
                     close=True,
                     ps_guild_slug=guild_id,
-                    linked_issue_repo=linked_issue_repo,
-                    linked_issue_number=linked_issue_number,
                     task_id=task_id,
                 ),
                 name=f"discord.pr-closed:{_pr_label}",
@@ -1119,9 +1039,8 @@ async def github_webhook(
                 url=pr_url or None,
                 issue_repo=repo,
                 issue_number=pr_number,
+                kind="pr",
                 ps_guild_slug=guild_id,
-                linked_issue_repo=linked_issue_repo,
-                linked_issue_number=linked_issue_number,
                 task_id=task_id,
             ),
             name=f"discord.pr-updated:{_pr_label}",
@@ -1141,9 +1060,8 @@ async def github_webhook(
                 url=(review.get("html_url") or pr_url) or None,
                 issue_repo=repo,
                 issue_number=pr_number,
+                kind="pr",
                 ps_guild_slug=guild_id,
-                linked_issue_repo=linked_issue_repo,
-                linked_issue_number=linked_issue_number,
                 task_id=task_id,
             ),
             name=f"discord.pr-review:{_pr_label}",
@@ -1169,8 +1087,6 @@ async def github_webhook(
                     issue_repo=repo,
                     issue_number=pr_number,
                     ps_guild_slug=guild_id,
-                    linked_issue_repo=linked_issue_repo,
-                    linked_issue_number=linked_issue_number,
                     task_id=task_id,
                 ),
                 name=f"discord.ci-check:{_pr_label}:{check_name}",

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -16,8 +16,37 @@ import httpx
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from datetime import UTC, datetime
 
 import discord_notifier
+from helpers import _sync_session, insert_guild, insert_task
+from models import GithubPullRequest
+from sqlalchemy import insert as sa_insert
+
+
+def _insert_gh_pr(db_url: str, repo: str, number: int, *, body: str | None = None) -> None:
+    now = datetime.now(UTC)
+    with _sync_session(db_url) as session:
+        session.execute(
+            sa_insert(GithubPullRequest).values(
+                repo=repo,
+                number=number,
+                title="",
+                state="open",
+                body=body,
+                merged=False,
+                draft=False,
+                assignees=[],
+                labels=[],
+                created_at=now,
+                updated_at=now,
+                raw={},
+            )
+        )
+        session.commit()
+
 
 BOT_TOKEN = "Bot.test.token"
 CHANNEL_ID = "111222333444"
@@ -514,21 +543,26 @@ async def test_notify_event_falls_back_to_channel_when_thread_creation_fails(mon
 
 @pytest.mark.asyncio
 async def test_notify_event_routes_pr_into_linked_issue_thread(monkeypatch):
-    """A PR notification with a linked issue thread posts there, not a new PR thread."""
+    """A PR event whose canonical key resolves to its linked issue posts (and
+    creates, if needed) the ISSUE's thread — named after the issue — never a
+    separate PR-numbered thread."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
     mock_client = _make_mock_client(status_code=204)
     issue_thread_id = "111222333444"
 
-    async def fake_lookup_thread(repo, number):
-        assert (repo, number) == ("org/repo", 7)
-        return issue_thread_id
-
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_lookup_thread", fake_lookup_thread),
-        patch.object(discord_notifier, "_ensure_thread", AsyncMock()) as ensure_mock,
+        patch.object(
+            discord_notifier, "_canonical_coords", AsyncMock(return_value=("org/repo", 7))
+        ),
+        patch.object(
+            discord_notifier, "_issue_thread_name", AsyncMock(return_value="#7: The issue")
+        ),
+        patch.object(
+            discord_notifier, "_ensure_thread", AsyncMock(return_value=issue_thread_id)
+        ) as ensure_mock,
     ):
         await discord_notifier.notify_event(
             "pr-opened",
@@ -536,21 +570,22 @@ async def test_notify_event_routes_pr_into_linked_issue_thread(monkeypatch):
             description="New PR",
             issue_repo="org/repo",
             issue_number=42,
-            linked_issue_repo="org/repo",
-            linked_issue_number=7,
+            kind="pr",
         )
 
-    # Posted straight into the issue's existing thread...
+    # The thread was ensured under the ISSUE's coordinates, named after the issue...
+    ensure_mock.assert_called_once()
+    args = ensure_mock.call_args[0]
+    assert args[:3] == ("org/repo", 7, "#7: The issue")
+    # ...and the message posted into it.
     mock_client.post.assert_called_once()
     call_url = mock_client.post.call_args[0][0]
     assert f"/channels/{issue_thread_id}/messages" in call_url
-    # ...and never created (or looked up) a separate PR-numbered thread.
-    ensure_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_notify_event_falls_back_to_pr_thread_when_no_linked_issue_thread(monkeypatch):
-    """No thread on record for the linked issue: falls back to the PR-keyed thread."""
+async def test_notify_event_falls_back_to_pr_thread_when_no_linked_issue(monkeypatch):
+    """A PR with no resolvable linked issue keys its thread by the PR number."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
@@ -559,8 +594,12 @@ async def test_notify_event_falls_back_to_pr_thread_when_no_linked_issue_thread(
 
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
-        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=pr_thread_id)),
+        patch.object(
+            discord_notifier, "_canonical_coords", AsyncMock(return_value=("org/repo", 42))
+        ),
+        patch.object(
+            discord_notifier, "_ensure_thread", AsyncMock(return_value=pr_thread_id)
+        ) as ensure_mock,
     ):
         await discord_notifier.notify_event(
             "pr-opened",
@@ -568,10 +607,11 @@ async def test_notify_event_falls_back_to_pr_thread_when_no_linked_issue_thread(
             description="New PR",
             issue_repo="org/repo",
             issue_number=42,
-            linked_issue_repo="org/repo",
-            linked_issue_number=7,
+            kind="pr",
         )
 
+    ensure_mock.assert_called_once()
+    assert ensure_mock.call_args[0][:2] == ("org/repo", 42)
     mock_client.post.assert_called_once()
     call_url = mock_client.post.call_args[0][0]
     assert f"/channels/{pr_thread_id}/messages" in call_url
@@ -588,7 +628,11 @@ async def test_notify_event_ignores_close_when_routed_to_linked_issue_thread(mon
 
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=issue_thread_id)),
+        patch.object(
+            discord_notifier, "_canonical_coords", AsyncMock(return_value=("org/repo", 7))
+        ),
+        patch.object(discord_notifier, "_issue_thread_name", AsyncMock(return_value=None)),
+        patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=issue_thread_id)),
     ):
         await discord_notifier.notify_event(
             "pr-merged",
@@ -596,9 +640,8 @@ async def test_notify_event_ignores_close_when_routed_to_linked_issue_thread(mon
             description="Merged!",
             issue_repo="org/repo",
             issue_number=42,
+            kind="pr",
             close=True,
-            linked_issue_repo="org/repo",
-            linked_issue_number=7,
         )
 
     mock_client.post.assert_called_once()
@@ -606,63 +649,72 @@ async def test_notify_event_ignores_close_when_routed_to_linked_issue_thread(mon
 
 
 @pytest.mark.asyncio
-async def test_notify_event_resolves_linked_issue_from_task_id(monkeypatch):
-    """When only task_id is given, the linked issue is resolved via Task.issue_repo/number."""
+async def test_notify_event_archives_pr_thread_on_close(monkeypatch):
+    """close=True archives the thread when the subject IS the canonical key
+    (a PR with no linked issue owns its thread)."""
     monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
     monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
 
     mock_client = _make_mock_client(status_code=204)
-    issue_thread_id = "999000111222"
 
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
         patch.object(
-            discord_notifier,
-            "_lookup_task_issue_coords",
-            AsyncMock(return_value=("org/repo", 7)),
+            discord_notifier, "_canonical_coords", AsyncMock(return_value=("org/repo", 42))
         ),
-        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=issue_thread_id)),
-    ):
-        await discord_notifier.notify_event(
-            "task-complete",
-            title="Task complete",
-            description="desc",
-            issue_repo="org/repo",
-            issue_number=42,
-            task_id="t-abc",
-        )
-
-    mock_client.post.assert_called_once()
-    call_url = mock_client.post.call_args[0][0]
-    assert f"/channels/{issue_thread_id}/messages" in call_url
-
-
-@pytest.mark.asyncio
-async def test_notify_event_task_id_skipped_when_linked_issue_explicit(monkeypatch):
-    """Explicit linked_issue_repo/number take precedence — task_id lookup is skipped."""
-    monkeypatch.setenv("DISCORD_BOT_TOKEN", BOT_TOKEN)
-    monkeypatch.setenv("DISCORD_CHANNEL_ID", CHANNEL_ID)
-
-    mock_client = _make_mock_client(status_code=204)
-
-    with (
-        patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock()) as coords_mock,
-        patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
         patch.object(discord_notifier, "_ensure_thread", AsyncMock(return_value=THREAD_ID)),
     ):
         await discord_notifier.notify_event(
-            "pr-opened",
-            title="PR opened",
-            description="desc",
+            "pr-closed",
+            title="PR closed",
+            description="Closed.",
             issue_repo="org/repo",
             issue_number=42,
-            linked_issue_repo="org/repo",
-            linked_issue_number=7,
-            task_id="t-abc",
+            kind="pr",
+            close=True,
         )
 
-    coords_mock.assert_not_called()
+    mock_client.post.assert_called_once()
+    mock_client.patch.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_canonical_coords_prefers_task_issue_linkage(client):
+    """_canonical_coords resolves a task's issue linkage ahead of the PR subject."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-coords1")
+    insert_task(
+        db_url,
+        "g-coords1",
+        "t-coords1",
+        state="working",
+        issue_repo="org/repo",
+        issue_number=7,
+        pr_repo="org/repo",
+        pr_number=42,
+    )
+
+    coords = await discord_notifier._canonical_coords(
+        "org/repo", 42, kind="pr", task_id="t-coords1"
+    )
+    assert coords == ("org/repo", 7)
+
+
+@pytest.mark.asyncio
+async def test_canonical_coords_resolves_issue_from_cached_pr_body(client):
+    """With no task linkage, the cached PR body's Closes-reference wins."""
+    _test_client, db_url = client
+    _insert_gh_pr(db_url, "org/coords-repo", 43, body="Fixes #9")
+
+    coords = await discord_notifier._canonical_coords("org/coords-repo", 43, kind="pr")
+    assert coords == ("org/coords-repo", 9)
+
+
+@pytest.mark.asyncio
+async def test_canonical_coords_issue_subject_passes_through(client):
+    """An issue subject is already canonical — returned as-is."""
+    coords = await discord_notifier._canonical_coords("org/repo", 5, kind="issue")
+    assert coords == ("org/repo", 5)
 
 
 @pytest.mark.asyncio
@@ -1027,7 +1079,7 @@ async def test_notify_foreman_chat_task_scoped_routes_to_task_thread(monkeypatch
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
         patch.object(
             discord_notifier,
-            "_lookup_task_issue_coords",
+            "_canonical_coords",
             AsyncMock(return_value=("org/repo", 42)),
         ),
         patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=task_thread_id)),
@@ -1051,7 +1103,7 @@ async def test_notify_foreman_chat_no_task_id_skips_task_lookup(monkeypatch):
 
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock()) as coords_mock,
+        patch.object(discord_notifier, "_canonical_coords", AsyncMock()) as coords_mock,
     ):
         await discord_notifier.notify_foreman_chat("guild-1", "General update.")
 
@@ -1075,7 +1127,7 @@ async def test_notify_foreman_chat_task_scoped_no_thread_posts_to_main_channel(m
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
         patch.object(
             discord_notifier,
-            "_lookup_task_issue_coords",
+            "_canonical_coords",
             AsyncMock(return_value=("org/repo", 42)),
         ),
         patch.object(discord_notifier, "_lookup_thread", AsyncMock(return_value=None)),
@@ -1098,7 +1150,7 @@ async def test_notify_foreman_chat_task_with_no_linked_issue_posts_to_main_chann
 
     with (
         patch.object(discord_notifier, "_get_client", return_value=mock_client),
-        patch.object(discord_notifier, "_lookup_task_issue_coords", AsyncMock(return_value=None)),
+        patch.object(discord_notifier, "_canonical_coords", AsyncMock(return_value=None)),
         patch.object(discord_notifier, "_lookup_thread", AsyncMock()) as lookup_thread_mock,
     ):
         await discord_notifier.notify_foreman_chat(
@@ -1154,12 +1206,14 @@ async def test_lookup_discord_user_db_error_returns_none():
 
 
 @pytest.mark.asyncio
-async def test_lookup_task_issue_coords_db_error_returns_none():
-    """_lookup_task_issue_coords swallows DB errors and returns None (never raises)."""
+async def test_canonical_coords_db_error_falls_back_to_subject():
+    """_canonical_coords swallows DB errors: falls back to the given subject
+    coordinates, and to None when it has nothing to fall back to."""
     with patch("database.AsyncSessionLocal", side_effect=RuntimeError("db down")):
-        result = await discord_notifier._lookup_task_issue_coords("t-abc")
-
-    assert result is None
+        assert await discord_notifier._canonical_coords(
+            "org/repo", 42, kind="pr", task_id="t-abc"
+        ) == ("org/repo", 42)
+        assert await discord_notifier._canonical_coords(None, None, task_id="t-abc") is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -249,40 +249,23 @@ class TestBuildSystemPrompt:
 
         assert "parent_task_id" in FOREMAN_SYSTEM
 
-    def test_devready_pickup_creates_issue_root_task_first(self):
-        """Picking up a devReady issue must create a phase='issue' root task before any
-        plan/execute task (#829)."""
+    def test_devready_pickup_has_no_issue_root_step(self):
+        """phase='issue' root tasks are retired — the pickup flow must not instruct
+        the foreman to create one anywhere in the prompt."""
+        from foreman.prompt import FOREMAN_SYSTEM
+
+        assert "phase='issue'" not in FOREMAN_SYSTEM
+        assert 'phase="issue"' not in FOREMAN_SYSTEM
+
+    def test_devready_pickup_passes_issue_linkage(self):
+        """Pickup must instruct create_task + assign_task with issue linkage on both
+        calls — that linkage is what groups the tasks and routes their Discord
+        notifications now that there is no issue-root anchor task."""
         from foreman.prompt import FOREMAN_SYSTEM
 
         section_start = FOREMAN_SYSTEM.index("Periodic devReady issue pickup")
         section = FOREMAN_SYSTEM[section_start:]
-        assert "create_task(phase='issue'" in section or 'create_task(phase="issue"' in section
-        # Anchor to the lettered sub-steps rather than a loose substring search — step
-        # 'c' (issue-root creation) must be described before step 'd' (plan/execute pair).
-        step_c_idx = section.index("c. Call create_task(phase='issue'")
-        step_d_idx = section.index("d. Call create_task + assign_task")
-        assert step_c_idx < step_d_idx
-
-    def test_devready_pickup_child_tasks_reference_issue_root(self):
-        """Subsequent plan/execute tasks for a devReady issue must pass parent_task_id
-        pointing at the issue-root task (#829)."""
-        from foreman.prompt import FOREMAN_SYSTEM
-
-        section_start = FOREMAN_SYSTEM.index("Periodic devReady issue pickup")
-        section = FOREMAN_SYSTEM[section_start:]
-        # Assert the full phrase, not just the bare "parent_task_id" token, which also
-        # appears in unrelated sections of FOREMAN_SYSTEM (e.g. review dispatch).
-        assert "parent_task_id=<issue-root task_id" in section
-
-    def test_devready_issue_root_never_assigned_to_worker(self):
-        """Prompt must describe the issue-root task as never assigned to a worker and
-        without a branch/PR (#829)."""
-        from foreman.prompt import FOREMAN_SYSTEM
-
-        section_start = FOREMAN_SYSTEM.index("Periodic devReady issue pickup")
-        section = FOREMAN_SYSTEM[section_start:]
-        assert "never assigned to a worker" in section
-        assert "no branch or PR" in section or "no branch/PR" in section
+        assert "issue_repo on both calls" in section
 
 
 # ---------------------------------------------------------------------------
@@ -471,9 +454,9 @@ class TestExecToolsDispatching:
             phase = session.scalar(select(col(Task.phase)).where(col(Task.id) == task_id))
         assert phase == "plan"
 
-    async def test_create_task_issue_phase_creates_unassigned_root_task(self, db_session):
-        """create_task(phase='issue') must persist phase='issue' and leave the task
-        unassigned (no worker) — it's a sidebar anchor, never dispatched to a worker (#829)."""
+    async def test_create_task_persists_issue_and_pr_linkage(self, db_session):
+        """create_task must persist issue/PR linkage columns — they group the task
+        under its issue in the sidebar and route its Discord notifications."""
         insert_guild(db_session, "g-issuephase")
         with patch("foreman.tools.broadcast", new_callable=AsyncMock):
             results = await exec_tools(
@@ -482,9 +465,12 @@ class TestExecToolsDispatching:
                     _fake_tool_use(
                         "create_task",
                         {
-                            "name": "Issue: add foo",
-                            "description": "Root task for issue #123",
-                            "phase": "issue",
+                            "name": "Add foo",
+                            "description": "Implement issue #123",
+                            "issue_number": 123,
+                            "issue_repo": "acme/widgets",
+                            "pr_number": 456,
+                            "pr_repo": "acme/widgets",
                         },
                     )
                 ],
@@ -493,10 +479,11 @@ class TestExecToolsDispatching:
 
         with _sync_session(db_session) as session:
             task = session.get(Task, task_id)
-        assert task.phase == "issue"
+        assert task.issue_number == 123
+        assert task.issue_repo == "acme/widgets"
+        assert task.pr_number == 456
+        assert task.pr_repo == "acme/widgets"
         assert task.worker_id is None
-        assert task.pr_url is None
-        assert task.branch is None
 
     async def test_assign_task_unknown_worker(self, db_session):
         insert_guild(db_session, "g-assign-bad")
@@ -1876,18 +1863,19 @@ class TestExecToolsDispatching:
         assert ev is None, "No pending-followup event should be queued — follow-up was dispatched"
 
 
-class TestFinalizeIssueRootTaskAtomicity:
-    """finalize_issue_root_task (backend/foreman/tools.py) guards against a lost-update
+class TestFinalizeClosedIssueAtomicity:
+    """finalize_closed_issue (backend/foreman/tools.py) guards against a lost-update
     race (jmelloy/pioneer-square#851, PR #848 review) by making the terminal-state
-    check and the state='done' write a single conditional UPDATE...RETURNING instead
-    of a SELECT followed by an UPDATE. A prior SELECT would let two concurrent callers
-    (the issues webhook and the periodic closed-issue sweep) both observe the
-    non-terminal state, then both write — double-finalizing the task and racing on
-    which worker_id gets broadcast. With the atomic UPDATE, Postgres serializes the
-    two writers on the row and only the first to commit can win."""
+    check and the state='done' write on legacy phase='issue' rows a single
+    conditional UPDATE...RETURNING instead of a SELECT followed by an UPDATE. A
+    prior SELECT would let two concurrent callers (the issues webhook and the
+    periodic closed-issue sweep) both observe the non-terminal state, then both
+    write — double-finalizing the task and racing on which worker_id gets
+    broadcast. With the atomic UPDATE, Postgres serializes the two writers on the
+    row and only the first to commit can win."""
 
     async def test_concurrent_finalize_only_one_caller_wins(self, db_session):
-        from foreman.tools import finalize_issue_root_task
+        from foreman.tools import finalize_closed_issue
 
         insert_guild(db_session, "g-race")
         _insert_worker(db_session, "g-race", "w-race")
@@ -1908,16 +1896,19 @@ class TestFinalizeIssueRootTaskAtomicity:
             guild_pk = await get_guild_pk(db_a, "g-race")
             with patch("foreman.tools._guild_github_token", return_value=None):
                 results = await asyncio.gather(
-                    finalize_issue_root_task(db_a, guild_pk, "g-race", "t-race-root"),
-                    finalize_issue_root_task(db_b, guild_pk, "g-race", "t-race-root"),
+                    finalize_closed_issue(db_a, guild_pk, "g-race", "o/r", 42),
+                    finalize_closed_issue(db_b, guild_pk, "g-race", "o/r", 42),
                 )
         finally:
             await db_a.close()
             await db_b.close()
 
-        # Exactly one of the two concurrent callers must observe the terminal-state
-        # guard flip and back off — a lost-update bug would let both return True.
-        assert sorted(results) == [False, True]
+        # Exactly one of the two concurrent callers must win the conditional
+        # UPDATE and finalize the legacy root — a lost-update bug would let
+        # both return it.
+        winners = sorted(results, key=len)
+        assert winners[0] == []
+        assert winners[1] == ["t-race-root"]
 
         with _sync_session(db_session) as session:
             state, deleted_at = session.execute(

--- a/backend/tests/test_github_webhooks.py
+++ b/backend/tests/test_github_webhooks.py
@@ -554,9 +554,9 @@ def test_issues_closed_webhook_finalizes_issue_root_task(client):
     assert deleted_at is not None
 
 
-def test_issues_closed_webhook_ignores_already_terminal_root(client):
-    """Must not re-finalize (or error on) a phase='issue' root already in a
-    terminal state — the webhook path should be a no-op there."""
+def test_issues_closed_webhook_sweeps_already_terminal_root(client):
+    """A phase='issue' root already in a terminal state is not re-finalized,
+    but the closed-issue sweep stamps its soft-delete so it ages out."""
     test_client, db_url = client
     insert_guild(db_url, "gissue2")
     _set_webhook_secret(db_url, "gissue2", "sissue2")
@@ -581,8 +581,9 @@ def test_issues_closed_webhook_ignores_already_terminal_root(client):
         deleted_at = session.scalar(
             select(col(Task.deleted_at)).where(col(Task.id) == "t-issue-root2")
         )
-    # Was already 'done' with no expiry set before the webhook — must stay untouched.
-    assert deleted_at is None
+    # Already 'done' before the webhook: state untouched, but the sweep
+    # stamps deleted_at so the finished row ages out of the sidebar.
+    assert deleted_at is not None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -31,6 +31,12 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 import database as database_module  # noqa: E402
 from _test_config import TEST_DATABASE_URL  # noqa: E402
+from discord_notifier import (  # noqa: E402
+    linked_issue_number_from_body as _linked_issue_number_from_body,
+)
+from discord_notifier import (  # noqa: E402
+    linked_issue_number_from_branch as _linked_issue_number_from_branch,
+)
 from foreman.tools import exec_tools  # noqa: E402
 from helpers import (  # noqa: E402
     _sync_session,
@@ -48,8 +54,6 @@ from routes.webhooks import (  # noqa: E402
     _build_foreman_summary,
     _devready_issue_trigger,
     _get_guild_owner_github_login,
-    _linked_issue_number_from_body,
-    _linked_issue_number_from_branch,
     _should_dispatch_to_foreman,
 )
 from sqlalchemy import update  # noqa: E402

--- a/backend/util/model_tiers.py
+++ b/backend/util/model_tiers.py
@@ -108,7 +108,7 @@ def select_model_tier(
     """Return the appropriate tier string for a task.
 
     Args:
-        phase: Task phase — ``"issue"``, ``"plan"``, ``"execute"``, or ``"review"``.
+        phase: Task phase — ``"plan"``, ``"execute"``, or ``"review"``.
                Unknown values fall back to ``TIER_STANDARD``.
         tool: Runner name — ``"claude"``, ``"codex"``, or ``"pi"``.
               Unknown values fall back to the phase tier.

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -895,6 +895,7 @@ async def handle_task_complete(ctx: WSContext, data: dict) -> None:
                 url=pr_url or None,
                 issue_repo=_pr_repo_disc,
                 issue_number=_pr_num_disc,
+                kind="pr",
                 ps_guild_slug=ctx.guild_id,
                 task_id=task_id,
             ),


### PR DESCRIPTION
Follow-up to #870 (merged) — uses the linkage columns and `github_pull_requests` cache that PR established. Fixes #866.

## Discord: one work item, one thread

`discord_threads` was keyed by a single `(issue_repo, issue_number)` namespace that callers fed **either** issue numbers or PR numbers, with per-call-site `linked_issue_*` plumbing trying to bridge the two. Since GitHub issues and PRs share one number sequence per repo, the key can't collide — the real failure mode was *fragmentation*: a PR's events keyed under the PR number while its issue's events keyed under the issue number, splitting one work item's conversation across two threads. (`notify_event`'s linked-issue path only posted to *existing* threads, so whenever the issue had no thread yet it minted a PR-numbered one.)

Now every thread-aware entry point (`notify_event`, `notify_existing_thread`, `notify_foreman_chat`) resolves its subject to one canonical `(repo, number)` via `_canonical_coords`:

1. the task's own `issue_repo`/`issue_number`
2. for PRs: any task linked to the PR that knows its issue, then the cached PR's branch-name suffix (`-<N>-t-<id>`) or `Closes #N` body reference
3. the subject as given

Callers stop computing/passing `linked_issue_*` entirely; PR-subject sites pass `kind="pr"`. When a PR event has to create its linked issue's thread, the thread is named from the `github_issues` cache title, not the transient event title. `close=True` archives only PR-owned threads, never a linked issue's.

## phase='issue' retired

With sidebar grouping by `coalesce(issue, pr)` (#870) and Discord threads keyed by issue coords, the synthetic root row has no job left — it existed to anchor both, and cost a patch-train (#847, #851, #853, #861, #863).

- `create_task` drops `'issue'` from its phase enum; `ensure_issue_root_thread` and the `_resolve_root_thread_id` recursive parent-chain walk are deleted.
- `finalize_issue_root_task` → `finalize_closed_issue(repo, number)`: finalizes legacy roots (same TOCTOU-safe conditional `UPDATE…RETURNING`), stamps soft-delete on already-terminal linked tasks, warns about open ones, posts one close-summary comment. Shared by the `issues/closed` webhook and the periodic sweep, which now iterates distinct linked issues instead of root rows.
- Foreman prompt + webhook instructions lose the issue-root steps ("create exactly one per issue", "skip if one already exists", parent_task_id gymnastics) — pickup is now claim + `create_task`/`assign_task` with issue linkage on both.
- Bonus #866 fix: the `/review` slash command stops writing the PR number into the task's `issue_repo`/`issue_number` columns.

**Migration** folds legacy roots' `discord_thread_id` into `discord_threads` under their issue coordinates — in-flight issues keep their existing thread, and inbound Discord replies (which resolve via `discord_threads`) now work for root-anchored threads too, which they previously didn't — then drops the column.

Legacy `phase='issue'` rows still render in the tree and still finalize when their issue closes; they just stop being created.

## Deploy order

1. Run #870's backfills first (`backfill_github_cache.py`, then `backfill_task_linkage.py --apply`) so legacy roots have issue coords.
2. Deploy this; `alembic upgrade head` does the thread fold + column drop.

## Verification

- Full backend suite: **981 passed** after rebase onto main (notifier routing tests rewritten for canonical resolution incl. DB-backed `_canonical_coords` tests; finalize-atomicity race test ported to `finalize_closed_issue`; devReady prompt tests assert no `phase='issue'` remains).
- Migration run against a prod data copy: column dropped, legacy root threads folded into `discord_threads`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
