### PR TITLE
fix: update pyproject.toml for CalVer versioning

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,9 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pioneer-square"
-# Placeholder: the real version is set at release time by the CalVer release
-# workflow (.github/workflows/release.yml), which tags each merge to main as
-# YYYY.MM.DD-<short-sha> and is not derived from this field.
+# Placeholder, rewritten in CI: the release workflow
+# (.github/workflows/release.yml) sed-replaces this line with the CalVer
+# version (YYYY.MM.DD-<short-sha>) before building the wheel/sdist it attaches
+# to each GitHub release, so the built package's reported version always
+# matches its release tag.
 version = "0.0.0"
 description = "Pioneer Square unified CLI: one `pioneer` binary serving the HTTP backend, foreman, and worker."
 requires-python = ">=3.11"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -8,7 +8,7 @@ name = "pioneer-square"
 # (.github/workflows/release.yml) sed-replaces this line with the CalVer
 # version (YYYY.MM.DD-<short-sha>) before building the wheel/sdist it attaches
 # to each GitHub release, so the built package's reported version always
-# matches its release tag.
+# matches its release tag. See issue #924 and PR #925 for the full mechanism.
 version = "0.0.0"
 description = "Pioneer Square unified CLI: one `pioneer` binary serving the HTTP backend, foreman, and worker."
 requires-python = ">=3.11"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pioneer-square"
-version = "0.1.0"
+# Placeholder: the real version is set at release time by the CalVer release
+# workflow (.github/workflows/release.yml), which tags each merge to main as
+# YYYY.MM.DD-<short-sha> and is not derived from this field.
+version = "0.0.0"
 description = "Pioneer Square unified CLI: one `pioneer` binary serving the HTTP backend, foreman, and worker."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- PR #923 added a CalVer+SHA release workflow (`.github/workflows/release.yml`) that tags each merge to `main` as `YYYY.MM.DD-<short-sha>` and creates a GitHub Release, but never touches `pyproject.toml`.
- The workflow doesn't build or publish a Python artifact, so there's no version-derivation pipeline to wire up (e.g. setuptools-scm would have nothing to consume, since the tag is created after the workflow runs, not before a build step).
- Replaced the static `version = "0.1.0"` in `cli/pyproject.toml` with a `0.0.0` placeholder and a comment explaining that the real version comes from the release workflow, so the two schemes no longer disagree.

Closes #924

## Test plan
- [x] Confirmed `cli/pyproject.toml` still parses (no build/publish step depends on this value)