### PR TITLE
refactor: consolidate duplicated code from audit

### DIFF
--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -160,7 +160,7 @@ def _get_client() -> httpx.AsyncClient:
     return _client
 
 
-def _bot_token() -> str | None:
+def bot_token() -> str | None:
     return os.environ.get("DISCORD_BOT_TOKEN") or None
 
 
@@ -175,7 +175,7 @@ def is_configured() -> bool:
     (e.g. a live GitHub API call to resolve a thread title) when Discord
     notifications are disabled entirely.
     """
-    return bool(_bot_token())
+    return bool(bot_token())
 
 
 # ---------------------------------------------------------------------------
@@ -200,7 +200,7 @@ async def notify(
     destination channel are not configured. Never raises — errors are logged
     at WARNING level by the underlying bot request.
     """
-    if not _bot_token():
+    if not bot_token():
         return
 
     channel = await _resolve_channel_for_guild(ps_guild_slug)
@@ -221,15 +221,15 @@ async def _bot_request_raw(
     method: str,
     path: str,
     json_body: dict | None = None,
-) -> dict:
+) -> dict | list:
     """Make an authenticated Discord bot API request, raising on failure.
 
-    Returns the parsed JSON response dict, or an empty dict for 204/empty
-    bodies. Unlike ``_bot_request``, this does not swallow errors — callers
+    Returns the parsed JSON response (dict or list), or an empty dict for
+    204/empty bodies. Unlike ``_bot_request``, this does not swallow errors — callers
     that need to distinguish an expected API failure (``httpx.HTTPError``)
     from a genuine bug use this directly (see ``send_welcome_dm``).
     """
-    token = _bot_token()
+    token = bot_token()
     headers = {
         "Authorization": f"Bot {token}",
         "Content-Type": "application/json",
@@ -248,13 +248,13 @@ async def _bot_request(
     method: str,
     path: str,
     json_body: dict | None = None,
-) -> dict | None:
+) -> dict | list | None:
     """Make an authenticated Discord bot API request.
 
-    Returns the parsed JSON response dict, an empty dict for 204/empty bodies,
-    or None on error.  Never raises.
+    Returns the parsed JSON response (dict or list), an empty dict for
+    204/empty bodies, or None on error.  Never raises.
     """
-    if not _bot_token():
+    if not bot_token():
         return None
     try:
         return await _bot_request_raw(method, path, json_body)
@@ -263,6 +263,21 @@ async def _bot_request(
             "Discord bot API request failed method=%s path=%s", method, path, exc_info=True
         )
         return None
+
+
+async def get(path: str) -> dict | list | None:
+    """GET a Discord bot API endpoint. Returns parsed JSON, or None on error/no token."""
+    return await _bot_request("get", path)
+
+
+async def post(path: str, payload: dict | None = None) -> dict | list | None:
+    """POST to a Discord bot API endpoint. Returns parsed JSON, or None on error/no token."""
+    return await _bot_request("post", path, payload)
+
+
+async def patch(path: str, payload: dict) -> dict | list | None:
+    """PATCH a Discord bot API endpoint. Returns parsed JSON, or None on error/no token."""
+    return await _bot_request("patch", path, payload)
 
 
 async def _resolve_channel_for_guild(ps_guild_slug: str | None) -> str | None:
@@ -662,7 +677,7 @@ async def send_welcome_dm(discord_user_id: str, username: str | None = None) -> 
     message in that case, which is caught and logged at WARNING. Silent
     no-op when the bot token is not configured. Never raises.
     """
-    if not _bot_token():
+    if not bot_token():
         return
     try:
         dm_channel = await _bot_request_raw(
@@ -725,7 +740,7 @@ async def notify_foreman_chat(
     """
     if not content or not content.strip():
         return
-    if not _bot_token():
+    if not bot_token():
         return
 
     channel = await _resolve_channel_for_guild(guild_id)
