### PR TITLE
fix: GitHub failed event notifications missing in Discord

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -835,6 +835,37 @@ async def notify_discord_redirect(
     )
 
 
+async def notify_discord_task_finalized(
+    issue_repo: str | None,
+    issue_number: int | None,
+    task_id: str,
+    state: str,
+    reason: str | None = None,
+) -> None:
+    """Post a task-closed notification into the task's existing Discord thread.
+
+    Covers the outcomes that never trigger a notification anywhere else:
+    ``finalize_task(outcome="failed")`` and ``cancel_task`` both closed a task
+    out silently before this — unlike a successful finish, which is already
+    covered by ``handle_task_complete``'s ``task-complete`` notification (#920).
+    See ``notify_discord_followup`` — same existing-thread-only routing.
+    """
+    if not discord_notifier.is_configured():
+        return
+    verb = "cancelled" if state == "cancelled" else "failed"
+    description = f"Task `{task_id}` was {verb}."
+    if reason:
+        description += f" Reason: {reason[:400]}"
+    await discord_notifier.notify_existing_thread(
+        f"task-{verb}",
+        title=f"Task {verb}: {task_id}",
+        description=description,
+        issue_repo=issue_repo,
+        issue_number=issue_number,
+        task_id=task_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # code-review-agent helpers
 # ---------------------------------------------------------------------------
@@ -2034,6 +2065,13 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                             await post_issue_close_summary_comment(
                                 guild_id, task.issue_repo, task.issue_number, descendants
                             )
+                        if outcome == "failed":
+                            spawn(
+                                notify_discord_task_finalized(
+                                    task.issue_repo, task.issue_number, task_id, "failed"
+                                ),
+                                name=f"discord.finalize:{task_id}",
+                            )
                         result_text = (
                             f"Task {task_id} finalized as {outcome}; soft-delete at "
                             f"{deleted_at.isoformat() if deleted_at is not None else 'unknown'}."
@@ -2094,15 +2132,18 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 task_id = inp["task_id"]
                 reason = inp.get("reason", "")
                 result = await db.exec(
-                    select(col(Task.worker_id), col(Task.state)).where(
-                        col(Task.id) == task_id, col(Task.guild_id) == guild_pk
-                    )
+                    select(
+                        col(Task.worker_id),
+                        col(Task.state),
+                        col(Task.issue_repo),
+                        col(Task.issue_number),
+                    ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
                 )
                 row = result.one_or_none()
                 if not row:
                     result_text = f"Task {task_id} not found."
                 else:
-                    worker_id_val, state = row
+                    worker_id_val, state, cancel_issue_repo, cancel_issue_number = row
                     if state in ("done", "failed", "cancelled"):
                         result_text = f"Task {task_id} is already {state}."
                     else:
@@ -2130,6 +2171,16 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                                 state="cancelled",
                                 deletedAt=deleted_at.isoformat(),
                             ),
+                        )
+                        spawn(
+                            notify_discord_task_finalized(
+                                cancel_issue_repo,
+                                cancel_issue_number,
+                                task_id,
+                                "cancelled",
+                                reason=reason or None,
+                            ),
+                            name=f"discord.cancel:{task_id}",
                         )
                         result_text = f"Task {task_id} cancelled." + (
                             f" Reason: {reason}" if reason else ""

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1189,6 +1189,50 @@ class TestExecToolsDispatching:
             state = session.scalar(select(col(Task.state)).where(col(Task.id) == "t-fin-fail"))
         assert state == "failed"
 
+    async def test_finalize_task_failed_notifies_discord(self, db_session):
+        """finalize_task(outcome='failed') must fire a Discord notification (#920) —
+        unlike a successful finalize, a failed one has no other notification path."""
+        insert_guild(db_session, "g-finalize-fail-notify")
+        _insert_worker(db_session, "g-finalize-fail-notify", "w-fin-fail-notify")
+        _insert_task(
+            db_session, "t-fin-fail-notify", "g-finalize-fail-notify", "w-fin-fail-notify"
+        )
+        with (
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+            patch(
+                "foreman.tools.notify_discord_task_finalized", new_callable=AsyncMock
+            ) as notify_mock,
+        ):
+            await exec_tools(
+                "g-finalize-fail-notify",
+                [
+                    _fake_tool_use(
+                        "finalize_task", {"task_id": "t-fin-fail-notify", "outcome": "failed"}
+                    )
+                ],
+            )
+        notify_mock.assert_called_once()
+        assert notify_mock.call_args[0][2:] == ("t-fin-fail-notify", "failed")
+
+    async def test_finalize_task_done_does_not_notify_discord(self, db_session):
+        """A successful finalize must not duplicate the task-complete notification."""
+        insert_guild(db_session, "g-finalize-done-notify")
+        _insert_worker(db_session, "g-finalize-done-notify", "w-fin-done-notify")
+        _insert_task(
+            db_session, "t-fin-done-notify", "g-finalize-done-notify", "w-fin-done-notify"
+        )
+        with (
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+            patch(
+                "foreman.tools.notify_discord_task_finalized", new_callable=AsyncMock
+            ) as notify_mock,
+        ):
+            await exec_tools(
+                "g-finalize-done-notify",
+                [_fake_tool_use("finalize_task", {"task_id": "t-fin-done-notify"})],
+            )
+        notify_mock.assert_not_called()
+
     async def test_finalize_task_invalid_outcome_defaults_to_done(self, db_session):
         """An unrecognised outcome value must not break finalize_task — it falls back to 'done'."""
         insert_guild(db_session, "g-finalize-inv")
@@ -1458,6 +1502,26 @@ class TestExecToolsDispatching:
             )
         assert "cancelled" in results[0]["content"].lower()
         assert "No longer needed" in results[0]["content"]
+
+    async def test_cancel_task_notifies_discord(self, db_session):
+        """cancel_task must fire a Discord notification — cancelling a task closed
+        it out silently before, with no notification anywhere (#920)."""
+        insert_guild(db_session, "g-cancel-notify")
+        _insert_worker(db_session, "g-cancel-notify", "w-cancel-notify")
+        _insert_task(db_session, "t-cnotify", "g-cancel-notify", "w-cancel-notify", state="pending")
+        with (
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+            patch(
+                "foreman.tools.notify_discord_task_finalized", new_callable=AsyncMock
+            ) as notify_mock,
+        ):
+            await exec_tools(
+                "g-cancel-notify",
+                [_fake_tool_use("cancel_task", {"task_id": "t-cnotify", "reason": "stale"})],
+            )
+        notify_mock.assert_called_once()
+        assert notify_mock.call_args[0][2:] == ("t-cnotify", "cancelled")
+        assert notify_mock.call_args.kwargs.get("reason") == "stale"
 
         with _sync_session(db_session) as session:
             state = session.scalar(select(col(Task.state)).where(col(Task.id) == "t-cpend"))

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1194,9 +1194,7 @@ class TestExecToolsDispatching:
         unlike a successful finalize, a failed one has no other notification path."""
         insert_guild(db_session, "g-finalize-fail-notify")
         _insert_worker(db_session, "g-finalize-fail-notify", "w-fin-fail-notify")
-        _insert_task(
-            db_session, "t-fin-fail-notify", "g-finalize-fail-notify", "w-fin-fail-notify"
-        )
+        _insert_task(db_session, "t-fin-fail-notify", "g-finalize-fail-notify", "w-fin-fail-notify")
         with (
             patch("foreman.tools.broadcast", new_callable=AsyncMock),
             patch(
@@ -1218,9 +1216,7 @@ class TestExecToolsDispatching:
         """A successful finalize must not duplicate the task-complete notification."""
         insert_guild(db_session, "g-finalize-done-notify")
         _insert_worker(db_session, "g-finalize-done-notify", "w-fin-done-notify")
-        _insert_task(
-            db_session, "t-fin-done-notify", "g-finalize-done-notify", "w-fin-done-notify"
-        )
+        _insert_task(db_session, "t-fin-done-notify", "g-finalize-done-notify", "w-fin-done-notify")
         with (
             patch("foreman.tools.broadcast", new_callable=AsyncMock),
             patch(

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1520,7 +1520,7 @@ class TestExecToolsDispatching:
         assert notify_mock.call_args.kwargs.get("reason") == "stale"
 
         with _sync_session(db_session) as session:
-            state = session.scalar(select(col(Task.state)).where(col(Task.id) == "t-cpend"))
+            state = session.scalar(select(col(Task.state)).where(col(Task.id) == "t-cnotify"))
         assert state == "cancelled"
 
     async def test_shutdown_worker_not_found(self, db_session):

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -624,9 +624,7 @@ def test_task_update_failed_notifies_discord(client):
     insert_worker(db_url, guild_id, worker_id, state="online")
     insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="working")
 
-    with patch.object(
-        discord_notifier, "notify_existing_thread", new=AsyncMock()
-    ) as mock_notify:
+    with patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify:
         with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
             ws.send_json(
                 {
@@ -670,9 +668,7 @@ def test_task_update_cancelled_notifies_discord(client):
     insert_worker(db_url, guild_id, worker_id, state="online")
     insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="working")
 
-    with patch.object(
-        discord_notifier, "notify_existing_thread", new=AsyncMock()
-    ) as mock_notify:
+    with patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify:
         with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
             ws.send_json(
                 {
@@ -716,9 +712,7 @@ def test_task_update_working_does_not_notify_discord(client):
     insert_worker(db_url, guild_id, worker_id, state="online")
     insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="pending")
 
-    with patch.object(
-        discord_notifier, "notify_existing_thread", new=AsyncMock()
-    ) as mock_notify:
+    with patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify:
         with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
             ws.send_json(
                 {

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -609,6 +609,144 @@ def test_followup_done_max_turns_caps_last_text_at_4000_chars(client):
 # ---------------------------------------------------------------------------
 
 
+def test_task_update_failed_notifies_discord(client):
+    """A worker-reported task-update with state=failed must post a Discord
+    notification (#920) — this path (bad tool config, unresolvable PR branch,
+    push errors) bypasses finalize_task/cancel_task entirely, and previously
+    notified nobody."""
+    test_client, db_url = client
+    guild_id = "nfy020"
+    worker_id = "w-nfy020"
+    task_id = "t-nfy020"
+    agent_id = "a-nfy020"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+    insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="working")
+
+    with patch.object(
+        discord_notifier, "notify_existing_thread", new=AsyncMock()
+    ) as mock_notify:
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # task-assigned replay
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json(
+                {
+                    "type": "task-update",
+                    "taskId": task_id,
+                    "workerId": worker_id,
+                    "state": "failed",
+                }
+            )
+            ws.receive_json()  # task-update broadcast
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong — ensures handler is done
+
+    mock_notify.assert_called_once()
+    args, kwargs = mock_notify.call_args
+    assert args[0] == "task-failed"
+    assert kwargs["task_id"] == task_id
+
+
+def test_task_update_cancelled_notifies_discord(client):
+    """A worker-reported task-update with state=cancelled must post a Discord notification."""
+    test_client, db_url = client
+    guild_id = "nfy021"
+    worker_id = "w-nfy021"
+    task_id = "t-nfy021"
+    agent_id = "a-nfy021"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+    insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="working")
+
+    with patch.object(
+        discord_notifier, "notify_existing_thread", new=AsyncMock()
+    ) as mock_notify:
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # task-assigned replay
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json(
+                {
+                    "type": "task-update",
+                    "taskId": task_id,
+                    "workerId": worker_id,
+                    "state": "cancelled",
+                }
+            )
+            ws.receive_json()  # task-update broadcast
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong — ensures handler is done
+
+    mock_notify.assert_called_once()
+    args, kwargs = mock_notify.call_args
+    assert args[0] == "task-cancelled"
+    assert kwargs["task_id"] == task_id
+
+
+def test_task_update_working_does_not_notify_discord(client):
+    """A non-terminal task-update (e.g. state=working) must not post a Discord notification."""
+    test_client, db_url = client
+    guild_id = "nfy022"
+    worker_id = "w-nfy022"
+    task_id = "t-nfy022"
+    agent_id = "a-nfy022"
+
+    insert_guild(db_url, guild_id, owner_user_id=None)
+    insert_worker(db_url, guild_id, worker_id, state="online")
+    insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="pending")
+
+    with patch.object(
+        discord_notifier, "notify_existing_thread", new=AsyncMock()
+    ) as mock_notify:
+        with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
+            ws.send_json(
+                {
+                    "type": "join",
+                    "agentId": agent_id,
+                    "agentName": "Test Worker",
+                    "agentType": "worker",
+                    "workerId": worker_id,
+                }
+            )
+            ws.receive_json()  # task-assigned replay
+            ws.receive_json()  # agent-joined broadcast
+
+            ws.send_json(
+                {
+                    "type": "task-update",
+                    "taskId": task_id,
+                    "workerId": worker_id,
+                    "state": "working",
+                }
+            )
+            ws.receive_json()  # task-update broadcast
+            ws.send_json({"type": "ping"})
+            ws.receive_json()  # pong — ensures handler is done
+
+    mock_notify.assert_not_called()
+
+
 def test_worker_online_not_sent_to_foreign_guild(client):
     """worker-register from a worker that belongs to guild_A must NOT trigger
     a worker-online event in guild_B, even when the worker connects to guild_B's

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -624,7 +624,12 @@ def test_task_update_failed_notifies_discord(client):
     insert_worker(db_url, guild_id, worker_id, state="online")
     insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="working")
 
