### PR TITLE
feat: GitHub App identity for automated comments/PR actions

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -28,7 +28,7 @@ from foreman.message_utils import _json_default, truncate_tool_result
 from foreman.tools_schema import (
     FOREMAN_TOOLS,  # noqa: F401 — re-exported for test compatibility
 )
-from github_app_auth import get_app_installation_token
+from github_app_auth import get_app_installation_token, get_app_slug
 from lock_service import LockService
 from models import (
     Agent,
@@ -493,7 +493,7 @@ async def _guild_github_token(guild_id: str, user_id: str | None = None) -> tupl
         else:
             app_token = get_app_installation_token()
             if app_token:
-                return (app_token, "github-app[bot]")
+                return (app_token, get_app_slug())
 
         result = await db.exec(
             select(col(GithubToken.access_token), col(GithubToken.github_username))

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -28,6 +28,7 @@ from foreman.message_utils import _json_default, truncate_tool_result
 from foreman.tools_schema import (
     FOREMAN_TOOLS,  # noqa: F401 — re-exported for test compatibility
 )
+from github_app_auth import get_app_installation_token
 from lock_service import LockService
 from models import (
     Agent,
@@ -462,8 +463,11 @@ async def _guild_github_token(guild_id: str, user_id: str | None = None) -> tupl
 
     When *user_id* is given, prefer that member's own GitHub token so actions
     (issue claims, PR reviews, etc.) attribute to the acting human rather than
-    the guild owner. Falls back to the guild owner's token when *user_id* is
-    None (background/automated operations) or has no token on file.
+    the guild owner. For background/automated operations (*user_id* is None),
+    prefer the GitHub App installation token when configured — so automated
+    comments/reviews are attributed to the App identity — and fall back to
+    the guild owner's token when the App isn't configured or has no token on
+    file.
     """
     from auth_deps import get_guild_pk
 
@@ -486,6 +490,10 @@ async def _guild_github_token(guild_id: str, user_id: str | None = None) -> tupl
             row = result.first()
             if row:
                 return (row.access_token, row.github_username)
+        else:
+            app_token = get_app_installation_token()
+            if app_token:
+                return (app_token, "github-app[bot]")
 
         result = await db.exec(
             select(col(GithubToken.access_token), col(GithubToken.github_username))

--- a/backend/github_app_auth.py
+++ b/backend/github_app_auth.py
@@ -1,0 +1,135 @@
+"""GitHub App authentication — installation-token generation and caching.
+
+Lets Pioneer Square comment on GitHub as a GitHub App identity (e.g.
+``pioneer-square-melloy[bot]``) instead of a personal access token, so
+automated comments/reviews are attributed to the automation rather than
+whichever human's PAT happens to be configured.
+
+Enabled by setting all three of ``GITHUB_APP_ID``, ``GITHUB_APP_PRIVATE_KEY``
+(or ``GITHUB_APP_PRIVATE_KEY_PATH``), and ``GITHUB_APP_INSTALLATION_ID``. When
+any is missing, :func:`get_github_token` falls back to the ``GITHUB_TOKEN``
+env var — existing deployments without a GitHub App configured see no change
+in behavior.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import httpx
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+# ---------------------------------------------------------------------------
+# Config (read at call time from environment — see module docstring)
+# ---------------------------------------------------------------------------
+
+GITHUB_APP_ID = "GITHUB_APP_ID"
+GITHUB_APP_PRIVATE_KEY = "GITHUB_APP_PRIVATE_KEY"
+GITHUB_APP_PRIVATE_KEY_PATH = "GITHUB_APP_PRIVATE_KEY_PATH"
+GITHUB_APP_INSTALLATION_ID = "GITHUB_APP_INSTALLATION_ID"
+
+# Cached installation token, refreshed once within 5 minutes of expiry.
+_token_cache: dict[str, Any] = {"token": None, "expires_at": None}
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def generate_jwt(app_id: str, private_key_pem: str) -> str:
+    """Generate a short-lived (10 min) RS256 JWT for GitHub App authentication.
+
+    Signed with the App's private key; ``iss`` is the App ID, per GitHub's
+    JWT-based App authentication scheme.
+    """
+    now = int(time.time())
+    header = {"alg": "RS256", "typ": "JWT"}
+    payload = {
+        "iat": now - 60,  # allow for clock drift, as GitHub's docs recommend
+        "exp": now + 10 * 60,
+        "iss": str(app_id),
+    }
+    header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+
+    private_key = load_pem_private_key(private_key_pem.encode(), password=None)
+    signature = private_key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    return f"{header_b64}.{payload_b64}.{_b64url_encode(signature)}"
+
+
+def _request_installation_token(app_id: str, private_key_pem: str, installation_id: str) -> dict:
+    """POST to GitHub's installation access-token endpoint and return the parsed JSON body."""
+    jwt_token = generate_jwt(app_id, private_key_pem)
+    response = httpx.post(
+        f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+        headers={
+            "Authorization": f"Bearer {jwt_token}",
+            "Accept": "application/vnd.github+json",
+        },
+        timeout=15,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_installation_token(app_id: str, private_key_pem: str, installation_id: str) -> str:
+    """Exchange a signed App JWT for a short-lived installation access token."""
+    return _request_installation_token(app_id, private_key_pem, installation_id)["token"]
+
+
+def _app_credentials() -> tuple[str, str, str] | None:
+    """Return (app_id, private_key_pem, installation_id) if all App env vars are set, else None."""
+    app_id = os.environ.get(GITHUB_APP_ID)
+    installation_id = os.environ.get(GITHUB_APP_INSTALLATION_ID)
+    private_key_pem = os.environ.get(GITHUB_APP_PRIVATE_KEY)
+    if not private_key_pem:
+        key_path = os.environ.get(GITHUB_APP_PRIVATE_KEY_PATH)
+        if key_path:
+            private_key_pem = Path(key_path).read_text()
+    if app_id and installation_id and private_key_pem:
+        return app_id, private_key_pem, installation_id
+    return None
+
+
+def get_app_installation_token() -> str | None:
+    """Return a cached GitHub App installation token, or None if the App isn't configured.
+
+    Refreshes when the cached token is within 5 minutes of expiry.
+    """
+    creds = _app_credentials()
+    if creds is None:
+        return None
+    app_id, private_key_pem, installation_id = creds
+
+    now = datetime.now(UTC)
+    cached_expiry = _token_cache["expires_at"]
+    if _token_cache["token"] and cached_expiry and cached_expiry - now > timedelta(minutes=5):
+        return _token_cache["token"]
+
+    data = _request_installation_token(app_id, private_key_pem, installation_id)
+    _token_cache["token"] = data["token"]
+    _token_cache["expires_at"] = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
+    return _token_cache["token"]
+
+
+def get_github_token(fallback: str | None = None) -> str:
+    """Return the GitHub token to use for API/``gh`` CLI calls.
+
+    Prefers a GitHub App installation token when the App env vars are set;
+    otherwise returns *fallback* if given, else the ``GITHUB_TOKEN`` env var.
+    """
+    token = get_app_installation_token()
+    if token:
+        return token
+    if fallback is not None:
+        return fallback
+    return os.environ.get("GITHUB_TOKEN", "")

--- a/backend/github_app_auth.py
+++ b/backend/github_app_auth.py
@@ -10,13 +10,19 @@ Enabled by setting all three of ``GITHUB_APP_ID``, ``GITHUB_APP_PRIVATE_KEY``
 any is missing, :func:`get_github_token` falls back to the ``GITHUB_TOKEN``
 env var — existing deployments without a GitHub App configured see no change
 in behavior.
+
+``GITHUB_APP_SLUG`` is an optional fourth var giving the bot's attributed
+username (e.g. ``pioneer-square-melloy[bot]``); see :func:`get_app_slug`. It
+defaults to a generic placeholder when unset.
 """
 
 from __future__ import annotations
 
 import base64
 import json
+import logging
 import os
+import threading
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -27,6 +33,8 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
+logger = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
 # Config (read at call time from environment — see module docstring)
 # ---------------------------------------------------------------------------
@@ -35,9 +43,18 @@ GITHUB_APP_ID = "GITHUB_APP_ID"
 GITHUB_APP_PRIVATE_KEY = "GITHUB_APP_PRIVATE_KEY"
 GITHUB_APP_PRIVATE_KEY_PATH = "GITHUB_APP_PRIVATE_KEY_PATH"
 GITHUB_APP_INSTALLATION_ID = "GITHUB_APP_INSTALLATION_ID"
+GITHUB_APP_SLUG = "GITHUB_APP_SLUG"
+DEFAULT_APP_SLUG = "github-app[bot]"
 
 # Cached installation token, refreshed once within 5 minutes of expiry.
 _token_cache: dict[str, Any] = {"token": None, "expires_at": None}
+
+# Guards the cache check + refresh in get_app_installation_token(). A plain
+# threading.Lock (not asyncio.Lock) because this function is synchronous and
+# is called from both sync (utils.build_spawn_worker_env) and async
+# (foreman/tools._guild_github_token) call sites — an asyncio.Lock can't be
+# used outside a running event loop's coroutine context.
+_cache_lock = threading.Lock()
 
 
 def _b64url_encode(data: bytes) -> str:
@@ -94,10 +111,26 @@ def _app_credentials() -> tuple[str, str, str] | None:
     if not private_key_pem:
         key_path = os.environ.get(GITHUB_APP_PRIVATE_KEY_PATH)
         if key_path:
-            private_key_pem = Path(key_path).read_text()
+            try:
+                private_key_pem = Path(key_path).read_text()
+            except OSError:
+                logger.warning(
+                    "Failed to read GITHUB_APP_PRIVATE_KEY_PATH %r; falling back to GITHUB_TOKEN",
+                    key_path,
+                    exc_info=True,
+                )
+                return None
     if app_id and installation_id and private_key_pem:
         return app_id, private_key_pem, installation_id
     return None
+
+
+def get_app_slug() -> str:
+    """Return the bot username to attribute App-authenticated actions to.
+
+    Falls back to a generic default when ``GITHUB_APP_SLUG`` isn't set.
+    """
+    return os.environ.get(GITHUB_APP_SLUG) or DEFAULT_APP_SLUG
 
 
 def get_app_installation_token() -> str | None:
@@ -110,26 +143,30 @@ def get_app_installation_token() -> str | None:
         return None
     app_id, private_key_pem, installation_id = creds
 
-    now = datetime.now(UTC)
-    cached_expiry = _token_cache["expires_at"]
-    if _token_cache["token"] and cached_expiry and cached_expiry - now > timedelta(minutes=5):
+    with _cache_lock:
+        now = datetime.now(UTC)
+        cached_expiry = _token_cache["expires_at"]
+        if _token_cache["token"] and cached_expiry and cached_expiry - now > timedelta(minutes=5):
+            return _token_cache["token"]
+
+        data = _request_installation_token(app_id, private_key_pem, installation_id)
+        _token_cache["token"] = data["token"]
+        _token_cache["expires_at"] = datetime.fromisoformat(
+            data["expires_at"].replace("Z", "+00:00")
+        )
         return _token_cache["token"]
 
-    data = _request_installation_token(app_id, private_key_pem, installation_id)
-    _token_cache["token"] = data["token"]
-    _token_cache["expires_at"] = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
-    return _token_cache["token"]
 
-
-def get_github_token(fallback: str | None = None) -> str:
-    """Return the GitHub token to use for API/``gh`` CLI calls.
+def get_github_token(fallback: str | None = None) -> str | None:
+    """Return the GitHub token to use for API/``gh`` CLI calls, or None if unconfigured.
 
     Prefers a GitHub App installation token when the App env vars are set;
-    otherwise returns *fallback* if given, else the ``GITHUB_TOKEN`` env var.
+    otherwise returns *fallback* if given, else the ``GITHUB_TOKEN`` env var
+    (or None if neither the App nor ``GITHUB_TOKEN`` is configured).
     """
     token = get_app_installation_token()
     if token:
         return token
     if fallback is not None:
         return fallback
-    return os.environ.get("GITHUB_TOKEN", "")
+    return os.environ.get("GITHUB_TOKEN") or None

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -21,9 +21,9 @@ from auth_deps import (
 )
 from database import get_db_dep
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from github_app_auth import get_app_installation_token
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials
+from github_app_auth import get_app_installation_token
 from models import (
     ClaudeCredentials,
     GithubToken,

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -21,6 +21,7 @@ from auth_deps import (
 )
 from database import get_db_dep
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from github_app_auth import get_app_installation_token
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials
 from models import (
@@ -88,10 +89,19 @@ async def get_github_token(
     _principal: str = Depends(require_worker_or_member),
     db: AsyncSession = Depends(get_db_dep),
 ):
-    """Return the stored OAuth token for the guild's linked GitHub user. Used by workers.
+    """Return a GitHub token for the guild, for workers to use.
+
+    Prefers the GitHub App installation token when configured (so worker
+    actions like ``gh pr comment`` are attributed to the App identity);
+    otherwise falls back to the stored OAuth token for the guild's linked
+    GitHub user.
 
     Requires a worker auth_token (from registration) or a member login_token.
     Without auth, anyone knowing a guild_id could exfiltrate the GitHub token."""
+    app_token = get_app_installation_token()
+    if app_token:
+        return {"access_token": app_token, "username": "github-app[bot]"}
+
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="No GitHub account linked to this guild")

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -23,7 +23,7 @@ from database import get_db_dep
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials
-from github_app_auth import get_app_installation_token
+from github_app_auth import get_app_installation_token, get_app_slug
 from models import (
     ClaudeCredentials,
     GithubToken,
@@ -100,7 +100,7 @@ async def get_github_token(
     Without auth, anyone knowing a guild_id could exfiltrate the GitHub token."""
     app_token = get_app_installation_token()
     if app_token:
-        return {"access_token": app_token, "username": "github-app[bot]"}
+        return {"access_token": app_token, "username": get_app_slug()}
 
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:

--- a/backend/routes/debug.py
+++ b/backend/routes/debug.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from datetime import UTC, datetime
 from typing import Any
 
@@ -19,6 +18,7 @@ from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from fastapi import APIRouter, Depends, HTTPException
 from foreman.github_url_parser import parse_github_urls
+from github_app_auth import get_github_token
 from models import GithubEvent, GithubToken, LlmUsage, Task, TaskLog
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -490,17 +490,18 @@ async def get_task_debug_timeline(
     # Collect all sensitive credential strings now so we can scrub them from
     # the response regardless of which code path set them.
     _sensitive: list[str] = []
-    _env_gh_token: str | None = os.getenv("GITHUB_TOKEN")
+    _env_gh_token: str | None = get_github_token() or None
     if _env_gh_token:
         _sensitive.append(_env_gh_token)
 
     # ── 5. Live GitHub API ────────────────────────────────────────────────────
     if task.pr_url:
-        # GITHUB_TOKEN is a shared server credential with broad read access to
-        # all repos the server account can see.  This endpoint is intentionally
-        # server-side: it is an internal debug view gated by guild membership,
-        # not a per-user GitHub proxy.  If per-user visibility scoping is ever
-        # required, replace this with a per-user OAuth token lookup.
+        # This is a shared server credential (GitHub App installation token or
+        # GITHUB_TOKEN) with broad read access to all repos the server account
+        # can see.  This endpoint is intentionally server-side: it is an
+        # internal debug view gated by guild membership, not a per-user GitHub
+        # proxy.  If per-user visibility scoping is ever required, replace
+        # this with a per-user OAuth token lookup.
         github_token: str | None = _env_gh_token
         if not github_token:
             tok_result = await db.exec(

--- a/backend/routes/debug.py
+++ b/backend/routes/debug.py
@@ -490,7 +490,7 @@ async def get_task_debug_timeline(
     # Collect all sensitive credential strings now so we can scrub them from
     # the response regardless of which code path set them.
     _sensitive: list[str] = []
-    _env_gh_token: str | None = get_github_token() or None
+    _env_gh_token: str | None = get_github_token()
     if _env_gh_token:
         _sensitive.append(_env_gh_token)
 

--- a/backend/tests/test_github_app_auth.py
+++ b/backend/tests/test_github_app_auth.py
@@ -17,8 +17,10 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 import github_app_auth  # noqa: E402
 from github_app_auth import (  # noqa: E402
+    DEFAULT_APP_SLUG,
     generate_jwt,
     get_app_installation_token,
+    get_app_slug,
     get_github_token,
     get_installation_token,
 )
@@ -47,6 +49,7 @@ def _reset_token_cache(monkeypatch):
     monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY", raising=False)
     monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
     monkeypatch.delenv("GITHUB_APP_INSTALLATION_ID", raising=False)
+    monkeypatch.delenv("GITHUB_APP_SLUG", raising=False)
     github_app_auth._token_cache["token"] = None
     github_app_auth._token_cache["expires_at"] = None
     yield
@@ -209,3 +212,25 @@ def test_app_credentials_supports_private_key_path(monkeypatch, rsa_keypair, tmp
     monkeypatch.setattr(github_app_auth.httpx, "post", lambda *a, **kw: FakeResponse())
 
     assert get_app_installation_token() == "ghs_from_path"
+
+
+def test_get_github_token_returns_none_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert get_github_token() is None
+
+
+def test_app_credentials_returns_none_when_private_key_file_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_PATH", str(tmp_path / "does-not-exist.pem"))
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "789")
+
+    assert get_app_installation_token() is None
+
+
+def test_get_app_slug_defaults_when_unset():
+    assert get_app_slug() == DEFAULT_APP_SLUG
+
+
+def test_get_app_slug_uses_env_var_when_set(monkeypatch):
+    monkeypatch.setenv("GITHUB_APP_SLUG", "pioneer-square-melloy[bot]")
+    assert get_app_slug() == "pioneer-square-melloy[bot]"

--- a/backend/tests/test_github_app_auth.py
+++ b/backend/tests/test_github_app_auth.py
@@ -1,0 +1,211 @@
+"""Unit tests for GitHub App JWT/installation-token generation and caching."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import github_app_auth  # noqa: E402
+from github_app_auth import (  # noqa: E402
+    generate_jwt,
+    get_app_installation_token,
+    get_github_token,
+    get_installation_token,
+)
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding_needed = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding_needed)
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    return private_key, pem
+
+
+@pytest.fixture(autouse=True)
+def _reset_token_cache(monkeypatch):
+    """Clear the module-level installation-token cache and App env vars for isolation."""
+    monkeypatch.delenv("GITHUB_APP_ID", raising=False)
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.delenv("GITHUB_APP_INSTALLATION_ID", raising=False)
+    github_app_auth._token_cache["token"] = None
+    github_app_auth._token_cache["expires_at"] = None
+    yield
+    github_app_auth._token_cache["token"] = None
+    github_app_auth._token_cache["expires_at"] = None
+
+
+def test_generate_jwt_has_correct_claims_and_signature(rsa_keypair):
+    private_key, pem = rsa_keypair
+    token = generate_jwt("123456", pem)
+
+    header_b64, payload_b64, sig_b64 = token.split(".")
+    header = json.loads(_b64url_decode(header_b64))
+    payload = json.loads(_b64url_decode(payload_b64))
+
+    assert header == {"alg": "RS256", "typ": "JWT"}
+    assert payload["iss"] == "123456"
+    assert payload["exp"] - payload["iat"] <= 660  # ~10 min + clock-drift allowance
+
+    signature = _b64url_decode(sig_b64)
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    public_key = private_key.public_key()
+    # Raises InvalidSignature if the token wasn't actually signed by this key.
+    public_key.verify(signature, signing_input, padding.PKCS1v15(), hashes.SHA256())
+
+
+def test_get_github_token_falls_back_to_env_var_when_app_not_configured(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_fallback_token")
+    assert get_github_token() == "ghp_fallback_token"
+
+
+def test_get_github_token_falls_back_to_explicit_fallback_arg(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert get_github_token(fallback="explicit-fallback") == "explicit-fallback"
+
+
+def test_get_installation_token_calls_api_with_jwt(monkeypatch, rsa_keypair):
+    _private_key, pem = rsa_keypair
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"token": "ghs_installation_token", "expires_at": "2099-01-01T00:00:00Z"}
+
+    def fake_post(url, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        return FakeResponse()
+
+    monkeypatch.setattr(github_app_auth.httpx, "post", fake_post)
+
+    token = get_installation_token("123456", pem, "789")
+
+    assert token == "ghs_installation_token"
+    assert captured["url"] == "https://api.github.com/app/installations/789/access_tokens"
+    assert captured["headers"]["Authorization"].startswith("Bearer ")
+
+
+def test_get_app_installation_token_none_when_not_configured():
+    assert get_app_installation_token() is None
+
+
+def test_token_caching_avoids_refetch_within_expiry_window(monkeypatch, rsa_keypair):
+    _private_key, pem = rsa_keypair
+    monkeypatch.setenv("GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", pem)
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "789")
+
+    call_count = {"n": 0}
+    far_future = (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"token": f"ghs_token_{call_count['n']}", "expires_at": far_future}
+
+    def fake_post(url, headers=None, timeout=None):
+        call_count["n"] += 1
+        return FakeResponse()
+
+    monkeypatch.setattr(github_app_auth.httpx, "post", fake_post)
+
+    first = get_github_token()
+    second = get_github_token()
+
+    assert first == second == "ghs_token_1"
+    assert call_count["n"] == 1
+
+
+def test_token_refetches_when_near_expiry(monkeypatch, rsa_keypair):
+    _private_key, pem = rsa_keypair
+    monkeypatch.setenv("GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", pem)
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "789")
+
+    call_count = {"n": 0}
+    soon = (datetime.now(UTC) + timedelta(minutes=2)).isoformat().replace("+00:00", "Z")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            call_count["n"] += 1
+            return {"token": f"ghs_token_{call_count['n']}", "expires_at": soon}
+
+    def fake_post(url, headers=None, timeout=None):
+        return FakeResponse()
+
+    monkeypatch.setattr(github_app_auth.httpx, "post", fake_post)
+
+    first = get_github_token()
+    second = get_github_token()
+
+    assert first == "ghs_token_1"
+    assert second == "ghs_token_2"
+    assert call_count["n"] == 2
+
+
+def test_get_github_token_prefers_app_token_over_fallback(monkeypatch, rsa_keypair):
+    _private_key, pem = rsa_keypair
+    monkeypatch.setenv("GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", pem)
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "789")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_should_be_ignored")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"token": "ghs_app_token", "expires_at": "2099-01-01T00:00:00Z"}
+
+    monkeypatch.setattr(github_app_auth.httpx, "post", lambda *a, **kw: FakeResponse())
+
+    assert get_github_token() == "ghs_app_token"
+
+
+def test_app_credentials_supports_private_key_path(monkeypatch, rsa_keypair, tmp_path):
+    _private_key, pem = rsa_keypair
+    key_file = tmp_path / "app-key.pem"
+    key_file.write_text(pem)
+
+    monkeypatch.setenv("GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_PATH", str(key_file))
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "789")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"token": "ghs_from_path", "expires_at": "2099-01-01T00:00:00Z"}
+
+    monkeypatch.setattr(github_app_auth.httpx, "post", lambda *a, **kw: FakeResponse())
+
+    assert get_app_installation_token() == "ghs_from_path"

--- a/backend/tests/test_github_app_auth.py
+++ b/backend/tests/test_github_app_auth.py
@@ -6,6 +6,8 @@ import base64
 import json
 import os
 import sys
+import threading
+import time
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -225,6 +227,56 @@ def test_app_credentials_returns_none_when_private_key_file_missing(monkeypatch,
     monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "789")
 
     assert get_app_installation_token() is None
+
+
+def test_concurrent_get_github_token_is_race_free(monkeypatch, rsa_keypair):
+    """Two threads racing on an empty cache must not both hit the network.
+
+    Regression test for the module-level ``_token_cache`` dict being mutated
+    without a lock (jmelloy's PR #912 review comment): without
+    ``_cache_lock`` serializing the check-then-fetch-then-store sequence,
+    both threads would see no cached token and both would call the
+    installation-token endpoint.
+    """
+    _private_key, pem = rsa_keypair
+    monkeypatch.setenv("GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", pem)
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "789")
+
+    call_count = {"n": 0}
+    call_lock = threading.Lock()
+    far_future = (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"token": "ghs_racey_token", "expires_at": far_future}
+
+    def fake_post(url, headers=None, timeout=None):
+        with call_lock:
+            call_count["n"] += 1
+        # Widen the race window so an unlocked cache would very likely fetch twice.
+        time.sleep(0.05)
+        return FakeResponse()
+
+    monkeypatch.setattr(github_app_auth.httpx, "post", fake_post)
+
+    results = [None, None]
+
+    def worker(idx):
+        results[idx] = get_github_token()
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results == ["ghs_racey_token", "ghs_racey_token"]
+    assert call_count["n"] == 1
+    assert github_app_auth._token_cache["token"] == "ghs_racey_token"
 
 
 def test_get_app_slug_defaults_when_unset():

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -16,6 +16,8 @@ import string
 import time
 import unicodedata
 
+from github_app_auth import get_github_token
+
 _VOWELS = frozenset("aeiou")
 _MIN_LEN = 5
 _TARGET_LEN = 8
@@ -264,10 +266,11 @@ def build_spawn_worker_env(
     public_url = source_env.get("FRONTEND_URL", "").rstrip("/")
     if public_url:
         env["PIONEER_FRONTEND_URL"] = public_url
-    gh_token = source_env.get("GITHUB_TOKEN", "")
+    gh_token = get_github_token(fallback=source_env.get("GITHUB_TOKEN", ""))
     if gh_token:
         # PIONEER_GITHUB_TOKEN feeds the worker config loader; GITHUB_TOKEN is
-        # what gh CLI inside the worker reads when opening PRs.
+        # what gh CLI inside the worker reads when opening PRs. Prefers a
+        # GitHub App installation token when the App env vars are configured.
         env["PIONEER_GITHUB_TOKEN"] = gh_token
         env["GITHUB_TOKEN"] = gh_token
     # ANTHROPIC_API_KEY is intentionally NOT forwarded — that's the foreman's

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -10,6 +10,7 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import random
 import re
 import string
@@ -17,6 +18,8 @@ import time
 import unicodedata
 
 from github_app_auth import get_github_token
+
+logger = logging.getLogger(__name__)
 
 _VOWELS = frozenset("aeiou")
 _MIN_LEN = 5
@@ -266,7 +269,14 @@ def build_spawn_worker_env(
     public_url = source_env.get("FRONTEND_URL", "").rstrip("/")
     if public_url:
         env["PIONEER_FRONTEND_URL"] = public_url
-    gh_token = get_github_token(fallback=source_env.get("GITHUB_TOKEN", ""))
+    try:
+        gh_token = get_github_token(fallback=source_env.get("GITHUB_TOKEN", ""))
+    except Exception:
+        logger.warning(
+            "Failed to obtain GitHub App installation token; falling back to GITHUB_TOKEN",
+            exc_info=True,
+        )
+        gh_token = source_env.get("GITHUB_TOKEN", "")
     if gh_token:
         # PIONEER_GITHUB_TOKEN feeds the worker config loader; GITHUB_TOKEN is
         # what gh CLI inside the worker reads when opening PRs. Prefers a


### PR DESCRIPTION
## Summary
- Adds `backend/github_app_auth.py`: generates a short-lived RS256 JWT (`generate_jwt`), exchanges it for an installation access token (`get_installation_token`/`_request_installation_token`), and caches the token (`get_app_installation_token`), refreshing when within 5 minutes of expiry
- `get_github_token()` prefers the GitHub App installation token when `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY` (or `GITHUB_APP_PRIVATE_KEY_PATH`), and `GITHUB_APP_INSTALLATION_ID` are all set; otherwise falls back to `GITHUB_TOKEN` — no behavior change for existing deployments
- Wires the new helper into the places that read GitHub credentials:
  - `backend/foreman/tools.py` (`_guild_github_token`, for background/automated operations)
  - `backend/routes/auth.py` (`/github/token` endpoint used by workers)
  - `backend/routes/debug.py` (task debug timeline's live GitHub API lookup)
  - `backend/utils.py` (`build_spawn_worker_env`, which sets `GITHUB_TOKEN`/`PIONEER_GITHUB_TOKEN` in worker subprocess env — this is what the `gh` CLI reads inside workers)
- Uses only the already-present `httpx` and `cryptography` deps — no new dependencies

## Test plan
- [x] `pytest backend/tests/test_github_app_auth.py` — 9 tests covering JWT claims/signature, fallback to `GITHUB_TOKEN`, installation-token API call (mocked), caching behavior (no refetch within expiry window, refetch near expiry), and `GITHUB_APP_PRIVATE_KEY_PATH` support — all pass

Closes #911.