@@ -830,7 +845,7 @@ async def notify_event(
     operations fail. Silent no-op when the bot token is not configured.
     Never raises.
     """
-    if _bot_token():
+    if bot_token():
         coords = await _canonical_coords(issue_repo, issue_number, kind=kind, task_id=task_id)
         if coords:
             repo, number = coords
@@ -898,7 +913,7 @@ async def notify_existing_thread(
     the configured channel when there isn't one. Silent no-op / never raises,
     same guarantees as ``notify_event``.
     """
-    if _bot_token():
+    if bot_token():
         coords = await _canonical_coords(issue_repo, issue_number, kind=kind, task_id=task_id)
         if coords:
             thread_id = await _lookup_thread(_SUBJECT_ISSUE, _issue_subject_key(*coords))
@@ -944,7 +959,7 @@ def _stream_enabled() -> bool:
     always routed into a per-task thread (never a flat channel post).
     """
     flag = os.environ.get("DISCORD_STREAM_TASKS", "").strip().lower()
-    return bool(_bot_token()) and flag in ("1", "true", "yes", "on")
+    return bool(bot_token()) and flag in ("1", "true", "yes", "on")
 
 
 @dataclass
@@ -1343,7 +1358,7 @@ async def notify_ci_check(
     *key* and treating it as freshly created (forcing a new flush task) keeps
     it from being silently dropped.
     """
-    if not _bot_token():
+    if not bot_token():
         return
 
     key = f"{issue_repo}#{issue_number}" if issue_repo and issue_number is not None else pr_label

--- a/backend/routes/debug.py
+++ b/backend/routes/debug.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -19,6 +18,7 @@ import httpx
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from fastapi import APIRouter, Depends, HTTPException
+from foreman.github_url_parser import parse_github_urls
 from models import GithubEvent, GithubToken, LlmUsage, Task, TaskLog
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -37,10 +37,8 @@ _GITHUB_API = "https://api.github.com"
 
 def _parse_pr_url(pr_url: str) -> tuple[str, str, int] | None:
     """Return (owner, repo, pr_number) from a GitHub PR URL, or None."""
-    m = re.match(r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url)
-    if not m:
-        return None
-    return m.group(1), m.group(2), int(m.group(3))
+    refs = [ref for ref in parse_github_urls(pr_url) if ref.ref_type == "pull"]
+    return (refs[0].owner, refs[0].repo, refs[0].number) if refs else None
 
 
 def _iso(dt: datetime | None) -> str | None:

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -32,16 +32,16 @@ import json
 import logging
 import os
 import random
-import re
 import string
 import uuid
 from datetime import UTC, datetime, timedelta
 
-import httpx
+import discord_notifier
 from database import AsyncSessionLocal
 from discord.auth import is_member_authorized
 from events import broadcast_msg
 from fastapi import APIRouter, BackgroundTasks, Request, Response
+from foreman.github_url_parser import parse_github_urls
 from foreman.tools import spawn_worker
 from models import (
     Agent,
@@ -61,8 +61,6 @@ from ws_types import TaskCancelMsg, TaskCreatedMsg, TaskUpdateMsg
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-_DISCORD_API_BASE = "https://discord.com/api/v10"
 
 # Discord interaction types
 _PING = 1
@@ -99,10 +97,6 @@ def _public_key() -> str | None:
 
 def _application_id() -> str | None:
     return os.environ.get("DISCORD_APPLICATION_ID") or None
-
-
-def _bot_token() -> str | None:
-    return os.environ.get("DISCORD_BOT_TOKEN") or None
 
 
 def _pioneer_guild_slug() -> str | None:
@@ -165,7 +159,7 @@ async def _has_operator_role(interaction: dict) -> bool:
     if not discord_guild_id or not user_role_ids:
         return False
 
-    roles = await _discord_get(f"/guilds/{discord_guild_id}/roles")
+    roles = await discord_notifier.get(f"/guilds/{discord_guild_id}/roles")
     if not roles:
         return False
     role_name = _operator_role_name()
@@ -186,41 +180,6 @@ async def _can_manage_channel_bindings(interaction: dict) -> bool:
     return await _has_operator_role(interaction)
 
 
-# ---------------------------------------------------------------------------
-# Discord API helper
-# ---------------------------------------------------------------------------
-
-
-async def _discord_get(path: str) -> list | dict | None:
-    """GET a Discord REST endpoint. Returns parsed JSON, or None on error/no token."""
-    token = _bot_token()
-    if not token:
-        return None
-    headers = {"Authorization": f"Bot {token}"}
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(f"{_DISCORD_API_BASE}{path}", headers=headers)
-            resp.raise_for_status()
-            return resp.json()
-    except Exception:
-        logger.warning("discord: GET %s failed", path, exc_info=True)
-        return None
-
-
-async def _discord_patch(path: str, payload: dict) -> None:
-    """PATCH a Discord REST endpoint. Errors are logged and swallowed."""
-    token = _bot_token()
-    if not token:
-        return
-    headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.patch(f"{_DISCORD_API_BASE}{path}", json=payload, headers=headers)
-            resp.raise_for_status()
-    except Exception:
-        logger.warning("discord: PATCH %s failed", path, exc_info=True)
-
-
 async def _send_followup(
     interaction_token: str, content: str | None = None, embeds: list | None = None
 ) -> None:
@@ -233,29 +192,24 @@ async def _send_followup(
         payload["content"] = content
     if embeds is not None:
         payload["embeds"] = embeds
-    await _discord_patch(f"/webhooks/{app_id}/{interaction_token}/messages/@original", payload)
+    await discord_notifier.patch(
+        f"/webhooks/{app_id}/{interaction_token}/messages/@original", payload
+    )
 
 
 # ---------------------------------------------------------------------------
 # GitHub URL parsers
 # ---------------------------------------------------------------------------
 
-_GH_ISSUE_RE = re.compile(r"https://github\.com/([^/\s]+/[^/\s]+)/issues/(\d+)", re.IGNORECASE)
-_GH_PR_RE = re.compile(r"https://github\.com/([^/\s]+/[^/\s]+)/pull/(\d+)", re.IGNORECASE)
-
 
 def _parse_issue_url(url: str) -> tuple[str, int] | None:
-    m = _GH_ISSUE_RE.search(url)
-    if not m:
-        return None
-    return m.group(1), int(m.group(2))
+    refs = [ref for ref in parse_github_urls(url) if ref.ref_type == "issues"]
+    return (refs[0].slug, refs[0].number) if refs else None
 
 
 def _parse_pr_url(url: str) -> tuple[str, int] | None:
-    m = _GH_PR_RE.search(url)
-    if not m:
-        return None
-    return m.group(1), int(m.group(2))
+    refs = [ref for ref in parse_github_urls(url) if ref.ref_type == "pull"]
+    return (refs[0].slug, refs[0].number) if refs else None
 
 
 def _new_task_id() -> str:

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -12,12 +12,9 @@ Existing (unchanged):
   POST /guilds/{guild_id}/foreman/clear-context  — debug: delete all turns for calling user
 
 State reads:
-  GET  /guilds/{guild_id}/foreman/state          — online workers, active tasks, guild metadata
-  GET  /guilds/{guild_id}/foreman/history        — raw ForemanTurn rows for a given user_id
-  GET  /guilds/{guild_id}/guild-key              — Ed25519 private key PEM for JWT signing
+  GET  /guilds/{guild_id}/foreman/env-vars       — guild foreman env vars (unmasked)
 
 State writes:
-  POST  /guilds/{guild_id}/foreman/history       — persist one ForemanTurn row
   POST  /guilds/{guild_id}/tasks                 — create a foreman-owned task
   PATCH /guilds/{guild_id}/tasks/{task_id}       — update task fields (state, worker, branch, …)
   POST  /guilds/{guild_id}/messages              — persist a chat message
@@ -25,7 +22,6 @@ State writes:
 
 from __future__ import annotations
 
-import json
 import logging
 import random
 import string
@@ -35,16 +31,12 @@ from typing import Literal
 from auth_deps import get_guild_pk, require_member, require_worker_or_member_path
 from database import get_db_dep
 from events import broadcast_msg
-from fastapi import APIRouter, Depends, HTTPException, Query
-from foreman.runner import _fetch_online_workers, clear_foreman_history, get_foreman_history
+from fastapi import APIRouter, Depends, HTTPException
+from foreman.runner import clear_foreman_history, get_foreman_history
 from models import (
-    ForemanTurn,
     Guild,
-    GuildKey,
-    GuildMember,
     Message,
     Task,
-    live_tasks_filter,
 )
 from pydantic import BaseModel
 from sqlalchemy import update
@@ -121,177 +113,6 @@ async def clear_foreman_context(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/guilds/{guild_id}/foreman/state")
-async def get_foreman_state(
-    guild_id: str,
-    _caller: str = Depends(require_worker_or_member_path),
-    db: AsyncSession = Depends(get_db_dep),
-):
-    """Return a snapshot of guild state for debugging/API clients.
-
-    Response shape::
-
-        {
-          "guild": { "name": str, "primary_repo": str | null },
-          "workers": [
-            {
-              "id": str,
-              "state": str,          # "online" | "offline"
-              "repos": list[str],
-              "org": str | null,
-              "agent_count": int,
-              "agents": str          # "agentId:state,…" summary
-            }
-          ],
-          "tasks": [
-            {
-              "id": str, "worker_id": str, "name": str, "description": str,
-              "state": str, "phase": str, "branch": str | null,
-              "pr_url": str | null, "deleted_at": str | null
-            }
-          ]
-        }
-
-    ``workers`` lists only online workers (state == 'online'). ``tasks``
-    lists all non-terminal, non-soft-deleted tasks, most recent first.
-    Mirrors the state snapshot built by ``run_foreman_ai()``.
-    """
-    guild_pk = await get_guild_pk(db, guild_id)
-    if guild_pk is None:
-        raise HTTPException(status_code=404, detail="Guild not found")
-
-    # Guild metadata
-    guild_res = await db.exec(
-        select(col(Guild.name), col(Guild.primary_repo)).where(col(Guild.slug) == guild_id)
-    )
-    guild_row = guild_res.one_or_none()
-
-    # Fetch guild owner user_id for the standalone foreman
-    owner_res = await db.exec(
-        select(col(GuildMember.user_id))
-        .where(col(GuildMember.guild_id) == guild_pk, col(GuildMember.role) == "owner")
-        .limit(1)
-    )
-    owner_user_id = owner_res.one_or_none()
-
-    guild_data = {
-        "name": guild_row.name if guild_row else None,
-        "primary_repo": guild_row.primary_repo if guild_row else None,
-        "owner_user_id": owner_user_id,
-    }
-
-    # Online workers with their active agents
-    worker_rows = await _fetch_online_workers(db, guild_id)
-    workers_data = [
-        {
-            "id": r["id"],
-            "state": r["worker_state"] or "idle",
-            "repos": json.loads(r["repos"] or "[]"),
-            **({"org": r["org"]} if r.get("org") else {}),
-            "agent_count": r["agent_count"] or 0,
-            "agents": r["agents"] or "",
-            "tools": json.loads(r["tools"] or "[]"),
-        }
-        for r in worker_rows
-    ]
-
-    # Active (non-terminal, non-soft-deleted) tasks
-    _TERMINAL = {"done", "failed", "cancelled"}
-    tasks_res = await db.exec(
-        select(
-            col(Task.id),
-            col(Task.worker_id),
-            col(Task.name),
-            col(Task.description),
-            col(Task.state),
-            col(Task.phase),
-            col(Task.branch),
-            col(Task.pr_url),
-            col(Task.deleted_at),
-            col(Task.created_at),
-            col(Task.user_id),
-        )
-        .where(
-            col(Task.guild_id) == guild_pk,
-            ~col(Task.state).in_(list(_TERMINAL)),
-            live_tasks_filter(),
-        )
-        .order_by(col(Task.created_at).desc())
-    )
-    tasks_data = [dict(r._mapping) for r in tasks_res.all()]
-
-    return {"guild": guild_data, "workers": workers_data, "tasks": tasks_data}
-
-
-@router.get("/guilds/{guild_id}/foreman/history")
-async def get_foreman_history_for_user(
-    guild_id: str,
-    user_id: str = Query(..., description="GitHub user_id whose thread to fetch"),
-    limit: int | None = Query(default=None, description="Max rows to return (newest first)"),
-    task_id: str | None = Query(
-        default=None,
-        description="When set, return only turns tagged with this task_id (per-task child context).",
-    ),
-    _caller: str = Depends(require_worker_or_member_path),
-    db: AsyncSession = Depends(get_db_dep),
-):
-    """Return raw ForemanTurn rows for a given user, ordered oldest→newest.
-
-    Response shape::
-
-        [
-          {
-            "id": int,
-            "role": str,              # "user" | "assistant" | "system"
-            "content_json": str,      # JSON-serialised content blocks
-            "is_tool_response": bool,
-            "parent_id": int | null,
-            "created_at": str
-          }
-        ]
-
-    The standalone foreman applies its own sliding-window logic (equivalent
-    to ``_load_history()``) on top of these raw rows. ``limit`` caps the
-    number of rows returned (applied before the sliding window).
-    """
-    guild_pk = await get_guild_pk(db, guild_id)
-    if guild_pk is None:
-        raise HTTPException(status_code=404, detail="Guild not found")
-
-    stmt = (
-        select(
-            col(ForemanTurn.id),
-            col(ForemanTurn.role),
-            col(ForemanTurn.content_json),
-            col(ForemanTurn.is_tool_response),
-            col(ForemanTurn.parent_id),
-            col(ForemanTurn.created_at),
-            col(ForemanTurn.api_calls_json),
-        )
-        .where(col(ForemanTurn.guild_id) == guild_pk, col(ForemanTurn.user_id) == user_id)
-        .order_by(col(ForemanTurn.id))
-    )
-    if task_id is not None:
-        stmt = stmt.where(col(ForemanTurn.task_id) == task_id)
-    if limit is not None and limit > 0:
-        stmt = stmt.limit(limit)
-    result = await db.exec(stmt)
-    turns = result.all()
-
-    return [
-        {
-            "id": t.id,
-            "role": t.role,
-            "content_json": t.content_json,
-            "is_tool_response": bool(t.is_tool_response),
-            "parent_id": t.parent_id,
-            "created_at": t.created_at,
-            "api_calls_json": t.api_calls_json,
-        }
-        for t in turns
-    ]
-
-
 @router.get("/guilds/{guild_id}/foreman/env-vars")
 async def get_foreman_env_vars(
     guild_id: str,
@@ -314,87 +135,9 @@ async def get_foreman_env_vars(
     return {"env_vars": config.get("env_vars", [])}
 
 
-@router.get("/guilds/{guild_id}/guild-key")
-async def get_guild_key(
-    guild_id: str,
-    _caller: str = Depends(require_worker_or_member_path),
-    db: AsyncSession = Depends(get_db_dep),
-):
-    """Return the guild's Ed25519 signing key for JWT operations.
-
-    Response shape::
-
-        { "key_id": str, "private_key_pem": str }
-
-    Used by the standalone foreman's ``dnsid sign`` tool to create JWTs
-    without direct DB access. Returns 404 if no key has been generated yet.
-    """
-    guild_pk = await get_guild_pk(db, guild_id)
-    if guild_pk is None:
-        raise HTTPException(status_code=404, detail="Guild not found")
-    result = await db.exec(
-        select(col(GuildKey.key_id), col(GuildKey.private_key_pem)).where(
-            col(GuildKey.guild_id) == guild_pk
-        )
-    )
-    row = result.one_or_none()
-
-    if row is None:
-        raise HTTPException(status_code=404, detail="No signing key found for this guild")
-    return {"key_id": row.key_id, "private_key_pem": row.private_key_pem}
-
-
 # ---------------------------------------------------------------------------
 # Phase 1 — State writes
 # ---------------------------------------------------------------------------
-
-
-class ForemanTurnCreate(BaseModel):
-    """Body for POST /guilds/{guild_id}/foreman/history."""
-
-    user_id: str
-    role: str  # "user" | "assistant" | "system"
-    content_json: str  # JSON-serialised content blocks (string, list, …)
-    is_tool_response: bool = False
-    parent_id: int | None = None
-    api_calls: list | None = None  # per-HTTP-call metadata from tool execution
-    task_id: str | None = None
-
-
-@router.post("/guilds/{guild_id}/foreman/history")
-async def create_foreman_turn(
-    guild_id: str,
-    body: ForemanTurnCreate,
-    _caller: str = Depends(require_worker_or_member_path),
-    db: AsyncSession = Depends(get_db_dep),
-):
-    """Persist one foreman conversation turn to the DB.
-
-    Response: ``{ "id": int, "created_at": str }``
-    """
-    import json as _json
-
-    guild_pk = await get_guild_pk(db, guild_id)
-    if guild_pk is None:
-        raise HTTPException(status_code=404, detail="Guild not found")
-    if body.task_id is not None:
-        await _require_task_in_guild(db, body.task_id, guild_pk)
-    created_at = datetime.now(UTC)
-    turn = ForemanTurn(
-        guild_id=guild_pk,
-        user_id=body.user_id,
-        role=body.role,
-        content_json=body.content_json,
-        is_tool_response=1 if body.is_tool_response else 0,
-        parent_id=body.parent_id,
-        created_at=created_at,
-        api_calls_json=_json.dumps(body.api_calls) if body.api_calls else None,
-        task_id=body.task_id,
-    )
-    db.add(turn)
-    await db.commit()
-    await db.refresh(turn)
-    return {"id": turn.id, "created_at": created_at}
 
 
 class ForemanTaskCreate(BaseModel):
@@ -612,67 +355,3 @@ async def create_message(
         ),
     )
     return {"message_id": msg_id, "created_at": created_at}
-
-
-# ---------------------------------------------------------------------------
-# Phase 3 — Token counts + tool execution for standalone foreman
-# ---------------------------------------------------------------------------
-
-
-class TurnTokensUpdate(BaseModel):
-    input_tokens: int
-    output_tokens: int
-
-
-@router.patch("/guilds/{guild_id}/foreman/turns/{turn_id}/tokens")
-async def update_turn_tokens(
-    guild_id: str,
-    turn_id: int,
-    body: TurnTokensUpdate,
-    _caller: str = Depends(require_worker_or_member_path),
-    db: AsyncSession = Depends(get_db_dep),
-):
-    """Update token counts for a saved foreman turn. Used by the standalone foreman."""
-    from sqlalchemy import update as sa_update
-
-    guild_pk = await get_guild_pk(db, guild_id)
-    if guild_pk is None:
-        raise HTTPException(status_code=404, detail="Guild not found")
-    await db.exec(
-        sa_update(ForemanTurn)
-        .where(col(ForemanTurn.id) == turn_id)
-        .values(input_tokens=body.input_tokens, output_tokens=body.output_tokens)
-    )
-    await db.commit()
-    return {"ok": True}
-
-
-class ToolExecRequest(BaseModel):
-    tool_name: str
-    tool_id: str
-    tool_input: dict
-    user_id: str | None = None
-
-
-@router.post("/guilds/{guild_id}/foreman/exec_tool")
-async def exec_tool(
-    guild_id: str,
-    body: ToolExecRequest,
-    _caller: str = Depends(require_worker_or_member_path),
-):
-    """Execute a single foreman tool call. Used by the standalone foreman process.
-
-    This delegates to _exec_one_tool() in foreman/tools.py, keeping all business
-    logic (locks, worker selection, DB writes, WS broadcasts) in the backend.
-
-    Returns a tool_result block: {"type": "tool_result", "tool_use_id": str, "content": str, "is_error": bool}
-    """
-    from foreman.tools import _exec_one_tool
-
-    class _FakeToolUse:
-        def __init__(self):
-            self.name = body.tool_name
-            self.id = body.tool_id
-            self.input = body.tool_input
-
-    return await _exec_one_tool(guild_id, _FakeToolUse(), body.user_id)

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -298,23 +298,6 @@ async def get_pending_auth(
     return [{"workerId": wid, "url": url} for wid, url in pending.items()]
 
 
-@router.get("/guilds/{guild_id}/workers")
-async def list_workers(
-    guild_id: str,
-    github_user_id: str = Depends(require_member()),
-    db: AsyncSession = Depends(get_db_dep),
-):
-    guild_pk = await get_guild_pk(db, guild_id)
-    if guild_pk is None:
-        raise HTTPException(status_code=404, detail="Guild not found")
-    result = await db.exec(
-        select(Worker)
-        .where(col(Worker.guild_id) == guild_pk)
-        .order_by(col(Worker.created_at).desc())
-    )
-    return [row_to_dict(w) for w in result.all()]
-
-
 @router.post("/guilds/{guild_id}/workers/{worker_id}/tasks")
 async def assign_task(
     guild_id: str,

--- a/backend/tests/test_discord_connect.py
+++ b/backend/tests/test_discord_connect.py
@@ -82,7 +82,7 @@ async def test_cmd_connect_account_mints_token_and_sends_link(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.FRONTEND_URL", "https://pioneer-square.example"),
     ):
         from routes.discord import _cmd_connect_account
@@ -112,7 +112,7 @@ async def test_cmd_connect_account_unknown_user_sends_error(monkeypatch):
     async def fake_patch(path, payload):
         sent.append(payload)
 
-    with patch("routes.discord._discord_patch", new=fake_patch):
+    with patch("discord_notifier.patch", new=fake_patch):
         from routes.discord import _cmd_connect_account
 
         await _cmd_connect_account({"token": "tok-noone"})

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -320,7 +320,7 @@ async def test_cmd_status_sends_embed(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_status
 
@@ -364,7 +364,7 @@ async def test_cmd_workers_sends_embed(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_workers
 
@@ -401,7 +401,7 @@ async def test_cmd_pickup_creates_task_and_broadcasts(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.broadcast_msg", new=fake_broadcast),
     ):
         from routes.discord import _cmd_pickup
@@ -426,7 +426,7 @@ async def test_cmd_pickup_invalid_url_sends_error(monkeypatch):
     async def fake_patch(path, payload):
         sent.append(payload)
 
-    with patch("routes.discord._discord_patch", new=fake_patch):
+    with patch("discord_notifier.patch", new=fake_patch):
         from routes.discord import _cmd_pickup
 
         await _cmd_pickup("tok-bad", "test-guild", "not-a-url")
@@ -461,7 +461,7 @@ async def test_cmd_review_creates_task(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.broadcast_msg", new=fake_broadcast),
     ):
         from routes.discord import _cmd_review
@@ -508,7 +508,7 @@ async def test_cmd_cancel_cancels_task(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.broadcast_msg", new=fake_broadcast),
     ):
         from routes.discord import _cmd_cancel
@@ -547,7 +547,7 @@ async def test_cmd_cancel_already_done(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_cancel
 
@@ -607,7 +607,7 @@ async def test_cmd_worker_spawn_success(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.spawn_worker", new=fake_spawn_worker),
     ):
         from routes.discord import _cmd_worker_spawn
@@ -659,7 +659,7 @@ async def test_cmd_worker_spawn_reports_queued_status(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.spawn_worker", new=fake_spawn_worker),
     ):
         from routes.discord import _cmd_worker_spawn
@@ -693,7 +693,7 @@ async def test_cmd_worker_spawn_requires_connected_account(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.spawn_worker", new=fake_spawn_worker),
     ):
         from routes.discord import _cmd_worker_spawn
@@ -730,7 +730,7 @@ async def test_cmd_worker_spawn_unknown_guild(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_worker_spawn
 
@@ -771,7 +771,7 @@ async def test_cmd_worker_spawn_reports_tool_error(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.spawn_worker", new=fake_spawn_worker),
     ):
         from routes.discord import _cmd_worker_spawn
@@ -816,7 +816,7 @@ async def test_has_operator_role_matches(monkeypatch):
         {"id": "role-1", "name": "Someone Else"},
         {"id": "role-2", "name": "Pioneer Square Operator"},
     ]
-    with patch("routes.discord._discord_get", new=AsyncMock(return_value=roles)):
+    with patch("discord_notifier.get", new=AsyncMock(return_value=roles)):
         assert await _has_operator_role(interaction) is True
 
 
@@ -827,7 +827,7 @@ async def test_has_operator_role_no_match(monkeypatch):
 
     interaction = {"guild_id": "g1", "member": {"roles": ["role-1"]}}
     roles = [{"id": "role-1", "name": "Someone Else"}]
-    with patch("routes.discord._discord_get", new=AsyncMock(return_value=roles)):
+    with patch("discord_notifier.get", new=AsyncMock(return_value=roles)):
         assert await _has_operator_role(interaction) is False
 
 
@@ -836,7 +836,7 @@ async def test_has_operator_role_no_roles_short_circuits():
     """No member roles at all → deny without calling the Discord API."""
     from routes.discord import _has_operator_role
 
-    with patch("routes.discord._discord_get", new=AsyncMock()) as mock_get:
+    with patch("discord_notifier.get", new=AsyncMock()) as mock_get:
         assert await _has_operator_role({"guild_id": "g1", "member": {"roles": []}}) is False
         mock_get.assert_not_called()
 
@@ -914,7 +914,7 @@ async def test_cmd_join_channel_creates_new_binding(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_join_channel
 
@@ -974,7 +974,7 @@ async def test_cmd_join_channel_updates_existing_binding(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_join_channel
 
@@ -1016,7 +1016,7 @@ async def test_cmd_join_channel_unknown_guild_slug(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_join_channel
 
@@ -1047,7 +1047,7 @@ async def test_cmd_join_channel_denies_without_permission(monkeypatch):
     }
 
     with (
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord._has_operator_role", new=AsyncMock(return_value=False)),
     ):
         from routes.discord import _cmd_join_channel
@@ -1074,7 +1074,7 @@ async def test_cmd_join_channel_requires_guild_context(monkeypatch):
         "member": {"permissions": str(0x10)},
     }
 
-    with patch("routes.discord._discord_patch", new=fake_patch):
+    with patch("discord_notifier.patch", new=fake_patch):
         from routes.discord import _cmd_join_channel
 
         await _cmd_join_channel(interaction)
@@ -1112,7 +1112,7 @@ async def test_cmd_leave_channel_deletes_binding(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_leave_channel
 
@@ -1157,7 +1157,7 @@ async def test_cmd_leave_channel_explicit_channel_option(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_leave_channel
 
@@ -1192,7 +1192,7 @@ async def test_cmd_leave_channel_no_binding_found(monkeypatch):
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
     ):
         from routes.discord import _cmd_leave_channel
 
@@ -1221,7 +1221,7 @@ async def test_cmd_leave_channel_denies_without_permission(monkeypatch):
     }
 
     with (
-        patch("routes.discord._discord_patch", new=fake_patch),
+        patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord._has_operator_role", new=AsyncMock(return_value=False)),
     ):
         from routes.discord import _cmd_leave_channel

--- a/backend/tests/test_foreman_context_api.py
+++ b/backend/tests/test_foreman_context_api.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
-from helpers import _sync_session, insert_guild, insert_member, insert_task, make_auth_token
+from helpers import _sync_session, insert_guild, insert_member, make_auth_token
 from models import ForemanTurn, Guild
 from sqlalchemy import select
 from sqlmodel import col  # noqa: E402
@@ -179,80 +179,3 @@ def test_get_foreman_context_isolates_across_guilds(client):
     )
     assert resp.status_code == 200
     assert resp.json()["count"] == 0
-
-
-# ---------------------------------------------------------------------------
-# task_id propagation
-# ---------------------------------------------------------------------------
-
-
-def test_create_foreman_turn_persists_task_id(client):
-    """POST /guilds/{guild_id}/foreman/history with task_id stores it on the row."""
-    test_client, db_url = client
-    insert_guild(db_url, "g-ftask")
-    token = make_auth_token(db_url)
-    insert_task(db_url, "g-ftask", "t-ftask1")
-
-    resp = test_client.post(
-        "/guilds/g-ftask/foreman/history",
-        json={
-            "user_id": "gh-user-test",
-            "role": "user",
-            "content_json": '"Hello"',
-            "task_id": "t-ftask1",
-        },
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    assert resp.status_code == 200
-    turn_id = resp.json()["id"]
-
-    with _sync_session(db_url) as session:
-        turn = session.scalar(select(ForemanTurn).where(col(ForemanTurn.id) == turn_id))
-    assert turn is not None
-    assert turn.task_id == "t-ftask1"
-
-
-def test_create_foreman_turn_null_task_id_by_default(client):
-    """POST /guilds/{guild_id}/foreman/history without task_id stores NULL."""
-    test_client, db_url = client
-    insert_guild(db_url, "g-ftask-null")
-    token = make_auth_token(db_url)
-
-    resp = test_client.post(
-        "/guilds/g-ftask-null/foreman/history",
-        json={
-            "user_id": "gh-user-test",
-            "role": "user",
-            "content_json": '"Hello"',
-        },
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    assert resp.status_code == 200
-    turn_id = resp.json()["id"]
-
-    with _sync_session(db_url) as session:
-        turn = session.scalar(select(ForemanTurn).where(col(ForemanTurn.id) == turn_id))
-    assert turn is not None
-    assert turn.task_id is None
-
-
-def test_create_foreman_turn_cross_guild_task_returns_404(client):
-    """task_id that belongs to a different guild must return 404."""
-    test_client, db_url = client
-    insert_guild(db_url, "g-xguild-a")
-    insert_guild(db_url, "g-xguild-b")
-    token = make_auth_token(db_url)
-    insert_task(db_url, "g-xguild-a", "t-xguild1")
-
-    # Reference guild-A's task from guild-B's endpoint — must be rejected.
-    resp = test_client.post(
-        "/guilds/g-xguild-b/foreman/history",
-        json={
-            "user_id": "gh-user-test",
-            "role": "user",
-            "content_json": '"Hello"',
-            "task_id": "t-xguild1",
-        },
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    assert resp.status_code == 404

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -21,9 +21,7 @@ def _workers_for_guild(db_url: str, guild_id: str) -> list[Worker]:
     """Query workers for *guild_id* directly (no list-workers REST endpoint exists)."""
     with _sync_session(db_url) as session:
         guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == guild_id))
-        return list(
-            session.scalars(select(Worker).where(col(Worker.guild_id) == guild_pk)).all()
-        )
+        return list(session.scalars(select(Worker).where(col(Worker.guild_id) == guild_pk)).all())
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 from helpers import _sync_session, insert_guild, insert_member, make_auth_token
-from models import Agent, User, Worker
+from models import Agent, Guild, User, Worker
 from sqlalchemy import select, update
 from sqlmodel import col  # noqa: E402
 
@@ -15,6 +15,15 @@ from sqlmodel import col  # noqa: E402
 def _auth(db_url: str) -> dict:
     """Helper: return Authorization header for the default test user."""
     return {"Authorization": f"Bearer {make_auth_token(db_url)}"}
+
+
+def _workers_for_guild(db_url: str, guild_id: str) -> list[Worker]:
+    """Query workers for *guild_id* directly (no list-workers REST endpoint exists)."""
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == guild_id))
+        return list(
+            session.scalars(select(Worker).where(col(Worker.guild_id) == guild_pk)).all()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -25,9 +34,7 @@ def _auth(db_url: str) -> dict:
 def test_list_workers_empty(client):
     test_client, db_url = client
     insert_guild(db_url, "guild01")
-    resp = test_client.get("/guilds/guild01/workers", headers=_auth(db_url))
-    assert resp.status_code == 200
-    assert resp.json() == []
+    assert _workers_for_guild(db_url, "guild01") == []
 
 
 def test_create_worker_returns_id(client):
@@ -48,11 +55,9 @@ def test_create_worker_appears_in_list(client):
     test_client, db_url = client
     insert_guild(db_url, "guild03")
     test_client.post("/guilds/guild03/workers", json={"repos": ["org/backend"]})
-    resp = test_client.get("/guilds/guild03/workers", headers=_auth(db_url))
-    assert resp.status_code == 200
-    workers = resp.json()
+    workers = _workers_for_guild(db_url, "guild03")
     assert len(workers) == 1
-    assert isinstance(workers[0]["guild_id"], int)
+    assert isinstance(workers[0].guild_id, int)
 
 
 def test_create_worker_does_not_insert_agent_row(client):
@@ -78,8 +83,7 @@ def test_create_multiple_workers(client):
     insert_guild(db_url, "guild04")
     test_client.post("/guilds/guild04/workers", json={"repos": []})
     test_client.post("/guilds/guild04/workers", json={"repos": ["x/y"]})
-    resp = test_client.get("/guilds/guild04/workers", headers=_auth(db_url))
-    assert len(resp.json()) == 2
+    assert len(_workers_for_guild(db_url, "guild04")) == 2
 
 
 def test_create_worker_attributes_to_user(client):

--- a/backend/tests/test_worker_name.py
+++ b/backend/tests/test_worker_name.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from utils import format_worker_id, worker_display_name
 
 sys.path.insert(0, os.path.dirname(__file__))
-from helpers import _sync_session, insert_guild, make_auth_token
+from helpers import _sync_session, insert_guild
 from models import Worker
 from sqlalchemy import select
 from sqlmodel import col  # noqa: E402
@@ -96,10 +96,6 @@ def test_worker_display_name_with_hostname_format():
 # ---------------------------------------------------------------------------
 
 
-def _auth(db_url: str) -> dict:
-    return {"Authorization": f"Bearer {make_auth_token(db_url)}"}
-
-
 def test_register_worker_name_without_hostname(client):
     """Name is the droid-formatted worker ID even without a hostname."""
     test_client, db_url = client
@@ -137,7 +133,7 @@ def test_register_worker_name_short_hostname(client):
 
 
 def test_list_workers_includes_name(client):
-    """GET /workers response includes a ``name`` field for each worker."""
+    """The worker row persists a ``name`` derived from hostname + worker id."""
     test_client, db_url = client
     insert_guild(db_url, "wname04")
     create_resp = test_client.post(
@@ -147,12 +143,9 @@ def test_list_workers_includes_name(client):
     assert create_resp.status_code == 200
     wid = create_resp.json()["id"]
 
-    list_resp = test_client.get("/guilds/wname04/workers", headers=_auth(db_url))
-    assert list_resp.status_code == 200
-    workers = list_resp.json()
-    assert len(workers) == 1
-    assert "name" in workers[0]
-    assert workers[0]["name"] == f"testhost/{format_worker_id(wid)}"
+    with _sync_session(db_url) as session:
+        name = session.scalar(select(col(Worker.name)).where(col(Worker.id) == wid))
+    assert name == f"testhost/{format_worker_id(wid)}"
 
 
 def test_list_workers_name_persisted_correctly(client):

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -172,7 +172,6 @@ def decode_claude_oauth_token(blob: str | None) -> str | None:
 # ---------------------------------------------------------------------------
 
 _FOREMAN_JWT_SUB = "pioneer-foreman"
-_FOREMAN_JWT_TTL = 3600  # seconds; foreman refreshes before expiry
 
 
 def _b64url_encode(data: bytes) -> str:
@@ -184,29 +183,6 @@ def _b64url_decode(s: str) -> bytes:
     if padding != 4:
         s += "=" * padding
     return base64.urlsafe_b64decode(s)
-
-
-def make_foreman_jwt(guild_id: str, secret: str, ttl: int = _FOREMAN_JWT_TTL) -> str:
-    """Create a short-lived HS256 JWT for Foreman REST helper endpoints.
-
-    The signer and backend (via ``PIONEER_FOREMAN_KEY`` env var) must share the
-    same *secret*. The token is valid for *ttl* seconds (default 1 hour).
-    """
-    header = _b64url_encode(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
-    now = int(time.time())
-    payload = _b64url_encode(
-        json.dumps(
-            {
-                "sub": _FOREMAN_JWT_SUB,
-                "slug": guild_id,
-                "iat": now,
-                "exp": now + ttl,
-            }
-        ).encode()
-    )
-    signing_input = f"{header}.{payload}"
-    sig = _b64url_encode(hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest())
-    return f"{signing_input}.{sig}"
 
 
 def verify_foreman_jwt(token: str, secret: str, guild_id: str) -> bool:

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -31,6 +31,7 @@ from events import (
 )
 from fastapi import WebSocket
 from foreman.classify import is_human_event
+from foreman.github_url_parser import parse_github_urls
 from foreman.proxy import fail_pending_for_websocket, resolve_foreman_api_response
 from foreman.runner import reset_foreman_poll, run_foreman_ai
 from foreman.tools import maybe_post_plan_comment
@@ -86,23 +87,25 @@ _DISCORD_STREAM_LEVELS = frozenset({None, "info", "thinking"})
 def _parse_pr_url(pr_url: str | None) -> tuple[int | None, str | None]:
     """Extract ``(pr_number, "owner/repo")`` from a GitHub PR URL.
 
-    Accepts both web URLs (``https://github.com/o/r/pull/42``) and API URLs
-    (``https://api.github.com/repos/o/r/pulls/42``). Returns ``(None, None)``
-    on anything that doesn't look like a PR URL — the caller stamps both
-    columns to NULL in that case so we don't link a stale (number, repo) to
-    a task whose PR was retracted.
+    Delegates to the canonical parser (``foreman.github_url_parser``) for the
+    standard web URL form (``https://github.com/o/r/pull/42``). Also accepts
+    API URLs (``https://api.github.com/repos/o/r/pulls/42``), which the
+    canonical parser doesn't cover. Returns ``(None, None)`` on anything that
+    doesn't look like a PR URL — the caller stamps both columns to NULL in
+    that case so we don't link a stale (number, repo) to a task whose PR was
+    retracted.
     """
     if not pr_url or not isinstance(pr_url, str):
         return None, None
+
+    refs = [ref for ref in parse_github_urls(pr_url) if ref.ref_type == "pull"]
+    if refs:
+        return refs[0].number, refs[0].slug
+
     parts = pr_url.rstrip("/").split("/")
     try:
-        # ``…/{owner}/{repo}/pull/{n}`` or ``…/repos/{owner}/{repo}/pulls/{n}``
-        if "pull" in parts:
-            idx = parts.index("pull")
-        elif "pulls" in parts:
-            idx = parts.index("pulls")
-        else:
-            return None, None
+        # ``…/repos/{owner}/{repo}/pulls/{n}`` (API form; not handled above)
+        idx = parts.index("pulls")
         owner = parts[idx - 2]
         repo = parts[idx - 1]
         number = int(parts[idx + 1])

--- a/frontend/src/utils/nativeBridge.ts
+++ b/frontend/src/utils/nativeBridge.ts
@@ -24,14 +24,6 @@ declare global {
   }
 }
 
-export function isNative(): boolean {
-  return typeof window !== 'undefined' && !!window.pioneerSquareNative
-}
-
-export function nativePlatform(): 'ios' | 'web' {
-  return window.pioneerSquareNative?.platform ?? 'web'
-}
-
 export function requestPushPermission(): void {
   window.pioneerSquareNative?.send({ type: 'requestPushPermission' })
 }


### PR DESCRIPTION
## Summary
- Consolidate Discord bot HTTP client logic (`bot_token()`, `get()`, `patch()`, `post()`) so both notifications and slash-command handling in `backend/routes/discord.py` share the same client in `backend/discord_notifier.py`.
- Consolidate GitHub PR/issue URL parsing onto the canonical `backend/foreman/github_url_parser.py`, removing duplicate parser implementations in `backend/ws_handlers.py`, `backend/routes/debug.py`, and `backend/routes/discord.py`.
- Remove dead code and unused endpoints/imports flagged in the audit (`backend/routes/foreman.py`, `backend/routes/workers.py`, `backend/utils.py`, `frontend/src/utils/nativeBridge.ts`).

Closes #891

## Test plan
- [x] `ruff check` passes
- [x] Backend test suite passes