### PR TITLE
fix: close cross-context lock gap between parent and child foreman runs

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -129,6 +129,7 @@ def is_child_task_run_active(guild_id: str, task_id: str) -> bool:
     state = _guild_locks.get((guild_id, f"task:{task_id}"))
     return bool(state and state.busy)
 
+
 # Max number of queued human messages per (guild, user)/(guild, task) key.
 # Bounded so a guild nobody is watching can't grow this without limit; the
 # oldest entry is dropped (with a warning) once the cap is hit.

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -111,6 +111,24 @@ class _GuildRunLock:
 
 _guild_locks: dict[tuple[str, str | None], _GuildRunLock] = {}
 
+
+def is_child_task_run_active(guild_id: str, task_id: str) -> bool:
+    """Return True if a per-task child Foreman run is currently in-flight for *task_id*.
+
+    Checks the same ``_guild_locks`` map used to serialise ``run_foreman_ai``
+    invocations, keyed on ``(guild_id, "task:<task_id>")`` — the lock key a
+    per-task child context claims for the duration of its run (see
+    ``run_foreman_ai``). A *parent* run's task-mutating tool handlers
+    (send_followup, redirect_task, cancel_task, finalize_task) call this
+    before acting on a specific task_id so they can detect that task's own
+    child context is mid-flight and skip rather than race it — closing the
+    cross-context lock gap from issue #927 (parent and child runs otherwise
+    key on different (guild_id, key) pairs and never serialise against each
+    other for the same task).
+    """
+    state = _guild_locks.get((guild_id, f"task:{task_id}"))
+    return bool(state and state.busy)
+
 # Max number of queued human messages per (guild, user)/(guild, task) key.
 # Bounded so a guild nobody is watching can't grow this without limit; the
 # oldest entry is dropped (with a warning) once the cap is hit.
