### PR TITLE
feat(foreman): parse GitHub URLs pasted into chat

### DIFF
--- a/backend/foreman/github_url_parser.py
+++ b/backend/foreman/github_url_parser.py
@@ -1,0 +1,96 @@
+"""Parse GitHub URLs from chat messages and annotate them for the Foreman.
+
+When a user pastes a GitHub URL like:
+  https://github.com/owner/repo/pull/123
+  https://github.com/owner/repo/issues/456
+
+This module extracts the owner/repo slug and issue/PR number so the Foreman
+can reference them directly in tool calls.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Matches GitHub issue and PR URLs, handling:
+# - Trailing slashes
+# - Query strings (?foo=bar)
+# - Fragment anchors (#issuecomment-123)
+# - Optional /files, /commits sub-paths on PRs
+_GITHUB_URL_RE = re.compile(
+    r"https?://github\.com/"
+    r"(?P<owner>[A-Za-z0-9\-_.]+)/"
+    r"(?P<repo>[A-Za-z0-9\-_.]+)/"
+    r"(?P<type>(?:pull|issues))/"
+    r"(?P<number>\d+)"
+    r"(?:/[^\s]*)?"  # optional sub-path (e.g. /files, /commits)
+    r"(?:\?[^\s#]*)?"  # optional query string
+    r"(?:#[^\s]*)?"  # optional fragment
+)
+
+
+@dataclass
+class GitHubReference:
+    """A parsed GitHub issue or PR reference."""
+
+    owner: str
+    repo: str
+    number: int
+    ref_type: str  # "pull" or "issues"
+
+    @property
+    def slug(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+    @property
+    def kind(self) -> str:
+        return "PR" if self.ref_type == "pull" else "Issue"
+
+    def __str__(self) -> str:
+        return f"[GitHub {self.kind} #{self.number} in {self.slug}]"
+
+
+def parse_github_urls(text: str) -> list[GitHubReference]:
+    """Extract all GitHub issue/PR references from a text string.
+
+    Returns an empty list if no valid URLs are found. Malformed or
+    non-GitHub URLs are silently ignored.
+    """
+    refs: list[GitHubReference] = []
+    seen: set[tuple[str, str, int, str]] = set()
+
+    for match in _GITHUB_URL_RE.finditer(text):
+        owner = match.group("owner")
+        repo = match.group("repo")
+        number = int(match.group("number"))
+        ref_type = match.group("type")
+
+        key = (owner, repo, number, ref_type)
+        if key not in seen:
+            seen.add(key)
+            refs.append(GitHubReference(owner=owner, repo=repo, number=number, ref_type=ref_type))
+
+    return refs
+
+
+def annotate_message(message: str) -> str:
+    """Annotate a chat message with parsed GitHub URL metadata.
+
+    If the message contains GitHub issue/PR URLs, appends a structured
+    annotation block that the Foreman can reference. If no URLs are found,
+    returns the message unchanged.
+    """
+    refs = parse_github_urls(message)
+    if not refs:
+        return message
+
+    annotations = []
+    for ref in refs:
+        annotations.append(
+            f"  - {ref.kind} #{ref.number} in {ref.slug} "
+            f"(https://github.com/{ref.slug}/{ref.ref_type}/{ref.number})"
+        )
+
+    annotation_block = "\n\n---\n[Parsed GitHub references:\n" + "\n".join(annotations) + "\n]"
+    return message + annotation_block

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -21,6 +21,7 @@ from foreman.constants import (
     _TERMINAL_STATES,
     MAX_FOREMAN_ROUNDS,
 )
+from foreman.github_url_parser import annotate_message as _annotate_github_urls
 from foreman.llm import (
     ANTHROPIC_SDK_PROVIDERS,
     HAS_ANTHROPIC,
@@ -1199,6 +1200,10 @@ async def _run_foreman_ai(
         )
         logger.debug("guild=%s workers_block: %s", guild_id, workers_block)
         # logger.debug("guild=%s tasks_block: %s", guild_id, tasks_block)
+
+        # Annotate any GitHub URLs in the human message so the Foreman can
+        # reference owner/repo and issue/PR numbers directly.
+        human_message = _annotate_github_urls(human_message)
 
         # Persist the rendered prompt + human turn for auditing; the API receives
         # `system_blocks` (cacheable) and the state preamble injected at send time.

--- a/backend/tests/test_github_url_parser.py
+++ b/backend/tests/test_github_url_parser.py
@@ -1,0 +1,134 @@
+"""Tests for backend/foreman/github_url_parser.py."""
+
+import sys
+from pathlib import Path
+
+# Ensure the backend source is importable.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from foreman.github_url_parser import GitHubReference, annotate_message, parse_github_urls
+
+
+class TestParseGitHubUrls:
+    def test_pull_request_url(self):
+        text = "Check this PR: https://github.com/acme/widgets/pull/42"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+        assert refs[0] == GitHubReference(owner="acme", repo="widgets", number=42, ref_type="pull")
+        assert refs[0].slug == "acme/widgets"
+        assert refs[0].kind == "PR"
+
+    def test_issue_url(self):
+        text = "See https://github.com/owner/repo/issues/456"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+        assert refs[0].owner == "owner"
+        assert refs[0].repo == "repo"
+        assert refs[0].number == 456
+        assert refs[0].ref_type == "issues"
+        assert refs[0].kind == "Issue"
+
+    def test_trailing_slash(self):
+        text = "https://github.com/o/r/pull/1/"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+        assert refs[0].number == 1
+
+    def test_query_string(self):
+        text = "https://github.com/o/r/issues/99?foo=bar&baz=1"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+        assert refs[0].number == 99
+
+    def test_fragment(self):
+        text = "https://github.com/o/r/pull/7#issuecomment-12345"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+        assert refs[0].number == 7
+
+    def test_query_and_fragment(self):
+        text = "https://github.com/o/r/issues/5?q=1#fragment"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+        assert refs[0].number == 5
+
+    def test_pr_subpath(self):
+        """PR URLs with /files or /commits sub-paths."""
+        text = "https://github.com/o/r/pull/10/files"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+        assert refs[0].number == 10
+
+    def test_multiple_urls(self):
+        text = "Look at https://github.com/a/b/pull/1 and https://github.com/c/d/issues/2"
+        refs = parse_github_urls(text)
+        assert len(refs) == 2
+        assert refs[0].slug == "a/b"
+        assert refs[1].slug == "c/d"
+
+    def test_duplicate_urls_deduplicated(self):
+        text = "https://github.com/o/r/pull/5 https://github.com/o/r/pull/5"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+
+    def test_no_github_url(self):
+        text = "Just a normal message with no URLs"
+        refs = parse_github_urls(text)
+        assert refs == []
+
+    def test_non_github_url_ignored(self):
+        text = "See https://gitlab.com/owner/repo/issues/1"
+        refs = parse_github_urls(text)
+        assert refs == []
+
+    def test_malformed_url_no_number(self):
+        text = "https://github.com/o/r/pull/"
+        refs = parse_github_urls(text)
+        assert refs == []
+
+    def test_malformed_url_not_issue_or_pull(self):
+        text = "https://github.com/o/r/tree/main"
+        refs = parse_github_urls(text)
+        assert refs == []
+
+    def test_empty_string(self):
+        assert parse_github_urls("") == []
+
+    def test_owner_with_dots_and_hyphens(self):
+        text = "https://github.com/my-org.name/repo-name.js/issues/100"
+        refs = parse_github_urls(text)
+        assert len(refs) == 1
+        assert refs[0].owner == "my-org.name"
+        assert refs[0].repo == "repo-name.js"
+
+
+class TestAnnotateMessage:
+    def test_no_urls_unchanged(self):
+        msg = "Hello foreman, please help"
+        assert annotate_message(msg) == msg
+
+    def test_pr_annotation(self):
+        msg = "Please review https://github.com/acme/app/pull/42"
+        result = annotate_message(msg)
+        assert "Parsed GitHub references:" in result
+        assert "PR #42 in acme/app" in result
+        # Original message preserved
+        assert msg in result
+
+    def test_issue_annotation(self):
+        msg = "Fix https://github.com/org/lib/issues/7"
+        result = annotate_message(msg)
+        assert "Issue #7 in org/lib" in result
+
+    def test_multiple_refs_annotated(self):
+        msg = "https://github.com/a/b/pull/1 https://github.com/c/d/issues/2"
+        result = annotate_message(msg)
+        assert "PR #1 in a/b" in result
+        assert "Issue #2 in c/d" in result
+
+    def test_str_representation(self):
+        ref = GitHubReference(owner="o", repo="r", number=5, ref_type="pull")
+        assert str(ref) == "[GitHub PR #5 in o/r]"
+
+        ref2 = GitHubReference(owner="o", repo="r", number=3, ref_type="issues")
+        assert str(ref2) == "[GitHub Issue #3 in o/r]"


### PR DESCRIPTION
## Summary

When a user pastes a GitHub issue or PR URL into the Foreman chat, the system now automatically extracts the `owner/repo` slug and number and appends a structured annotation to the message. This allows the Foreman to reference them directly in tool calls without requiring the user to spell them out.

## Changes

- **`backend/foreman/github_url_parser.py`** — New module with regex-based URL parser that handles:
  - `https://github.com/<owner>/<repo>/pull/<N>`
  - `https://github.com/<owner>/<repo>/issues/<N>`
  - Trailing slashes, query strings, fragments, sub-paths (`/files`, `/commits`)
  - Deduplication of repeated URLs
  - Graceful no-op on malformed or non-GitHub URLs

- **`backend/foreman/runner.py`** — Integrated the annotation step just before the human message is saved and sent to the Foreman AI conversation loop.

- **`backend/tests/test_github_url_parser.py`** — 20 tests covering parsing and annotation logic.

## How it works

When `annotate_message()` finds GitHub URLs, it appends a block like:

```
---
[Parsed GitHub references:
  - PR #42 in acme/app (https://github.com/acme/app/pull/42)
]
```

Messages without GitHub URLs pass through unchanged.

Closes #872