### PR TITLE
fix: review_pr_internal biases toward APPROVE, firm on real bugs

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -71,7 +71,9 @@ Always create_task first and finalize_task after — whether you use a worker or
 
 **Shallow/fallback review** (no worker available, or quick diff-only review):
 1. create_task(name="Review PR #N: <title>", phase="review", pr_number=N, pr_repo="owner/repo") → returns task_id
-2. review_pr_internal (or review_pr) — pass the PR details
+2. review_pr_internal (or review_pr) — pass the PR details. Omit `action` to let the tool pick
+   the verdict itself from its own diff analysis (see "Review action policy" below); only pass
+   `action` explicitly to override that judgement.
 3. finalize_task(task_id=<task_id from step 1>) — call after the review returns. \
    Use expires_in_seconds=86400 for error/failed reviews; omit (default 3 days) otherwise.
 
@@ -79,6 +81,21 @@ CRITICAL — review output must go to GitHub PR review comments, never to a new 
 Workers in review phase receive explicit instructions to post via `gh pr review` and are
 forbidden from committing or opening a new PR. review_pr_internal and review_pr post
 directly via the GitHub Reviews API. In both paths, there is nothing to commit or push.
+
+## Review action policy
+This applies to every PR review path — worker-driven `gh pr review` and review_pr_internal alike:
+- **APPROVE** — the diff is functionally correct and any issues are minor nits (style, naming,
+  formatting). Submit APPROVE with inline comments noting the nits; don't withhold approval over
+  them.
+- **COMMENT** — moderate concerns (performance, clarity) that don't block merging.
+- **REQUEST_CHANGES** — reserved for genuine bugs, security issues, or logic errors that must be
+  fixed before merge. Be specific and firm: explain what breaks and why it must be fixed. Never
+  use this for style preferences.
+Tone: polite and constructive. Firm when flagging a real bug ("This will cause X under condition
+Y and should be fixed before merge") — never apologetic about calling out a real bug. Never
+pedantic, and never block a merge over style.
+When dispatching a worker for a review-phase task, include this policy in the task description
+so the worker's `gh pr review` verdict follows it too.
 
 ## Finalize expiry windows
 Every finalize_task call sets a soft-delete window via expires_in_seconds so the

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -2442,16 +2442,27 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             )
 
                     elif tu.name == "review_pr_internal":
+                        # Review action policy (mirrors the worker-driven `gh pr review` path):
+                        #   APPROVE           - functionally correct; issues are minor nits
+                        #                       (style, naming, formatting). Note nits inline.
+                        #   COMMENT           - moderate concerns (performance, clarity) that
+                        #                       don't block merging.
+                        #   REQUEST_CHANGES   - genuine bugs, security issues, or logic errors
+                        #                       only. Be specific and firm about what breaks and
+                        #                       why it must be fixed before merge. Never for
+                        #                       style preferences.
+                        # Tone: polite but firm. Never apologetic about calling out a real bug.
+                        # Never blocking a merge over style.
+                        #
+                        # An explicit `action` input overrides the tool's own judgement; when
+                        # omitted, the verdict comes from the diff analysis below and is biased
+                        # toward APPROVE per the policy above.
                         pr_url = inp["pr_url"]
