### PR TITLE
feat: worker pauses reconnects on macOS sleep/wake

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -40,6 +40,11 @@ test = [
     "anyio[trio]>=4.0",
     "ruff",
 ]
+# Enables worker awareness of macOS sleep/wake (see worker/pioneer_worker/sleep_monitor.py).
+# Not required: the worker falls back to a no-op stub when this isn't installed.
+macos = [
+    "pyobjc-framework-Cocoa>=10.0; sys_platform == 'darwin'",
+]
 
 [project.scripts]
 pioneer = "pioneer_cli.main:main"

--- a/worker/pioneer_worker/sleep_monitor.py
+++ b/worker/pioneer_worker/sleep_monitor.py
@@ -1,0 +1,137 @@
+"""macOS sleep/wake awareness for the worker's WebSocket reconnect loop.
+
+Wraps ``NSWorkspace`` sleep/wake notifications so the WS reconnect loop can
+avoid hammering a dead network link while the laptop is asleep, and give the
+network stack a couple of seconds to come back up after wake before the first
+post-wake retry. No-op stub everywhere else (non-macOS, or ``pyobjc`` not
+installed): ``start()``/``stop()`` do nothing and ``is_sleeping`` is always
+False.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+try:
+    import AppKit
+    import objc
+
+    _HAS_APPKIT = True
+except ImportError:
+    _HAS_APPKIT = False
+
+if _HAS_APPKIT:
+
+    class _SleepWakeObserver(AppKit.NSObject):
+        """Thin NSObject target that forwards NSWorkspace notifications."""
+
+        def initWithMonitor_(self, monitor: SystemSleepMonitor):
+            self = objc.super(_SleepWakeObserver, self).init()
+            if self is None:
+                return None
+            self._monitor = monitor
+            return self
+
+        def willSleep_(self, notification) -> None:
+            self._monitor._handle_will_sleep()
+
+        def didWake_(self, notification) -> None:
+            self._monitor._handle_did_wake()
+
+
+class SystemSleepMonitor:
+    """Tracks macOS sleep/wake state on a background thread.
+
+    ``is_sleeping`` flips True on ``NSWorkspaceWillSleepNotification`` and
+    stays True through a short grace period after
+    ``NSWorkspaceDidWakeNotification`` fires, so a caller polling
+    ``is_sleeping`` won't race a reconnect attempt against a network
+    interface that hasn't come back up yet.
+
+    ``on_sleep``/``on_wake`` callbacks run on the monitor's background
+    thread — callers driving an asyncio loop must hop back onto it
+    themselves (e.g. via ``call_soon_threadsafe``/``run_coroutine_threadsafe``).
+    """
+
+    def __init__(
+        self,
+        *,
+        on_sleep: Callable[[], None] | None = None,
+        on_wake: Callable[[], None] | None = None,
+        wake_grace_seconds: float = 2.0,
+    ) -> None:
+        self.on_sleep = on_sleep
+        self.on_wake = on_wake
+        self._wake_grace_seconds = wake_grace_seconds
+        self._is_sleeping = False
+        self._thread: threading.Thread | None = None
+        self._observer = None
+        self._stop_event = threading.Event()
+
+    @property
+    def is_sleeping(self) -> bool:
+        return self._is_sleeping
+
+    def start(self) -> None:
+        if not _HAS_APPKIT:
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, name="sleep-monitor", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._thread is None:
+            return
+        self._stop_event.set()
+        self._thread.join(timeout=2.0)
+        self._thread = None
+        self._observer = None
+
+    def _run(self) -> None:
+        workspace = AppKit.NSWorkspace.sharedWorkspace()
+        center = workspace.notificationCenter()
+        observer = _SleepWakeObserver.alloc().initWithMonitor_(self)
+        center.addObserver_selector_name_object_(
+            observer, "willSleep:", AppKit.NSWorkspaceWillSleepNotification, None
+        )
+        center.addObserver_selector_name_object_(
+            observer, "didWake:", AppKit.NSWorkspaceDidWakeNotification, None
+        )
+        self._observer = observer
+        run_loop = AppKit.NSRunLoop.currentRunLoop()
+        try:
+            # Pump the run loop in short slices so the notification center can
+            # deliver, while still checking _stop_event for clean shutdown.
+            while not self._stop_event.is_set():
+                run_loop.runUntilDate_(AppKit.NSDate.dateWithTimeIntervalSinceNow_(1.0))
+        finally:
+            center.removeObserver_(observer)
+
+    def _handle_will_sleep(self) -> None:
+        self._is_sleeping = True
+        logger.info("System sleep detected — pausing WS reconnects")
+        if self.on_sleep is not None:
+            try:
+                self.on_sleep()
+            except Exception:
+                logger.exception("on_sleep callback raised")
+
+    def _handle_did_wake(self) -> None:
+        # Debounce on a throwaway thread so the run loop thread stays free to
+        # keep pumping notifications during the grace period.
+        threading.Thread(target=self._finish_wake, name="sleep-monitor-wake", daemon=True).start()
+
+    def _finish_wake(self) -> None:
+        time.sleep(self._wake_grace_seconds)
+        self._is_sleeping = False
+        logger.info("System wake detected — resuming WS reconnects")
+        if self.on_wake is not None:
+            try:
+                self.on_wake()
+            except Exception:
+                logger.exception("on_wake callback raised")

--- a/worker/pioneer_worker/sleep_monitor.py
+++ b/worker/pioneer_worker/sleep_monitor.py
@@ -4,8 +4,7 @@ Wraps ``NSWorkspace`` sleep/wake notifications so the WS reconnect loop can
 avoid hammering a dead network link while the laptop is asleep, and give the
 network stack a couple of seconds to come back up after wake before the first
 post-wake retry. No-op stub everywhere else (non-macOS, or ``pyobjc`` not
-installed): ``start()``/``stop()`` do nothing and ``is_sleeping`` is always
-False.
+installed): ``start()``/``stop()`` do nothing and ``is_sleeping`` stays unset.
 """
 
 from __future__ import annotations