-    with patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify:
+    _triggered, fake_trigger = _make_trigger_spy()
+
+    with (
+        patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger),
+        patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify,
+    ):
         with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
             ws.send_json(
                 {
@@ -668,7 +673,12 @@ def test_task_update_cancelled_notifies_discord(client):
     insert_worker(db_url, guild_id, worker_id, state="online")
     insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="working")
 
-    with patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify:
+    _triggered, fake_trigger = _make_trigger_spy()
+
+    with (
+        patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger),
+        patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify,
+    ):
         with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
             ws.send_json(
                 {
@@ -712,7 +722,12 @@ def test_task_update_working_does_not_notify_discord(client):
     insert_worker(db_url, guild_id, worker_id, state="online")
     insert_task(db_url, guild_id, task_id, worker_id=worker_id, state="pending")
 
-    with patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify:
+    _triggered, fake_trigger = _make_trigger_spy()
+
+    with (
+        patch.object(ws_handlers, "_trigger_foreman", new=fake_trigger),
+        patch.object(discord_notifier, "notify_existing_thread", new=AsyncMock()) as mock_notify,
+    ):
         with test_client.websocket_connect(f"/ws/{guild_id}") as ws:
             ws.send_json(
                 {

--- a/backend/tests/test_worker_foreman_notify.py
+++ b/backend/tests/test_worker_foreman_notify.py
@@ -651,7 +651,10 @@ def test_task_update_failed_notifies_discord(client):
                     "state": "failed",
                 }
             )
-            ws.receive_json()  # task-update broadcast
+            # No receive here: handle_task_update's broadcast excludes the
+            # sender's own connection (it's the worker reporting its own
+            # state), so this single-connection test never gets it back.
+            # The ping/pong round-trip below is what proves the handler ran.
             ws.send_json({"type": "ping"})
             ws.receive_json()  # pong — ensures handler is done
 
@@ -700,7 +703,10 @@ def test_task_update_cancelled_notifies_discord(client):
                     "state": "cancelled",
                 }
             )