-                        action = (inp.get("action") or "COMMENT").upper()
-                        if action not in ("APPROVE", "REQUEST_CHANGES", "COMMENT"):
-                            action = "COMMENT"
-                        logger.info(
-                            "guild=%s review_pr_internal: pr_url=%s action=%s",
-                            guild_id,
-                            pr_url,
-                            action,
-                        )
+                        explicit_action = inp.get("action")
+                        if explicit_action:
+                            explicit_action = explicit_action.upper()
+                            if explicit_action not in ("APPROVE", "REQUEST_CHANGES", "COMMENT"):
+                                explicit_action = None
                         pr_match = _PR_URL_RE.match(pr_url.rstrip("/"))
                         if not pr_match:
                             result_text = (
@@ -2497,19 +2508,34 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     review_model,
                                 ) = await resolve_foreman_client(guild_id, guild_cfg)
                                 review_prompt = (
-                                    "You are a thorough code reviewer. Review the following "
-                                    "GitHub pull request and provide structured feedback.\n\n"
+                                    "You are a thorough but fair code reviewer. Review the "
+                                    "following GitHub pull request and provide structured "
+                                    "feedback.\n\n"
                                     f"PR: {pr_title}\n"
                                     f"Base: {base_ref} ← Head: {head_ref}\n"
                                     f"Description: {pr_body_text[:1000]}\n\n"
                                     f"Diff (up to 40 000 chars):\n{diff_text[:40000]}\n\n"
                                     "Respond with a JSON object only (no markdown fences) "
                                     "with exactly these fields:\n"
-                                    '{"summary": "3-5 markdown bullet points (use - prefix)", '
+                                    '{"verdict": "APPROVE|REQUEST_CHANGES|COMMENT", '
+                                    '"summary": "3-5 markdown bullet points (use - prefix)", '
                                     '"comments": [{"path": "file.py", "line": 42, '
                                     '"side": "RIGHT", "body": "concise comment"}]}\n\n'
+                                    "Verdict policy — bias toward APPROVE:\n"
+                                    "- APPROVE: the code is functionally correct and any issues "
+                                    "are minor nits (style, naming, formatting). Note the nits as "
+                                    "inline comments but still approve.\n"
+                                    "- COMMENT: moderate concerns (performance, clarity) that "
+                                    "don't block merging.\n"
+                                    "- REQUEST_CHANGES: reserved for genuine bugs, security "
+                                    "issues, or logic errors that must be fixed before merge. "
+                                    "Never use this for style preferences alone.\n\n"
                                     "Rules:\n"
-                                    "- summary: 3-5 bullet points covering key findings\n"
+                                    "- summary: 3-5 bullet points covering key findings, written "
+                                    "in a polite, constructive tone. Be firm and specific when "
+                                    "flagging a real bug (explain what breaks and why it must be "
+                                    "fixed before merge) — never apologetic about it. Don't be "
+                                    "pedantic or block merging over style.\n"
                                     "- comments: 0-5 objects for the most important issues\n"
                                     "- line: line number in the NEW file version (RIGHT side)\n"
                                     "- Only comment on lines present in the diff\n"
@@ -2537,6 +2563,7 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                     exc_info=True,
                                 )
                                 review_json = {
+                                    "verdict": "COMMENT",
                                     "summary": (
                                         "Review could not be generated by the AI agent "
                                         f"({type(exc).__name__}: {exc})."
@@ -2556,6 +2583,26 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 for c in raw_comments
                                 if c.get("path") and c.get("line") and c.get("body")
                             ]
+
+                            recommended_verdict = str(
+                                review_json.get("verdict") or "COMMENT"
+                            ).upper()
+                            if recommended_verdict not in (
+                                "APPROVE",
+                                "REQUEST_CHANGES",
+                                "COMMENT",
+                            ):
+                                recommended_verdict = "COMMENT"
+                            action = explicit_action or recommended_verdict
+                            logger.info(
+                                "guild=%s review_pr_internal: pr_url=%s action=%s"
+                                " (explicit=%s recommended=%s)",
+                                guild_id,
+                                pr_url,
+                                action,
+                                bool(explicit_action),
+                                recommended_verdict,
+                            )
 
                             try:
                                 threads_resolved = await _supersede_prior_bot_reviews(

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -528,7 +528,9 @@ FOREMAN_TOOLS = [
             "Fetches the PR diff directly from the GitHub API, uses the Foreman AI to "
             "analyse it, then posts a GitHub PR review with a 3–5 bullet-point summary "
             "and up to 5 inline comments on specific lines. "
-            "Supports action values APPROVE, REQUEST_CHANGES, or COMMENT (default COMMENT). "
+            "Supports action values APPROVE, REQUEST_CHANGES, or COMMENT. If action is omitted, "
+            "the tool analyses the diff itself and picks a verdict biased toward APPROVE — see "
+            "the action parameter for the exact policy. "
             "Findings are posted as review comments on the original PR via the GitHub Reviews "
             "API, never as a new PR. "
             "Use this for a quick diff-only review when no worker is available, or when "
@@ -546,9 +548,14 @@ FOREMAN_TOOLS = [
                     "type": "string",
                     "enum": ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
                     "description": (
-                        "Review verdict to submit to GitHub. "
-                        "APPROVE — looks good; REQUEST_CHANGES — must fix before merge; "
-                        "COMMENT — neutral feedback (default)."
+                        "Review verdict to submit to GitHub. Omit to let the tool decide from its "
+                        "own analysis of the diff — biased toward APPROVE. Policy: "
+                        "APPROVE — the code is functionally correct and any issues are minor nits "
+                        "(style, naming, formatting); note the nits as inline comments but approve. "
+                        "COMMENT — moderate concerns (performance, clarity) that don't block "
+                        "merging. REQUEST_CHANGES — reserved for genuine bugs, security issues, or "
+                        "logic errors that must be fixed before merge; never for style preferences. "
+                        "Only pass this explicitly to override the tool's own judgement."
                     ),
                 },
             },

--- a/backend/tests/test_review_pr_tool.py
+++ b/backend/tests/test_review_pr_tool.py
@@ -511,6 +511,102 @@ class TestReviewPrInternal:
         parsed = json.loads(results[0]["content"])
         assert "could not resolve credentials from session" in parsed["summary"]
 
+    @pytest.mark.asyncio
+    async def test_verdict_from_analysis_biases_toward_approve(self, db_session):
+        """When no explicit action is passed, the tool submits whatever verdict
+        its own diff analysis recommends — see issue #899."""
+        insert_guild(db_session, "g-revint-approve")
+
+        gh_post_calls = []
+
+        def capture_gh_post(path, token, payload, method="POST"):
+            gh_post_calls.append(payload)
+            return {"id": 7}
+
+        async def fake_resolve(guild_id, guild_cfg):
+            return object(), "anthropic", "claude-sonnet-4-6"
+
+        async def fake_call_llm(guild_id, **kwargs):
+            review_text = json.dumps(
+                {
+                    "verdict": "APPROVE",
+                    "summary": "- Minor naming nit only, otherwise correct",
+                    "comments": [],
+                }
+            )
+            return SimpleNamespace(
+                response=SimpleNamespace(content=[SimpleNamespace(text=review_text)])
+            )
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.tools._gh_api", return_value=self._pr_data()),
+            patch("foreman.tools._gh_api_diff", return_value="diff --git a b"),
+            patch("foreman.tools._gh_api_post", side_effect=capture_gh_post),
+            patch("foreman.runner._load_foreman_config", return_value={}),
+            patch("foreman.runner.resolve_foreman_client", side_effect=fake_resolve),
+            patch("foreman.runner._call_llm", side_effect=fake_call_llm),
+        ):
+            results = await exec_tools(
+                "g-revint-approve",
+                [_fake_tu("review_pr_internal", {"pr_url": "https://github.com/org/repo/pull/3"})],
+            )
+
+        assert results[0].get("is_error") is not True
+        assert gh_post_calls[0]["event"] == "APPROVE"
+        parsed = json.loads(results[0]["content"])
+        assert parsed["verdict"] == "APPROVE"
+
+    @pytest.mark.asyncio
+    async def test_explicit_action_overrides_recommended_verdict(self, db_session):
+        """An explicit `action` input takes precedence over the tool's own
+        analysis-derived recommendation."""
+        insert_guild(db_session, "g-revint-override")
+
+        gh_post_calls = []
+
+        def capture_gh_post(path, token, payload, method="POST"):
+            gh_post_calls.append(payload)
+            return {"id": 8}
+
+        async def fake_resolve(guild_id, guild_cfg):
+            return object(), "anthropic", "claude-sonnet-4-6"
+
+        async def fake_call_llm(guild_id, **kwargs):
+            review_text = json.dumps(
+                {"verdict": "APPROVE", "summary": "- Looks fine", "comments": []}
+            )
+            return SimpleNamespace(
+                response=SimpleNamespace(content=[SimpleNamespace(text=review_text)])
+            )
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.tools._gh_api", return_value=self._pr_data()),
+            patch("foreman.tools._gh_api_diff", return_value="diff --git a b"),
+            patch("foreman.tools._gh_api_post", side_effect=capture_gh_post),
+            patch("foreman.runner._load_foreman_config", return_value={}),
+            patch("foreman.runner.resolve_foreman_client", side_effect=fake_resolve),
+            patch("foreman.runner._call_llm", side_effect=fake_call_llm),
+        ):
+            results = await exec_tools(
+                "g-revint-override",
+                [
+                    _fake_tu(
+                        "review_pr_internal",
+                        {
+                            "pr_url": "https://github.com/org/repo/pull/4",
+                            "action": "REQUEST_CHANGES",
+                        },
+                    )
+                ],
+            )
+
+        assert results[0].get("is_error") is not True
+        assert gh_post_calls[0]["event"] == "REQUEST_CHANGES"
+        parsed = json.loads(results[0]["content"])
+        assert parsed["verdict"] == "REQUEST_CHANGES"
+
 
 class TestReviewPrSupersedePriorReviews:
     """Integration tests: review_pr tool calls _supersede_prior_bot_reviews."""


### PR DESCRIPTION
Fixes #899.

## Summary
- `review_pr_internal` previously required the caller to pass an explicit `action` and silently defaulted to `COMMENT` regardless of diff quality.
- The tool's internal diff-analysis LLM call now also returns a recommended `verdict`, used as the GitHub review event unless the caller passes an explicit `action` override.
- Verdict policy encoded in the analysis prompt, the tool schema, and the foreman system prompt:
  - **APPROVE** — functionally correct; issues are minor nits (style, naming, formatting) — note them inline but still approve.
  - **COMMENT** — moderate concerns (performance, clarity) that don't block merging.
  - **REQUEST_CHANGES** — reserved for genuine bugs, security issues, or logic errors; never for style preferences.
  - Tone: polite and constructive; firm and specific when flagging a real bug; never pedantic or blocking over style.

## Test plan
- [x] `pytest backend/tests/test_review_pr_tool.py` — 20 passed, including two new tests covering analysis-driven verdict selection and explicit-action override
- [x] `pytest backend/tests/test_foreman.py backend/tests/test_review_pr_tool.py` — 162 passed