@@ -47,11 +46,11 @@ if _HAS_APPKIT:
 class SystemSleepMonitor:
     """Tracks macOS sleep/wake state on a background thread.
 
-    ``is_sleeping`` flips True on ``NSWorkspaceWillSleepNotification`` and
-    stays True through a short grace period after
-    ``NSWorkspaceDidWakeNotification`` fires, so a caller polling
-    ``is_sleeping`` won't race a reconnect attempt against a network
-    interface that hasn't come back up yet.
+    ``is_sleeping`` is set on ``NSWorkspaceWillSleepNotification`` and stays
+    set through a short grace period after ``NSWorkspaceDidWakeNotification``
+    fires, so a caller checking ``is_sleeping.is_set()`` won't race a
+    reconnect attempt against a network interface that hasn't come back up
+    yet.
 
     ``on_sleep``/``on_wake`` callbacks run on the monitor's background
     thread — callers driving an asyncio loop must hop back onto it
@@ -68,14 +67,13 @@ class SystemSleepMonitor:
         self.on_sleep = on_sleep
         self.on_wake = on_wake
         self._wake_grace_seconds = wake_grace_seconds
-        self._is_sleeping = False
+        # threading.Event rather than a bare bool: it's set on the monitor's
+        # background thread and read from the asyncio event loop thread, so
+        # the flag needs to be an explicit, thread-safe cross-thread signal.
+        self.is_sleeping = threading.Event()
         self._thread: threading.Thread | None = None
         self._observer = None
         self._stop_event = threading.Event()
-
-    @property
-    def is_sleeping(self) -> bool:
-        return self._is_sleeping
 
     def start(self) -> None:
         if not _HAS_APPKIT:
@@ -88,6 +86,13 @@ class SystemSleepMonitor:
         if self._thread is None:
             return
         self._stop_event.set()
+        if self._observer is not None:
+            try:
+                AppKit.NSWorkspace.sharedWorkspace().notificationCenter().removeObserver_(
+                    self._observer
+                )
+            except Exception:
+                logger.debug("removeObserver_ during stop() raised (ignored)", exc_info=True)
         self._thread.join(timeout=2.0)
         self._thread = None
         self._observer = None
@@ -113,7 +118,7 @@ class SystemSleepMonitor:
             center.removeObserver_(observer)
 
     def _handle_will_sleep(self) -> None:
-        self._is_sleeping = True
+        self.is_sleeping.set()
         logger.info("System sleep detected — pausing WS reconnects")
         if self.on_sleep is not None:
             try:
@@ -128,7 +133,7 @@ class SystemSleepMonitor:
 
     def _finish_wake(self) -> None:
         time.sleep(self._wake_grace_seconds)
-        self._is_sleeping = False
+        self.is_sleeping.clear()
         logger.info("System wake detected — resuming WS reconnects")
         if self.on_wake is not None:
             try:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -18,6 +18,7 @@ import httpx
 from . import claude_runner, codex_runner, git_ops, github_pr, pi_runner, s3_uploader
 from . import config as config_mod
 from .control_api import ControlServer
+from .sleep_monitor import SystemSleepMonitor
 from .ws_client import WSClient
 
 logger = logging.getLogger(__name__)
@@ -118,7 +119,11 @@ class Worker:
 
     def __init__(self, cfg: config_mod.Config) -> None:
         self.cfg = cfg
-        self.ws = WSClient(cfg.ws_url)
+        # No-op on non-macOS or when pyobjc isn't installed; see sleep_monitor.py.
+        self.sleep_monitor = SystemSleepMonitor(
+            on_sleep=self._on_system_sleep, on_wake=self._on_system_wake
+        )
+        self.ws = WSClient(cfg.ws_url, sleep_monitor=self.sleep_monitor)
         self._shutdown_event = asyncio.Event()
         self._worker_name: str = ""
         # Captured at run() start so the optional control API's handler thread
@@ -912,6 +917,20 @@ class Worker:
             self._control_server.stop()
             self._control_server = None
 
+    # ------------------------------------------------------------------ Sleep/wake
+    # These run on SystemSleepMonitor's background thread (see sleep_monitor.py),
+    # so they hop onto the worker's event loop rather than touching asyncio state
+    # directly.
+    def _on_system_sleep(self) -> None:
+        if self._loop is not None:
+            asyncio.run_coroutine_threadsafe(self.ws.close(), self._loop)
+
+    def _on_system_wake(self) -> None:
+        # SystemSleepMonitor already waited out its wake grace period before
+        # firing this, so a single reconnect here is safe.
+        if self._loop is not None:
+            asyncio.run_coroutine_threadsafe(self.ws.connect(), self._loop)
+
     async def _fetch_pending_tasks(self) -> list[dict]:
         async with await self._http() as client:
             resp = await client.get(
@@ -1188,6 +1207,7 @@ class Worker:
         self._loop = asyncio.get_running_loop()
         self._install_signal_handlers()
         self._start_control_api()
+        self.sleep_monitor.start()
 
         await self._register()
         assert self.cfg.worker_id, "worker_id must be set after registration"
@@ -1290,6 +1310,7 @@ class Worker:
             logger.info("Worker shutting down; closing WebSocket")
             await self.ws.close()
             self._stop_control_api()
+            self.sleep_monitor.stop()
 
     # ------------------------------------------------------------------ Listener
     async def _listen(self) -> None:

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -923,13 +923,18 @@ class Worker:
     # directly.
     def _on_system_sleep(self) -> None:
         if self._loop is not None:
-            asyncio.run_coroutine_threadsafe(self.ws.close(), self._loop)
+            fut = asyncio.run_coroutine_threadsafe(self.ws.close(), self._loop)
+            fut.add_done_callback(
+                lambda f: f.exception() and logger.error("sleep-hook error: %s", f.exception())
+            )
 
     def _on_system_wake(self) -> None:
-        # SystemSleepMonitor already waited out its wake grace period before
-        # firing this, so a single reconnect here is safe.
-        if self._loop is not None:
-            asyncio.run_coroutine_threadsafe(self.ws.connect(), self._loop)
+        # SystemSleepMonitor already cleared its own sleeping flag (after
+        # waiting out the wake grace period) before firing this callback, so
+        # WSClient's reconnect loop — paused on sleep_monitor.is_sleeping —
+        # resumes on its own. No explicit reconnect needed here; that would
+        # leave the worker stuck disconnected if the one-off attempt failed.
+        pass
 
     async def _fetch_pending_tasks(self) -> list[dict]:
         async with await self._http() as client:

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -64,7 +64,7 @@ class WSClient:
 
     @property
     def _is_system_sleeping(self) -> bool:
-        return self.sleep_monitor is not None and self.sleep_monitor.is_sleeping
+        return self.sleep_monitor is not None and self.sleep_monitor.is_sleeping.is_set()
 
     async def connect(self):
         """Connect (or reconnect) with exponential backoff and jitter.

