### PR TITLE
chore(postgres): enable pg_stat_statements and auto_explain

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,24 @@
 services:
   postgres:
     image: postgres:18
+    # Enable query-stats extensions. shared_preload_libraries requires a
+    # server restart, so it must be set via -c rather than CREATE EXTENSION.
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements,auto_explain"
+      - "-c"
+      - "compute_query_id=on"
+      - "-c"
+      - "pg_stat_statements.max=10000"
+      - "-c"
+      - "pg_stat_statements.track=all"
+      - "-c"
+      - "track_io_timing=on"
+      - "-c"
+      - "auto_explain.log_min_duration=500ms"
+      - "-c"
+      - "auto_explain.log_analyze=on"
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-pioneer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
Preload pg_stat_statements and auto_explain via server -c flags (shared_preload_libraries requires a restart, not CREATE EXTENSION), and turn on compute_query_id and track_io_timing for useful stats.