### PR TITLE
docs: audit and trim markdown files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ SQLite/Alembic schema, WebSocket handlers, and Foreman logic under `backend/fore
 standalone Python worker package in `worker/pioneer_worker/` and its tests in `worker/tests/`.
 The opt-in standalone foreman lives in `foreman-proxy/`. `cli/` holds the unified `pioneer` launcher
 (`cli/pioneer_cli/`) and the single `cli/pyproject.toml` that installs and serves all three
-runtimes — there are no longer separate per-runtime `pyproject.toml` files. Shared operational docs
-are in `docs/`, prompt text in `prompts/`, and helper scripts in `scripts/`.
+runtimes. Shared operational docs are in `docs/`, prompt text in `prompts/`, and helper scripts in
+`scripts/`.
 
 ## Build, Test, and Development Commands
 
@@ -35,9 +35,9 @@ uv venv && source .venv/bin/activate
 uv pip install -e "cli[test]"      # one install serves all modes
 ```
 
-The launcher keeps the existing source trees in place (`backend/`, `foreman-proxy/`, `worker/`) and puts
-the right directory on `sys.path` for the selected mode (resolving the repo root from `cli/`'s
-parent, overridable via `PIONEER_ROOT`). It does not move source or rewrite imports.
+The launcher keeps the existing source trees in place (`backend/`, `foreman-proxy/`, `worker/`) and
+puts the right directory on `sys.path` for the selected mode, without moving source or rewriting
+imports (repo root resolved from `cli/`'s parent, overridable via `PIONEER_ROOT`).
 
 ### Backend (HTTP server)
 ```bash
@@ -119,7 +119,7 @@ npm run format      # prettier --write (run from frontend/)
 ```
 
 Config lives at `ruff.toml` (root) and `frontend/eslint.config.js` + `frontend/.prettierrc.json`.
-There is no CI wired up yet — these are local guards.
+`.github/workflows/ci.yml` runs ruff lint plus backend, worker, and frontend tests on push/PR.
 
 ## Testing Guidelines
 
@@ -132,8 +132,8 @@ lifecycle changes, and store updates when touching those paths.
 ```bash
 # Backend tests require the postgres-test container (localhost:5433):
 docker compose up -d postgres-test
-cd backend && python -m pytest         # 119 tests
-cd worker && python -m pytest          # 49 tests
+cd backend && python -m pytest         # currently ~1000 tests
+cd worker && python -m pytest          # currently ~250 tests
 cd frontend && npm test && npm run type-check
 ```
 
@@ -160,12 +160,13 @@ Browser ──WebSocket──► Backend (FastAPI/SQLite)
 Worker ──WebSocket──────────┘
 ```
 
-**Backend** (`backend/main.py`) is a FastAPI app — still mostly one large file (~1700 lines:
-routes, WS handlers, OAuth) plus the `backend/foreman/` package (`runner.py`, `tools.py`,
-`prompt.py`, `state.py`) and `backend/events.py` for WS broadcast helpers. Persists all state in
-`pioneer_square.db` (SQLite via aiosqlite, schema managed by Alembic in
-`backend/alembic/versions/`), holds in-memory WebSocket connections per guild, and runs the
-Foreman AI inline as `asyncio.create_task` calls.
+**Backend** (`backend/main.py`) is a FastAPI app. `main.py` is currently a thin ~570-line wiring
+module: routes live under `backend/routes/`, OAuth helpers in `backend/oauth.py`, WS message
+handling in `backend/ws_handlers.py`/`ws_types.py`, and the Foreman AI in the `backend/foreman/`
+package. Persists all state in `pioneer_square.db` (SQLite via aiosqlite, schema managed by
+Alembic in `backend/alembic/versions/`), holds in-memory WebSocket connections per guild, and runs
+the Foreman AI as background tasks via the `spawn()` helper in `backend/util/tasks.py` (a tracked
+wrapper around `asyncio.create_task`).
 
 **Frontend** (`frontend/src/`) is Vue 3 + Pinia + Vite + TypeScript. It connects to the backend
 WebSocket for real-time events and uses REST to fetch initial state. Stores in `src/stores/`
@@ -184,9 +185,9 @@ backend restarts.
   appears in URLs and `pioneer-worker.toml` as `guild_id`).
 - **Worker**: a registered worker entity in the DB (`workers` table, id prefix `w-`). Persisted
   across restarts.
-- **Agent**: a WebSocket participant (`agents` table, id prefix `a-`). A worker process creates
-  one `agent_id` per process lifetime (stable within a run, not across restarts). The `worker_id`
-  is for DB routing; `agent_id` is the live WebSocket identity.
+- **Agent**: a WebSocket participant (`agents` table, id prefix `a-`). A worker process runs
+  `max_agents` concurrent agent slots, each with its own `agent_id` (stable within a run, not
+  across restarts). The `worker_id` is for DB routing; `agent_id` is the live WebSocket identity.
 - **Task**: a unit of work (`tasks` table, id prefix `t-`). Foreman-created tasks have
   `worker_id=NULL` (unassigned) until the foreman's `assign_task` tool sets a real worker; worker
   tasks are owned by a real worker.
@@ -197,14 +198,17 @@ backend restarts.
 
 After a worker sends `task-complete`, the backend triggers the Foreman AI. The foreman either
 calls `send_followup` (worker re-runs Claude in the same worktree on the same branch) or
-`finalize_task` (marks done). A 300-second timeout auto-finalizes if the foreman doesn't respond.
+`finalize_task` (marks done). Independently, a GitHub webhook auto-finalizes a task to `done`
+when its PR is merged, without waiting on the foreman.
 
 ### Foreman AI
 
-Lives in `backend/foreman/` (`runner.py` for the Claude SDK loop, `tools.py` for tool
-definitions, `prompt.py` for the system prompt, `state.py` for in-memory conversation history).
-Uses `claude-sonnet-4-6`. Conversation history is kept in-memory (trimmed to 40 messages). The
-foreman is triggered by:
+Lives in `backend/foreman/` — key modules are `runner.py` (the Claude SDK loop), `tools.py` (tool
+definitions), and `prompt.py` (system prompt); the package has grown to include auth, proxy, and
+LLM-provider helpers too. Currently uses `claude-sonnet-4-6` (`FOREMAN_MODEL` env var). Conversation
+history is DB-backed (loaded per guild/user from the `messages`/`foreman_turns` tables), windowed
+to the last few human turns and capped at `MAX_HISTORY_MESSAGES` (currently 20) before each call.
+The foreman is triggered by:
 1. Human chat messages addressed to `foreman`
 2. `task-complete` WS messages from workers
 3. `task-followup-done` WS messages
@@ -241,20 +245,24 @@ All real-time communication is JSON over `ws://localhost:8000/ws/{guild_id}`. Ke
 
 ### Database schema
 
-Tables: `guilds`, `agents`, `workers`, `tasks`, `task_logs`, `messages`, `github_tokens`,
-`claude_credentials`, `user_sessions`. Schema is defined in `backend/models.py` (SQLAlchemy ORM)
-and migrated by Alembic — see `backend/alembic/versions/`. `init_db()` runs `alembic upgrade head`
+Core tables include `guilds`, `agents`, `workers`, `tasks`, `task_logs`, `messages`,
+`github_tokens`, `claude_credentials`, `user_sessions`; the schema has grown well beyond this list
+(Discord integration, GitHub issue/PR caching, usage tracking, etc.) — `backend/models.py`
+(SQLModel ORM) is the authoritative source. Migrated by Alembic — see
+`backend/alembic/versions/`. `init_db()` runs `alembic upgrade head`
 on startup; pre-Alembic databases are stamped to `head` so the upgrade is a no-op. On every
 backend startup, all workers and worker agents are reset to `offline`.
 
 ### Worker internals
 
-`worker/pioneer_worker/worker.py` has three concurrent asyncio tasks:
+`worker/pioneer_worker/worker.py` runs several concurrent asyncio tasks:
 - `_listen()` — processes incoming WS messages (task assignments, follow-ups, finalize signals,
   mid-task stdin injections via `worker-message`)
-- `_task_runner()` — serial task execution loop (one task at a time per worker process)
+- `_agent_loop(slot)` — one instance per agent slot (`max_agents` config, default 4), so a single
+  worker process can run that many tasks concurrently rather than strictly serially
 - `_idle_puller()` — polls REST every `pull_interval` seconds to pick up tasks missed during
   downtime; also runs `git pull` on repos while idle
+- `_worktree_sweeper()` and (when configured) `_s3_syncer()` — background maintenance tasks
 
 Runners: `claude_runner.py` (primary), `codex_runner.py`, `pi_runner.py`. All return
 `(success: bool, stop_reason: str, last_text: str)`. The claude runner uses a 16 MiB stdout line
@@ -262,11 +270,14 @@ limit to handle large `tool_result` payloads.
 
 ### Auth
 
-GitHub OAuth flow: frontend triggers `/auth/github/login` → GitHub redirects to
-`/auth/github/callback` → backend stores token in `github_tokens`, issues a `login_token`,
-redirects to frontend with params in query string. Frontend stores the token in `localStorage`;
-sends it as `Authorization: Bearer <token>` on REST calls. Workers fetch the OAuth token from
-`/auth/github/token?guild_id=...` if no token is in their config.
+GitHub OAuth flow: frontend calls `/auth/github/login` (gets an authorize URL) → GitHub redirects
+back with `code`+`state`. By default `GITHUB_REDIRECT_URI` points at the frontend, which POSTs
+`code`+`state` to `/auth/github/exchange`; the backend stores the token in `github_tokens` and
+returns a `login_token` + GitHub profile fields as JSON. (`/auth/github/callback` is a legacy path
+for setups where GitHub redirects to the backend instead — same exchange, then a redirect to the
+frontend with the same fields in the query string.) Frontend stores the token in `localStorage`
+and sends it as `Authorization: Bearer <token>` on REST calls. Workers fetch the OAuth token from
+`/auth/github/token?guild_id=...` if none is in their config.
 
 ### Frontend stores
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,8 +198,9 @@ backend restarts.
 
 After a worker sends `task-complete`, the backend triggers the Foreman AI. The foreman either
 calls `send_followup` (worker re-runs Claude in the same worktree on the same branch) or
-`finalize_task` (marks done). Independently, a GitHub webhook auto-finalizes a task to `done`
-when its PR is merged, without waiting on the foreman.
+`finalize_task` (marks done). A 300-second timeout auto-finalizes if the foreman doesn't respond.
+Independently, a GitHub webhook auto-finalizes a task to `done` when its PR is merged, without
+waiting on the foreman.
 
 ### Foreman AI
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A real-time multi-agent workspace with a colorful pixel-art factory floor UI.
 - 🤖 Agent avatars with state-based animations (idle/thinking/working/busy/error)
 - 💬 Real-time chat with the Foreman agent
 - 🖥️ Terminal log panes per agent
-- 🔗 WebRTC peer connections for agent-to-agent communication
-- 📡 WebSocket signaling for real-time updates
-- 🔑 Short 6-char session URLs for sharing
+- 📡 WebSocket signaling for real-time updates (the backend also relays WebRTC
+  offer/answer/ICE messages, though no client currently establishes peer connections)
+- 🔑 Short 6-char guild URLs for sharing
 
 ## Setup
 
@@ -26,8 +26,8 @@ docker compose up --build
 
 App (backend + SPA): http://localhost:8056. PostgreSQL data is persisted in the `postgres-data` volume.
 
-`docker compose up` starts a `postgres:17` container automatically. The backend waits for it
-to pass its health-check, then runs `alembic upgrade head` before accepting connections.
+`docker compose up` starts a `postgres:18` container automatically, waits for its health-check,
+then runs `alembic upgrade head` before the backend accepts connections.
 
 The worker is opt-in (it needs a `pioneer-worker.toml`):
 
@@ -37,63 +37,45 @@ cp worker/pioneer-worker.toml.example worker/pioneer-worker.toml
 docker compose --profile worker up --build worker
 ```
 
-The standalone foreman process (Phase 2) is also opt-in.  It offloads the Foreman
-AI out of the backend process — useful if you want to scale or restart the foreman
-independently.  The backend falls back to its embedded foreman when no external one
-is connected.
-
-The foreman authenticates to the backend with a shared HMAC secret
-(`PIONEER_FOREMAN_KEY`).  Generate one with:
+The standalone foreman process is also opt-in — it offloads Foreman LLM API calls out of the
+backend process, e.g. to scale or restart the foreman independently. As of this writing it
+authenticates with a short-lived JWT signed using a shared secret, set as `PIONEER_FOREMAN_KEY`
+on both sides (generate one with `openssl rand -hex 32`):
 
 ```bash
-openssl rand -hex 32
-```
-
-Set the **same value** on both sides — `PIONEER_FOREMAN_KEY` on the backend and
-`GUILD_ID` + the key for the foreman:
-
-```bash
-# Backend (.env or shell):
+# Backend:
 PIONEER_FOREMAN_KEY=<your-secret>
 
 # Foreman (docker compose):
-GUILD_ID=abc123 PIONEER_FOREMAN_KEY=<your-secret> \
-  docker compose --profile foreman up --build foreman
+GUILD_ID=abc123 PIONEER_FOREMAN_KEY=<your-secret> docker compose --profile foreman up --build foreman
 ```
+
+See [Standalone Foreman](#standalone-foreman-local-no-docker) below for the non-Docker setup.
 
 ### GitHub OAuth App
 
-Pioneer Square uses GitHub OAuth instead of personal access tokens. You need to create a GitHub OAuth App and set the credentials as environment variables before starting the backend.
+Pioneer Square authenticates users via GitHub OAuth rather than personal access tokens. Create an
+OAuth App at **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
+(https://github.com/settings/applications/new) with:
 
-1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
-   (direct link: https://github.com/settings/applications/new)
-2. Fill in:
-   - **Application name**: Pioneer Square (or anything you like)
-   - **Homepage URL**: `http://localhost:5173`
-   - **Authorization callback URL**: `http://localhost:8000/auth/github/callback`
-3. Click **Register application**, then generate a **Client secret**.
+- **Homepage URL**: `http://localhost:5173`
+- **Authorization callback URL**: `http://localhost:8000/auth/github/callback`
 
-Set the credentials before running the backend:
-
-```bash
-export GITHUB_CLIENT_ID=your_client_id_here
-export GITHUB_CLIENT_SECRET=your_client_secret_here
-# Optional overrides (defaults shown):
-# export GITHUB_REDIRECT_URI=http://localhost:8000/auth/github/callback
-# export FRONTEND_URL=http://localhost:5173
-```
-
-Or put them in `backend/.env`:
+Then generate a client secret and set both in `backend/.env` (or the shell environment) before
+starting the backend:
 
 ```
 GITHUB_CLIENT_ID=your_client_id_here
 GITHUB_CLIENT_SECRET=your_client_secret_here
+# Optional overrides (defaults shown):
+# GITHUB_REDIRECT_URI=http://localhost:8000/auth/github/callback
+# FRONTEND_URL=http://localhost:5173
 ```
 
 ### Install the CLI
 
-All three Python runtimes (HTTP server, foreman, worker) install from a single
-package and are launched through one `pioneer` command:
+The HTTP server, foreman, and worker all install from one package and run through a single
+`pioneer` command:
 
 ```bash
 uv venv                              # creates .venv/
@@ -115,7 +97,7 @@ npm install
 npm run dev
 ```
 
-Open http://localhost:5173 — a new session will be created automatically.
+Open http://localhost:5173 — a new guild will be created automatically.
 
 ### Worker
 
@@ -135,9 +117,9 @@ See [`worker/README.md`](worker/README.md) for details.
 
 ### Standalone Foreman (local, no Docker)
 
-The backend-owned foreman loop remains responsible for state, history, tools, and task
-coordination. The standalone process is only an optional LLM API proxy for calling Anthropic,
-Bedrock, or an OpenAI-compatible endpoint from a different network environment.
+As of this writing, the backend-owned foreman loop remains responsible for state, history,
+tools, and task coordination; the standalone process is only an optional LLM API proxy for
+calling Anthropic, Bedrock, or an OpenAI-compatible endpoint from a different network environment.
 
 ```bash
 cp foreman-proxy/pioneer-foreman.toml.example foreman-proxy/pioneer-foreman.toml
@@ -161,9 +143,10 @@ from the embedded foreman.
 
 ### Discord integration (optional)
 
-Pioneer Square can post event notifications, per-PR/issue discussion threads, a live Foreman
-chat mirror, and `/ps` slash commands into a Discord server. It's entirely opt-in — with no
-`DISCORD_*` env vars set, nothing changes. See [`docs/discord.md`](docs/discord.md) for setup.
+As of this writing, Pioneer Square can post event notifications, per-PR/issue discussion threads,
+a live Foreman chat mirror, and `/ps` slash commands into a Discord server. It's entirely
+opt-in — with no `DISCORD_*` env vars set, nothing changes. See
+[`docs/discord.md`](docs/discord.md) for setup.
 
 ## Migrating from SQLite
 
@@ -187,27 +170,27 @@ already exist in PostgreSQL are silently skipped.
 
 ## Architecture
 
-- **Backend**: FastAPI + asyncpg + WebSocket signaling
-- **Frontend**: Vue 3 + Pinia + Vue Router + WebRTC
-- **Worker**: Standalone Python process (`pioneer-worker` CLI) that runs
-  Claude on assigned tasks and opens GitHub PRs.
-- **Database**: PostgreSQL (guilds, agents, messages, workers, tasks)
+Three processes as of this writing: a FastAPI backend (WebSocket + REST, PostgreSQL via asyncpg),
+a Vue 3/Pinia frontend, and standalone worker processes that run Claude on assigned tasks and
+open GitHub PRs. A fourth, opt-in standalone foreman can offload LLM API calls from the backend.
+See [AGENTS.md](AGENTS.md) for the full reference (terminology, task lifecycle, WebSocket
+protocol, database schema, and store layout).
 
 ## Connecting Agents
 
-Agents connect via WebSocket at `ws://localhost:8000/ws/{sessionId}` and send:
+Agents connect via WebSocket at `ws://localhost:8000/ws/{guild_id}` and send messages such as:
 
 ```json
 { "type": "join", "agentId": "agent-1", "agentName": "Builder", "agentType": "worker" }
 { "type": "agent-state", "agentId": "agent-1", "state": "working" }
-{ "type": "terminal-output", "agentId": "agent-1", "line": "Building project..." }
 ```
 
-States: `idle` | `thinking` | `working` | `busy` | `error`
+States: `idle` | `thinking` | `working` | `busy` | `error`. See AGENTS.md for the full message
+protocol table.
 
 ## A2A AgentCard
 
-Pioneer Square implements the [A2A (Agent-to-Agent) protocol](https://google.github.io/A2A/)
+Pioneer Square currently implements the [A2A (Agent-to-Agent) protocol](https://google.github.io/A2A/)
 AgentCard discovery document. Each guild exposes its identity at:
 
 ```
@@ -215,36 +198,8 @@ GET /.well-known/agent.json        # subdomain-routed (e.g. myguild.pioneer-squa
 GET /guilds/{guild_id}/agent-card  # direct REST (requires auth)
 ```
 
-The card describes the guild's Foreman AI and lists all currently-online workers
-as skills. Example response:
+The card describes the guild's Foreman AI and lists currently-online workers as skills
+(`name`, `description`, `url`, `version`, `capabilities`, `skills[]`, `provider`).
 
-```json
-{
-  "name": "My Factory",
-  "description": "A real-time multi-agent workspace...",
-  "url": "https://myguild.pioneer-square.melloy.life",
-  "version": "1.0.0",
-  "capabilities": { "streaming": true },
-  "defaultInputModes": ["text/plain"],
-  "defaultOutputModes": ["text/plain"],
-  "skills": [
-    { "id": "foreman", "name": "Foreman", "tags": ["orchestration", "planning", "review"], ... },
-    { "id": "w-abc123", "name": "Worker (my-org/my-repo)", "tags": ["coding", "github"], ... }
-  ],
-  "provider": { "organization": "Pioneer Square", "url": "https://github.com/jmelloy/pioneer-square" }
-}
-```
-
-### Customising the card
-
-Update a guild's AgentCard fields via `PATCH /guilds/{id}`:
-
-```bash
-curl -X PATCH http://localhost:8000/guilds/{guild_id} \
-  -H "Authorization: Bearer <token>" \
-  -H "Content-Type: application/json" \
-  -d '{"description": "My factory description", "url": "https://my-instance.example.com", "version": "1.0.0"}'
-```
-
-All three fields (`description`, `url`, `version`) are optional — the endpoint
-falls back to sensible defaults when they are unset.
+Guild-level fields are editable via `PATCH /guilds/{guild_id}` with a JSON body of
+`description`, `url`, and/or `version` (all optional; unset fields fall back to defaults).

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -1,8 +1,7 @@
 # A2A (Agent-to-Agent) Wiring
 
 Pioneer Square's Foreman can call remote A2A-compatible agents using the
-`call_agent` tool.  This document explains the protocol, the architecture,
-and how to add new agents.
+`call_agent` tool, and DNS identity operations via the `dnsid` tool.
 
 ## Architecture
 
@@ -20,14 +19,12 @@ Backend ─── Foreman AI (Claude) ─── call_agent tool ──► HTTP A
 
 ```
 Foreman                     Remote Agent
-  │                               │
   │  GET /.well-known/agent.json  │
   │ ─────────────────────────────►│
   │        AgentCard (JSON)        │
   │ ◄─────────────────────────────│
-  │                               │
-  │  POST /a2a  (tasks/send)      │
-  │  { skill_id, message }        │
+  │  POST /jsonrpc                │
+  │  (tasks/send or message/stream)│
   │ ─────────────────────────────►│
   │         result (JSON)         │
   │ ◄─────────────────────────────│
@@ -37,16 +34,14 @@ Foreman                     Remote Agent
 
 ### `call_agent` — HTTP A2A agents
 
-The `call_agent` tool calls any HTTP-based A2A agent.
-
 | Parameter   | Type   | Required | Description |
 |-------------|--------|----------|-------------|
 | `agent_url` | string | yes      | Base URL of the target agent |
 | `skill`     | string | yes      | Skill id to invoke |
 | `params`    | object | no       | Skill-specific parameters (JSON object) |
 
-How it works: fetches `{agent_url}/.well-known/agent.json`, verifies the skill
-exists, then POSTs a JSON-RPC `tasks/send` to `{agent_url}/a2a`.
+Fetches `{agent_url}/.well-known/agent.json`, verifies the skill exists, then
+POSTs a JSON-RPC `tasks/send` to `{agent_url}/jsonrpc`.
 
 ### `dnsid` — DNSid operations
 
@@ -55,47 +50,33 @@ The `dnsid` tool calls the `dnsid-py` Python library directly.
 | Command   | Required params          | Optional params   | Description |
 |-----------|--------------------------|-------------------|-------------|
 | `resolve` | `fqdn`                   | —                 | Look up an FQDN's `_dnsid` TXT record and JWKS |
-| `sign`    | `claims` (object)        | —                 | Sign a JWT with the agent's Ed25519 identity (`DNSID_AGENT_CONFIG`) |
+| `sign`    | `claims` (object)        | —                 | Sign a JWT using the calling guild's Ed25519 key (stored in the DB, same key served at `/.well-known/jwks.json`) |
 | `verify`  | `jwt`, `expected_aud`    | `expected_nonce`  | Verify a JWT against its DNSid record |
 
-All three return the CLI's JSON output (`{"ok": true, ...}`).
-
-Example Foreman prompts:
-
-> "Use dnsid to resolve the identity record for example.com."
-```json
-{"command": "resolve", "fqdn": "example.com"}
-```
-
-> "Use dnsid to verify this token against aud=pioneer-square.melloy.life."
-```json
-{"command": "verify", "jwt": "<token>", "expected_aud": "pioneer-square.melloy.life"}
-```
+All three return JSON (`{"ok": true, ...}`); `sign` fails if the guild has no
+signing key yet.
 
 ## Known agents
 
-### code-review-agent (`https://agent.meyers.life`)
+### code-review-agent
 
-Automated GitHub PR code review via the `review_pr` Foreman tool (MCP transport).
-The Foreman also exposes the `review_pr` tool which is purpose-built for this
-agent; `call_agent` is an alternative generic path.
+Automated GitHub PR code review via the `review_pr` Foreman tool, which uses a
+dedicated A2A client (`backend/foreman/a2a_client.py`) to call the agent's
+`pr-review` skill directly — not the generic `call_agent` path. Defaults to
+`https://agent.meyers.life`, overridable per-deployment via `REVIEWER_AGENT_URL`.
+See `docs/code-review-agent.md` for details.
 
 ### dnsid-py
 
-A Python library for DNS identity operations.
-The Foreman calls it via the `dnsid` tool rather than `call_agent`.
-
-Operations exposed:
-- `resolve(fqdn)` — look up `_dnsid` TXT record + JWKS
-- `sign(claims, private_key_pem)` — sign JWT with Ed25519 key
-- `verify(jwt, expected_aud, expected_nonce?)` — verify JWT via DNS trust chain
-
-Install: `pip install dnspython cryptography` (both are listed in `cli/pyproject.toml`).
+A Python library for DNS identity operations (`resolve` / `sign` / `verify`,
+per the table above). The Foreman calls it via the `dnsid` tool rather than
+`call_agent`. Install: `pip install dnspython cryptography` (listed in
+`cli/pyproject.toml`).
 
 ## Adding a new agent
 
 1. Ensure the agent serves `GET /.well-known/agent.json` with a valid AgentCard.
-2. Ensure the agent accepts `POST /a2a` with JSON-RPC `tasks/send` payloads.
+2. Ensure the agent accepts `POST /jsonrpc` with JSON-RPC `tasks/send` payloads.
 3. Tell the Foreman the agent URL and skill id — no code changes required.
 
 ## Running the live integration test
@@ -108,15 +89,16 @@ python scripts/test_a2a_live.py
 DNSID_PRIVATE_KEY_PEM="$(cat path/to/key.pem)" python scripts/test_a2a_live.py
 ```
 
-The script prints `[PASS]`, `[FAIL]`, or `[SKIP]` per check and exits 0 only
-if all reachable checks pass. sign/verify are skipped when `DNSID_PRIVATE_KEY_PEM`
-is not set.
+Prints `[PASS]`/`[FAIL]`/`[SKIP]` per check and exits 0 only if all reachable
+checks pass; sign/verify are skipped without `DNSID_PRIVATE_KEY_PEM`.
 
 ## AgentCard format
 
-Pioneer Square itself serves an AgentCard at
-`GET /.well-known/agent.json` (see `backend/routes/wellknown.py`).  The card
-is guild-specific: the guild's workers become skills in the card.
+Pioneer Square itself serves an AgentCard at `GET /.well-known/agent.json`
+(see `backend/routes/wellknown.py`), per the
+[A2A AgentCard spec](https://google.github.io/A2A/specification/#agent-card).
+The card is guild-specific: a `foreman` skill is always included, plus one
+skill per online worker. Simplified example:
 
 ```json
 {
@@ -125,7 +107,10 @@ is guild-specific: the guild's workers become skills in the card.
   "url": "https://g-abc123.pioneer-square.melloy.life",
   "version": "1.0",
   "capabilities": {"streaming": true},
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
   "skills": [
+    {"id": "foreman", "name": "Foreman", "description": "..."},
     {"id": "w-xyz", "name": "Python worker", "description": "..."}
   ]
 }

--- a/docs/code-review-agent.md
+++ b/docs/code-review-agent.md
@@ -1,108 +1,68 @@
 # Automated PR Reviews via code-review-agent
 
-Pioneer Square's Foreman AI can request automated code reviews through the
-[code-review-agent](https://github.com/Identity-Digital/code-review-agent) MCP
-server. When enabled, the Foreman can call `review_pr` to get a structured
-review posted directly to a GitHub pull request.
+Pioneer Square's Foreman AI can request automated code reviews from the
+external [code-review-agent](https://github.com/Identity-Digital/code-review-agent),
+an A2A-protocol agent. The Foreman calls its `review_pr` tool to get a
+structured review posted directly to a GitHub pull request.
 
 ## Architecture
 
 ```
-Foreman AI ──► MCPClient ──stdio──► crv-mcp ──HTTPS──► crv harness ──► Claude worker
-                                   (MCP server)        (HTTP service)   (does the review)
+Foreman AI ──► A2AClient ──HTTPS (JSON-RPC/SSE)──► code-review-agent ──► Claude worker
+        (backend/foreman/a2a_client.py)         (agent.meyers.life)   (does the review)
 ```
 
-The integration involves two components from the code-review-agent repository:
-
-- **crv harness** (`crv start`): long-running HTTP service that spawns Claude
-  review workers. Runs on its own host/port.
-- **crv-mcp** (`bin/crv-mcp`): stdio MCP server that the Foreman backend
-  launches as a subprocess. It proxies JSON-RPC calls to the harness.
+`review_pr` uses a dedicated `A2AClient` (not the generic `call_agent` tool)
+to fetch the agent's card, negotiate DNSid auth if the card requires it, and
+dispatch the `pr-review` skill over the `message/stream` JSON-RPC method.
 
 ## Setup
 
-### 1. Install code-review-agent
-
-Follow the [code-review-agent README](https://github.com/Identity-Digital/code-review-agent)
-to install and start the harness. You will need:
-- A running `crv start` harness process
-- The `crv-mcp` binary accessible in the backend container's `PATH` (or at an
-  absolute path you configure)
-
-### 2. Configure the backend
-
-Add the following to your `backend/.env` (or the root `.env` used by
+By default the Foreman targets `https://agent.meyers.life`. To point at a
+different deployment, set in `backend/.env` (or the root `.env` used by
 `docker-compose`):
 
 ```env
-# Shell command to launch the crv-mcp stdio MCP server.
-# Must be reachable from inside the backend container.
-REVIEWER_MCP_CMD=/opt/code-review-agent/bin/crv-mcp
-
-# Alternatively, point at an MCP-over-HTTP endpoint:
-# REVIEWER_MCP_URL=http://crv-mcp:9000/mcp
-
-# URL of the code-review-agent harness (the crv start process).
-REVIEWER_AGENT_URL=https://crv.example.com
+REVIEWER_AGENT_URL=https://your-code-review-agent.example.com
 ```
 
-Only one of `REVIEWER_MCP_CMD` or `REVIEWER_MCP_URL` is required.
-`REVIEWER_AGENT_URL` is always required (it is passed to the MCP server so it
-knows which harness to call).
-
-### 3. Restart the backend
-
-```bash
-docker compose restart backend
-# or
-uvicorn main:app --reload --port 8000
-```
+No other configuration is required — the guild's existing Ed25519 identity
+(the same key served at `/.well-known/jwks.json`) is used automatically if
+the agent's card declares DNSid auth.
 
 ## How it works
 
 When the Foreman calls `review_pr(pr_url)`:
 
-1. **MCPClient** (`backend/foreman/mcp_client.py`) launches `crv-mcp` as a
-   subprocess (or POSTs to `REVIEWER_MCP_URL`) and performs the MCP
-   initialization handshake.
-2. The Foreman calls the MCP tool `start_conversation` with:
-   - `agent_url`: the harness URL from `REVIEWER_AGENT_URL`
-   - `capability`: `"review_pr"`
-   - `initial_text`: the GitHub PR URL
-3. `crv-mcp` forwards the request to the harness via HTTPS, which spawns a
-   Claude worker that fetches the PR diff and produces a structured JSON review
-   report.
-4. The report is returned to the MCPClient as a tool result. Pioneer Square
-   extracts the verdict (`approved` / `changes-requested` / `comment`) and the
-   Markdown review body.
-5. The Foreman posts the review to GitHub via the Pull Request Reviews API
-   (`POST /repos/{owner}/{repo}/pulls/{number}/reviews`) using the guild's
-   OAuth token.
+1. `A2AClient` fetches the agent's `/.well-known/agent.json` card and, if it
+   declares DNSid auth, runs a challenge-response using the guild's key.
+2. It POSTs a `message/stream` JSON-RPC request for the `pr-review` skill with
+   the PR URL, and collects the resulting SSE artifact/status events.
+3. The Foreman extracts the verdict (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`)
+   and review body from the result, then posts it to GitHub via
+   `POST /repos/{owner}/{repo}/pulls/{number}/reviews` using the guild's OAuth
+   token.
+
+If the external agent is unavailable, `review_pr_internal` performs a
+self-contained review (Foreman AI directly analyses the diff) as a fallback.
 
 ## Feedback loop
 
-When the code-review-agent posts a `REQUEST_CHANGES` review, GitHub emits a
-`pull_request_review` webhook event with `action: "submitted"` and
-`review.state: "changes_requested"`. Pioneer Square receives this as a
-`[github-event]` message, which triggers the Foreman AI. The Foreman
-recognises the `changes_requested` state and calls `send_followup` to dispatch
-the relevant worker to address the review comments — closing the loop
-automatically.
-
-This path is handled entirely by the existing Foreman webhook integration and
-requires no additional configuration.
+When code-review-agent posts a review requesting changes, GitHub emits a
+`pull_request_review` webhook (`action: "submitted"`,
+`review.state: "changes_requested"`). Pioneer Square routes this to the
+Foreman AI, which can call `send_followup` to dispatch a worker to address the
+comments — closing the loop automatically, with no extra configuration.
 
 ## Env vars reference
 
 | Variable | Required | Description |
 |---|---|---|
-| `REVIEWER_MCP_CMD` | one of these two | Shell command to launch `crv-mcp` |
-| `REVIEWER_MCP_URL` | one of these two | HTTP endpoint of an MCP-over-HTTP server |
-| `REVIEWER_AGENT_URL` | yes | Base URL of the `crv start` harness |
+| `REVIEWER_AGENT_URL` | no | Base URL of the code-review-agent; defaults to `https://agent.meyers.life` |
 
 ## Timeouts
 
-The `crv-mcp` MCP server blocks while the harness runs the review (default
-timeout 120 s, set via `CRV_MCP_TURN_TIMEOUT_SECONDS`). Pioneer Square's
-`MCPClient` uses a 180 s timeout, so the review has time to complete. Reviews
-of large PRs (many files, high diff size) may need a longer `CRV_MCP_TURN_TIMEOUT_SECONDS`.
+`A2AClient` uses a 180 s timeout for both the agent-card fetch and the
+review request (reviews of large PRs can take a couple of minutes). This is
+currently a fixed constant in `backend/foreman/a2a_client.py`, not
+configurable via env var.

--- a/docs/code-review-agent.md
+++ b/docs/code-review-agent.md
@@ -26,9 +26,11 @@ different deployment, set in `backend/.env` (or the root `.env` used by
 REVIEWER_AGENT_URL=https://your-code-review-agent.example.com
 ```
 
-No other configuration is required — the guild's existing Ed25519 identity
-(the same key served at `/.well-known/jwks.json`) is used automatically if
-the agent's card declares DNSid auth.
+No other configuration is required — the guild's Ed25519 identity (the same
+key served at `/.well-known/jwks.json`) is used automatically if the agent's
+card declares DNSid auth. If a guild has no key yet, one is generated lazily
+on first request (see `backend/routes/wellknown.py`), so there's nothing to
+provision ahead of time.
 
 ## How it works
 

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,20 +1,21 @@
 # Discord Integration
 
 Pioneer Square can mirror activity into a Discord server: event notifications, per-PR/issue
-discussion threads, a live Foreman chat feed, and `/ps` slash commands that let you drive
-the factory floor from Discord. Everything is optional and additive — with no Discord env
-vars set, the integration is a silent no-op.
+discussion threads, a live Foreman chat feed, and `/ps` slash commands that let you drive the
+factory floor from Discord — all optional and additive, driven by a single bot, layering up as
+you add credentials.
 
-Everything is driven by the Discord bot (the "gateway app"). The feature set layers up as you
-add credentials:
+**Silent no-op by design:** with no Discord env vars set — or whenever a specific feature's
+required vars are missing — the relevant code path does nothing and logs nothing as an error.
+HTTP and DB failures are logged at WARNING and swallowed, never raised. This applies
+throughout the doc below and isn't repeated per-section.
 
 | Layer | What it adds | Needs |
 |---|---|---|
 | Notifications | Flat-channel embeds, per-PR/issue threads, thread archiving | `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` |
 | Slash commands | `/ps` commands, Foreman chat mirror, @-mentions | `DISCORD_APPLICATION_ID` + `DISCORD_PUBLIC_KEY` (+ the bot vars) |
 
-You can stop after the notification layer — set the bot token and channel for embeds and
-threads without ever setting up slash commands.
+You can stop after the notification layer without ever setting up slash commands.
 
 ## Setup guide
 
@@ -27,19 +28,11 @@ In the [Discord Developer Portal](https://discord.com/developers/applications):
    Keep it out of version control.
 3. Under **General Information**, copy the **Application ID** (`DISCORD_APPLICATION_ID`) and
    **Public Key** (`DISCORD_PUBLIC_KEY`).
-4. If you plan to use slash commands, set **Interactions Endpoint URL** on the same
-   page to `https://<your-domain>/discord/interactions` (e.g.
-   `https://pioneer-square.melloy.life/discord/interactions`) — the backend serves both the
-   SPA and the API from a single public origin, so this is the same host users open in a
-   browser, not a separate backend-only address. Discord will send a PING to this URL and
-   expects a signed PONG back — it won't save the URL until the backend is reachable and
-   `DISCORD_PUBLIC_KEY` is configured, so deploy the backend first.
-
-   > **Ordering matters:** `DISCORD_PUBLIC_KEY` (see [step 3](#3-environment-variables)) must
-   > already be set on the *running* backend before you try to save the Interactions Endpoint
-   > URL here — Discord's verification PING is signature-checked against that key, and the
-   > save fails if the backend doesn't have it yet. Set the env var, (re)deploy, confirm the
-   > backend is reachable, then come back and save the URL.
+4. For slash commands, set **Interactions Endpoint URL** to
+   `https://<your-domain>/discord/interactions` (the same public origin the SPA and API use).
+   Discord verifies it with a signed PING/PONG, so `DISCORD_PUBLIC_KEY`
+   ([step 3](#3-environment-variables)) must already be live on the backend first — set the env
+   var, deploy, confirm reachability, *then* save the URL.
 
 ### 2. Bot permissions and invite
 
@@ -49,38 +42,32 @@ In the [Discord Developer Portal](https://discord.com/developers/applications):
 | `CREATE_PUBLIC_THREADS` | Creating per-PR/issue threads |
 | `MANAGE_THREADS` | Archiving threads on PR merge/close |
 
-Build an invite URL with the **OAuth2 URL Generator** (OAuth2 → URL Generator):
-- Scopes: `bot` (and `applications.commands` if you want slash commands)
-- Bot permissions: the three above
-
-Open the generated URL and invite the bot to your server before setting any env vars — the
-bot must already be a member of the guild that owns `DISCORD_CHANNEL_ID`.
+Build an invite URL with the **OAuth2 URL Generator** (scopes: `bot`, plus
+`applications.commands` for slash commands; bot permissions: the three above), then invite the
+bot to your server before setting any env vars — it must already be a member of the guild that
+owns `DISCORD_CHANNEL_ID`.
 
 ### 3. Environment variables
 
 | Variable | Required | Description |
 |---|---|---|
-| `DISCORD_BOT_TOKEN` | For any notifications | Bot token from the Developer Portal. Drives flat-channel embeds, thread routing, slash commands, and the Foreman chat mirror. |
-| `DISCORD_CHANNEL_ID` | With `DISCORD_BOT_TOKEN` | ID of the text channel where flat embeds are posted and new threads are created. Enable Developer Mode in Discord settings, then right-click the channel → *Copy Channel ID*. |
-| `DISCORD_APPLICATION_ID` | For slash commands | Application ID, used to build the followup-message URL when editing a deferred slash command reply. |
-| `DISCORD_PUBLIC_KEY` | For slash commands | Ed25519 public key (hex) used to verify `POST /discord/interactions` requests. Without it, the endpoint refuses all requests with 401. |
-| `DISCORD_ALLOWED_ROLE_IDS` | No | Comma-separated Discord role IDs allowed to run `/ps` commands. Empty/unset = everyone allowed. DM interactions are always denied when this is set (no role info is available outside a guild). |
-| `DISCORD_PIONEER_GUILD_SLUG` | For slash commands | The Pioneer Square guild (workspace) slug that `/ps` commands operate against. Not a Discord ID — see [Terminology note](#terminology-note-guild-vs-guild) below. |
-| `DISCORD_OPERATOR_ROLE_NAME` | No | Discord role name (in addition to the Manage Channels permission) allowed to run `/join-channel` and `/leave-channel`. Default `Pioneer Square Operator`. |
-| `DISCORD_DEV_GUILD_ID` | No (registration only) | Discord server ID. When set, `scripts/register_discord_commands.py` registers commands to that one server (near-instant) instead of globally (up to 1 hour to propagate). |
-| `DISCORD_STREAM_TASKS` | No | When truthy (`1`/`true`/`yes`/`on`), mirror each working task's live terminal output into a dedicated per-task Discord thread as silent, low-priority messages. Off by default (high-volume). Requires `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` — the feed always routes into a thread, never a flat channel post. |
-| `DISCORD_PR_DEBOUNCE_SECONDS` | No | Seconds to buffer `check_run`/`check_suite` completions for the same PR before flushing them as one combined, silent Discord message. Default `15`. |
+| `DISCORD_BOT_TOKEN` | For any notifications | Bot token from the Developer Portal; backs embeds, thread routing, slash commands, and the Foreman chat mirror. |
+| `DISCORD_CHANNEL_ID` | With `DISCORD_BOT_TOKEN` | Text channel where flat embeds post and threads are created (Developer Mode → right-click channel → *Copy Channel ID*). |
+| `DISCORD_APPLICATION_ID` | For slash commands | Used to build the followup-message URL when editing a deferred slash-command reply. |
+| `DISCORD_PUBLIC_KEY` | For slash commands | Ed25519 public key (hex) verifying `POST /discord/interactions` requests; missing it → all requests refused with 401. |
+| `DISCORD_ALLOWED_ROLE_IDS` | No | Comma-separated role IDs allowed to run `/ps` commands. Empty/unset = everyone. DMs are always denied once this is set (no role info outside a guild). |
+| `DISCORD_PIONEER_GUILD_SLUG` | For slash commands | The Pioneer Square guild (workspace) slug `/ps` commands operate against — not a Discord ID (see terminology note below). |
+| `DISCORD_OPERATOR_ROLE_NAME` | No | Role name (besides Manage Channels) allowed to run `/join-channel`/`/leave-channel`. Default `Pioneer Square Operator`. |
+| `DISCORD_DEV_GUILD_ID` | No (registration only) | Scopes `scripts/register_discord_commands.py` registration to one server (near-instant) instead of globally (up to 1 hour). |
+| `DISCORD_STREAM_TASKS` | No | When truthy (`1`/`true`/`yes`/`on`), mirror each working task's live terminal output into a dedicated per-task Discord thread as silent, low-priority messages. Currently off by default (high-volume). Requires `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` — the feed always routes into a thread, never a flat channel post. |
+| `DISCORD_PR_DEBOUNCE_SECONDS` | No | Seconds to buffer `check_run`/`check_suite` completions for the same PR before flushing them as one combined, silent Discord message. Currently defaults to `15`. |
 
 `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` must be set **together** — the bot needs both
 the credential and a destination channel to create threads.
 
-#### Terminology note: guild vs. guild
-
-Discord calls a server a "guild." Pioneer Square independently calls a workspace a "guild"
-(the 6-character ID used in URLs and `pioneer-worker.toml`). `DISCORD_PIONEER_GUILD_SLUG` is
-a **Pioneer Square** guild slug, not a Discord server ID — it tells the `/ps` command handler
-which Pioneer Square workspace to query and mutate. The Discord server your bot lives in is
-identified only implicitly, via `DISCORD_CHANNEL_ID`.
+**Terminology note:** Discord calls a server a "guild." Pioneer Square independently calls a
+workspace a "guild" (the 6-character ID used in URLs and `pioneer-worker.toml`).
+`DISCORD_PIONEER_GUILD_SLUG` is the latter, not a Discord server ID.
 
 ### 4. Register slash commands (slash commands only)
 
@@ -91,48 +78,24 @@ whenever `scripts/register_discord_commands.py` changes:
 DISCORD_APPLICATION_ID=<id> DISCORD_BOT_TOKEN=<token> python scripts/register_discord_commands.py
 ```
 
-For faster iteration during development, scope registration to one server instead of waiting
-up to an hour for a global rollout:
+Add `DISCORD_DEV_GUILD_ID=<guild_id>` to the same command to scope registration to one server
+instead — near-instant, versus up to an hour to propagate globally — handy while iterating.
 
-```bash
-DISCORD_APPLICATION_ID=<id> DISCORD_BOT_TOKEN=<token> \
-    DISCORD_DEV_GUILD_ID=<guild_id> python scripts/register_discord_commands.py
-```
-
-### docker-compose
-
-`docker-compose.yml` already forwards all Discord variables to the `backend` service; set
-them in your `.env` (copy from `.env.example`):
-
-```dotenv
-# Bot-based flat-channel embeds and per-PR/issue thread notifications.
-# Both required together.
-DISCORD_BOT_TOKEN=MTxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-DISCORD_CHANNEL_ID=1234567890123456789
-
-# Slash commands & bidirectional control.
-DISCORD_APPLICATION_ID=1234567890123456789
-DISCORD_PUBLIC_KEY=<hex public key>
-DISCORD_ALLOWED_ROLE_IDS=1111111111111111,2222222222222222
-DISCORD_PIONEER_GUILD_SLUG=abc123
-```
-
-```bash
-docker compose up --build backend
-```
+**docker-compose:** `docker-compose.yml` already forwards all Discord variables above to the
+`backend` service — set them in your `.env` (copy from `.env.example`), then
+`docker compose up --build backend`.
 
 ## Feature reference
 
 ### Flat-channel notifications
 
 With `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` set, events that don't map to a per-PR/issue
-thread post colour-coded embeds directly to the configured channel via the bot. Delivery is
-fire-and-forget: notifications run as detached background tasks and never block the caller;
-HTTP failures are logged at WARNING and swallowed, never raised.
+thread post colour-coded embeds to the configured channel via the bot, fire-and-forget (never
+blocks the caller).
 
-Colour palette (sidebar colour of the embed):
+Colour palette (sidebar colour of the embed) as of this writing:
 
-| Event | Colour |
+| Event(s) | Colour |
 |---|---|
 | `task-complete`, `ci-pass` | green |
 | `task-failed`, `task-cancelled`, `ci-fail` | red |
@@ -143,115 +106,88 @@ Colour palette (sidebar colour of the embed):
 | `worker-offline` | orange |
 | anything else | blurple (default) |
 
-`task-failed` and `task-cancelled` have colours reserved but are not currently emitted by any
-call site — only the events listed below actually fire notifications today:
-
-- `pr-opened`, `pr-merged`, `pr-closed` — fired from the GitHub webhook handler.
-- `ci-pass`, `ci-fail` — fired from GitHub `check_run`/`check_suite` webhook events.
-- `task-complete` — fired when a worker reports a task finished.
+`task-failed` and `task-cancelled` have colours reserved but currently have no call site that
+emits them — only `pr-opened`/`pr-merged`/`pr-closed` (GitHub webhook handler),
+`ci-pass`/`ci-fail` (check_run/check_suite events), and `task-complete` (worker report) fire
+notifications today.
 
 **CI check debounce/combine** — `check_run`/`check_suite` completions for the same PR are
-buffered per PR and flushed as a single combined message (e.g. `✅ 3 checks passed: lint, test,
-build`) after `DISCORD_PR_DEBOUNCE_SECONDS` (default 15) of silence on that PR, instead of one
-Discord message per check — a CI matrix routinely completes several checks within seconds of
-each other. The combined message always carries Discord's `SUPPRESS_NOTIFICATIONS` flag so CI
-results don't trigger a push notification. Non-CI events (PR opened/merged/closed, reviews) are
-unaffected — they post immediately, at normal notification priority.
-
-`DISCORD_PR_DEBOUNCE_SECONDS` is a **fixed-start** window, not a sliding one: the timer arms on
-the first buffered check for a PR and is not reset by later checks arriving in the same window.
-A CI matrix with checks completing at t=0s, t=14s, and t=14.5s will flush at t=15s and catch all
-three, but one completing at t=16s misses the window and gets its own follow-up message instead
-of joining the summary. Set the value comfortably above the longest expected gap between checks
-in your CI matrix to avoid fragmenting a single CI run across two Discord messages.
+currently buffered and flushed as one combined, silent message after
+`DISCORD_PR_DEBOUNCE_SECONDS` (default 15s) of quiet, instead of one message per check; non-CI
+events post immediately. Currently a **fixed-start** window (arms on the first buffered check,
+not reset by later ones) — set it above the longest expected gap between checks, or a late one
+gets its own follow-up message instead of joining the summary.
 
 ### Per-PR/issue threads
 
 Add `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` to route PR/issue-related events into one
-Discord thread per `(issue_repo, issue_number)` pair instead of a flat channel.
-
-**Thread lifecycle:**
+Discord thread per `(issue_repo, issue_number)` pair instead of a flat channel. Lifecycle:
 
 1. **Lazy creation** — the first thread-aware event for a given PR/issue posts a starter
    message in `DISCORD_CHANNEL_ID`, then creates a public thread off that message named
    `#<number>: <title>` (truncated to 100 chars).
-2. **Persistence** — the mapping is written to the `discord_threads` table
-   (`issue_repo`, `issue_number`, `thread_id`), unique on `(issue_repo, issue_number)`, so a
-   backend restart reuses the existing thread instead of creating a duplicate.
+2. **Persistence** — the mapping is stored in `discord_thread_bindings`, keyed
+   `subject_type="issue"`, `subject_key="<issue_repo>#<issue_number>"`, unique on
+   `(subject_type, subject_key)`. This table is shared with the other thread-aware features
+   below via one lookup/create path, so a backend restart always reuses the existing thread.
 3. **Reuse** — every subsequent event for the same PR/issue (CI results, task-complete) is
    posted as an embed inside the existing thread.
 4. **Archive** — on `pr-merged` or `pr-closed`, a closing summary is posted and the thread is
    archived (`PATCH` with `archived: true`).
 
-**Fallback behaviour** — thread routing is attempted only when the event carries
-`issue_repo`/`issue_number`. When it doesn't, or when thread creation fails (missing channel,
-Discord API error, DB error), the event falls back to a flat embed posted to the configured
-channel via the bot.
-
-If `DISCORD_BOT_TOKEN` is not set, notifications are a silent no-op — nothing is sent and
-nothing is logged as an error.
+Thread routing only kicks in when the event carries `issue_repo`/`issue_number`; when it
+doesn't, or thread creation fails (missing channel, Discord API error, DB error), the event
+falls back to a flat embed in the configured channel.
 
 ### Slash commands & bidirectional control
 
 Adds `POST /discord/interactions`, a signed webhook endpoint Discord calls for every
 interaction (health-check pings and slash-command invocations).
 
-- **Signature verification** — every request must carry valid `X-Signature-Ed25519` and
-  `X-Signature-Timestamp` headers, verified against `DISCORD_PUBLIC_KEY` over the raw request
-  body. Missing/invalid signatures get a `401`. Requests are rejected outright if
-  `DISCORD_PUBLIC_KEY` isn't configured.
-- **PING** — Discord's endpoint health-check; answered immediately with `PONG`.
-- **Authorization** — checked against `DISCORD_ALLOWED_ROLE_IDS` before anything else runs.
-  No roles configured = everyone allowed. DMs are always denied once a role restriction is
-  configured, since Discord doesn't include member/role data on DM interactions.
-- **Deferred replies** — Discord requires a response within 3 seconds. The endpoint
-  immediately acknowledges with a deferred *ephemeral* (only visible to the invoking user)
-  response, then runs the actual command in a background task and edits the reply in place
-  once it finishes.
+- **Signature verification** — every request must carry valid `X-Signature-Ed25519` /
+  `X-Signature-Timestamp` headers, verified against `DISCORD_PUBLIC_KEY`; missing/invalid
+  signatures (or a missing key) get a `401`. Discord's health-check `PING` gets an immediate
+  `PONG`.
+- **Authorization** — checked against `DISCORD_ALLOWED_ROLE_IDS` first; no roles configured
+  means everyone is allowed. DMs are always denied once set (Discord omits member/role data on
+  DM interactions).
+- **Deferred replies** — Discord requires a response within 3 seconds, so the endpoint
+  acknowledges immediately with a deferred *ephemeral* reply, then runs the command in the
+  background and edits the reply in place once done.
 
-See [Slash command reference](#slash-command-reference) below for the full command list.
+See [Slash command reference](#slash-command-reference) for `/ps` and channel-routing commands;
+a couple more (account linking, worker management) are covered under
+[User identity linking](#user-identity-linking).
 
 ### Foreman chat mirror
 
 When `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` are set, every plain-text line the Foreman AI
-sends to a user (not tool-call traces) is mirrored into Discord via
-`notify_foreman_chat(guild_id, content)`.
-
-- One thread is created per `(guild_id, session_key)` pair, where `session_key` defaults to
-  the current UTC date (`YYYY-MM-DD`) — so a whole day's Foreman conversation for a given
-  Pioneer Square guild lands in one thread, named `Foreman session <date> (<guild_id>)`.
-- The mapping persists in the `discord_foreman_threads` table, unique on
-  `(guild_id, session_key)`.
-- Silent no-op if the bot token/channel aren't configured, or if the content is blank.
+sends to a user (not tool-call traces) is mirrored into Discord. If the line is scoped to a task
+whose PR/issue already has a Discord thread, it posts there; otherwise it posts to the guild's
+main channel — currently there's no separate daily/dated fallback thread. No-op if blank.
 
 ### Live task-stream mirroring
 
-Set `DISCORD_STREAM_TASKS` (plus `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID`) to
-mirror a worker task's **live terminal output** into Discord while it runs — a low-priority
-feed of what each agent is actually doing, without leaving the app.
+Set `DISCORD_STREAM_TASKS` (plus `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID`) to mirror a
+worker task's **live terminal output** into Discord while it runs. Currently off by default,
+since the volume is high.
 
-- **Per-task thread** — the streamed output for a task lands in its own thread (created lazily
-  off a starter message in the configured channel, named `⚙ <task-id>: <description>`). The
-  mapping persists in the `discord_task_threads` table, unique on `task_id`, so restarts reuse
-  the same thread. This is intentionally separate from the PR/issue thread: the stream is a
-  verbose working feed, created while the task runs (before any PR exists), whereas the PR
-  thread holds the tidy embed summary.
-- **What's mirrored** — only actual agent/Claude output (terminal-output frames at `info` or
-  `thinking` level). Worker lifecycle, auth, and Claude-runner framing lines are filtered out
-  as noise.
-- **Low priority** — every message is posted with Discord's `SUPPRESS_NOTIFICATIONS`
-  ("silent") flag and with mention parsing disabled, so the feed never pings anyone or fires a
-  push notification.
-- **Batched** — lines are buffered and flushed roughly every few seconds (or sooner once the
-  buffer fills), rather than one HTTP POST per line, to stay well under Discord's rate limits.
-  The buffer is drained and freed when the task reaches a terminal state.
-- **Off by default** — because the volume is high, the whole feature is opt-in via
-  `DISCORD_STREAM_TASKS`. Silent no-op when the flag is unset or the bot token is missing.
+- **Per-task thread** — created lazily off a starter message, currently named
+  `⚙ <task-id>: <description>`, persisted in `discord_thread_bindings`
+  (`subject_type="task_stream"`, keyed by task ID). Kept deliberately separate from the
+  PR/issue thread: this is the verbose working feed, while that one holds the tidy summary.
+- **What's mirrored** — only actual agent/Claude output (`info`/`thinking`-level frames); worker
+  lifecycle, auth, and runner framing lines are filtered out.
+- **Low priority, batched** — messages currently carry `SUPPRESS_NOTIFICATIONS` and disabled
+  mention parsing, and lines are flushed every few seconds (or sooner once buffered) rather than
+  one POST per line, to stay under Discord's rate limits.
 
 ## Slash command reference
 
-The `/ps` subcommands are scoped to the guild in `DISCORD_PIONEER_GUILD_SLUG`. Every reply is
-ephemeral. Requires a role in `DISCORD_ALLOWED_ROLE_IDS` (or no restriction configured).
+The `/ps` subcommands are scoped to the guild in `DISCORD_PIONEER_GUILD_SLUG`, require a role in
+`DISCORD_ALLOWED_ROLE_IDS` (or no restriction), and always reply ephemerally. Commands are
+defined in `scripts/register_discord_commands.py` and must be re-registered (step 4 above)
+whenever that file changes.
 
 | Command | Description | Notes |
 |---|---|---|
@@ -263,21 +199,14 @@ ephemeral. Requires a role in `DISCORD_ALLOWED_ROLE_IDS` (or no restriction conf
 | `/join-channel <channel> [guild]` | Wires a Discord channel to a Pioneer Square guild so its events post there | Requires **Manage Channels** or the `DISCORD_OPERATOR_ROLE_NAME` role. `guild` is optional if exactly one Pioneer Square guild is configured. Re-running on an already-wired channel updates the binding. |
 | `/leave-channel [channel]` | Removes a channel's Pioneer Square guild binding (defaults to the current channel) | Same permission check as `/join-channel`. Replies "No binding found" if the channel isn't wired. |
 
-Commands are defined in `scripts/register_discord_commands.py` and must be re-registered
-(see [Setup guide](#4-register-slash-commands-phase-3-only)) whenever that file changes.
-
 ### Per-channel guild routing (`/join-channel` / `/leave-channel`)
 
-By default, all Discord notifications go to the single channel in `DISCORD_CHANNEL_ID`. The
-`discord_channel_guilds` table lets you fan events for a specific Pioneer Square guild out to
-additional channels — e.g. one channel per team, each wired to its own guild:
-
-- `/join-channel channel:#my-team-updates guild:my-guild-slug` upserts a
-  `(discord_guild_id, discord_channel_id) → ps_guild_id` row.
-- `notify_event(...)` and `notify_foreman_chat(...)` resolve the destination channel by looking
-  up the event's Pioneer Square guild in `discord_channel_guilds` first, falling back to
-  `DISCORD_CHANNEL_ID` when no binding exists.
-- `/leave-channel` deletes the row; events for that guild then fall back to `DISCORD_CHANNEL_ID`.
+By default, all notifications go to the single channel in `DISCORD_CHANNEL_ID`. The
+`discord_channel_guilds` table lets you fan a specific Pioneer Square guild's events out to
+additional channels — e.g. one channel per team. `/join-channel channel:#my-team-updates
+guild:my-guild-slug` upserts a `(discord_guild_id, discord_channel_id) → ps_guild_id` row;
+`notify_event(...)`/`notify_foreman_chat(...)` look up the event's guild here first, falling
+back to `DISCORD_CHANNEL_ID`. `/leave-channel` deletes the row, restoring that fallback.
 
 ## User identity linking
 
@@ -290,8 +219,10 @@ notifications can @-mention the right person instead of printing a plain `@login
 | `discord_user_id` | Discord snowflake ID |
 | `created_at` / `updated_at` | Timestamps |
 
-There is no automated discovery and no in-Discord `/link-account` command — a user links
-their own account via the REST API:
+No automated discovery, and no in-Discord command populates this mapping directly — link via
+the REST API below. (A separate `/connect-account` command links a Discord identity to a
+Pioneer Square *account* for command authorization like `/worker-spawn`, via a different table,
+`discord_account_links` — unrelated to @-mentions.)
 
 | Endpoint | Auth | Behaviour |
 |---|---|---|
@@ -300,15 +231,14 @@ their own account via the REST API:
 | `PUT /api/discord-users/{github_login}` | Must be authenticated **as** `github_login` | Upsert `{"discord_user_id": "..."}`; `403` if you try to set someone else's mapping |
 | `DELETE /api/discord-users/{github_login}` | Must be authenticated **as** `github_login` | Remove your own mapping |
 
-To find your own Discord user ID: enable **Developer Mode** in Discord (User Settings →
-Advanced), then right-click your username anywhere → **Copy User ID**.
+To find your own Discord user ID: enable **Developer Mode** (User Settings → Advanced), then
+right-click your username → **Copy User ID**.
 
 **@-mention behaviour** — `mention_or_login(github_login)` is used wherever a GitHub actor is
-rendered in a notification (currently: PR-opened assignees). It:
-- Returns a real `<@discord_user_id>` mention when a mapping exists.
-- Falls back to a plain `@github_login` string when no mapping exists.
-- Returns `""` for an empty/missing login.
-- Never raises — a DB error during lookup degrades to the plain-text fallback.
+rendered in a notification (currently: PR-opened assignees). It returns a real
+`<@discord_user_id>` mention when a mapping exists, otherwise falls back to a plain
+`@github_login` string (or `""` for an empty login) — never raises, so a DB error during
+lookup just degrades to the plain-text fallback.
 
 ## Troubleshooting
 
@@ -322,4 +252,4 @@ rendered in a notification (currently: PR-opened assignees). It:
 | "You are not authorized to use Pioneer Square commands" | `DISCORD_ALLOWED_ROLE_IDS` is set and the invoking user has none of the listed roles. Note DMs are always denied once this restriction is configured. |
 | `/ps` commands reply "Pioneer guild `` not found" | `DISCORD_PIONEER_GUILD_SLUG` is unset or doesn't match an existing Pioneer Square guild slug. |
 | @-mentions show as plain `@login` instead of a real mention | No `discord_users` row for that GitHub login yet — the user needs to `PUT /api/discord-users/{their_login}` with their Discord user ID. |
-| Duplicate threads for the same PR/issue | Shouldn't happen — `discord_threads` has a unique index on `(issue_repo, issue_number)`. If seen, confirm the `add_discord_threads` Alembic migration has actually been applied. |
+| Duplicate threads for the same PR/issue | Shouldn't happen — `discord_thread_bindings` has a unique index on `(subject_type, subject_key)`. If seen, confirm all Discord-related Alembic migrations have actually been applied. |

--- a/docs/foreman-per-task-context.md
+++ b/docs/foreman-per-task-context.md
@@ -11,24 +11,22 @@
 The backend Foreman can run task-scoped child turns for review-loop events while
 keeping cross-cutting work in the parent guild context.
 
-Task-scoped events:
+- **Task-scoped events:** `task-complete`, `followup-done`, `needs-input`, `task-error`.
+- **Parent-context events:** human chat, worker lifecycle, periodic checks,
+  Claude/auth events, task creation and assignment.
 
-- `task-complete`
-- `followup-done`
-- `needs-input`
-- `task-error`
+`ws_handlers._trigger_foreman()` decides which path a trigger takes:
 
-Parent-context events:
+```python
+child = bool(task_id) and event in _CHILD_FOREMAN_EVENTS
+spawn(run_foreman_ai(guild_id, message, task_id=task_id, child=child))
+```
 
-- human chat
-- worker lifecycle
-- periodic checks
-- Claude/auth events
-- task creation and assignment
-
-The standalone `pioneer foreman` process no longer participates in this routing.
-It is only an LLM API proxy. All child-context decisions happen in
-`backend/foreman/runner.py` and `backend/ws_handlers.py`.
+This decision is made entirely in `backend/foreman/runner.py` and
+`backend/ws_handlers.py`, independent of whether a standalone proxy is
+connected — the proxy, when present, is only used later by
+`backend.foreman.runner` to execute the concrete LLM API call. See
+[foreman-split-plan.md](foreman-split-plan.md) for how the proxy fits in.
 
 ---
 
@@ -42,14 +40,13 @@ single Foreman turn with three pieces of isolation:
    `run_foreman_ai(child=True, task_id=...)`.
 3. A per-task `asyncio.Lock` keyed as `(guild_id, "task:<id>")` in `_guild_locks`.
 
-If a task-scoped run is already active for the same task, the new invocation is
-dropped instead of queued — unless it's human-originated (e.g. a user-requested
-follow-up posted from the web UI), in which case it's appended to a small FIFO
-queue and drained once the in-flight run for that task finishes. See
-"Human message queueing" below. Automated child-context triggers (task-complete,
-followup-done, needs-input) keep the drop-if-busy behavior; the backend
-poll/re-trigger mechanism recovers stale or missed work on a later tick.
-Different tasks may run concurrently.
+If a task-scoped run is already active for the same task, a new automated
+invocation (task-complete, followup-done, needs-input) is dropped rather than
+queued; the poll/re-trigger mechanism recovers stale or missed work on a later
+tick. A human-originated invocation (e.g. a follow-up posted from the web UI)
+is instead appended to a small FIFO queue (`_enqueue_human_turn`/
+`_drain_human_queue` in `runner.py`) and drained once the in-flight run for
+that task finishes. Different tasks run concurrently.
 
 Parent runs are keyed by `(guild_id, user_id)` and never read task-tagged child
 history, even if the incoming parent trigger includes a `task_id` for Discord
@@ -59,41 +56,20 @@ thread routing.
 
 ## Prompt And History
 
-Child runs use:
-
-- `build_child_system_blocks(...)`
-- `build_child_state_preamble(...)`
-- `CHILD_FOREMAN_TOOLS`
+Child runs use `build_child_system_blocks(...)`, `build_child_state_preamble(...)`,
+and `CHILD_FOREMAN_TOOLS`.
 
 `CHILD_FOREMAN_TOOLS` excludes `create_task` and `assign_task`, so child turns can
 review, follow up, finalize, cancel, redirect, or inspect their task but do not
-create or assign new work.
-
-The child state preamble includes only the relevant task and assigned worker.
-This keeps task review context small and prevents unrelated task history from
-bleeding into the review loop.
-
----
-
-## WebSocket Routing
-
-`ws_handlers._trigger_foreman()` determines whether a trigger should be child
-scoped:
-
-```python
-child = bool(task_id) and event in _CHILD_FOREMAN_EVENTS
-spawn(run_foreman_ai(guild_id, message, task_id=task_id, child=child))
-```
-
-The external proxy is not involved in routing. If connected, it is used later by
-`backend.foreman.runner` only when a concrete LLM API request needs to be
-executed.
+create or assign new work. The child state preamble includes only the relevant
+task and assigned worker, keeping review context small and free of unrelated
+task history.
 
 ---
 
 ## Operational Notes
 
-- There is no child queue, respawn, or teardown path.
+- No child queue, respawn, or teardown path exists today.
 - There is no standalone `TaskContext` class.
 - Continuity comes from database-backed `ForemanTurn.task_id` history.
 - Frontend/Discord messages produced inside a child turn are tagged with that

--- a/docs/foreman-split-plan.md
+++ b/docs/foreman-split-plan.md
@@ -3,6 +3,10 @@
 **Status:** Current architecture. The backend owns the Foreman loop; the optional
 standalone process is a thin LLM API proxy.
 
+For how the embedded Foreman splits parent-guild vs. per-task child turns, see
+[foreman-per-task-context.md](foreman-per-task-context.md) — that split is
+internal to the backend and orthogonal to the proxy boundary described here.
+
 ---
 
 ## Architecture
@@ -25,19 +29,21 @@ backend embedded Foreman
                                       Anthropic / Bedrock / OpenAI-compatible
 ```
 
-The proxy does not read the database, persist history, execute tools, route
-triggers, or broadcast to frontend/worker sockets. That keeps all product logic
-in the backend and lets operators run only the provider call across a
-network/firewall boundary or against a local endpoint such as Ollama.
+The proxy never reads the database, persists history, executes tools, routes
+triggers, or broadcasts to frontend/worker sockets, so operators can run just
+the provider call across a network/firewall boundary, or against a local
+endpoint such as Ollama.
 
-Periodic task-health polling is scheduled entirely by the backend
-(`backend/foreman/runner.py`'s `_poll_loop`) for every guild. Poll ticks call
-`ws_handlers._trigger_foreman()`, which always dispatches into the embedded
-runner; the runner delegates API calls to a connected proxy only when needed.
+Periodic task-health polling also runs entirely in the backend (`_poll_loop`
+in `backend/foreman/runner.py`), calling `ws_handlers._trigger_foreman()` on
+each tick; a connected proxy only ever handles the API call.
 
 ---
 
 ## Packages and files
+
+Files relevant to the proxy boundary; `backend/foreman/` also has unrelated
+modules (A2A, OIDC, URL parsing, constants) not shown here.
 
 ### Standalone proxy — `foreman-proxy/`
 
@@ -54,17 +60,14 @@ foreman-proxy/
 ### Backend Foreman — `backend/foreman/`
 
 ```
-backend/foreman/
-  runner.py          – Foreman conversation loop; uses proxy at the LLM boundary
-  proxy.py           – pending foreman-api-request registry
-  tools.py           – canonical backend-side tool execution
-  prompt.py          – system prompt and prompt builders
-  tools_schema.py    – Foreman tool JSON schema
-  message_utils.py   – Anthropic message/history helpers
-  llm.py             – provider/model selection and Anthropic/Bedrock client factory
+runner.py          – Foreman conversation loop; uses proxy at the LLM boundary
+proxy.py           – pending foreman-api-request registry
+tools.py           – canonical backend-side tool execution
+prompt.py          – system prompt and prompt builders
+tools_schema.py    – Foreman tool JSON schema
+message_utils.py   – Anthropic message/history helpers
+llm.py             – provider/model selection and Anthropic/Bedrock client factory
 ```
-
-Shared Foreman helpers live in the backend Foreman package with the runner that owns them.
 
 ---
 
@@ -87,8 +90,8 @@ Shared Foreman helpers live in the backend Foreman package with the runner that 
 | `foreman-disconnect` | `{ guildId? }` | Graceful shutdown notice |
 
 The `response` payload is Anthropic Messages shaped even when the proxy calls an
-OpenAI-compatible endpoint. This lets the backend keep one message/history/tool
-pipeline.
+OpenAI-compatible endpoint, so the backend can keep one message/history/tool
+pipeline regardless of provider.
 
 ---
 
@@ -108,8 +111,8 @@ base_url = "http://localhost:11434/v1"
 api_key = "ollama"                  # optional for local unauthenticated servers
 ```
 
-`[claude]` is still accepted as a backward-compatible alias for `[llm]`, but new
-configs should use `[llm]`.
+`[claude]` is accepted as a backward-compatible alias for `[llm]`; new configs
+should use `[llm]`.
 
 **Environment variables:**
 
@@ -139,30 +142,21 @@ pioneer foreman [--config PATH] [--backend-url URL] [--guild-id ID]
 
 ## Design decisions
 
-### Backend-owned Foreman loop
+**Backend-owned loop.** No message crosses the process boundary to trigger a
+run — `ws_handlers._trigger_foreman()` always spawns the embedded
+`backend.foreman.runner.run_foreman_ai()` path, and a connected proxy is only
+ever asked to execute a single LLM API call. Accordingly, the standalone
+process holds no REST client, JWT helper, tool executor, message-history
+loader, task locks, or child-context supervisor of its own.
 
-`foreman-trigger` was removed. Triggers no longer cross the process boundary.
-`ws_handlers._trigger_foreman()` always spawns the embedded
-`backend.foreman.runner.run_foreman_ai()` path.
+**Provider normalization.** Request/response translation for each provider —
+the Anthropic SDK client factory/call and the OpenAI-compatible
+`POST /chat/completions` translation — lives in `backend/foreman/llm.py`,
+shared by the embedded foreman and this proxy (issue #826). The proxy's config
+only picks the client/credentials; it forwards `llm.py`'s already
+Anthropic-shaped response back to the backend. Anthropic, Bedrock, and
+OpenAI-compatible endpoints are the providers supported today.
 
-### API proxy only
-
-The standalone process no longer has a REST client, JWT helper, tool executor,
-message-history loader, task locks, or child-context supervisor. It executes one
-provider call per `foreman-api-request`.
-
-### Provider normalization
-
-All provider request/response translation — the Anthropic SDK client factory
-and call, and OpenAI-compatible `POST /chat/completions` translation — lives in
-`backend/foreman/llm.py`, shared by the embedded foreman and this proxy (issue
-#826). The proxy holds no provider-specific logic of its own: it only decides
-*which machine* makes the call (its own config selects the client/credentials)
-and forwards the shared module's already Anthropic-shaped response back to the
-backend.
-
-### Single-proxy enforcement
-
-The backend tracks one active external proxy per guild. A second `join` evicts
-the first via `foreman-evicted`. Any pending API requests owned by a disconnecting
-proxy socket fail immediately.
+**Single-proxy enforcement.** The backend tracks one active external proxy per
+guild; a second `join` evicts the first via `foreman-evicted`, and any pending
+requests owned by a disconnecting proxy socket fail immediately.

--- a/docs/state-audit.md
+++ b/docs/state-audit.md
@@ -1,7 +1,10 @@
 # Pioneer Square — Worker / Agent / Task State Audit
 
-> Generated: 2026-05-26
-> Verified at commit: fc64c4478e91949438d4467238671baf69d401ac
+> Generated: 2026-05-26 · Verified at commit: fc64c4478e91949438d4467238671baf69d401ac
+>
+> Point-in-time snapshot, not living documentation — re-grep the named file/function in
+> current code rather than trusting exact line numbers, and read "X is vestigial/legacy"
+> style observations as true as of the date above, not as permanent verdicts.
 
 ## Executive Summary
 
@@ -25,24 +28,21 @@ Relationship: `Guild → Workers → Agents` (one agent per live worker process;
 | `online` | No | `handle_join` on WebSocket connect | No |
 | `offline` | No | Disconnect handler, startup reset, stale sweeper | No |
 
-### Where Defined
-
-- **Database schema**: `backend/alembic/versions/20260428_000000_initial_schema.py:63` — `workers.state` TEXT, `server_default='idle'`
-- **ORM model**: `backend/models.py:98` — `Worker.state`, Python default `"idle"`
+*Defined in* `backend/models.py` (`Worker.state`, Python default `"idle"`) *and* `backend/alembic/versions/20260428_000000_initial_schema.py` (`workers.state` TEXT, `server_default='idle'`).
 
 ### State Transition Locations
 
-| Transition | To State | File & Location | Trigger |
+| Transition | To State | File & Function | Trigger |
 |-----------|----------|-----------------|---------|
-| Worker WebSocket joins | `online` | `backend/ws_handlers.py:247` (`handle_join`) | `join` WS message |
-| Worker WebSocket disconnects | `offline` | `backend/ws_handlers.py:578` (`handle_worker_disconnect`) | WS close event |
-| Startup reset | `offline` | `backend/main.py:75` | App startup — resets all workers |
-| Stale-worker sweeper | `offline` | `backend/main.py:146` | Background sweeper task |
+| Worker WebSocket joins | `online` | `backend/ws_handlers.py` — `handle_join` | `join` WS message |
+| Worker WebSocket disconnects | `offline` | `backend/ws_handlers.py` — `handle_worker_disconnect` | WS close event |
+| Startup reset | `offline` | `backend/main.py` — `reset_connection_state` | App startup — resets all workers |
+| Stale-worker sweeper | `offline` | `backend/main.py` — `_sweep_stale_workers_once` | Background sweeper task |
 
 ### Notes
 
-- Worker state is coarse: only online/offline/idle. The fine-grained "what is the worker doing right now" is captured by agent state (below).
-- Frontend does **not** have a separate state vocabulary for workers. The computed worker list in `frontend/src/stores/agents.ts:52–72` derives a display state from the highest-priority agent state for that worker.
+- Worker state is coarse (online/offline/idle only); fine-grained "what is it doing" lives in agent state (below). The frontend has no separate worker vocabulary — `frontend/src/stores/agents.ts` derives a display state from the highest-priority agent state for that worker.
+- `backend/worker_lifecycle.py` (added after this audit) layers drain/reconcile behavior on top of the same three-value column, without adding new state values.
 
 ---
 
@@ -52,7 +52,7 @@ Relationship: `Guild → Workers → Agents` (one agent per live worker process;
 
 TypeScript union (authoritative frontend type):
 ```typescript
-// frontend/src/types.ts:1
+// frontend/src/types.ts
 type AgentState = 'idle' | 'thinking' | 'working' | 'busy' | 'error' | 'offline'
 ```
 
@@ -67,14 +67,14 @@ type AgentState = 'idle' | 'thinking' | 'working' | 'busy' | 'error' | 'offline'
 
 ### Complementary Field: `activity`
 
-A granular sub-state that refines the `working` state. It is **not** a separate state field — it is emitted alongside `agent-state` messages and cleared when the agent is not working.
+A granular sub-state refining `working`, emitted alongside `agent-state` messages and cleared on offline/idle. Now persisted on `agents.activity` (migration `20260501_000000_add_activity_to_agents`) — no longer memory-only as an earlier version of this audit assumed.
 
 ```typescript
-// frontend/src/types.ts:3–10
+// frontend/src/types.ts
 type AgentActivity = 'reading' | 'editing' | 'running' | 'searching' | 'fetching' | 'thinking' | 'planning'
 ```
 
-Mapping from Claude tool names to activities (`worker/pioneer_worker/claude_runner.py:40–52`):
+Mapping from Claude tool names to activities (`worker/pioneer_worker/claude_runner.py`):
 
 | Tool | Activity |
 |------|----------|
@@ -86,46 +86,34 @@ Mapping from Claude tool names to activities (`worker/pioneer_worker/claude_runn
 | `Agent`, `TodoWrite` | `planning` |
 | Thinking block | `thinking` |
 
-### Where Defined
-
-- **Database schema**: `backend/alembic/versions/20260428_000000_initial_schema.py:74` — `agents.state` TEXT, `server_default='idle'`
-- **ORM model**: `backend/models.py:58` — `Agent.state`, Python default `"idle"`
-- **Frontend type**: `frontend/src/types.ts:1`
+*Defined in* `backend/models.py` (`Agent.state`), the same initial-schema migration (`agents.state`, `server_default='idle'`), and `frontend/src/types.ts` (`AgentState`).
 
 ### State Transition Locations
 
-| Transition | To State | File & Location | Trigger |
+| Transition | To State | File & Function | Trigger |
 |-----------|----------|-----------------|---------|
-| Agent joins | `idle` | `backend/ws_handlers.py:224` | `join` WS message (upsert) |
-| Task begins | `working` | `worker/pioneer_worker/worker.py:1600` | `_set_state("working")` |
-| Claude crash | `error` | `worker/pioneer_worker/worker.py:1683, 1909` | Subprocess failure / timeout |
-| Task completes successfully | `idle` | `worker/pioneer_worker/worker.py:1010, 1826, 1840, 1915` | End of task execution |
-| WS closes (worker side) | `offline` | `worker/pioneer_worker/worker.py:1564` | `_set_state("offline")` |
-| WS closes (backend side) | `offline` | `backend/ws_handlers.py:572` | Connection handler |
-| Stale sweeper | `offline` | `backend/main.py:132` | Background sweeper task |
-| Startup reset | `offline` | `backend/main.py:79` | App startup |
-| Explicit WS message | any | `backend/ws_handlers.py:357–422` | `agent-state` message from worker |
+| Agent joins | `idle` | `backend/ws_handlers.py` — `handle_join` (upsert) | `join` WS message |
+| Task begins | `working` | `worker/pioneer_worker/worker.py` — `_set_state("working", agent)` | Task dispatch |
+| Claude crash | `error` | `worker/pioneer_worker/worker.py` — multiple `_set_state("error", ...)` call sites | Subprocess failure / timeout |
+| Task completes successfully | `idle` | `worker/pioneer_worker/worker.py` — `_set_state("idle", ...)` call sites | End of task execution |
+| WS closes (worker side) | `offline` | `worker/pioneer_worker/worker.py` — `_set_state("offline", ...)` | Connection loss |
+| WS closes (backend side) | `offline` | `backend/ws_handlers.py` — `handle_worker_disconnect` | Connection handler |
+| Stale sweeper | `offline` | `backend/main.py` — `_sweep_stale_workers_once` | Background sweeper task |
+| Startup reset | `offline` | `backend/main.py` — `reset_connection_state` | App startup |
+| Explicit WS message | any | `backend/ws_handlers.py` — `handle_agent_state` | `agent-state` message from worker |
 
 ### Lock-Release States
 
 ```python
-# backend/ws_handlers.py:354
+# backend/ws_handlers.py
 _LOCK_RELEASE_AGENT_STATES = frozenset({"idle", "offline", "error", "timeout"})
 ```
 
-When an agent enters one of these states, the backend checks whether it owns a `working` task and, if so, moves it to `awaiting-review`.
+When an agent enters one of these states, the backend checks whether it owns a `working` task and, if so, moves it to `awaiting-review` (guarded so the task's `worker_id` must match the agent's, to avoid a stale `current_task_id` releasing the wrong lock).
 
-> **`timeout` state discrepancy:** `_LOCK_RELEASE_AGENT_STATES` includes `"timeout"` but the TypeScript `AgentState` union (`frontend/src/types.ts:1`) does **not** list `timeout` as a valid value. No code path in the audited codebase emits `agent-state: timeout` from either the worker or the backend — the entry in `_LOCK_RELEASE_AGENT_STATES` appears to be a defensive placeholder (if a `timeout` state were ever emitted, the lock would release). This discrepancy requires a decision: either confirm a code path that emits `timeout` and add it to the TypeScript union, or remove it from `_LOCK_RELEASE_AGENT_STATES` if no such path is planned.
+> **`timeout` state discrepancy (still present):** `_LOCK_RELEASE_AGENT_STATES` includes `"timeout"` but the TypeScript `AgentState` union does **not** list it, and no code path in worker or backend emits `agent-state: timeout`. It appears to be a defensive placeholder. Still worth a decision: confirm an emitting path and add it to the union, or drop it from the constant.
 
-### Frontend Priority Ranking
-
-Used by `frontend/src/stores/agents.ts:9–16` to derive a single display state when a worker has multiple agents:
-
-```typescript
-const STATE_RANK = { working: 0, thinking: 1, busy: 2, error: 3, idle: 4, offline: 5 }
-```
-
-Lower rank = higher priority (most active state wins).
+**Frontend priority ranking** — `frontend/src/stores/agents.ts` derives one display state per worker from its most-active agent via `STATE_RANK = { working: 0, thinking: 1, busy: 2, error: 3, idle: 4, offline: 5 }` (lower = higher priority).
 
 ---
 
@@ -135,7 +123,7 @@ Lower rank = higher priority (most active state wins).
 
 TypeScript union (authoritative frontend type):
 ```typescript
-// frontend/src/types.ts:52–60
+// frontend/src/types.ts
 type TaskState =
   | 'pending'         // newly created, awaiting dispatch
   | 'planning'        // foreman planning phase (rare)
@@ -150,11 +138,11 @@ type TaskState =
 ### Terminal States
 
 ```python
-# backend/ws_handlers.py:40
-_TERMINAL_STATES = ("done", "failed", "cancelled")
+# backend/ws_handlers.py
+_TERMINAL_STATES = ("done", "failed", "cancelled", "error")
 ```
 
-Once a task enters a terminal state it cannot transition further (guarded at every endpoint).
+`"error"` was added to this tuple since the original audit (mirrored in `frontend/src/stores/tasks.ts`'s `TERMINAL_STATES`) but is still missing from the `TaskState` union above and from the label/color maps below — a drift worth reconciling. Once a task enters a terminal state it cannot transition further (guarded at every endpoint).
 
 ### State Transition Graph
 
@@ -168,7 +156,7 @@ Once a task enters a terminal state it cannot transition further (guarded at eve
     ▼                                                                 │
  working ──(task-update: state=planning)──► planning ────────────────┤
     │  │                                    [unguarded; no watchdog]  │
-    │  └──(task-update: state=failed)────────────────────► failed     │
+    │  └──(task-update: state=failed/error)──────────────► failed/error
     │                                                                 │
     │ (task-complete / agent: idle, offline, error, timeout)          │
     ▼                                                                 │
@@ -182,22 +170,22 @@ Once a task enters a terminal state it cannot transition further (guarded at eve
 
 ### State Transition Locations
 
-| Transition | From → To | File & Location | Trigger |
+| Transition | From → To | File & Function | Trigger |
 |-----------|-----------|-----------------|---------|
-| Task created | `→ pending` | `backend/ws_handlers.py:154–162` (frontend msg) / foreman | `task-created` WS or Foreman tool |
-| Foreman assigns | `pending → working` | `backend/routes/foreman.py` / Foreman `assign_task` tool | Foreman AI decision |
-| Worker sends task-update | `→ (any)` | `backend/ws_handlers.py:619` | `task-update` WS message from worker |
-| Worker sends task-complete | `working → awaiting-review` | `backend/ws_handlers.py:648–649` | `task-complete` WS (guarded: `state == "working"`) |
-| Agent enters lock-release state | `working → awaiting-review` | `backend/ws_handlers.py:405–408` | `agent-state` handler (agent idle/offline/error) |
-| Stale task watchdog | `working → awaiting-review` | `backend/main.py:202–203` | Sweeper: orphaned working task, no active agent |
-| Follow-up done | `(non-terminal) → awaiting-review` | `backend/ws_handlers.py:693–696` | `task-followup-done` WS |
-| Finalize | `(non-terminal) → done` | `backend/routes/tasks.py:276` | `finalize_task` REST endpoint |
-| Cancel | `(non-terminal) → cancelled` | `backend/routes/tasks.py:327` | `cancel_task` REST endpoint |
-| Redirect | `(non-terminal) → working` | `backend/routes/tasks.py:378` | `redirect_task` REST endpoint |
+| Task created | `→ pending` | `backend/foreman/tools.py` — `create_task` tool | Foreman AI decision (no frontend "task-created" WS message exists) |
+| Foreman assigns | `pending → working` | `backend/foreman/tools.py` — `assign_task` tool | Foreman AI decision |
+| Worker sends task-update | `→ (any)` | `backend/ws_handlers.py` — `handle_task_update` | `task-update` WS message from worker |
+| Worker sends task-complete | `working → awaiting-review` | `backend/ws_handlers.py` — `handle_task_complete` | `task-complete` WS (guarded: `state == "working"`) |
+| Agent enters lock-release state | `working → awaiting-review` | `backend/ws_handlers.py` — `handle_agent_state` | `agent-state` handler (agent idle/offline/error) |
+| Stale task watchdog | `working → awaiting-review` | `backend/main.py` — orphaned-task sweep in the lifespan sweeper | Sweeper: orphaned working task, no active agent |
+| Follow-up done | `(non-terminal) → awaiting-review` | `backend/ws_handlers.py` — `handle_task_followup_done` | `task-followup-done` WS |
+| Finalize | `(non-terminal) → done` | `backend/routes/tasks.py` — `finalize_task_endpoint` | REST endpoint |
+| Cancel | `(non-terminal) → cancelled` | `backend/routes/tasks.py` — `cancel_task_endpoint` | REST endpoint |
+| Redirect | `(non-terminal) → working` | `backend/routes/tasks.py` — `redirect_task_endpoint` | REST endpoint |
 
 ### Frontend State Rendering
 
-Labels and colors defined in `frontend/src/stores/tasks.ts:16–36`:
+Labels and colors defined in `frontend/src/stores/tasks.ts` (`STATE_LABELS`/`STATE_COLORS`):
 
 | Backend State | Display Label | Color |
 |--------------|---------------|-------|
@@ -210,9 +198,7 @@ Labels and colors defined in `frontend/src/stores/tasks.ts:16–36`:
 | `followup` | **`follow-up`** (hyphenated) | `orange` |
 | `cancelled` | `cancelled` | `red` |
 
-**Vocabulary differences** (frontend display vs. backend value):
-- `awaiting-review` → `review`
-- `followup` → `follow-up`
+**Vocabulary differences** (frontend display vs. backend value): `awaiting-review` → `review`, `followup` → `follow-up`.
 
 ---
 
@@ -226,77 +212,27 @@ Guild
        └─ Agent (fine-grained: idle/working/thinking/busy/error/offline)
             └─ current_task_id (link to Task)
 
-Task (state: pending/working/awaiting-review/done/failed/followup/cancelled)
+Task (state: pending/working/awaiting-review/done/failed/followup/cancelled/error)
 ```
 
-### Worker State ← Agent State (Frontend Only)
+- **Worker state ← agent state (frontend only):** the DB never derives worker state from agent state — independent. The frontend computes a per-worker display state from the highest-priority agent state (`frontend/src/stores/agents.ts`), so a worker can show "working" while the DB says "online" — intentional; backend worker state is a coarse connectivity flag, not a workload indicator.
+- **Agent state → task state (lock release):** when an agent transitions to `idle`, `offline`, `error`, or `timeout`, the backend checks whether its `current_task_id` points to a `working` task owned by the same worker, and if so releases the lock and moves the task to `awaiting-review` (`backend/ws_handlers.py` — `handle_agent_state`). Primary safety mechanism against tasks stuck in `working` after a worker crash.
+- **Task state ← agent state:** none beyond the lock-release above, by design. A task staying `awaiting-review` while its agent is `idle` is normal — it's waiting on the foreman.
 
-- The **database** does not derive worker state from agent state. They are independent.
-- The **frontend** computes a display state for each worker by selecting the highest-priority agent state among all agents belonging to that worker (`frontend/src/stores/agents.ts:52–72`).
-- This means the frontend can show a worker as "working" while the DB has it as "online". This is intentional — the backend worker state is a coarse connectivity flag, not a workload indicator.
+### Design Observations (at time of writing)
 
-### Agent State → Task State (Lock Release)
+1. **`thinking`/`busy` agent states remain undefined in production** — present in the frontend union, `STATE_RANK`, and the stale-task watchdog's active-agent query (`backend/main.py`), but no worker path emits them (confirmed still true). The related frontend color/rank branches are dead code.
 
-- When an agent transitions to `idle`, `offline`, `error`, or `timeout`, the backend checks whether that agent's `current_task_id` points to a `working` task owned by the same worker.
-- If so, it releases the task lock and moves the task to `awaiting-review`.
-- This is the primary safety mechanism preventing tasks from getting stuck in `working` when a worker crashes.
-- Location: `backend/ws_handlers.py:354–421`
+2. **Worker state is still coarse**, cycling only `idle → online → offline` while the frontend prefers agent-derived state. `worker.state` can diverge from actual agent liveness (e.g. `online` worker, all agents `offline`). New lifecycle columns (`container_id`, `spawned_version`, `started_at`, `drain_requested_at`) add richer tracking alongside `state`, but don't change its three values.
 
-### Task State ← Agent State (None — by design)
+3. **`followup` task state is still legacy/rare** — present in the frontend union, color map, a UI dropdown, and tests, but no backend path sets `task.state = 'followup'` (the follow-up flow stays in `awaiting-review`). Confirmed still true; likely dead code.
 
-- Task state does **not** automatically change based on agent state transitions (other than the lock-release above).
-- A task staying `awaiting-review` while its agent is `idle` is normal — the task is waiting for the foreman to finalize or send a follow-up.
+4. **Security concern — `task-update` is still unvalidated.** `handle_task_update` (`backend/ws_handlers.py`) applies a worker's requested state change without checking it owns the task (confirmed unpatched). A rogue worker can set `state=planning` on any task; since `planning` is outside both `_TERMINAL_STATES` and the watchdog's `state == "working"` guard, the victim task stalls indefinitely. **Fix:** validate `task.worker_id == requesting agent's worker_id`, mirroring the guard already present in `handle_agent_state`'s lock-release path.
 
-### Potential Design Issues
-
-1. **`thinking` and `busy` agent states are undefined in production code.** They appear in `backend/main.py:188` (active-agent query) and the frontend type union but are never emitted by the real worker. This means the query might never match any real agent in those states, and the frontend color/rank mappings for them are dead code paths.
-
-2. **Worker state is nearly vestigial.** The only transitions are `idle → online → offline`. The frontend ignores it in favor of agent-derived state. The backend uses it mainly as a connectivity flag. There is a risk that `worker.state` and the set of online agents diverge (e.g., worker shows `online` but all its agents are `offline` after a crash).
-
-3. **`followup` task state is legacy/rare.** It appears in the frontend type union and color mapping but no backend code path currently sets `state = 'followup'` directly. The follow-up flow uses `awaiting-review` as the state while a follow-up is in progress. This state may be dead code.
-
-4. **Security concern — `task-update` state changes are unvalidated.** The `task-update` WebSocket message handler (`backend/ws_handlers.py:619`) applies the requested state change without verifying that the requesting worker owns the task. A rogue or compromised worker can therefore set `state=planning` on *any* other worker's task. Because `planning` is absent from both `_TERMINAL_STATES` and `_LOCK_RELEASE_AGENT_STATES`, the stale-task watchdog does not reclaim it — the victim task is stalled indefinitely with no automatic recovery path.
-
-   **Recommended fix:** Add server-side ownership validation to the `task-update` handler. Before applying a state change, verify that `task.assigned_worker_id == requesting_agent.worker_id`. Reject the update (e.g. a `task-update-error` WS message) if the IDs do not match.
-
-5. **Agent `activity` is not persisted.** It is only in memory / WS broadcast. A browser reload loses the current activity display. This is probably fine for a display hint but worth noting.
+5. ~~**Agent `activity` is not persisted.**~~ **Resolved** — `activity` is now a persisted `agents` column (migration `20260501_000000_add_activity_to_agents`), surviving restarts rather than living only in memory.
 
 ---
 
 ## 5. File Reference Map
 
-### State Definitions
-
-| File | What It Defines |
-|------|----------------|
-| `backend/models.py:58, 98, 128` | ORM field defaults for agent, worker, task state |
-| `backend/alembic/versions/20260428_000000_initial_schema.py:63, 74, 88` | DB column defaults |
-| `backend/ws_handlers.py:40, 354` | `_TERMINAL_STATES`, `_LOCK_RELEASE_AGENT_STATES` constants |
-| `frontend/src/types.ts:1, 52–60` | TypeScript `AgentState`, `AgentActivity`, `TaskState` unions |
-
-### State Transitions — Backend
-
-| File | Responsibility |
-|------|----------------|
-| `backend/ws_handlers.py:210–344` | `handle_join`: agent register, worker → online |
-| `backend/ws_handlers.py:357–422` | `handle_agent_state`: agent state changes + lock release |
-| `backend/ws_handlers.py:566–594` | `handle_worker_disconnect`: mark offline |
-| `backend/ws_handlers.py:628–680` | `handle_task_complete`: working → awaiting-review |
-| `backend/ws_handlers.py:683–702` | `handle_task_followup_done`: → awaiting-review |
-| `backend/routes/tasks.py:273–399` | `finalize_task`, `cancel_task`, `redirect_task` endpoints |
-| `backend/main.py:72–206` | Startup reset + stale sweeper |
-
-### State Transitions — Worker
-
-| File | Responsibility |
-|------|----------------|
-| `worker/pioneer_worker/worker.py:751–760` | `_set_state()`: updates local state + broadcasts |
-| `worker/pioneer_worker/worker.py:733–749` | `_emit_agent_state()`: sends `agent-state` WS message |
-| `worker/pioneer_worker/claude_runner.py:40–52, 80` | Maps Claude tool events to `activity` values |
-
-### Frontend Rendering
-
-| File | Responsibility |
-|------|----------------|
-| `frontend/src/stores/agents.ts:9–16, 52–72, 98–113` | State rank, computed worker state, agent updates |
-| `frontend/src/stores/tasks.ts:16–36, 241–245` | Task labels and color mapping |
+Superseded by the "Where Defined" / "State Transition Locations" tables in sections 1–3, which already name the responsible file and function for every state and transition covered by this audit. Grep those names in current code rather than relying on a separate index here.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -17,7 +17,7 @@ _build_chat_line()        ──→  DB persist + WS broadcast  [filtered from c
 
 Two parallel paths are created for each actionable event:
 
-1. **Foreman summary** (`_build_foreman_summary`) — a structured message fed directly to the Foreman AI via `run_foreman_ai()`. This contains event-specific guidance (e.g. "PR merged — call `finalize_task`") and is part of the AI's internal reasoning context.
+1. **Foreman summary** (`_build_foreman_summary`) — a structured message fed to the Foreman AI via `run_foreman_ai()`. It contains event-specific guidance (e.g. "PR merged — call `finalize_task`") and is part of the AI's internal reasoning context.
 
 2. **Chat line** (`_build_chat_line`) — a human-readable `[github-event]` line stored in the `messages` table and broadcast as `type: "chat"` with `from: "github"`.
 
@@ -36,9 +36,9 @@ Only events that pass `_should_dispatch_to_foreman()` wake the Foreman AI:
 
 | Event | Condition |
 |-------|-----------|
-| `pull_request` | Matching task found; skip bot senders unless CI-related |
-| `pull_request_review` | Review submitted with `changes_requested` or `approved` |
-| `check_run` / `check_suite` | `completed` conclusion (failure, success, etc.) |
-| `status` | Terminal state (failure, error, success) |
+| `pull_request` | Matching task found; bot senders skipped unless CI-related |
+| `pull_request_review` | Matching task found |
+| `check_run` / `check_suite` | Matching task found; `completed` status with conclusion other than `neutral`/`skipped` |
+| `status` | Matching task found |
 
 Pending, neutral, or skipped check states are silently ignored.

--- a/ios/README.md
+++ b/ios/README.md
@@ -9,15 +9,15 @@ shell exists to add the things a browser can't:
 - **Persistent auth.** Store the GitHub OAuth token in the iOS Keychain
   via `WKWebsiteDataStore` cookies that survive backgrounding.
 - **Safe-area aware viewport.** Render edge-to-edge under the iPhone
-  home indicator and notch, with the existing mobile breakpoint at
-  `AppView.vue:195` providing the layout.
+  home indicator and notch, using the frontend's existing mobile breakpoint
+  (`AppView.vue`) for layout.
 - **Deep links.** Tap an APNs notification → land directly on the task.
 
 ## Layout
 
 ```
 ios/
-├── PioneerSquare/
+├── PioneerSquare/PioneerSquare/
 │   ├── PioneerSquareApp.swift   # SwiftUI App entry + AppDelegate
 │   ├── WebViewContainer.swift   # UIViewRepresentable around WKWebView
 │   ├── NativeBridge.swift       # WKScriptMessageHandler — JS↔native
@@ -32,18 +32,17 @@ The frontend side of the bridge lives at
 
 ## First-time setup
 
-This branch ships **source files only** — generate the Xcode project
-yourself so it isn't checked in as binary `project.pbxproj`:
+This repo ships **source files only** — the Xcode project file is gitignored, so
+generate it locally:
 
-1. Xcode → **File → New → Project → iOS → App**.
-2. Product Name: `PioneerSquare`. Interface: **SwiftUI**. Language: **Swift**.
-3. Save the project at `ios/` (so the generated `PioneerSquare/` folder
-   lines up with the source files in this directory). Replace the
-   generated `*.swift` files with the ones already here.
-4. In the target's **Signing & Capabilities**:
-   - Add **Push Notifications** capability.
-   - Add **Background Modes** → check **Remote notifications**.
-5. In `Info.plist`, set `PIONEER_BACKEND_URL` to your backend (e.g.
+1. Xcode → **File → New → Project → iOS → App**. Product Name:
+   `PioneerSquare`. Interface: **SwiftUI**. Language: **Swift**.
+2. Save the project at `ios/` (so the generated `PioneerSquare/` folder lines
+   up with the source files in this directory), then replace the generated
+   `*.swift` files with the ones already here.
+3. In the target's **Signing & Capabilities**, add **Push Notifications** and
+   **Background Modes → Remote notifications**.
+4. In `Info.plist`, set `PIONEER_BACKEND_URL` to your backend (e.g.
    `https://pioneer-square.example.com`). For local dev see the ATS
    exception note in [`Info.plist`](PioneerSquare/Info.plist).
 
@@ -66,9 +65,9 @@ Messages sent native → web come back on `window.pioneerSquareNative.*`
 callbacks (set by `nativeBridge.ts`). See `NativeBridge.swift` for the
 full message catalog.
 
-## Out of scope for this branch
+## Out of scope
 
-- `/api/push/register` endpoint on the FastAPI backend (separate branch).
-- APNs cert/key setup with Apple — that's per-deployment.
-- `ASWebAuthenticationSession` for GitHub OAuth. The current redirect
-  flow works in-WebView; we can revisit if SSO/keychain sharing is needed.
+- APNs cert/key setup with Apple — that's per-deployment (see `backend/push.py`
+  for the required `APNS_*` env vars).
+- `ASWebAuthenticationSession` for GitHub OAuth. The current redirect flow
+  works in-WebView; revisit if SSO/keychain sharing is needed later.

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,7 +1,7 @@
 # Pioneer Square Worker
 
 Standalone worker agent for [Pioneer Square](../README.md). Connects to a backend
-session over WebSocket, listens for task assignments, runs
+guild over WebSocket, listens for task assignments, runs
 `claude --dangerously-skip-permissions` against a fresh git worktree, then
 pushes the result and opens a GitHub PR.
 
@@ -20,50 +20,28 @@ uv pip install -e cli
 ```
 
 This provides the `pioneer` command; run a worker with `pioneer worker`. The
-`pioneer-worker` console script remains available as a backward-compatible alias.
+`pioneer-worker` console script is a backward-compatible alias used below for
+brevity.
 
 ## Expected toolchain
 
-A worker shells out to a coding agent (`claude`, `codex`, or `pi`), which in
-turn runs whatever the task needs — installing dependencies, running tests,
-linting, building, opening PRs. To keep agents from having to bootstrap a
-language runtime mid-task, every worker host should have the following
+A worker shells out to a coding agent (`claude`, `codex`, or `pi`), which runs
+whatever the task needs. Every worker host should have the following
 pre-installed and on `PATH`:
 
-**Core**
+- **Core**: `git`, `curl`, `jq`, `make`, `unzip`, `openssh-client`, `ripgrep`, a
+  C/C++ toolchain (`build-essential` on Debian), [`gh`](https://cli.github.com/)
+- **Python 3.11+**: `python3`, `pip`, `venv`, [`ruff`](https://docs.astral.sh/ruff/),
+  [`pytest`](https://docs.pytest.org/), [`uv`](https://docs.astral.sh/uv/), [`pipx`](https://pipx.pypa.io/)
+- **Node.js 24+**: `node`, `npm`, `npx`, `corepack` enabled, plus the agent
+  CLIs (`@anthropic-ai/claude-code`, `@openai/codex`, `@mariozechner/pi-coding-agent`)
+- **Go 1.23+**: `go` on `PATH`, with `GOPATH` writable by the worker user
 
-- `git`, `curl`, `jq`, `make`, `unzip`, `openssh-client`, `ripgrep`
-- A C/C++ toolchain (`build-essential` on Debian — needed to compile native
-  Python wheels and Node addons)
-- [`gh`](https://cli.github.com/) — used by agents to inspect issues and PRs
-
-**Python 3.11+**
-
-- `python3`, `pip`, `venv`
-- [`ruff`](https://docs.astral.sh/ruff/) (lint + format)
-- [`pytest`](https://docs.pytest.org/)
-- [`uv`](https://docs.astral.sh/uv/) (fast resolver/installer used by some repos)
-- [`pipx`](https://pipx.pypa.io/) (sandboxed CLI installs)
-
-**Node.js 24+**
-
-- `node`, `npm`, `npx`
-- `corepack` enabled, so repos pinned to `pnpm`/`yarn` via `packageManager` work
-- The agent CLIs themselves: `@anthropic-ai/claude-code`, `@openai/codex`,
-  `@mariozechner/pi-coding-agent`
-
-**Go 1.23+**
-
-- `go` on `PATH`, with `GOPATH` writable by the worker user
-
-The `worker` target in the root `Dockerfile` provisions exactly this set, so anything `docker
-compose --profile worker up` builds is already correct. If you run the worker
-directly on a host, install the equivalents through your package manager
-(`apt`, `brew`, etc.) before launching it.
-
-Anything outside this baseline (Rust, Java, Ruby, .NET, Terraform, etc.) is
-expected to be installed on demand by the task itself, or added to the
-Dockerfile in a follow-up PR if it becomes a recurring need.
+The `worker` target in the root `Dockerfile` currently provisions this set, so
+`docker compose --profile worker up` needs no extra setup. Running the worker
+directly on a host requires installing the equivalents yourself. Anything
+outside this baseline (Rust, Java, Ruby, .NET, Terraform, etc.) is expected to
+be installed on demand by the task itself.
 
 ## Configure
 
@@ -78,7 +56,7 @@ Required keys:
 
 - `backend_url` — `http://host:port` (or `ws://...`); the worker derives the
   WebSocket URL automatically.
-- `session_id` — the 6-char session id from the Pioneer Square UI.
+- `guild_id` — the 6-char guild id from the Pioneer Square UI.
 - `[github] repos` — list of `owner/repo` strings the worker may operate on.
 - `[github] org` — GitHub organisation name (e.g. `"jmelloy"`). When set, the
   worker accepts tasks targeting *any* repo under that org and clones repos
@@ -106,7 +84,7 @@ The worker stays running, reconnecting if the backend restarts.
 ## How it works
 
 1. On startup, registers (or claims) a worker id with the backend.
-2. Opens a WebSocket to `/ws/{session_id}` and announces itself with `join`
+2. Opens a WebSocket to `/ws/{guild_id}` and announces itself with `join`
    and `worker-register` messages.
 3. Fetches any pending tasks via REST so it can resume work across restarts.
 4. Listens for `task-assigned` messages whose `workerId` matches its own id.
@@ -118,12 +96,9 @@ The worker stays running, reconnecting if the backend restarts.
 
 ## Control API (drive a live worker without a frontend)
 
-A real worker only acts on tasks the backend/foreman assigns over WebSocket,
-which makes it awkward to test in isolation. Enable the optional HTTP control
-API to inject tasks straight into the worker's queue and inspect its state —
-the full execution path (clone, worktree, claude/codex/pi, push, PR) still
-runs, so it's a faithful smoke test against a real backend without driving the
-UI.
+Enable the optional HTTP control API to inject tasks straight into the
+worker's queue and inspect its state without driving the UI — the full
+execution path (clone, worktree, claude/codex/pi, push, PR) still runs.
 
 ```bash
 pioneer-worker --api-port 9200             # enable on 127.0.0.1:9200
@@ -163,7 +138,7 @@ curl -s localhost:9200/ | jq .
 
 ## Multiple workers
 
-Run more than one worker against the same session by giving each its own
+Run more than one worker against the same guild by giving each its own
 config directory (so the sidecar state file doesn't collide):
 
 ```bash


### PR DESCRIPTION
## Summary
- Removed outdated architecture/setup content across README.md, AGENTS.md, and docs/
- Trimmed verbose and redundant sections in docs/, worker/README.md, and ios/README.md
- Reframed definitive/permanent claims (especially Discord integration behavior) as current-state descriptions rather than fixed design guarantees

Closes #889

## Test plan
- [ ] Skim rendered docs for broken links/formatting
- [ ] Confirm no code was changed (docs-only diff)