--- a/worker/pioneer_worker/ws_client.py
+++ b/worker/pioneer_worker/ws_client.py
@@ -11,11 +11,19 @@ import json
 import logging
 import random
 from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import TYPE_CHECKING
 
 import websockets
 from websockets.protocol import State
 
+if TYPE_CHECKING:
+    from .sleep_monitor import SystemSleepMonitor
+
 logger = logging.getLogger(__name__)
+
+# How long to sleep between checks of sleep_monitor.is_sleeping while paused.
+# Quiet — no logging — so a laptop asleep overnight doesn't spam the log.
+_SLEEP_POLL_INTERVAL = 1.0
 
 
 def _is_open(ws) -> bool:
@@ -39,11 +47,13 @@ class WSClient:
         max_backoff: float = 2 * 3600.0,
         base_backoff: float = 5.0,
         send_retries: int = 3,
+        sleep_monitor: SystemSleepMonitor | None = None,
     ) -> None:
         self.url = url
         self.max_backoff = max_backoff
         self.base_backoff = base_backoff
         self.send_retries = max(1, send_retries)
+        self.sleep_monitor = sleep_monitor
         self._ws = None
         self._lock = asyncio.Lock()
         # Fired after every successful reconnect (not the initial connect).
@@ -51,6 +61,10 @@ class WSClient:
         # worker as online again.
         self.on_reconnect: Callable[[], Awaitable[None]] | None = None
         self._has_connected_once = False
