### PR TITLE
Enable pg_stat_statements + fix seq scans it surfaced

### DIFF
--- a/backend/alembic/versions/20260714_000000_add_task_logs_worker_agent_indexes.py
+++ b/backend/alembic/versions/20260714_000000_add_task_logs_worker_agent_indexes.py
@@ -1,0 +1,36 @@
+"""Add task_logs indexes on worker_id and agent_id.
+
+Revision ID: 20260714_000000_add_task_logs_worker_agent_indexes
+Revises: 20260712_000000_add_claude_session_id_to_tasks
+Create Date: 2026-07-14
+
+The worker- and agent-scoped log-fetch queries in routes/tasks.py filter on
+task_logs.worker_id (WHERE worker_id = ? AND task_id IS NULL) and
+task_logs.agent_id (WHERE agent_id = ?). Neither column was indexed, so both
+did a full sequential scan of task_logs (~500k rows and growing). Only the
+task_id lookup had an index. These add the two missing indexes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260714_000000_add_task_logs_worker_agent_indexes"
+down_revision: str | Sequence[str] | None = "20260712_000000_add_claude_session_id_to_tasks"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # task_logs: worker-scoped log fetch (worker_id = ? AND task_id IS NULL)
+    op.create_index("ix_task_logs_worker_id", "task_logs", ["worker_id"])
+
+    # task_logs: agent-scoped log fetch (agent_id = ?)
+    op.create_index("ix_task_logs_agent_id", "task_logs", ["agent_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_logs_agent_id", table_name="task_logs")
+    op.drop_index("ix_task_logs_worker_id", table_name="task_logs")

--- a/backend/alembic/versions/20260714_000000_add_task_logs_worker_agent_indexes.py
+++ b/backend/alembic/versions/20260714_000000_add_task_logs_worker_agent_indexes.py
@@ -30,7 +30,15 @@ def upgrade() -> None:
     # task_logs: agent-scoped log fetch (agent_id = ?)
     op.create_index("ix_task_logs_agent_id", "task_logs", ["agent_id"])
 
+    # foreman_turns: history fetch filters on (guild_id, user_id) and orders by
+    # id DESC. Without this it seq-scans the whole table (~90k rows) then sorts;
+    # the trailing id column lets it use a backward index scan and skip the sort.
+    op.create_index(
+        "ix_foreman_turns_guild_id_user_id_id", "foreman_turns", ["guild_id", "user_id", "id"]
+    )
+
 
 def downgrade() -> None:
+    op.drop_index("ix_foreman_turns_guild_id_user_id_id", table_name="foreman_turns")
     op.drop_index("ix_task_logs_agent_id", table_name="task_logs")
     op.drop_index("ix_task_logs_worker_id", table_name="task_logs")

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,11 +80,7 @@ WORKER_SWEEP_INTERVAL_SECONDS = float(os.environ.get("WORKER_SWEEP_INTERVAL_SECO
 async def reset_connection_state() -> None:
     # On every startup, no worker processes are connected yet.
     async with AsyncSessionLocal() as db:
-        await db.exec(
-            update(Worker)
-            .where(col(Worker.state) != "offline")
-            .values(state="offline")
-        )
+        await db.exec(update(Worker).where(col(Worker.state) != "offline").values(state="offline"))
         await db.exec(
             update(Agent)
             .where(

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,7 +80,11 @@ WORKER_SWEEP_INTERVAL_SECONDS = float(os.environ.get("WORKER_SWEEP_INTERVAL_SECO
 async def reset_connection_state() -> None:
     # On every startup, no worker processes are connected yet.
     async with AsyncSessionLocal() as db:
-        await db.exec(update(Worker).values(state="offline"))
+        await db.exec(
+            update(Worker)
+            .where(col(Worker.state) != "offline")
+            .values(state="offline")
+        )
         await db.exec(
             update(Agent)
             .where(

--- a/backend/models.py
+++ b/backend/models.py
@@ -409,6 +409,10 @@ class ForemanTurn(SQLModel, table=True):
     # Task this turn was produced for (mirrors api_request_log.task_id for convenience).
     task_id: str | None = Field(default=None, foreign_key="tasks.id")
 
+    # History fetch filters on (guild_id, user_id) and orders by id DESC; the
+    # trailing id lets Postgres satisfy the ORDER BY via a backward index scan.
+    __table_args__ = (Index("ix_foreman_turns_guild_id_user_id_id", "guild_id", "user_id", "id"),)
+
 
 class GithubEvent(SQLModel, table=True):
     __tablename__ = "github_events"  # type: ignore[assignment]

--- a/backend/models.py
+++ b/backend/models.py
@@ -311,8 +311,8 @@ class TaskLog(SQLModel, table=True):
     task_id: str | None = Field(default=None, foreign_key="tasks.id", index=True)
     timestamp: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     line: str
-    worker_id: str | None = None
-    agent_id: str | None = None
+    worker_id: str | None = Field(default=None, index=True)
+    agent_id: str | None = Field(default=None, index=True)
     data: str | None = None  # JSON: full tool input/output for click-to-expand
     # Semantic line type (worker/auth/claude/thinking/…) so the frontend can
     # style logs without parsing text prefixes. NULL = default agent output.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,24 @@
 services:
   postgres:
     image: postgres:18
+    # Enable query-stats extensions. shared_preload_libraries requires a
+    # server restart, so it must be set via -c rather than CREATE EXTENSION.
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements,auto_explain"
+      - "-c"
+      - "compute_query_id=on"
+      - "-c"
+      - "pg_stat_statements.max=10000"
+      - "-c"
+      - "pg_stat_statements.track=all"
+      - "-c"
+      - "track_io_timing=on"
+      - "-c"
+      - "auto_explain.log_min_duration=500ms"
+      - "-c"
+      - "auto_explain.log_analyze=on"
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-pioneer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
## Summary

Enables Postgres query-stats extensions, then fixes two issues they immediately surfaced.

### 1. Enable `pg_stat_statements` + `auto_explain`
`docker-compose.yml`: preload both libraries via server `-c` flags (`shared_preload_libraries` requires a restart, not `CREATE EXTENSION`), plus `compute_query_id=on`, `track_io_timing=on`, and `auto_explain.log_min_duration=500ms`. After `up -d --force-recreate postgres`, run `CREATE EXTENSION IF NOT EXISTS pg_stat_statements` once.

### 2. Index `task_logs.worker_id` / `agent_id`
`pg_stat_user_tables` flagged `task_logs` (~500k rows) as seq-scanned. The worker-scoped (`worker_id = ? AND task_id IS NULL`) and agent-scoped (`agent_id = ?`) log fetches in `routes/tasks.py` had no index — full parallel seq scans (EXPLAIN cost ~23k vs ~672 for the indexed `task_id` path). Adds indexes via migration plus matching `index=True` on the model fields.

### 3. Skip no-op worker resets on startup
`reset_connection_state()` ran a bare `UPDATE workers SET state='offline'` with no `WHERE`, rewriting every row each startup. Now only updates rows not already offline.

## Test plan
- [ ] `docker compose up -d --force-recreate postgres` and confirm `SHOW shared_preload_libraries` lists both
- [ ] `alembic upgrade head`, then `\d task_logs` shows `ix_task_logs_worker_id` / `ix_task_logs_agent_id`
- [ ] `EXPLAIN` on the worker/agent log queries shows index scans instead of seq scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)