### PR TITLE
feat: API latency logging + Amazon Bedrock (Nova/K2)

### DIFF
--- a/backend/foreman/llm.py
+++ b/backend/foreman/llm.py
@@ -30,6 +30,16 @@ from uuid import uuid4
 import httpx
 
 try:
+    # Absolute import works when backend/ itself is on sys.path (embedded
+    # backend, worker). The standalone foreman proxy only prepends the repo
+    # root (see foreman-proxy/pioneer_foreman/config.py), under which this
+    # module is reachable as backend.foreman.llm and util/ has no top-level
+    # name of its own — fall back to the fully-qualified path there.
+    from util.api_latency import track_api_call
+except ImportError:  # pragma: no cover - exercised under the proxy's import layout
+    from backend.util.api_latency import track_api_call
+
+try:
     import anthropic as _anthropic_mod
 
     HAS_ANTHROPIC = True
@@ -283,6 +293,33 @@ def make_anthropic_client(
             region or env.get("AWS_DEFAULT_REGION") or env.get("AWS_REGION") or _BEDROCK_REGION
         )
         resolved_profile = aws_profile or env.get("AWS_PROFILE") or None
+
+        # Bedrock also hosts foundation models with their own wire format —
+        # Amazon Nova, Kimi K2, ... — that the Anthropic SDK's Messages API
+        # cannot reach. Those go through the Bedrock Runtime Converse API
+        # instead (see providers/bedrock.py); everything else on this path
+        # is Claude-on-Bedrock via AsyncAnthropicBedrock, unchanged.
+        try:
+            # See the util.api_latency import fallback above for why both
+            # layouts are needed here.
+            from foreman.providers.bedrock import BedrockNativeClient, is_native_bedrock_model
+        except ImportError:  # pragma: no cover - exercised under the proxy's import layout
+            from backend.foreman.providers.bedrock import (
+                BedrockNativeClient,
+                is_native_bedrock_model,
+            )
+
+        if is_native_bedrock_model(resolved_model):
+            logger.info(
+                "Foreman using Amazon Bedrock Converse API (region=%s, profile=%s, model=%s)",
+                resolved_region,
+                resolved_profile,
+                resolved_model,
+            )
+            return BedrockNativeClient(
+                region=resolved_region, profile=resolved_profile, extra_env=env
+            )
+
         access_key = env.get("AWS_ACCESS_KEY_ID")
         secret_key = env.get("AWS_SECRET_ACCESS_KEY")
         session_token = env.get("AWS_SESSION_TOKEN")
