### PR TITLE
fix(discord): show actual tool name for single-tool-call turns

### DIFF
--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -1049,22 +1049,25 @@ def _format_stream_entries(entries: list[_StreamEntry], start_turn: int) -> tupl
         nonlocal turn_number, group
         if not group:
             return
-        tool_use_count = sum(
-            1 for entry in group if (entry.detail or {}).get("toolType") == "tool_use"
-        )
-        if tool_use_count <= 1:
-            output.extend(entry.line for entry in group)
-            group = []
-            return
-        turn_number += 1
+        tool_use_count = 0
         counts: dict[str, int] = {}
         for entry in group:
             detail = entry.detail or {}
             if detail.get("toolType") == "tool_use":
+                tool_use_count += 1
                 # Lowercase intentionally, to match the frontend's formatTurnCounts
                 # (LogList.vue) so tool names group consistently regardless of case.
                 name = str(detail.get("name") or "tool").lower()
                 counts[name] = counts.get(name, 0) + 1
+        if tool_use_count <= 1:
+            # Turn counter is intentionally NOT incremented for single-tool-call
+            # groups (matching the frontend, which also skips grouping these), so
+            # turn numbering may skip a number when a single-tool group sits
+            # between multi-tool groups.
+            output.extend(entry.line for entry in group)
+            group = []
+            return
+        turn_number += 1
         parts = ", ".join(f"{name} × {count}" for name, count in counts.items())
         output.append(f"▶ Turn {turn_number}: {parts or 'tool activity'}")
         group = []

--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -1034,7 +1034,10 @@ def _format_stream_entries(entries: list[_StreamEntry], start_turn: int) -> tupl
     Mirrors the frontend's turn grouping (see LogList.vue): a run of consecutive
     tool_use/tool_result entries between non-tool lines (assistant text, thinking,
     turn-completion markers) becomes one ``▶ Turn N: edit × 2, bash × 1`` line
-    instead of dumping every raw tool call and result into the thread. Non-tool
+    instead of dumping every raw tool call and result into the thread. A run with
+    at most one tool call carries no useful grouping information, so — like the
+    frontend — it passes through as its raw lines (e.g. ``▶ bash: pytest``)
+    instead of collapsing into a generic ``bash × 1`` turn summary. Non-tool
     lines pass through unchanged. Returns the formatted text and the turn count
     to carry into the next batch, so numbering stays sequential across flushes.
     """
@@ -1045,6 +1048,13 @@ def _format_stream_entries(entries: list[_StreamEntry], start_turn: int) -> tupl
     def flush_group() -> None:
         nonlocal turn_number, group
         if not group:
+            return
+        tool_use_count = sum(
+            1 for entry in group if (entry.detail or {}).get("toolType") == "tool_use"
+        )
+        if tool_use_count <= 1:
+            output.extend(entry.line for entry in group)
+            group = []
             return
         turn_number += 1
         counts: dict[str, int] = {}

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -1395,14 +1395,57 @@ def test_format_stream_entries_passes_through_non_tool_lines():
 
 def test_format_stream_entries_numbers_turns_across_flushes():
     """Turn numbers keep incrementing when starting from a prior batch's count."""
-    first_batch = [_entry("▶ bash: ls", "tool_use", "Bash")]
+    first_batch = [
+        _entry("▶ edit: foo.py", "tool_use", "Edit"),
+        _entry("  → ok", "tool_result"),
+        _entry("▶ bash: pytest", "tool_use", "Bash"),
+        _entry("  → 3 passed", "tool_result"),
+    ]
     _, turn_count = discord_notifier._format_stream_entries(first_batch, 0)
 
-    second_batch = [_entry("▶ edit: foo.py", "tool_use", "Edit")]
+    second_batch = [
+        _entry("▶ edit: foo.py", "tool_use", "Edit"),
+        _entry("  → ok", "tool_result"),
+        _entry("▶ bash: pytest", "tool_use", "Bash"),
+        _entry("  → 3 passed", "tool_result"),
+    ]
     content, turn_count = discord_notifier._format_stream_entries(second_batch, turn_count)
 
-    assert content == "▶ Turn 2: edit × 1"
+    assert content == "▶ Turn 2: edit × 1, bash × 1"
     assert turn_count == 2
+
+
+def test_format_stream_entries_single_tool_call_shows_actual_tool_name():
+    """A single tool call passes through its raw line instead of 'bash × 1' (issue #886)."""
+    entries = [
+        _entry("▶ bash: pytest -k test_foo", "tool_use", "Bash"),
+        _entry("  → 3 passed", "tool_result"),
+    ]
+
+    content, turn_count = discord_notifier._format_stream_entries(entries, 0)
+
+    assert content == "▶ bash: pytest -k test_foo\n  → 3 passed"
+    assert turn_count == 0
+
+
+def test_format_stream_entries_single_tool_call_with_no_result():
+    """A lone tool_use with no trailing tool_result still passes through raw."""
+    entries = [_entry("▶ write_file: notes.md", "tool_use", "Write")]
+
+    content, turn_count = discord_notifier._format_stream_entries(entries, 0)
+
+    assert content == "▶ write_file: notes.md"
+    assert turn_count == 0
+
+
+def test_format_stream_entries_zero_tool_calls_passes_through():
+    """A run of only tool_result entries (no tool_use) also passes through raw."""
+    entries = [_entry("  → stray result", "tool_result")]
+
+    content, turn_count = discord_notifier._format_stream_entries(entries, 0)
+
+    assert content == "  → stray result"
+    assert turn_count == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_discord_notifier.py
+++ b/backend/tests/test_discord_notifier.py
@@ -1429,7 +1429,12 @@ def test_format_stream_entries_single_tool_call_shows_actual_tool_name():
 
 
 def test_format_stream_entries_single_tool_call_with_no_result():
-    """A lone tool_use with no trailing tool_result still passes through raw."""
+    """A lone tool_use with no trailing tool_result still passes through raw.
+
+    This is an expected production scenario, not just a defensive edge case: a
+    batch can be flushed mid-turn (e.g. on a timer) before the matching
+    tool_result has streamed in yet.
+    """
     entries = [_entry("▶ write_file: notes.md", "tool_use", "Write")]
 
     content, turn_count = discord_notifier._format_stream_entries(entries, 0)


### PR DESCRIPTION
## Summary
- Turns with exactly one tool call now pass through their raw line (e.g. `▶ bash: pytest`) instead of collapsing into a generic `bash × 1` turn summary, matching the frontend's `LogList.vue` grouping which already skips grouping when `toolCallCount <= 1`.
- Turns with multiple tool calls keep the existing grouped `▶ Turn N: edit × 2, bash × 1` behavior unchanged.

## Test plan
- [x] Updated/added unit tests in `backend/tests/test_discord_notifier.py` covering single tool_use+tool_result, lone tool_use with no result, and zero-tool_use groups
- [x] `pytest tests/test_discord_notifier.py -k format_stream` passes
- [x] `ruff check` passes

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)