### PR TITLE
fix(foreman): inherit linked repo when assigning tasks

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1369,11 +1369,48 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 model = inp.get("model") or None
                 provider = inp.get("provider") or None
                 existing_task_id = inp.get("task_id")
+                existing_linkage: tuple[int | None, str | None, int | None, str | None] | None = (
+                    None
+                )
+                if existing_task_id:
+                    existing_linkage_result = await db.exec(
+                        select(
+                            col(Task.issue_number),
+                            col(Task.issue_repo),
+                            col(Task.pr_number),
+                            col(Task.pr_repo),
+                        ).where(col(Task.id) == existing_task_id, col(Task.guild_id) == guild_pk)
+                    )
+                    existing_linkage = existing_linkage_result.one_or_none()
+
+                effective_issue_number = inp.get("issue_number")
+                effective_issue_repo = inp.get("issue_repo")
+                effective_pr_number = inp.get("pr_number")
+                effective_pr_repo = inp.get("pr_repo")
+                if existing_linkage:
+                    (
+                        existing_issue_number,
+                        existing_issue_repo,
+                        existing_pr_number,
+                        existing_pr_repo,
+                    ) = existing_linkage
+                    if effective_issue_number is None:
+                        effective_issue_number = existing_issue_number
+                    if not effective_issue_repo:
+                        effective_issue_repo = existing_issue_repo
+                    if effective_pr_number is None:
+                        effective_pr_number = existing_pr_number
+                    if not effective_pr_repo:
+                        effective_pr_repo = existing_pr_repo
+
                 guild_result = await db.exec(
                     select(col(Guild.primary_repo)).where(col(Guild.id) == guild_pk)
                 )
                 primary_repo: str | None = guild_result.one_or_none()
-                repos: list[str] = inp.get("repos") or ([primary_repo] if primary_repo else [])
+                target_repo = effective_pr_repo or effective_issue_repo
+                repos: list[str] = inp.get("repos") or ([target_repo] if target_repo else [])
+                if not repos and primary_repo:
+                    repos = [primary_repo]
                 worker_result = await db.exec(
                     select(
                         col(Worker.id),
@@ -1532,14 +1569,14 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 }
                                 if name_override:
                                     update_values["name"] = name_override
-                                if inp.get("issue_number") is not None:
-                                    update_values["issue_number"] = inp["issue_number"]
-                                if inp.get("issue_repo"):
-                                    update_values["issue_repo"] = inp["issue_repo"]
-                                if inp.get("pr_number") is not None:
-                                    update_values["pr_number"] = inp["pr_number"]
-                                if inp.get("pr_repo"):
-                                    update_values["pr_repo"] = inp["pr_repo"]
+                                if effective_issue_number is not None:
+                                    update_values["issue_number"] = effective_issue_number
+                                if effective_issue_repo:
+                                    update_values["issue_repo"] = effective_issue_repo
+                                if effective_pr_number is not None:
+                                    update_values["pr_number"] = effective_pr_number
+                                if effective_pr_repo:
+                                    update_values["pr_repo"] = effective_pr_repo
                                 if parent_task_id is not None:
                                     update_values["parent_task_id"] = parent_task_id
                                 await db.exec(
@@ -1578,16 +1615,22 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         provider=provider,
                                         phase=phase,
                                         parentTaskId=parent_task_id,
-                                        issueNumber=inp.get("issue_number"),
-                                        issueRepo=inp.get("issue_repo"),
-                                        prNumber=inp.get("pr_number"),
-                                        prRepo=inp.get("pr_repo"),
+                                        issueNumber=effective_issue_number,
+                                        issueRepo=effective_issue_repo,
+                                        prNumber=effective_pr_number,
+                                        prRepo=effective_pr_repo,
                                         repos=repos,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )
                                 _spawn_discord_task_assigned(
                                     guild_id,
-                                    inp,
+                                    {
+                                        **inp,
+                                        "issue_number": effective_issue_number,
+                                        "issue_repo": effective_issue_repo,
+                                        "pr_number": effective_pr_number,
+                                        "pr_repo": effective_pr_repo,
+                                    },
                                     task_id,
                                     task_name,
                                     parent_task_id=effective_parent_task_id,
@@ -1610,10 +1653,10 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         model=model,
                                         model_tier=model_tier,
                                         provider=provider,
-                                        issue_number=inp.get("issue_number"),
-                                        issue_repo=inp.get("issue_repo"),
-                                        pr_number=inp.get("pr_number"),
-                                        pr_repo=inp.get("pr_repo"),
+                                        issue_number=effective_issue_number,
+                                        issue_repo=effective_issue_repo,
+                                        pr_number=effective_pr_number,
+                                        pr_repo=effective_pr_repo,
                                         state="pending",
                                         phase=phase,
                                         parent_task_id=parent_task_id,
@@ -1634,14 +1677,25 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                         provider=provider,
                                         phase=phase,
                                         parentTaskId=parent_task_id,
-                                        issueNumber=inp.get("issue_number"),
-                                        issueRepo=inp.get("issue_repo"),
-                                        prNumber=inp.get("pr_number"),
-                                        prRepo=inp.get("pr_repo"),
+                                        issueNumber=effective_issue_number,
+                                        issueRepo=effective_issue_repo,
+                                        prNumber=effective_pr_number,
+                                        prRepo=effective_pr_repo,
                                         repos=repos,
                                     ).model_dump(by_alias=True, exclude_none=True),
                                 )
