### PR TITLE
feat: Foreman GitHub tools use acting user's token

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -457,9 +457,7 @@ def _parse_review_from_claude(text: str) -> dict:
     return {"summary": stripped[:2000], "comments": []}
 
 
-async def _guild_github_token(
-    guild_id: str, user_id: str | None = None
-) -> tuple[str, str] | None:
+async def _guild_github_token(guild_id: str, user_id: str | None = None) -> tuple[str, str] | None:
     """Return (access_token, github_username) to act as for this guild, or None.
 
     When *user_id* is given, prefer that member's own GitHub token so actions

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -457,8 +457,16 @@ def _parse_review_from_claude(text: str) -> dict:
     return {"summary": stripped[:2000], "comments": []}
 
 
-async def _guild_github_token(guild_id: str) -> tuple[str, str] | None:
-    """Return (access_token, github_username) for this guild, or None."""
+async def _guild_github_token(
+    guild_id: str, user_id: str | None = None
+) -> tuple[str, str] | None:
+    """Return (access_token, github_username) to act as for this guild, or None.
+
+    When *user_id* is given, prefer that member's own GitHub token so actions
+    (issue claims, PR reviews, etc.) attribute to the acting human rather than
+    the guild owner. Falls back to the guild owner's token when *user_id* is
+    None (background/automated operations) or has no token on file.
+    """
     from auth_deps import get_guild_pk
 
     db = await get_db()
@@ -466,6 +474,21 @@ async def _guild_github_token(guild_id: str) -> tuple[str, str] | None:
         guild_pk = await get_guild_pk(db, guild_id)
         if guild_pk is None:
             return None
+
+        if user_id is not None:
+            result = await db.exec(
+                select(col(GithubToken.access_token), col(GithubToken.github_username))
+                .join(GuildMember, col(GuildMember.user_id) == col(GithubToken.github_user_id))
+                .where(
+                    col(GuildMember.guild_id) == guild_pk,
+                    col(GithubToken.github_user_id) == user_id,
+                )
+                .limit(1)
+            )
+            row = result.first()
+            if row:
+                return (row.access_token, row.github_username)
+
         result = await db.exec(
             select(col(GithubToken.access_token), col(GithubToken.github_username))
             .join(GuildMember, col(GuildMember.user_id) == col(GithubToken.github_user_id))
@@ -2145,7 +2168,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
             "review_pr_internal",
         ):
             logger.info("Executing GitHub tool %s with input %s", tu.name, inp)
-            creds = await _guild_github_token(guild_id)
+            creds = await _guild_github_token(guild_id, user_id)
             if not creds:
                 result_text = (
                     "No GitHub token found for this guild — user must connect GitHub first."

--- a/backend/tests/test_guild_github_token.py
+++ b/backend/tests/test_guild_github_token.py
@@ -1,0 +1,74 @@
+"""Unit tests for _guild_github_token's user_id-aware lookup and owner fallback."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import database as database_module
+from _test_config import TEST_DATABASE_URL  # noqa: E402
+from foreman.tools import _guild_github_token
+from helpers import create_db, insert_guild, insert_member, make_auth_token, truncate_all
+
+
+@pytest.fixture()
+def db_session(monkeypatch):
+    create_db(TEST_DATABASE_URL)
+    truncate_all(TEST_DATABASE_URL)
+    db_url = TEST_DATABASE_URL
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    engine = create_async_engine(db_url, echo=False, poolclass=NullPool)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    monkeypatch.setattr(database_module, "AsyncSessionLocal", session_factory)
+    yield db_url
+
+
+@pytest.mark.asyncio
+async def test_no_user_id_uses_owner_token(db_session):
+    db_url = db_session
+    make_auth_token(db_url, user_id="owner-1", username="owner-login")
+    insert_guild(db_url, "g1", owner_user_id="owner-1")
+
+    creds = await _guild_github_token("g1")
+
+    assert creds == ("gh_tok_fake", "owner-login")
+
+
+@pytest.mark.asyncio
+async def test_user_id_with_own_token_prefers_it_over_owner(db_session):
+    db_url = db_session
+    make_auth_token(db_url, user_id="owner-1", username="owner-login")
+    insert_guild(db_url, "g1", owner_user_id="owner-1")
+    make_auth_token(db_url, user_id="member-1", username="member-login")
+    insert_member(db_url, "g1", "member-1")
+
+    creds = await _guild_github_token("g1", user_id="member-1")
+
+    assert creds == ("gh_tok_fake", "member-login")
+
+
+@pytest.mark.asyncio
+async def test_user_id_without_token_falls_back_to_owner(db_session):
+    db_url = db_session
+    make_auth_token(db_url, user_id="owner-1", username="owner-login")
+    insert_guild(db_url, "g1", owner_user_id="owner-1")
+    insert_member(db_url, "g1", "member-no-token")
+
+    creds = await _guild_github_token("g1", user_id="member-no-token")
+
+    assert creds == ("gh_tok_fake", "owner-login")
+
+
+@pytest.mark.asyncio
+async def test_unknown_guild_returns_none(db_session):
+    creds = await _guild_github_token("no-such-guild", user_id="whoever")
+
+    assert creds is None


### PR DESCRIPTION
Closes #876

## Summary
- `_guild_github_token()` now accepts an optional `user_id` parameter. When provided, it looks up that user's token first and falls back to the guild owner's token if not found.
- All 8 GitHub tool call sites (`claim_github_issue`, `create_github_issue`, `list_github_issues`, `get_github_issue`, `search_github_issues`, `get_pr_status`, `review_pr_internal`, `review_pr`) pass `user_id` through when available.
- Background/automated operations (periodic check, webhook handlers with no acting user) continue to fall back to guild owner token.

All 1007 existing tests pass.