### PR TITLE
chore(release): bump cli/pyproject.toml version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        run: |
+          VERSION="$(date -u +%Y.%m.%d)-$(git rev-parse --short HEAD)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Bump pyproject version
+        run: |
+          sed -i -E 's/^version = ".*"/version = "${{ steps.version.outputs.version }}"/' cli/pyproject.toml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: release ${{ steps.version.outputs.tag }} [skip ci]"
+          git push origin HEAD:main
+
+      - name: Create and push tag
+        run: |
+          if git ls-remote --tags origin "refs/tags/${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "Tag ${{ steps.version.outputs.tag }} already exists on remote, skipping tag push"
+          else
+            git tag "${{ steps.version.outputs.tag }}"
+            git push origin "${{ steps.version.outputs.tag }}"
+          fi
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true


### PR DESCRIPTION
Makes the Release workflow update `cli/pyproject.toml` with the computed release version.

New `Bump pyproject version` step (runs before tagging):
- `sed`-replaces the `version = "..."` line in `cli/pyproject.toml` with `steps.version.outputs.version`
- commits it back to `main` with `[skip ci]` so the push doesn't retrigger Release
- the tag/release then points at the bump commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)