-                                _spawn_discord_task_assigned(guild_id, inp, task_id, name)
+                                _spawn_discord_task_assigned(
+                                    guild_id,
+                                    {
+                                        **inp,
+                                        "issue_number": effective_issue_number,
+                                        "issue_repo": effective_issue_repo,
+                                        "pr_number": effective_pr_number,
+                                        "pr_repo": effective_pr_repo,
+                                    },
+                                    task_id,
+                                    name,
+                                )
                                 result_text = f"Task {task_id} queued for {wid}."
                         finally:
                             await LockService(db).release(assign_lock_key, owner=assign_lock_id)

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -45,7 +45,7 @@ from foreman.runner import (
 from foreman.tools import exec_tools
 from helpers import _sync_session, create_db, insert_agent, insert_guild, insert_task, insert_worker
 from models import ForemanTurn, Guild, Lock, Task, TaskEvent, TaskLog, Worker  # noqa: E402
-from sqlalchemy import func, select  # noqa: E402
+from sqlalchemy import func, select, update  # noqa: E402
 from sqlmodel import col  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -540,6 +540,80 @@ class TestExecToolsDispatching:
             )
         assert "assigned" in results[0]["content"].lower()
         assert "t-exist1" in results[0]["content"]
+
+    async def test_assign_task_existing_task_inherits_github_linkage_for_repos(self, db_session):
+        """If create_task has issue linkage, assign_task(task_id=...) must inherit it.
+
+        Otherwise a pasted issue URL can create the correctly linked task row, but an
+        assign_task call that omits issue_repo/repos falls back to the guild primary repo
+        and dispatches the worker against the wrong repository.
+        """
+        insert_guild(db_session, "g-assign-inherit")
+        _insert_worker(
+            db_session,
+            "g-assign-inherit",
+            "w-inherit",
+        )
+        with _sync_session(db_session) as session:
+            guild_pk = session.scalar(
+                select(col(Guild.id)).where(col(Guild.slug) == "g-assign-inherit")
+            )
+            session.execute(
+                update(Guild).where(col(Guild.id) == guild_pk).values(primary_repo="wrong/repo")
+            )
+            session.execute(
+                update(Worker)
+                .where(col(Worker.id) == "w-inherit")
+                .values(repos=json.dumps(["right/repo", "wrong/repo"]))
+            )
+            session.commit()
+
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock) as mock_broadcast:
+            create_results = await exec_tools(
+                "g-assign-inherit",
+                [
+                    _fake_tool_use(
+                        "create_task",
+                        {
+                            "name": "Fix issue",
+                            "description": "Implement https://github.com/right/repo/issues/123",
+                            "issue_number": 123,
+                            "issue_repo": "right/repo",
+                        },
+                    )
+                ],
+            )
+            task_id = _extract_task_id(create_results[0]["content"])
+
+            results = await exec_tools(
+                "g-assign-inherit",
+                [
+                    _fake_tool_use(
+                        "assign_task",
+                        {
+                            "worker_id": "w-inherit",
+                            "description": "Implement the linked issue",
+                            "task_id": task_id,
+                        },
+                    )
+                ],
+            )
+
+        assert "assigned" in results[0]["content"].lower()
+        with _sync_session(db_session) as session:
+            task = session.get(Task, task_id)
+        assert task.issue_number == 123
+        assert task.issue_repo == "right/repo"
+
+        assigned_payloads = [
+            call.args[1]
+            for call in mock_broadcast.await_args_list
+            if call.args[1].get("type") == "task-assigned"
+        ]
+        assert assigned_payloads
+        assert assigned_payloads[-1]["issueRepo"] == "right/repo"
+        assert assigned_payloads[-1]["issueNumber"] == 123
+        assert assigned_payloads[-1]["repos"] == ["right/repo"]
 
     async def test_assign_task_update_path_persists_parent_task_id(self, db_session):
         """create_task -> assign_task(task_id=..., parent_task_id=...) must persist


### PR DESCRIPTION
## Summary
- inherit issue/PR linkage from existing create_task rows during assign_task
- prefer linked issue/PR repo over guild primary repo for worker dispatch
- add regression coverage for pasted issue URLs dispatching to the linked repo

## Tests
- ruff check . --fix && ruff format .
- cd backend && python -m pytest tests/test_foreman.py::TestExecToolsDispatching::test_assign_task_existing_task_inherits_github_linkage_for_repos