@@ -414,8 +451,17 @@ async def call_anthropic(
         kwargs["tools"] = tools
     if _has_payload(tool_choice):
         kwargs["tool_choice"] = tool_choice
-    raw = await client.messages.with_raw_response.create(**kwargs)
-    return raw.parse(), raw.headers.get("request-id")
+
+    provider = "bedrock" if "Bedrock" in type(client).__name__ else "anthropic"
+    with track_api_call(provider, model, method="messages.create") as call:
+        raw = await client.messages.with_raw_response.create(**kwargs)
+        parsed = raw.parse()
+        call.status_code = 200
+        usage = getattr(parsed, "usage", None)
+        if usage is not None:
+            call.input_tokens = getattr(usage, "input_tokens", None)
+            call.output_tokens = getattr(usage, "output_tokens", None)
+    return parsed, raw.headers.get("request-id")
 
 
 # ---------------------------------------------------------------------------
@@ -630,7 +676,13 @@ async def call_openai_compatible(
         headers["Authorization"] = f"Bearer {api_key}"
 
     url = f"{base_url.rstrip('/')}/chat/completions"
-    response = await client.post(url, json=body, headers=headers)
-    response.raise_for_status()
+    with track_api_call("openai", url, method="POST") as call:
+        response = await client.post(url, json=body, headers=headers)
+        call.status_code = response.status_code
+        response.raise_for_status()
+        response_json = response.json()
+        usage = response_json.get("usage") or {}
+        call.input_tokens = usage.get("prompt_tokens")
+        call.output_tokens = usage.get("completion_tokens")
     request_id = response.headers.get("x-request-id") or response.headers.get("request-id")
-    return openai_response_to_anthropic(response.json(), model), request_id
+    return openai_response_to_anthropic(response_json, model), request_id

--- a/backend/foreman/providers/__init__.py
+++ b/backend/foreman/providers/__init__.py
@@ -1,0 +1,3 @@
+"""Provider-specific wrappers for LLM backends that don't speak the Anthropic
+Messages API wire format directly (see bedrock.py for Bedrock foundation
+models other than Anthropic Claude)."""

--- a/backend/foreman/providers/bedrock.py
+++ b/backend/foreman/providers/bedrock.py
@@ -1,0 +1,338 @@
+"""Amazon Bedrock support for non-Anthropic foundation models (Amazon Nova, Kimi K2, ...).
+
+Claude-on-Bedrock is served through the Anthropic SDK's ``AsyncAnthropicBedrock``
+client (see ``backend/foreman/llm.py``) because it already speaks the Anthropic
+Messages API shape end to end. Bedrock also hosts foundation models with their
+own wire format — Amazon Nova, Kimi K2, and others — that the Anthropic SDK
+cannot call; those only speak the Bedrock Runtime Converse API. This module is
+the one place that calls it, translating requests/responses to and from the
+Anthropic Messages shape so the rest of the codebase (history storage,
+tool-use parsing, ``foreman.llm.call_anthropic``) never has to know which wire
+format actually served the request — the same boundary ``call_openai_compatible``
+draws for OpenAI-compatible endpoints.
+
+``BedrockNativeClient`` below exposes just enough of the Anthropic SDK client
+surface (``.messages.with_raw_response.create(**kwargs)``) for
+``foreman.llm.call_anthropic`` to use it unmodified: ``make_anthropic_client()``
+returns one of these instead of ``AsyncAnthropicBedrock`` when the configured
+model is a native (non-Anthropic) Bedrock model, and everything downstream
+proceeds exactly as it does for Claude-on-Bedrock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from collections.abc import Mapping
+from types import SimpleNamespace
+from typing import Any
+
+try:
+    # Absolute import works when backend/ itself is on sys.path (embedded
+    # backend, worker); the standalone foreman proxy prepends the repo root
+    # instead, under which this module has no top-level name of its own — fall
+    # back to the fully-qualified path there. See the matching fallback in
+    # backend/foreman/llm.py.
+    from util.api_latency import track_api_call
+except ImportError:  # pragma: no cover - exercised under the proxy's import layout
+    from backend.util.api_latency import track_api_call
+
+try:
+    import boto3
+
+    HAS_BOTO3 = True
+except ImportError:
+    boto3 = None  # type: ignore[assignment]
+    HAS_BOTO3 = False
+
+
+# Model-ID prefixes (after stripping a cross-region "us."/"eu."/"ap." prefix)
+# that identify a Bedrock foundation model with its own wire format, requiring
+# the Converse API rather than AsyncAnthropicBedrock's Messages-API path.
+# Deliberately an allowlist, not "anything without 'anthropic' in the name" —
+# free-form model IDs used elsewhere (tests, placeholder ARNs) must keep going
+# through the existing AsyncAnthropicBedrock path unchanged.
+_NATIVE_MODEL_PREFIXES = (
+    "amazon.nova",
+    "amazon.titan",
+    "moonshot.kimi",
+    "moonshotai.kimi",
+)
+
+_REGION_PREFIX_RE = re.compile(r"^(?:us|eu|ap)\.")
+
+
+def is_native_bedrock_model(model: str) -> bool:
+    """True when *model* is a non-Anthropic Bedrock model (Nova, Kimi K2, ...)
+    that must be called via the Converse API rather than AsyncAnthropicBedrock."""
+    stripped = _REGION_PREFIX_RE.sub("", model.lower())
+    return stripped.startswith(_NATIVE_MODEL_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# boto3 client cache
+# ---------------------------------------------------------------------------
+
+_clients: dict[tuple[str, str | None, str | None, str | None], Any] = {}
+
+
+def _get_client(region: str, profile: str | None, extra_env: Mapping[str, str] | None):
+    if not HAS_BOTO3 or boto3 is None:
+        raise ImportError("boto3 is not installed; add it to requirements.txt for Bedrock support")
+
+    env: Mapping[str, str] = extra_env if extra_env is not None else os.environ
+    access_key = env.get("AWS_ACCESS_KEY_ID")
+    secret_key = env.get("AWS_SECRET_ACCESS_KEY")
+    session_token = env.get("AWS_SESSION_TOKEN")
+
+    cache_key = (region, profile, access_key, secret_key)
+    if cache_key not in _clients:
+        session_kwargs: dict[str, Any] = {"region_name": region}
+        if access_key and secret_key:
+            session_kwargs["aws_access_key_id"] = access_key
+            session_kwargs["aws_secret_access_key"] = secret_key
+            if session_token:
+                session_kwargs["aws_session_token"] = session_token
+        elif profile:
+            session_kwargs["profile_name"] = profile
+        session = boto3.Session(**session_kwargs)
+        _clients[cache_key] = session.client("bedrock-runtime")
+    return _clients[cache_key]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic Messages <-> Bedrock Converse translation
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_content_to_converse_blocks(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, str):
+        return [{"text": content}] if content else []
+    if not isinstance(content, list):
+        return []
+    blocks: list[dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            blocks.append({"text": block.get("text") or ""})
+        elif btype == "tool_use":
+            blocks.append(
+                {
+                    "toolUse": {
+                        "toolUseId": block.get("id") or "",
+                        "name": block.get("name") or "",
+                        "input": block.get("input") or {},
+                    }
+                }
+            )
+        elif btype == "tool_result":
+            result_content = block.get("content")
+            if isinstance(result_content, str):
+                result_blocks = [{"text": result_content}]
+            elif isinstance(result_content, list):
+                result_blocks = [
+                    {"text": rc.get("text") or ""} for rc in result_content if isinstance(rc, dict)
+                ] or [{"text": ""}]
+            else:
+                result_blocks = [{"text": str(result_content or "")}]
+            tool_result: dict[str, Any] = {
+                "toolUseId": block.get("tool_use_id") or "",
+                "content": result_blocks,
+            }
+            if block.get("is_error"):
+                tool_result["status"] = "error"
+            blocks.append({"toolResult": tool_result})
+    return blocks
+
+
+def anthropic_messages_to_converse(
+    system: list[dict[str, Any]] | None, messages: list[dict[str, Any]] | None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Convert an Anthropic system+messages pair into Converse's (system, messages)."""
+    system_blocks = [{"text": b.get("text", "")} for b in (system or []) if b.get("text")]
+    converse_messages: list[dict[str, Any]] = []
+    for msg in messages or []:
+        blocks = _anthropic_content_to_converse_blocks(msg.get("content"))
+        if blocks:
+            converse_messages.append({"role": msg.get("role"), "content": blocks})
+    return system_blocks, converse_messages
+
+
+def anthropic_tools_to_converse(tools: list[dict[str, Any]]) -> dict[str, Any]:
+    """Convert Anthropic tool schemas into Converse's toolConfig shape."""
+    return {
+        "tools": [
+            {
+                "toolSpec": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "inputSchema": {"json": tool.get("input_schema") or {}},
+                }
+            }
+            for tool in tools
+        ]
+    }
+
+
+def anthropic_tool_choice_to_converse(tool_choice: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Convert an Anthropic tool_choice into Converse's toolChoice shape.
+
+    Converse has no equivalent of Anthropic's "none" (force no tool call); that
+    case is left to the caller to handle by omitting tools entirely.
+    """
+    if not tool_choice:
+        return None
+    choice_type = tool_choice.get("type")
+    if choice_type == "auto":
+        return {"auto": {}}
+    if choice_type == "any":
+        return {"any": {}}
+    if choice_type == "tool":
+        return {"tool": {"name": tool_choice.get("name") or ""}}
+    return None
+
+
+_STOP_REASON_MAP = {
+    "end_turn": "end_turn",
+    "tool_use": "tool_use",
+    "max_tokens": "max_tokens",
+    "stop_sequence": "stop_sequence",
+}
+
+
+def converse_response_to_anthropic(response: dict[str, Any], model: str) -> dict[str, Any]:
+    """Convert a Bedrock Converse API response into an Anthropic Messages API
+    response dict, so callers only ever handle one response shape."""
+    output_message = (response.get("output") or {}).get("message") or {}
+    content_blocks: list[dict[str, Any]] = []
+    for block in output_message.get("content") or []:
+        if "text" in block:
+            content_blocks.append({"type": "text", "text": block["text"]})
+        elif "toolUse" in block:
+            tool_use = block["toolUse"]
+            content_blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tool_use.get("toolUseId") or "",
+                    "name": tool_use.get("name") or "",
+                    "input": tool_use.get("input") or {},
+                }
+            )
+
+    bedrock_stop_reason = response.get("stopReason")
+    stop_reason = _STOP_REASON_MAP.get(bedrock_stop_reason, bedrock_stop_reason or "end_turn")
+
+    usage = response.get("usage") or {}
+    request_id = (response.get("ResponseMetadata") or {}).get("RequestId")
+    return {
+        "id": request_id or f"msg_bedrock_{id(response)}",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": content_blocks,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": usage.get("inputTokens", 0) or 0,
+            "output_tokens": usage.get("outputTokens", 0) or 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Adapter matching the slice of the Anthropic SDK client interface that
+# foreman.llm.call_anthropic() uses.
+# ---------------------------------------------------------------------------
+
+
+class _RawConverseResponse:
+    """Mimics the Anthropic SDK's ``.with_raw_response`` wrapper: ``.parse()``
+    returns the parsed response, ``.headers`` exposes the request id."""
+
+    def __init__(self, parsed: SimpleNamespace, request_id: str | None):
+        self._parsed = parsed
+        self.headers = {"request-id": request_id} if request_id else {}
+
+    def parse(self) -> SimpleNamespace:
+        return self._parsed
+
+
+def _response_dict_to_namespace(raw: dict[str, Any]) -> SimpleNamespace:
+    content = [SimpleNamespace(**block) for block in raw.get("content") or []]
+    usage = SimpleNamespace(**(raw.get("usage") or {}))
+    return SimpleNamespace(
+        id=raw.get("id"),
+        type=raw.get("type", "message"),
+        role=raw.get("role", "assistant"),
+        model=raw.get("model"),
+        content=content,
+        stop_reason=raw.get("stop_reason"),
+        stop_sequence=raw.get("stop_sequence"),
+        usage=usage,
+        model_dump=lambda: raw,
+    )
+
+
+class BedrockNativeClient:
+    """Adapter exposing ``.messages.with_raw_response.create(**kwargs)`` — the
+    slice of the Anthropic SDK client interface ``call_anthropic()`` needs —
+    backed by the Bedrock Runtime Converse API instead of the Anthropic
+    Messages API. Returned by ``make_anthropic_client()`` in place of
+    ``AsyncAnthropicBedrock`` when the configured model is a native
+    (non-Anthropic) Bedrock model such as Amazon Nova or Kimi K2.
+    """
+
+    def __init__(
+        self,
+        region: str,
+        profile: str | None = None,
+        extra_env: Mapping[str, str] | None = None,
+    ):
+        self._region = region
+        self._profile = profile
+        self._extra_env = extra_env
+        self.messages = SimpleNamespace(with_raw_response=self)
+
+    async def create(
+        self,
+        *,
+        model: str,
+        max_tokens: int,
+        system: list[dict[str, Any]] | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: dict[str, Any] | None = None,
+    ) -> _RawConverseResponse:
+        system_blocks, converse_messages = anthropic_messages_to_converse(system, messages)
+        request: dict[str, Any] = {
+            "modelId": model,
+            "messages": converse_messages,
+            "inferenceConfig": {"maxTokens": max_tokens},
+        }
+        if system_blocks:
+            request["system"] = system_blocks
+        if tools:
+            tool_config = anthropic_tools_to_converse(tools)
+            converse_choice = anthropic_tool_choice_to_converse(tool_choice)
+            if converse_choice:
+                tool_config["toolChoice"] = converse_choice
+            request["toolConfig"] = tool_config
+
+        client = _get_client(self._region, self._profile, self._extra_env)
+
+        with track_api_call("bedrock", model, method="Converse") as call:
+            response = await asyncio.to_thread(client.converse, **request)
+            usage = response.get("usage") or {}
+            call.status_code = (response.get("ResponseMetadata") or {}).get("HTTPStatusCode", 200)
+            call.input_tokens = usage.get("inputTokens")
+            call.output_tokens = usage.get("outputTokens")
+
+        response_dict = converse_response_to_anthropic(response, model)
+        parsed = _response_dict_to_namespace(response_dict)
+        request_id = (response.get("ResponseMetadata") or {}).get("RequestId")
+        return _RawConverseResponse(parsed, request_id)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ sqlmodel
 alembic
 python-multipart
 anthropic[bedrock]
+boto3
 python-dotenv
 docker
 httpx

--- a/backend/tests/test_bedrock_provider.py
+++ b/backend/tests/test_bedrock_provider.py
@@ -143,9 +143,7 @@ def test_converse_response_to_anthropic_tool_use():
     response = {
         "output": {
             "message": {
-                "content": [
-                    {"toolUse": {"toolUseId": "t1", "name": "search", "input": {"q": "x"}}}
-                ]
+                "content": [{"toolUse": {"toolUseId": "t1", "name": "search", "input": {"q": "x"}}}]
             }
         },
         "stopReason": "tool_use",
@@ -208,8 +206,9 @@ async def test_bedrock_native_client_create_success(monkeypatch):
 
 
 async def test_bedrock_native_client_create_without_boto3_raises():
-    with patch("foreman.providers.bedrock.HAS_BOTO3", False), patch(
-        "foreman.providers.bedrock.boto3", None
+    with (
+        patch("foreman.providers.bedrock.HAS_BOTO3", False),
+        patch("foreman.providers.bedrock.boto3", None),
     ):
         client = BedrockNativeClient(region="us-east-1", extra_env={})
         with pytest.raises(ImportError):

--- a/backend/tests/test_bedrock_provider.py
+++ b/backend/tests/test_bedrock_provider.py
@@ -1,0 +1,220 @@
+"""Tests for the Bedrock Converse API provider wrapper (Amazon Nova, Kimi K2)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from foreman.providers.bedrock import (
+    BedrockNativeClient,
+    anthropic_messages_to_converse,
+    anthropic_tool_choice_to_converse,
+    anthropic_tools_to_converse,
+    converse_response_to_anthropic,
+    is_native_bedrock_model,
+)
+
+# ---------------------------------------------------------------------------
+# is_native_bedrock_model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "amazon.nova-pro-v1:0",
+        "amazon.nova-lite-v1:0",
+        "us.amazon.nova-pro-v1:0",
+        "eu.amazon.titan-text-express-v1",
+        "moonshot.kimi-k2-instruct",
+        "moonshotai.kimi-k2-instruct",
+        "ap.moonshotai.kimi-k2-instruct",
+    ],
+)
+def test_is_native_bedrock_model_true(model):
+    assert is_native_bedrock_model(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic.claude-sonnet-4-6-20251001-v1:0",
+        "us.anthropic.claude-sonnet-4-6-20251001-v1:0",
+        "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6",
+        "claude-sonnet-4-6",
+    ],
+)
+def test_is_native_bedrock_model_false(model):
+    assert is_native_bedrock_model(model) is False
+
+
+# ---------------------------------------------------------------------------
+# Anthropic <-> Converse translation
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_messages_to_converse_text_only():
+    system, messages = anthropic_messages_to_converse(
+        [{"type": "text", "text": "be helpful"}],
+        [{"role": "user", "content": "hello"}],
+    )
+    assert system == [{"text": "be helpful"}]
+    assert messages == [{"role": "user", "content": [{"text": "hello"}]}]
+
+
+def test_anthropic_messages_to_converse_tool_use_and_result():
+    _, messages = anthropic_messages_to_converse(
+        None,
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "search", "input": {"q": "x"}}
+                ],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "result"}],
+            },
+        ],
+    )
+    assert messages[0]["content"] == [
+        {"toolUse": {"toolUseId": "t1", "name": "search", "input": {"q": "x"}}}
+    ]
+    assert messages[1]["content"] == [
+        {"toolResult": {"toolUseId": "t1", "content": [{"text": "result"}]}}
+    ]
+
+
+def test_anthropic_tools_to_converse():
+    tool_config = anthropic_tools_to_converse(
+        [{"name": "search", "description": "search the web", "input_schema": {"type": "object"}}]
+    )
+    assert tool_config == {
+        "tools": [
+            {
+                "toolSpec": {
+                    "name": "search",
+                    "description": "search the web",
+                    "inputSchema": {"json": {"type": "object"}},
+                }
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "tool_choice,expected",
+    [
+        ({"type": "auto"}, {"auto": {}}),
+        ({"type": "any"}, {"any": {}}),
+        ({"type": "tool", "name": "search"}, {"tool": {"name": "search"}}),
+        (None, None),
+        ({"type": "none"}, None),
+    ],
+)
+def test_anthropic_tool_choice_to_converse(tool_choice, expected):
+    assert anthropic_tool_choice_to_converse(tool_choice) == expected
+
+
+def test_converse_response_to_anthropic_text():
+    response = {
+        "output": {"message": {"content": [{"text": "hi there"}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 5},
+    }
+    result = converse_response_to_anthropic(response, "amazon.nova-pro-v1:0")
+    assert result["content"] == [{"type": "text", "text": "hi there"}]
+    assert result["stop_reason"] == "end_turn"
+    assert result["usage"] == {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
+
+
+def test_converse_response_to_anthropic_tool_use():
+    response = {
+        "output": {
+            "message": {
+                "content": [
+                    {"toolUse": {"toolUseId": "t1", "name": "search", "input": {"q": "x"}}}
+                ]
+            }
+        },
+        "stopReason": "tool_use",
+        "usage": {"inputTokens": 1, "outputTokens": 1},
+    }
+    result = converse_response_to_anthropic(response, "amazon.nova-pro-v1:0")
+    assert result["content"] == [
+        {"type": "tool_use", "id": "t1", "name": "search", "input": {"q": "x"}}
+    ]
+    assert result["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# BedrockNativeClient.create — mocked boto3
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_client_cache():
+    import foreman.providers.bedrock as bedrock_mod
+
+    bedrock_mod._clients.clear()
+    yield
+    bedrock_mod._clients.clear()
+
+
+async def test_bedrock_native_client_create_success(monkeypatch):
+    fake_boto_client = MagicMock()
+    fake_boto_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "hello from nova"}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 7, "outputTokens": 3},
+        "ResponseMetadata": {"HTTPStatusCode": 200, "RequestId": "req-123"},
+    }
+
+    fake_session = MagicMock()
+    fake_session.client.return_value = fake_boto_client
+
+    with patch("foreman.providers.bedrock.boto3") as fake_boto3:
+        fake_boto3.Session.return_value = fake_session
+        client = BedrockNativeClient(region="us-east-1", extra_env={})
+        raw = await client.messages.with_raw_response.create(
+            model="amazon.nova-pro-v1:0",
+            max_tokens=100,
+            system=[{"type": "text", "text": "be helpful"}],
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    parsed = raw.parse()
+    assert parsed.content[0].text == "hello from nova"
+    assert parsed.stop_reason == "end_turn"
+    assert parsed.usage.input_tokens == 7
+    assert parsed.usage.output_tokens == 3
+    assert raw.headers.get("request-id") == "req-123"
+
+    fake_boto_client.converse.assert_called_once()
+    call_kwargs = fake_boto_client.converse.call_args.kwargs
+    assert call_kwargs["modelId"] == "amazon.nova-pro-v1:0"
+    assert call_kwargs["inferenceConfig"] == {"maxTokens": 100}
+
+
+async def test_bedrock_native_client_create_without_boto3_raises():
+    with patch("foreman.providers.bedrock.HAS_BOTO3", False), patch(
+        "foreman.providers.bedrock.boto3", None
+    ):
+        client = BedrockNativeClient(region="us-east-1", extra_env={})
+        with pytest.raises(ImportError):
+            await client.messages.with_raw_response.create(
+                model="amazon.nova-pro-v1:0",
+                max_tokens=100,
+                messages=[{"role": "user", "content": "hi"}],
+            )

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -435,6 +435,35 @@ class TestMakeAnthropicClientDynamicEnv:
             mock_mod.AsyncAnthropicBedrock.assert_not_called()
 
 
+class TestMakeAnthropicClientNativeBedrockModel:
+    """Amazon Nova / Kimi K2 have their own wire format and must dispatch to
+    BedrockNativeClient (Converse API), not AsyncAnthropicBedrock (Messages API)."""
+
+    def test_nova_model_returns_bedrock_native_client(self, monkeypatch):
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        import foreman.llm as llm_mod
+        from foreman.providers.bedrock import BedrockNativeClient
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        client = llm_mod.make_anthropic_client(model="amazon.nova-pro-v1:0")
+        assert isinstance(client, BedrockNativeClient)
+        mock_mod.AsyncAnthropicBedrock.assert_not_called()
+
+    def test_claude_on_bedrock_model_still_uses_anthropic_sdk(self, monkeypatch):
+        """Sanity check: a Claude model ID on Bedrock must still take the
+        existing AsyncAnthropicBedrock path, not the native Converse path."""
+        monkeypatch.setenv("FOREMAN_PROVIDER", "bedrock")
+        import foreman.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(model="anthropic.claude-sonnet-4-6-20251001-v1:0")
+        mock_mod.AsyncAnthropicBedrock.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # OpenAI-compatible translation (issue #826: shared with the standalone proxy,
 # which has no translation logic of its own — see foreman/tests/test_runner.py)

--- a/backend/util/api_latency.py
+++ b/backend/util/api_latency.py
@@ -1,0 +1,70 @@
+"""Structured latency logging for outbound API calls (GitHub, LLM providers, etc.).
+
+Every call site wraps its request in ``track_api_call`` and fills in the
+``ApiCallMetrics`` it yields. On exit exactly one ``key=value``-formatted line
+is emitted through the standard ``logging`` module (under the ``api.latency``
+logger), so it inherits whatever handler/formatter the process already has
+configured (colored, plain, or JSON — see logging_config.py) while staying
+queryable by field regardless of format.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+logger = logging.getLogger("api.latency")
+
+
+class ApiCallMetrics:
+    """Mutable bag of fields filled in by the caller inside a ``track_api_call`` block."""
+
+    __slots__ = ("status_code", "input_tokens", "output_tokens", "error")
+
+    def __init__(self) -> None:
+        self.status_code: int | str | None = None
+        self.input_tokens: int | None = None
+        self.output_tokens: int | None = None
+        self.error: str | None = None
+
+
+@contextmanager
+def track_api_call(provider: str, endpoint: str, method: str = "GET") -> Iterator[ApiCallMetrics]:
+    """Time one outbound API call and log provider/endpoint/method/status/elapsed_ms.
+
+    Usage::
+
+        with track_api_call("github", "/repos/x/y/issues", method="GET") as call:
+            resp = await client.get(...)
+            call.status_code = resp.status_code
+
+    An exception raised inside the block is recorded on ``metrics.error``,
+    logged at WARNING, and re-raised unchanged — callers don't need their own
+    try/except just to get a latency log line out of a failed call.
+    """
+    metrics = ApiCallMetrics()
+    start = time.monotonic()
+    try:
+        yield metrics
+    except Exception as exc:
+        metrics.error = f"{type(exc).__name__}: {exc}"
+        raise
+    finally:
+        elapsed_ms = (time.monotonic() - start) * 1000
+        fields = [
+            f"provider={provider}",
+            f"endpoint={endpoint}",
+            f"method={method}",
+            f"status={metrics.status_code if metrics.status_code is not None else 'error'}",
+            f"elapsed_ms={elapsed_ms:.1f}",
+        ]
+        if metrics.input_tokens is not None:
+            fields.append(f"input_tokens={metrics.input_tokens}")
+        if metrics.output_tokens is not None:
+            fields.append(f"output_tokens={metrics.output_tokens}")
+        if metrics.error is not None:
+            fields.append(f"error={metrics.error!r}")
+        level = logging.WARNING if metrics.error is not None else logging.INFO
+        logger.log(level, "api_call " + " ".join(fields))


### PR DESCRIPTION
Implements API latency logging and Amazon Bedrock provider support (Nova/K2 models).

Closes #914.