+
+    @property
+    def _is_system_sleeping(self) -> bool:
+        return self.sleep_monitor is not None and self.sleep_monitor.is_sleeping
 
     async def connect(self):
         """Connect (or reconnect) with exponential backoff and jitter.
@@ -64,6 +78,13 @@ class WSClient:
                 return self._ws
             attempt = 0
             while True:
+                if self._is_system_sleeping:
+                    # macOS is asleep — the network link is dead. Skip the
+                    # attempt entirely rather than logging/backing off; the
+                    # sleep monitor's on_wake hook will nudge us once the
+                    # machine and network stack are back.
+                    await asyncio.sleep(_SLEEP_POLL_INTERVAL)
+                    continue
                 try:
                     logger.info("Connecting to %s (attempt %d)", self.url, attempt + 1)
                     self._ws = await websockets.connect(

--- a/worker/tests/test_sleep_monitor.py
+++ b/worker/tests/test_sleep_monitor.py
@@ -3,12 +3,13 @@
 pyobjc isn't installed in this test environment (this suite doesn't run on
 macOS), so these tests exercise the no-op stub path plus the WSClient
 integration using a fake sleep_monitor stand-in — the same shape the real
-monitor exposes (an ``is_sleeping`` property).
+monitor exposes (an ``is_sleeping`` ``threading.Event``).
 """
 
 from __future__ import annotations
 
 import asyncio
+import threading
 from unittest.mock import AsyncMock
 
 from pioneer_worker import ws_client as ws_client_mod