@@ -1407,7 +1425,9 @@ async def _run_foreman_ai(
 
             _tool_use_ts = _now  # capture before exec_tools may raise
 
-            tool_results = await exec_tools(guild_id, tool_uses, user_id=user_id)
+            tool_results = await exec_tools(
+                guild_id, tool_uses, user_id=user_id, own_task_id=_task_id
+            )
             # Truncate verbose results; filter to only IDs in the current batch so
             # stale results that survived history trimming are never persisted.
             current_tool_use_ids = {tu.id for tu in tool_uses}

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1899,7 +1899,11 @@ async def _exec_one_tool(
                                 effective_tool = (
                                     requested_tool
                                     or task_tool
-                                    or (followup_worker_tools[0] if followup_worker_tools else "claude")
+                                    or (
+                                        followup_worker_tools[0]
+                                        if followup_worker_tools
+                                        else "claude"
+                                    )
                                 )
                                 if requested_model is not None:
                                     effective_model = requested_model
@@ -2031,7 +2035,10 @@ async def _exec_one_tool(
                                         ),
                                         name=f"discord.followup:{task_id}",
                                     )
-                                    if target_worker_id != original_worker_id and original_worker_id:
+                                    if (
+                                        target_worker_id != original_worker_id
+                                        and original_worker_id
+                                    ):
                                         result_text = (
                                             f"Follow-up reassigned from {original_worker_id} "
                                             f"to {target_worker_id} (task {task_id} on branch {branch})."
@@ -2078,7 +2085,9 @@ async def _exec_one_tool(
                                 )
                             )
                             # Discard any queued follow-up events — the task is closed.
-                            await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
+                            await db.exec(
+                                delete(TaskEvent).where(col(TaskEvent.task_id) == task_id)
+                            )
                             await LockService(db).release(f"task:{task_id}")
 
                             # phase='issue' root tasks own an entire GitHub issue's worth of
@@ -2165,7 +2174,9 @@ async def _exec_one_tool(
                             await broadcast_msg(
                                 guild_id,
                                 TaskRedirectMsg(
-                                    workerId=worker_id_val, taskId=task_id, instructions=instructions
+                                    workerId=worker_id_val,
+                                    taskId=task_id,
+                                    instructions=instructions,
                                 ),
                             )
                             await broadcast_msg(

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1322,7 +1322,13 @@ async def spawn_worker(
 # ---------------------------------------------------------------------------
 
 
-async def exec_tools(guild_id: str, tool_uses: list, user_id: str | None = None) -> list:
+async def exec_tools(
+    guild_id: str,
+    tool_uses: list,
+    user_id: str | None = None,
+    *,
+    own_task_id: str | None = None,
+) -> list:
     """Execute tool calls from the foreman AI and return tool-result blocks.
 
     Independent tool calls in the same batch run concurrently — each opens its
@@ -1335,8 +1341,15 @@ async def exec_tools(guild_id: str, tool_uses: list, user_id: str | None = None)
     *user_id* identifies the human whose foreman session is running. It's
     stamped onto any tasks created by ``create_task`` / ``assign_task`` so
     worker-driven events later route back to the same user thread.
+
+    *own_task_id* is the task_id of the per-task child context this batch is
+    running in (None for parent/whole-guild runs). Passed through to
+    task-mutating handlers (send_followup, redirect_task, cancel_task,
+    finalize_task) so they can tell whether they're a task's own child
+    context (never conflicts with itself) versus a parent run reaching into a
+    task that a child run currently owns — see ``_task_mutation_blocked``.
     """
-    coros = [_exec_one_tool(guild_id, tu, user_id) for tu in tool_uses]
+    coros = [_exec_one_tool(guild_id, tu, user_id, own_task_id=own_task_id) for tu in tool_uses]
     return list(await asyncio.gather(*coros))
 
 
@@ -1364,7 +1377,34 @@ def _full_log_content(data_json: str | None) -> str | None:
     return None
 
 
-async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
+def _task_mutation_blocked(guild_id: str, task_id: str, own_task_id: str | None) -> str | None:
+    """Return a user-facing message if *task_id* is owned by a different in-flight
+    Foreman context right now, else None.
+
+    ``own_task_id`` is the task_id of the per-task child context this tool
+    call is itself running in (None for a parent/whole-guild run). A run
+    never conflicts with its own per-task lock — this only fires when a
+    *different* context holds it, which in practice means a parent run
+    (periodic-check or human chat) reaching into a task whose own child run
+    is currently mutating it. See issue #927: parent and child runs key on
+    different (guild_id, key) pairs and would otherwise never serialise
+    against each other for the same task.
+    """
+    if own_task_id == task_id:
+        return None
+    from foreman.runner import is_child_task_run_active  # noqa: PLC0415 — avoids circular import
+
+    if is_child_task_run_active(guild_id, task_id):
+        return (
+            f"Task {task_id} has an in-flight child Foreman run right now — "
+            "skipping this action to avoid racing it. Retry shortly once it completes."
+        )
+    return None
+
+
+async def _exec_one_tool(
+    guild_id: str, tu, user_id: str | None = None, *, own_task_id: str | None = None
+) -> dict:
     """Execute a single tool call and return its tool_result block."""
     inp = tu.input
     result_text = ""
@@ -1768,234 +1808,239 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                 requested_tool: str | None = inp.get("tool")
                 requested_model: str | None = inp.get("model") or None
                 requested_provider: str | None = inp.get("provider") or None
-                result = await db.exec(
-                    select(
-                        col(Task.worker_id),
-                        col(Task.state),
-                        col(Task.branch),
-                        col(Task.description),
-                        col(Task.name),
-                        col(Task.tool),
-                        col(Task.model),
-                        col(Task.provider),
-                        col(Task.issue_number),
-                        col(Task.issue_repo),
-                        col(Task.claude_session_id),
-                    ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
-                )
-                row = result.one_or_none()
-                if not row:
-                    result_text = f"Task {task_id} not found."
+                _blocked = _task_mutation_blocked(guild_id, task_id, own_task_id)
+                if _blocked:
+                    result_text = _blocked
+                    is_error = True
                 else:
-                    (
-                        original_worker_id,
-                        prior_state,
-                        branch,
-                        task_desc,
-                        task_name,
-                        task_tool,
-                        task_model,
-                        task_provider,
-                        task_issue_number,
-                        task_issue_repo,
-                        task_session_id,
-                    ) = row
-                    target_worker_id = await _select_followup_worker(
-                        db,
-                        guild_id=guild_id,
-                        original_worker_id=original_worker_id,
-                        preferred_worker_id=preferred_worker_id,
+                    result = await db.exec(
+                        select(
+                            col(Task.worker_id),
+                            col(Task.state),
+                            col(Task.branch),
+                            col(Task.description),
+                            col(Task.name),
+                            col(Task.tool),
+                            col(Task.model),
+                            col(Task.provider),
+                            col(Task.issue_number),
+                            col(Task.issue_repo),
+                            col(Task.claude_session_id),
+                        ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
                     )
-                    if not target_worker_id:
-                        result_text = (
-                            f"No idle worker available to continue task {task_id} on branch "
-                            f"{branch or '<unknown>'}. Wait for one to come online or shut "
-                            "down a busy worker before retrying."
-                        )
-                        is_error = True
-                    elif not branch:
-                        result_text = (
-                            f"Task {task_id} has no branch recorded — can't dispatch a "
-                            "follow-up. The task may have failed before its first push."
-                        )
-                        is_error = True
+                    row = result.one_or_none()
+                    if not row:
+                        result_text = f"Task {task_id} not found."
                     else:
-                        followup_worker_result = await db.exec(
-                            select(col(Worker.tools), col(Worker.provider)).where(
-                                col(Worker.id) == target_worker_id
-                            )
+                        (
+                            original_worker_id,
+                            prior_state,
+                            branch,
+                            task_desc,
+                            task_name,
+                            task_tool,
+                            task_model,
+                            task_provider,
+                            task_issue_number,
+                            task_issue_repo,
+                            task_session_id,
+                        ) = row
+                        target_worker_id = await _select_followup_worker(
+                            db,
+                            guild_id=guild_id,
+                            original_worker_id=original_worker_id,
+                            preferred_worker_id=preferred_worker_id,
                         )
-                        followup_worker_row = followup_worker_result.one_or_none()
-                        followup_worker_tools_json = (
-                            followup_worker_row[0] if followup_worker_row else None
-                        )
-                        followup_worker_provider = (
-                            followup_worker_row[1] if followup_worker_row else None
-                        )
-                        if isinstance(followup_worker_tools_json, str):
-                            followup_worker_tools: list[str] = json.loads(
-                                followup_worker_tools_json or "[]"
-                            )
-                        else:
-                            followup_worker_tools = followup_worker_tools_json or []
-
-                        if (
-                            requested_tool
-                            and followup_worker_tools
-                            and requested_tool not in followup_worker_tools
-                        ):
-                            available = ", ".join(followup_worker_tools)
+                        if not target_worker_id:
                             result_text = (
-                                f"Worker {target_worker_id} does not support tool "
-                                f"{requested_tool!r}. Available tools: {available}"
+                                f"No idle worker available to continue task {task_id} on branch "
+                                f"{branch or '<unknown>'}. Wait for one to come online or shut "
+                                "down a busy worker before retrying."
+                            )
+                            is_error = True
+                        elif not branch:
+                            result_text = (
+                                f"Task {task_id} has no branch recorded — can't dispatch a "
+                                "follow-up. The task may have failed before its first push."
                             )
                             is_error = True
                         else:
-                            effective_tool = (
+                            followup_worker_result = await db.exec(
+                                select(col(Worker.tools), col(Worker.provider)).where(
+                                    col(Worker.id) == target_worker_id
+                                )
+                            )
+                            followup_worker_row = followup_worker_result.one_or_none()
+                            followup_worker_tools_json = (
+                                followup_worker_row[0] if followup_worker_row else None
+                            )
+                            followup_worker_provider = (
+                                followup_worker_row[1] if followup_worker_row else None
+                            )
+                            if isinstance(followup_worker_tools_json, str):
+                                followup_worker_tools: list[str] = json.loads(
+                                    followup_worker_tools_json or "[]"
+                                )
+                            else:
+                                followup_worker_tools = followup_worker_tools_json or []
+
+                            if (
                                 requested_tool
-                                or task_tool
-                                or (followup_worker_tools[0] if followup_worker_tools else "claude")
-                            )
-                            if requested_model is not None:
-                                effective_model = requested_model
-                            elif requested_tool and requested_tool != task_tool:
-                                # Switching tools invalidates the previous model choice
-                                # (e.g. a claude model id is meaningless to codex/pi) —
-                                # drop it and let the worker pick its own default.
-                                effective_model = None
-                            else:
-                                effective_model = task_model
-                            effective_provider = (
-                                requested_provider
-                                if requested_provider is not None
-                                else task_provider
-                                if task_provider is not None
-                                else followup_worker_provider
-                            )
-                            if effective_model and effective_provider:
-                                from models import ModelCatalog  # noqa: PLC0415
-
-                                catalog_check = await db.exec(
-                                    select(col(ModelCatalog.model_id)).where(
-                                        col(ModelCatalog.provider) == effective_provider,
-                                        col(ModelCatalog.model_id) == effective_model,
-                                    )
-                                )
-                                if catalog_check.one_or_none() is None:
-                                    result_text = (
-                                        f"Model {effective_model!r} is not available for "
-                                        f"provider {effective_provider!r}. Use GET "
-                                        "/api/models to see available models for each provider."
-                                    )
-                                    is_error = True
-
-                        if not is_error:
-                            # Atomically acquire the follow-up lock to prevent two
-                            # concurrent foreman runs from both dispatching a worker.
-                            lock_id = "".join(
-                                random.choices(string.ascii_lowercase + string.digits, k=8)
-                            )
-                            lock_acquired = await LockService(db).acquire(
-                                f"task:{task_id}", owner=lock_id
-                            )
-                            await db.commit()
-                            if not lock_acquired:
-                                # Task already locked by a concurrent follow-up —
-                                # queue this request for replay when the lock releases.
-                                db.add(
-                                    TaskEvent(
-                                        task_id=task_id,
-                                        event_type="pending-followup",
-                                        payload_json=json.dumps(
-                                            {
-                                                "instructions": instructions,
-                                                "preferred_worker_id": preferred_worker_id,
-                                                "tool": requested_tool,
-                                                "model": requested_model,
-                                                "provider": requested_provider,
-                                            }
-                                        ),
-                                        created_at=datetime.now(UTC),
-                                    )
-                                )
-                                await db.commit()
+                                and followup_worker_tools
+                                and requested_tool not in followup_worker_tools
+                            ):
+                                available = ", ".join(followup_worker_tools)
                                 result_text = (
-                                    f"Task {task_id} is locked by an in-progress follow-up. "
-                                    "Instructions have been queued and will be passed to the "
-                                    "foreman when the current follow-up completes."
+                                    f"Worker {target_worker_id} does not support tool "
+                                    f"{requested_tool!r}. Available tools: {available}"
                                 )
+                                is_error = True
                             else:
-                                update_vals: dict = {
-                                    "state": "working",
-                                    "phase": "followup",
-                                    "worker_id": target_worker_id,
-                                    "tool": effective_tool,
-                                    "model": effective_model,
-                                    "provider": effective_provider,
-                                }
-                                if prior_state in ("done", "failed", "cancelled"):
-                                    # Re-opening a terminal task: clear soft-delete so it
-                                    # reappears in the live task list and isn't auto-purged.
-                                    update_vals["deleted_at"] = None
-                                await db.exec(
-                                    update(Task)
-                                    .where(col(Task.id) == task_id)
-                                    .values(**update_vals)
+                                effective_tool = (
+                                    requested_tool
+                                    or task_tool
+                                    or (followup_worker_tools[0] if followup_worker_tools else "claude")
+                                )
+                                if requested_model is not None:
+                                    effective_model = requested_model
+                                elif requested_tool and requested_tool != task_tool:
+                                    # Switching tools invalidates the previous model choice
+                                    # (e.g. a claude model id is meaningless to codex/pi) —
+                                    # drop it and let the worker pick its own default.
+                                    effective_model = None
+                                else:
+                                    effective_model = task_model
+                                effective_provider = (
+                                    requested_provider
+                                    if requested_provider is not None
+                                    else task_provider
+                                    if task_provider is not None
+                                    else followup_worker_provider
+                                )
+                                if effective_model and effective_provider:
+                                    from models import ModelCatalog  # noqa: PLC0415
+
+                                    catalog_check = await db.exec(
+                                        select(col(ModelCatalog.model_id)).where(
+                                            col(ModelCatalog.provider) == effective_provider,
+                                            col(ModelCatalog.model_id) == effective_model,
+                                        )
+                                    )
+                                    if catalog_check.one_or_none() is None:
+                                        result_text = (
+                                            f"Model {effective_model!r} is not available for "
+                                            f"provider {effective_provider!r}. Use GET "
+                                            "/api/models to see available models for each provider."
+                                        )
+                                        is_error = True
+
+                            if not is_error:
+                                # Atomically acquire the follow-up lock to prevent two
+                                # concurrent foreman runs from both dispatching a worker.
+                                lock_id = "".join(
+                                    random.choices(string.ascii_lowercase + string.digits, k=8)
+                                )
+                                lock_acquired = await LockService(db).acquire(
+                                    f"task:{task_id}", owner=lock_id
                                 )
                                 await db.commit()
-                                await broadcast(
-                                    guild_id,
-                                    TaskUpdateMsg(
-                                        taskId=task_id,
-                                        state="working",
-                                        workerId=target_worker_id,
-                                        deletedAt=None,
-                                    ).model_dump(by_alias=True, exclude_none=True),
-                                )
-                                # Only resume the prior agent session when the follow-up
-                                # stays on the same worker — a different machine won't
-                                # have the session data on disk (see _select_followup_worker).
-                                followup_session_id = (
-                                    task_session_id
-                                    if target_worker_id == original_worker_id
-                                    else None
-                                )
-                                await broadcast(
-                                    guild_id,
-                                    TaskFollowupMsg(
-                                        workerId=target_worker_id,
-                                        taskId=task_id,
-                                        name=task_name or "",
-                                        description=task_desc or "",
-                                        tool=effective_tool,
-                                        model=effective_model,
-                                        provider=effective_provider,
-                                        branch=branch,
-                                        instructions=instructions,
-                                        issueNumber=task_issue_number,
-                                        issueRepo=task_issue_repo,
-                                        sessionId=followup_session_id,
-                                    ).model_dump(by_alias=True, exclude_none=True),
-                                )
-                                spawn(
-                                    notify_discord_followup(
-                                        task_issue_repo,
-                                        task_issue_number,
-                                        task_id,
-                                        instructions,
-                                    ),
-                                    name=f"discord.followup:{task_id}",
-                                )
-                                if target_worker_id != original_worker_id and original_worker_id:
+                                if not lock_acquired:
+                                    # Task already locked by a concurrent follow-up —
+                                    # queue this request for replay when the lock releases.
+                                    db.add(
+                                        TaskEvent(
+                                            task_id=task_id,
+                                            event_type="pending-followup",
+                                            payload_json=json.dumps(
+                                                {
+                                                    "instructions": instructions,
+                                                    "preferred_worker_id": preferred_worker_id,
+                                                    "tool": requested_tool,
+                                                    "model": requested_model,
+                                                    "provider": requested_provider,
+                                                }
+                                            ),
+                                            created_at=datetime.now(UTC),
+                                        )
+                                    )
+                                    await db.commit()
                                     result_text = (
-                                        f"Follow-up reassigned from {original_worker_id} "
-                                        f"to {target_worker_id} (task {task_id} on branch {branch})."
+                                        f"Task {task_id} is locked by an in-progress follow-up. "
+                                        "Instructions have been queued and will be passed to the "
+                                        "foreman when the current follow-up completes."
                                     )
                                 else:
-                                    result_text = (
-                                        f"Follow-up sent to {target_worker_id} for task {task_id} "
-                                        f"on branch {branch}."
+                                    update_vals: dict = {
+                                        "state": "working",
+                                        "phase": "followup",
+                                        "worker_id": target_worker_id,
+                                        "tool": effective_tool,
+                                        "model": effective_model,
+                                        "provider": effective_provider,
+                                    }
+                                    if prior_state in ("done", "failed", "cancelled"):
+                                        # Re-opening a terminal task: clear soft-delete so it
+                                        # reappears in the live task list and isn't auto-purged.
+                                        update_vals["deleted_at"] = None
+                                    await db.exec(
+                                        update(Task)
+                                        .where(col(Task.id) == task_id)
+                                        .values(**update_vals)
                                     )
+                                    await db.commit()
+                                    await broadcast(
+                                        guild_id,
+                                        TaskUpdateMsg(
+                                            taskId=task_id,
+                                            state="working",
+                                            workerId=target_worker_id,
+                                            deletedAt=None,
+                                        ).model_dump(by_alias=True, exclude_none=True),
+                                    )
+                                    # Only resume the prior agent session when the follow-up
+                                    # stays on the same worker — a different machine won't
+                                    # have the session data on disk (see _select_followup_worker).
+                                    followup_session_id = (
+                                        task_session_id
+                                        if target_worker_id == original_worker_id
+                                        else None
+                                    )
+                                    await broadcast(
+                                        guild_id,
+                                        TaskFollowupMsg(
+                                            workerId=target_worker_id,
+                                            taskId=task_id,
+                                            name=task_name or "",
+                                            description=task_desc or "",
+                                            tool=effective_tool,
+                                            model=effective_model,
+                                            provider=effective_provider,
+                                            branch=branch,
+                                            instructions=instructions,
+                                            issueNumber=task_issue_number,
+                                            issueRepo=task_issue_repo,
+                                            sessionId=followup_session_id,
+                                        ).model_dump(by_alias=True, exclude_none=True),
+                                    )
+                                    spawn(
+                                        notify_discord_followup(
+                                            task_issue_repo,
+                                            task_issue_number,
+                                            task_id,
+                                            instructions,
+                                        ),
+                                        name=f"discord.followup:{task_id}",
+                                    )
+                                    if target_worker_id != original_worker_id and original_worker_id:
+                                        result_text = (
+                                            f"Follow-up reassigned from {original_worker_id} "
+                                            f"to {target_worker_id} (task {task_id} on branch {branch})."
+                                        )
+                                    else:
+                                        result_text = (
+                                            f"Follow-up sent to {target_worker_id} for task {task_id} "
+                                            f"on branch {branch}."
+                                        )
 
             elif tu.name == "finalize_task":
                 task_id = inp["task_id"]
@@ -2005,77 +2050,82 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
                     logger.warning(
                         "finalize_task: unknown outcome %r, defaulting to 'done'", raw_outcome
                     )
-                deleted_at, err = _resolve_finalize_deleted_at(inp)
-                if err:
-                    result_text = err
+                _blocked = _task_mutation_blocked(guild_id, task_id, own_task_id)
+                if _blocked:
+                    result_text = _blocked
                     is_error = True
                 else:
-                    result = await db.exec(
-                        select(Task)
-                        .where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
-                        .with_for_update()
-                    )
-                    task = result.one_or_none()
-                    if not task:
-                        result_text = f"Task {task_id} not found."
+                    deleted_at, err = _resolve_finalize_deleted_at(inp)
+                    if err:
+                        result_text = err
+                        is_error = True
                     else:
-                        await db.exec(
-                            update(Task)
-                            .where(col(Task.id) == task_id)
-                            .values(
-                                state=outcome,
-                                deleted_at=deleted_at,
-                            )
+                        result = await db.exec(
+                            select(Task)
+                            .where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+                            .with_for_update()
                         )
-                        # Discard any queued follow-up events — the task is closed.
-                        await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
-                        await LockService(db).release(f"task:{task_id}")
+                        task = result.one_or_none()
+                        if not task:
+                            result_text = f"Task {task_id} not found."
+                        else:
+                            await db.exec(
+                                update(Task)
+                                .where(col(Task.id) == task_id)
+                                .values(
+                                    state=outcome,
+                                    deleted_at=deleted_at,
+                                )
+                            )
+                            # Discard any queued follow-up events — the task is closed.
+                            await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
+                            await LockService(db).release(f"task:{task_id}")
 
-                        # phase='issue' root tasks own an entire GitHub issue's worth of
-                        # work — cascade the soft-delete to descendants that already
-                        # finished, but never force-close in-progress/pending ones (a
-                        # human decides whether to cancel in-flight work).
-                        descendants: list[Task] = []
-                        if task.phase == "issue":
-                            descendants = await find_descendant_tasks(db, task_id)
-                            await cascade_soft_delete_terminal_descendants(
-                                db, descendants, deleted_at
-                            )
+                            # phase='issue' root tasks own an entire GitHub issue's worth of
+                            # work — cascade the soft-delete to descendants that already
+                            # finished, but never force-close in-progress/pending ones (a
+                            # human decides whether to cancel in-flight work).
+                            descendants: list[Task] = []
+                            if task.phase == "issue":
+                                descendants = await find_descendant_tasks(db, task_id)
+                                await cascade_soft_delete_terminal_descendants(
+                                    db, descendants, deleted_at
+                                )
 
-                        await db.commit()
-                        await broadcast_msg(
-                            guild_id,
-                            TaskFinalizeMsg(workerId=task.worker_id, taskId=task_id),
-                        )
-                        await broadcast_msg(
-                            guild_id,
-                            TaskUpdateMsg(
-                                taskId=task_id,
-                                state=outcome,
-                                deletedAt=deleted_at.isoformat()
-                                if deleted_at is not None
-                                else None,
-                            ),
-                        )
-                        if (
-                            task.phase == "issue"
-                            and task.issue_repo
-                            and task.issue_number is not None
-                        ):
-                            await post_issue_close_summary_comment(
-                                guild_id, task.issue_repo, task.issue_number, descendants
+                            await db.commit()
+                            await broadcast_msg(
+                                guild_id,
+                                TaskFinalizeMsg(workerId=task.worker_id, taskId=task_id),
                             )
-                        if outcome == "failed":
-                            spawn(
-                                notify_discord_task_finalized(
-                                    task.issue_repo, task.issue_number, task_id, "failed"
+                            await broadcast_msg(
+                                guild_id,
+                                TaskUpdateMsg(
+                                    taskId=task_id,
+                                    state=outcome,
+                                    deletedAt=deleted_at.isoformat()
+                                    if deleted_at is not None
+                                    else None,
                                 ),
-                                name=f"discord.finalize:{task_id}",
                             )
-                        result_text = (
-                            f"Task {task_id} finalized as {outcome}; soft-delete at "
-                            f"{deleted_at.isoformat() if deleted_at is not None else 'unknown'}."
-                        )
+                            if (
+                                task.phase == "issue"
+                                and task.issue_repo
+                                and task.issue_number is not None
+                            ):
+                                await post_issue_close_summary_comment(
+                                    guild_id, task.issue_repo, task.issue_number, descendants
+                                )
+                            if outcome == "failed":
+                                spawn(
+                                    notify_discord_task_finalized(
+                                        task.issue_repo, task.issue_number, task_id, "failed"
+                                    ),
+                                    name=f"discord.finalize:{task_id}",
+                                )
+                            result_text = (
+                                f"Task {task_id} finalized as {outcome}; soft-delete at "
+                                f"{deleted_at.isoformat() if deleted_at is not None else 'unknown'}."
+                            )
 
             elif tu.name == "message_worker":
                 wid = inp["worker_id"]
@@ -2087,104 +2137,114 @@ async def _exec_one_tool(guild_id: str, tu, user_id: str | None = None) -> dict:
             elif tu.name == "redirect_task":
                 task_id = inp["task_id"]
                 instructions = inp["instructions"]
-                result = await db.exec(
-                    select(
-                        col(Task.worker_id),
-                        col(Task.state),
-                        col(Task.issue_number),
-                        col(Task.issue_repo),
-                    ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
-                )
-                row = result.one_or_none()
-                if not row:
-                    result_text = f"Task {task_id} not found."
+                _blocked = _task_mutation_blocked(guild_id, task_id, own_task_id)
+                if _blocked:
+                    result_text = _blocked
+                    is_error = True
                 else:
-                    worker_id_val, state, redirect_issue_number, redirect_issue_repo = row
-                    if state in ("done", "failed", "cancelled"):
-                        result_text = f"Task {task_id} is {state} — cannot redirect."
+                    result = await db.exec(
+                        select(
+                            col(Task.worker_id),
+                            col(Task.state),
+                            col(Task.issue_number),
+                            col(Task.issue_repo),
+                        ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+                    )
+                    row = result.one_or_none()
+                    if not row:
+                        result_text = f"Task {task_id} not found."
                     else:
-                        await db.exec(
-                            update(Task).where(col(Task.id) == task_id).values(state="working")
-                        )
-                        await db.commit()
-                        await broadcast_msg(
-                            guild_id,
-                            TaskRedirectMsg(
-                                workerId=worker_id_val, taskId=task_id, instructions=instructions
-                            ),
-                        )
-                        await broadcast_msg(
-                            guild_id, TaskUpdateMsg(taskId=task_id, state="working")
-                        )
-                        if redirect_issue_number is not None and redirect_issue_repo:
-                            spawn(
-                                notify_discord_redirect(
-                                    redirect_issue_repo,
-                                    redirect_issue_number,
-                                    task_id,
-                                    instructions,
-                                ),
-                                name=f"discord.redirect:{task_id}",
+                        worker_id_val, state, redirect_issue_number, redirect_issue_repo = row
+                        if state in ("done", "failed", "cancelled"):
+                            result_text = f"Task {task_id} is {state} — cannot redirect."
+                        else:
+                            await db.exec(
+                                update(Task).where(col(Task.id) == task_id).values(state="working")
                             )
-                        result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
+                            await db.commit()
+                            await broadcast_msg(
+                                guild_id,
+                                TaskRedirectMsg(
+                                    workerId=worker_id_val, taskId=task_id, instructions=instructions
+                                ),
+                            )
+                            await broadcast_msg(
+                                guild_id, TaskUpdateMsg(taskId=task_id, state="working")
+                            )
+                            if redirect_issue_number is not None and redirect_issue_repo:
+                                spawn(
+                                    notify_discord_redirect(
+                                        redirect_issue_repo,
+                                        redirect_issue_number,
+                                        task_id,
+                                        instructions,
+                                    ),
+                                    name=f"discord.redirect:{task_id}",
+                                )
+                            result_text = f"Redirect sent to {worker_id_val} for task {task_id}."
 
             elif tu.name == "cancel_task":
                 task_id = inp["task_id"]
                 reason = inp.get("reason", "")
-                result = await db.exec(
-                    select(
-                        col(Task.worker_id),
-                        col(Task.state),
-                        col(Task.issue_repo),
-                        col(Task.issue_number),
-                    ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
-                )
-                row = result.one_or_none()
-                if not row:
-                    result_text = f"Task {task_id} not found."
+                _blocked = _task_mutation_blocked(guild_id, task_id, own_task_id)
+                if _blocked:
+                    result_text = _blocked
+                    is_error = True
                 else:
-                    worker_id_val, state, cancel_issue_repo, cancel_issue_number = row
-                    if state in ("done", "failed", "cancelled"):
-                        result_text = f"Task {task_id} is already {state}."
+                    result = await db.exec(
+                        select(
+                            col(Task.worker_id),
+                            col(Task.state),
+                            col(Task.issue_repo),
+                            col(Task.issue_number),
+                        ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+                    )
+                    row = result.one_or_none()
+                    if not row:
+                        result_text = f"Task {task_id} not found."
                     else:
-                        deleted_at = datetime.now(UTC) + timedelta(
-                            seconds=DEFAULT_FINALIZE_TTL_SECONDS
-                        )
-                        await db.exec(
-                            update(Task)
-                            .where(col(Task.id) == task_id)
-                            .values(
-                                state="cancelled",
-                                deleted_at=deleted_at,
+                        worker_id_val, state, cancel_issue_repo, cancel_issue_number = row
+                        if state in ("done", "failed", "cancelled"):
+                            result_text = f"Task {task_id} is already {state}."
+                        else:
+                            deleted_at = datetime.now(UTC) + timedelta(
+                                seconds=DEFAULT_FINALIZE_TTL_SECONDS
                             )
-                        )
-                        await LockService(db).release(f"task:{task_id}")
-                        await db.commit()
-                        await broadcast_msg(
-                            guild_id,
-                            TaskCancelMsg(workerId=worker_id_val, taskId=task_id),
-                        )
-                        await broadcast_msg(
-                            guild_id,
-                            TaskUpdateMsg(
-                                taskId=task_id,
-                                state="cancelled",
-                                deletedAt=deleted_at.isoformat(),
-                            ),
-                        )
-                        spawn(
-                            notify_discord_task_finalized(
-                                cancel_issue_repo,
-                                cancel_issue_number,
-                                task_id,
-                                "cancelled",
-                                reason=reason or None,
-                            ),
-                            name=f"discord.cancel:{task_id}",
-                        )
-                        result_text = f"Task {task_id} cancelled." + (
-                            f" Reason: {reason}" if reason else ""
-                        )
+                            await db.exec(
+                                update(Task)
+                                .where(col(Task.id) == task_id)
+                                .values(
+                                    state="cancelled",
+                                    deleted_at=deleted_at,
+                                )
+                            )
+                            await LockService(db).release(f"task:{task_id}")
+                            await db.commit()
+                            await broadcast_msg(
+                                guild_id,
+                                TaskCancelMsg(workerId=worker_id_val, taskId=task_id),
+                            )
+                            await broadcast_msg(
+                                guild_id,
+                                TaskUpdateMsg(
+                                    taskId=task_id,
+                                    state="cancelled",
+                                    deletedAt=deleted_at.isoformat(),
+                                ),
+                            )
+                            spawn(
+                                notify_discord_task_finalized(
+                                    cancel_issue_repo,
+                                    cancel_issue_number,
+                                    task_id,
+                                    "cancelled",
+                                    reason=reason or None,
+                                ),
+                                name=f"discord.cancel:{task_id}",
+                            )
+                            result_text = f"Task {task_id} cancelled." + (
+                                f" Reason: {reason}" if reason else ""
+                            )
 
             elif tu.name == "shutdown_worker":
                 wid = inp["worker_id"]

--- a/backend/tests/test_foreman_runner.py
+++ b/backend/tests/test_foreman_runner.py
@@ -13,6 +13,8 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
@@ -214,6 +216,126 @@ def test_exec_tools_partial_failure_still_returns_all():
 # ---------------------------------------------------------------------------
 # GitHub error tests
 # ---------------------------------------------------------------------------
+
+
+
+# ---------------------------------------------------------------------------
+# Cross-context task lock tests (issue #927)
+#
+# Parent (whole-guild) runs and per-task child runs used to key their
+# `_guild_locks` serialisation entries differently — (guild_id, user_id) for
+# parents vs. (guild_id, "task:<id>") for children — so the two never
+# serialised against each other even when targeting the very same task. These
+# tests exercise the gate added to send_followup/redirect_task/cancel_task/
+# finalize_task that checks the other context's lock before mutating.
+# ---------------------------------------------------------------------------
+
+
+def test_is_child_task_run_active_reflects_guild_locks_state():
+    """is_child_task_run_active must track the same (guild, "task:<id>") lock
+    entries run_foreman_ai uses to serialise per-task child runs."""
+    from foreman.runner import _GuildRunLock, _guild_locks, is_child_task_run_active
+
+    guild_id = "g-lockcheck"
+    task_id = "t-lockcheck1"
+    key = (guild_id, f"task:{task_id}")
+
+    assert is_child_task_run_active(guild_id, task_id) is False
+
+    _guild_locks[key] = _GuildRunLock(busy=True)
+    try:
+        assert is_child_task_run_active(guild_id, task_id) is True
+        _guild_locks[key].busy = False
+        assert is_child_task_run_active(guild_id, task_id) is False
+    finally:
+        _guild_locks.pop(key, None)
+
+
+def _with_child_lock_busy(guild_id: str, task_id: str):
+    """Context manager marking (guild_id, "task:<task_id>") busy in _guild_locks,
+    mimicking an in-flight per-task child Foreman run."""
+    from contextlib import contextmanager
+
+    from foreman.runner import _GuildRunLock, _guild_locks
+
+    @contextmanager
+    def _cm():
+        key = (guild_id, f"task:{task_id}")
+        _guild_locks[key] = _GuildRunLock(busy=True)
+        try:
+            yield
+        finally:
+            _guild_locks.pop(key, None)
+
+    return _cm()
+
+
+@pytest.mark.parametrize(
+    "tool_name,extra_input",
+    [
+        ("send_followup", {"instructions": "fix ci"}),
+        ("redirect_task", {"instructions": "do something else"}),
+        ("cancel_task", {"reason": "no longer needed"}),
+        ("finalize_task", {}),
+    ],
+)
+def test_parent_run_blocked_when_child_run_active(tool_name, extra_input):
+    """A parent-context tool call (own_task_id=None) targeting a task whose
+    own child run currently holds the lock must be skipped, not executed."""
+    from foreman.tools import exec_tools
+
+    guild_id = "g-parent-vs-child"
+    task_id = "t-race1"
+    tu = _mock_tool_use(tool_name, f"toolu_{tool_name}", {"task_id": task_id, **extra_input})
+
+    with _with_child_lock_busy(guild_id, task_id):
+        with patch("foreman.tools.get_db", AsyncMock(return_value=_mock_session())):
+            results = _run(exec_tools(guild_id, [tu], own_task_id=None))
+
+    r = results[0]
+    assert r.get("is_error") is True
+    assert "in-flight child" in r["content"]
+
+
+@pytest.mark.parametrize(
+    "tool_name,extra_input",
+    [
+        ("send_followup", {"instructions": "fix ci"}),
+        ("redirect_task", {"instructions": "do something else"}),
+        ("cancel_task", {"reason": "no longer needed"}),
+        ("finalize_task", {}),
+    ],
+)
+def test_child_run_not_blocked_by_its_own_lock(tool_name, extra_input):
+    """A child run mutating its own task must never be blocked by the very
+    lock entry it holds — own_task_id == task_id must skip the gate."""
+    from foreman.tools import exec_tools
+
+    guild_id = "g-child-self"
+    task_id = "t-self1"
+    tu = _mock_tool_use(tool_name, f"toolu_{tool_name}", {"task_id": task_id, **extra_input})
+
+    with _with_child_lock_busy(guild_id, task_id):
+        with patch("foreman.tools.get_db", AsyncMock(return_value=_mock_session())):
+            results = _run(exec_tools(guild_id, [tu], own_task_id=task_id))
+
+    r = results[0]
+    assert "in-flight child" not in r["content"]
+
+
+def test_parent_run_not_blocked_when_no_child_run_active():
+    """Baseline: with no competing lock held, the parent gate is a no-op."""
+    from foreman.tools import exec_tools
+
+    guild_id = "g-no-race"
+    task_id = "t-norace1"
+    tu = _mock_tool_use("cancel_task", "toolu_norace", {"task_id": task_id})
+
+    with patch("foreman.tools.get_db", AsyncMock(return_value=_mock_session())):
+        results = _run(exec_tools(guild_id, [tu], own_task_id=None))
+
+    r = results[0]
+    assert "in-flight child" not in r["content"]
 
 
 def test_exec_tools_github_http_error_sets_is_error():

--- a/backend/tests/test_foreman_runner.py
+++ b/backend/tests/test_foreman_runner.py
@@ -218,7 +218,6 @@ def test_exec_tools_partial_failure_still_returns_all():
 # ---------------------------------------------------------------------------
 
 
-
 # ---------------------------------------------------------------------------
 # Cross-context task lock tests (issue #927)
 #
@@ -234,7 +233,7 @@ def test_exec_tools_partial_failure_still_returns_all():
 def test_is_child_task_run_active_reflects_guild_locks_state():
     """is_child_task_run_active must track the same (guild, "task:<id>") lock
     entries run_foreman_ai uses to serialise per-task child runs."""
-    from foreman.runner import _GuildRunLock, _guild_locks, is_child_task_run_active
+    from foreman.runner import _guild_locks, _GuildRunLock, is_child_task_run_active
 
     guild_id = "g-lockcheck"
     task_id = "t-lockcheck1"
@@ -256,7 +255,7 @@ def _with_child_lock_busy(guild_id: str, task_id: str):
     mimicking an in-flight per-task child Foreman run."""
     from contextlib import contextmanager
 
-    from foreman.runner import _GuildRunLock, _guild_locks
+    from foreman.runner import _guild_locks, _GuildRunLock
 
     @contextmanager
     def _cm():


### PR DESCRIPTION
## Summary
- Parent (whole-guild) runs and per-task child runs keyed their `_guild_locks` serialization entries differently — `(guild_id, user_id)` vs `(guild_id, "task:<id>")` — so a parent `periodic-check` run could race an in-flight child run mutating the same task.
- Adds `is_child_task_run_active(guild_id, task_id)` in `backend/foreman/runner.py`, which reads the same `_guild_locks` busy-flag state child runs claim under `(guild_id, "task:<id>")`.
- `send_followup`, `redirect_task`, `cancel_task`, and `finalize_task` in `backend/foreman/tools.py` now call `_task_mutation_blocked` before mutating a task: if a *different* context (i.e. not the run's own child context) holds that task's lock, the tool call is skipped with an `is_error` result instead of racing it. A child run's own mutation of its own task is never blocked.
- `exec_tools`/`_exec_one_tool` take a new `own_task_id` param (the calling run's own per-task child id, `None` for parent runs), threaded through from `_run_foreman_ai`'s existing `_task_id`.

Closes #927.

## Test plan
- [x] `pytest backend/tests/test_foreman_runner.py -q` — 19 passed, including new cross-context lock tests: parent blocked by an active child lock, child never blocked by its own lock, and a no-op baseline when no lock is held, across all four task-mutating tools.
- [x] Confirmed the wider `backend/tests` suite's pre-existing failures (DB connection errors) are unrelated to this change — they occur identically on unrelated tests due to no Postgres instance in this sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)