-            ws.receive_json()  # task-update broadcast
+            # No receive here: handle_task_update's broadcast excludes the
+            # sender's own connection (it's the worker reporting its own
+            # state), so this single-connection test never gets it back.
+            # The ping/pong round-trip below is what proves the handler ran.
             ws.send_json({"type": "ping"})
             ws.receive_json()  # pong — ensures handler is done
 
@@ -749,7 +755,10 @@ def test_task_update_working_does_not_notify_discord(client):
                     "state": "working",
                 }
             )
-            ws.receive_json()  # task-update broadcast
+            # No receive here: handle_task_update's broadcast excludes the
+            # sender's own connection (it's the worker reporting its own
+            # state), so this single-connection test never gets it back.
+            # The ping/pong round-trip below is what proves the handler ran.
             ws.send_json({"type": "ping"})
             ws.receive_json()  # pong — ensures handler is done
 

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -803,6 +803,29 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
             discord_notifier.flush_task_stream(task_id),
             name=f"discord.stream-flush:{task_id}",
         )
+    # Worker-reported terminal failures (bad tool config, unresolvable PR
+    # branch, push errors, etc.) bypass the foreman's finalize_task/cancel_task
+    # tools entirely — the worker sets state directly via this task-update
+    # message. Unlike the success path (handle_task_complete's "task-complete"
+    # notification below), nothing else notifies Discord for these, so they
+    # were silently dropped (#920). Mirrors task-complete's routing: post into
+    # the task's existing thread when one exists, else the flat channel.
+    if update_values.get("state") in ("failed", "cancelled"):
+        state_label = update_values["state"]
+        worker_id_msg = data.get("workerId", "")
+        spawn(
+            discord_notifier.notify_existing_thread(
+                f"task-{state_label}",
+                title=f"Task {state_label}: {task_id}",
+                description=(
+                    f"Worker `{worker_id_msg}` reported task `{task_id}` as {state_label}."
+                    if worker_id_msg
+                    else f"Task `{task_id}` was marked {state_label}."
+                ),
+                task_id=task_id,
+            ),
+            name=f"discord.task-{state_label}:{task_id}",
+        )
     # Drain any pending-followup events queued while the task was locked, and
     # notify the foreman so it can decide how to handle them.
     if update_values.get("state") == "error" and task_id:


### PR DESCRIPTION
Fixes the routing bug where task-update messages setting state=failed never triggered Discord notifications, and where finalize_task/cancel_task paths also missed notifications.

Closes #920