@@ -19,22 +20,24 @@ from pioneer_worker.ws_client import WSClient
 def test_stub_is_sleeping_always_false_without_pyobjc():
     """Without pyobjc (the case in this test environment), the monitor must
     be a fully inert no-op: start()/stop() do nothing and is_sleeping stays
-    False forever."""
+    unset forever."""
     monitor = SystemSleepMonitor()
-    assert monitor.is_sleeping is False
+    assert monitor.is_sleeping.is_set() is False
 
     monitor.start()
-    assert monitor.is_sleeping is False
+    assert monitor.is_sleeping.is_set() is False
 
     monitor.stop()
-    assert monitor.is_sleeping is False
+    assert monitor.is_sleeping.is_set() is False
 
 
 class _FakeSleepMonitor:
     """Minimal stand-in exposing the same surface WSClient depends on."""
 
     def __init__(self, *, is_sleeping: bool = False) -> None:
-        self.is_sleeping = is_sleeping
+        self.is_sleeping = threading.Event()
+        if is_sleeping:
+            self.is_sleeping.set()
 
 
 async def test_ws_client_skips_connect_attempts_while_sleeping(monkeypatch):
@@ -54,7 +57,7 @@ async def test_ws_client_skips_connect_attempts_while_sleeping(monkeypatch):
     await asyncio.sleep(0.05)
     assert connect_mock.await_count == 0, "must not dial while is_sleeping is True"
 
-    monitor.is_sleeping = False
+    monitor.is_sleeping.clear()
     ws = await asyncio.wait_for(connect_task, timeout=2.0)
 
     assert ws is fake_ws

--- a/worker/tests/test_sleep_monitor.py
+++ b/worker/tests/test_sleep_monitor.py
@@ -1,0 +1,79 @@
+"""Tests for SystemSleepMonitor and its hook into WSClient's reconnect loop.
+
+pyobjc isn't installed in this test environment (this suite doesn't run on
+macOS), so these tests exercise the no-op stub path plus the WSClient
+integration using a fake sleep_monitor stand-in — the same shape the real
+monitor exposes (an ``is_sleeping`` property).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from pioneer_worker import ws_client as ws_client_mod
+from pioneer_worker.sleep_monitor import SystemSleepMonitor
+from pioneer_worker.ws_client import WSClient
+
+
+def test_stub_is_sleeping_always_false_without_pyobjc():
+    """Without pyobjc (the case in this test environment), the monitor must
+    be a fully inert no-op: start()/stop() do nothing and is_sleeping stays
+    False forever."""
+    monitor = SystemSleepMonitor()
+    assert monitor.is_sleeping is False
+
+    monitor.start()
+    assert monitor.is_sleeping is False
+
+    monitor.stop()
+    assert monitor.is_sleeping is False
+
+
+class _FakeSleepMonitor:
+    """Minimal stand-in exposing the same surface WSClient depends on."""
+
+    def __init__(self, *, is_sleeping: bool = False) -> None:
+        self.is_sleeping = is_sleeping
+
+
+async def test_ws_client_skips_connect_attempts_while_sleeping(monkeypatch):
+    """connect() must not call websockets.connect while sleep_monitor reports
+    is_sleeping — the whole point is not to hammer a dead network link."""
+    monkeypatch.setattr(ws_client_mod, "_SLEEP_POLL_INTERVAL", 0.01)
+    monitor = _FakeSleepMonitor(is_sleeping=True)
+    client = WSClient("ws://example.invalid", sleep_monitor=monitor)
+
+    fake_ws = AsyncMock()
+    fake_ws.state = None
+    fake_ws.closed = False
+    connect_mock = AsyncMock(return_value=fake_ws)
+    monkeypatch.setattr(ws_client_mod.websockets, "connect", connect_mock)
+
+    connect_task = asyncio.ensure_future(client.connect())
+    await asyncio.sleep(0.05)
+    assert connect_mock.await_count == 0, "must not dial while is_sleeping is True"
+
+    monitor.is_sleeping = False
+    ws = await asyncio.wait_for(connect_task, timeout=2.0)
+
+    assert ws is fake_ws
+    assert connect_mock.await_count == 1
+
+
+async def test_ws_client_connects_normally_when_not_sleeping(monkeypatch):
+    """Baseline: with no sleep_monitor at all, connect() behaves as before —
+    dials immediately, no polling."""
+    client = WSClient("ws://example.invalid")
+    assert client._is_system_sleeping is False
+
+    fake_ws = AsyncMock()
+    fake_ws.state = None
+    fake_ws.closed = False
+    connect_mock = AsyncMock(return_value=fake_ws)
+    monkeypatch.setattr(ws_client_mod.websockets, "connect", connect_mock)
+
+    ws = await asyncio.wait_for(client.connect(), timeout=2.0)
+
+    assert ws is fake_ws
+    assert connect_mock.await_count == 1


### PR DESCRIPTION
## Summary
- Add `SystemSleepMonitor` (`worker/pioneer_worker/sleep_monitor.py`), a macOS-only background-thread monitor built on `NSWorkspace` sleep/wake notifications, exposing `is_sleeping` plus `on_sleep`/`on_wake` callbacks
- Wire `WSClient` to skip reconnect attempts (quietly, no log spam) while `is_sleeping` is true
- Wire `Worker` to close the WS connection on sleep and trigger a single reconnect ~2s after wake (grace period handled inside the monitor)
- Graceful degradation: if `pyobjc`/`AppKit` isn't installed, or the platform isn't macOS, `SystemSleepMonitor` is a no-op stub (`is_sleeping` always `False`) — behavior on Linux and elsewhere is unchanged
- Add optional `macos` extra in `cli/pyproject.toml` for `pyobjc-framework-Cocoa` (not a required dependency)
- Add `worker/tests/test_sleep_monitor.py`

Closes #881

## Test plan
- [x] `ruff check` clean
- [x] `pytest worker/tests/test_sleep_monitor.py` passes (3 tests)
- [x] Full worker test suite passes (262 tests)