### PR TITLE
Fix guild config popover clipping on small mobile viewports

### DIFF
--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -858,6 +858,9 @@ function goHome() {
   top: calc(100% + 4px);
   right: 12px;
   width: 320px;
+  max-height: calc(100dvh - 60px - env(safe-area-inset-bottom, 0px));
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   background: var(--color-bg-secondary);
   border: 2px solid var(--color-brass);
   box-shadow:


### PR DESCRIPTION
## Summary
- Fixes #916 — the guild settings popover in `TopBar.vue` had no `max-height`/`overflow-y`, and every ancestor container (`html`, `body`, `#app`, `.app-layout`, `.app-body`) has `overflow: hidden` with a fixed viewport height. On short screens (iPhone) the panel's lower fields (Foreman config, env vars, Members, Session ID) and buttons overflowed off the bottom of the viewport with no scrollable container anywhere to reach them.
- Adds `max-height: calc(100dvh - 60px - env(safe-area-inset-bottom, 0px))`, `overflow-y: auto`, and `-webkit-overflow-scrolling: touch` to `.settings-popover` so it scrolls its own content and clears the iOS home-indicator safe area, while keeping its existing width/positioning (including the mobile media query) unchanged.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint:check` passes
- [x] `npx prettier --check` passes on the changed file
- [x] `npm run build` succeeds; confirmed the new rules compile into the production CSS bundle for both the base and mobile (`max-width: 600px`) selectors
- [x] `npx vitest run` — 112 passed / 4 skipped, no regressions
- [ ] Manual visual check at 375/390/430px viewports (couldn't run a real browser in this sandbox — no root to install Chromium's system libs — so this should be spot-checked in a normal dev environment)