### PR TITLE
feat: Discord task-thread replies → send_followup/redirect (#906)

### DIFF
--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -279,7 +279,13 @@ async def _route_inbound_message(message: dict) -> None:
 
     author = message.get("author") or {}
     ps_user_id, label = await _resolve_identity(author.get("id"), author.get("username"))
-    human_message = f"[Discord] {label}: {content}"
+    discord_line = f"[Discord] {label}: {content}"
+    # A resolved task_id means this message landed in a thread already bound to a task
+    # (an "issue" or "task_stream" subject binding) — tag it so the Foreman can route
+    # straight to redirect_task/send_followup without a lookup, mirroring [github-event].
+    human_message = (
+        f"[discord-thread-reply] task_id={task_id}\n{discord_line}" if task_id else discord_line
+    )
 
     try:
         await _persist_inbound_message(guild_slug, content, user_id=ps_user_id, task_id=task_id)

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -153,6 +153,20 @@ Use the body to decide:
 Foreman events from bots on non-CI surfaces are filtered out before reaching you, so
 treat every `[github-event]` you see as something a human likely cares about.
 
+## Reacting to Discord task-thread replies
+Messages prefixed `[discord-thread-reply] task_id=t-xxxxxx` are human replies posted
+inside a Discord thread that is already bound to that task (its PR/issue thread or its
+live task-stream thread) — the task_id is given, no lookup needed. Route by the task's
+current state (check the `<state>` task list, or get_task_status if unsure):
+- **in-progress / running** (state `working`): call `redirect_task(task_id, instructions=<message
+  text>)` to course-correct the running worker in place.
+- **awaiting-review, done, or parked**: call `send_followup(task_id, instructions=<message
+  text>)` to continue on the same branch.
+Never open a new task or PR in response to a `[discord-thread-reply]` message — it is
+always about the linked task. The only exception is if the human's message explicitly
+requests fresh, unrelated work; treat that like any other chat message and use the normal
+create_task + assign_task flow instead.
+
 ## Reacting to devReady issue webhooks
 `[github-event] issues/labeled` (with a devReady-family label just applied) or
 `[github-event] issues/opened` / `issues/reopened` (already carrying a devReady-family label)

--- a/backend/tests/test_discord_router.py
+++ b/backend/tests/test_discord_router.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import sys
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -120,3 +121,59 @@ async def test_resolve_session_unresolvable_channel_returns_none(client):
     session = await router.resolve_session("channel-unknown-1")
 
     assert session is None
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_message_tags_task_thread_reply(client):
+    """A reply in a thread bound to a task is tagged [discord-thread-reply] task_id=... (#906)."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-router5")
+    insert_task(db_url, "g-router5", "t-router5", state="working")
+    _insert_binding(db_url, "task_stream", "t-router5", "thread-stream-5")
+
+    with (
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "please rename the variable",
+                "channel_id": "thread-stream-5",
+                "author": {"id": "d-user-1", "username": "alice"},
+            }
+        )
+
+    assert mock_trigger.await_count == 1
+    _args, kwargs = mock_trigger.await_args
+    assert kwargs["task_id"] == "t-router5"
+    human_message = _args[2]
+    assert human_message.startswith("[discord-thread-reply] task_id=t-router5\n")
+    assert "please rename the variable" in human_message
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_message_no_tag_for_general_chat(client):
+    """General chat with no task binding keeps the plain [Discord] prefix, untagged."""
+    _test_client, db_url = client
+    _insert_channel_guild(db_url, "channel-plain-2", "g-router6")
+
+    with (
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "what's the status?",
+                "channel_id": "channel-plain-2",
+                "author": {"id": "d-user-2", "username": "bob"},
+            }
+        )
+
+    assert mock_trigger.await_count == 1
+    _args, kwargs = mock_trigger.await_args
+    assert kwargs["task_id"] is None
+    human_message = _args[2]
+    assert not human_message.startswith("[discord-thread-reply]")
+    assert human_message.startswith("[Discord]")


### PR DESCRIPTION
## Summary

Closes #906. When a human replies inside a Discord thread that's linked to an existing Foreman task, the reply now routes to `redirect_task` (running work) or `send_followup` (parked/done work) on that task — never a new `create_task`/`assign_task` pair.

- **Discord gateway tagging** (`backend/discord/router.py`): `_route_inbound_message` now prefixes the forwarded message with `[discord-thread-reply] task_id=t-xxxxxx` whenever the message lands in a Discord thread already bound to a task (covers both PR/issue threads and per-task live-stream threads). General chat with no task binding is unaffected — it keeps the existing plain `[Discord] <label>: <content>` format.
- **Foreman system-prompt update** (`backend/foreman/prompt.py`): added a new "Reacting to Discord task-thread replies" section (placed right after "Reacting to GitHub PR events") instructing the Foreman to call `redirect_task` for in-progress/running tasks or `send_followup` for awaiting-review/done/parked tasks, and to never open a new task or PR in response — mirroring the existing `[github-event]` routing pattern.
- **Task thread ID tracking**: already implemented in the codebase via the unified `discord_thread_bindings` table (`DiscordThreadBinding`, #885) — thread IDs are recorded against a task (`"issue"` or `"task_stream"` subject bindings) the moment a task notification is first posted to Discord, and the gateway/router already resolve replies back to a `task_id` through it. No schema changes were needed for this part.

## Test plan
- [x] `cd backend && python -m pytest` — 1042 passed, 2 skipped (run serially against a local Postgres instance; verified no regressions in `[github-event]`/`[periodic-check]` handling)
- [x] Added `test_route_inbound_message_tags_task_thread_reply` and `test_route_inbound_message_no_tag_for_general_chat` in `backend/tests/test_discord_router.py` covering the new tagging behavior
- [x] `ruff check` / `ruff format --check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)