### PR TITLE
fix: bearer-token auth for Bedrock Converse (Kimi/Nova) path

### DIFF
--- a/backend/foreman/llm.py
+++ b/backend/foreman/llm.py
@@ -311,9 +311,16 @@ def make_anthropic_client(
 
         if is_native_bedrock_model(resolved_model):
             logger.info(
-                "Foreman using Amazon Bedrock Converse API (region=%s, profile=%s, model=%s)",
+                "Foreman using Amazon Bedrock Converse API (region=%s, profile=%s, auth=%s, model=%s)",
                 resolved_region,
                 resolved_profile,
+                "bearer-token"
+                if env.get("AWS_BEARER_TOKEN_BEDROCK")
+                else (
+                    "explicit-keys"
+                    if (env.get("AWS_ACCESS_KEY_ID") and env.get("AWS_SECRET_ACCESS_KEY"))
+                    else "sigv4"
+                ),
                 resolved_model,
             )
             return BedrockNativeClient(

--- a/backend/foreman/providers/bedrock.py
+++ b/backend/foreman/providers/bedrock.py
@@ -74,7 +74,7 @@ def is_native_bedrock_model(model: str) -> bool:
 # boto3 client cache
 # ---------------------------------------------------------------------------
 
-_clients: dict[tuple[str, str | None, str | None, str | None], Any] = {}
+_clients: dict[tuple[str, str | None, str | None, str | None, str | None], Any] = {}
 
 
 def _get_client(region: str, profile: str | None, extra_env: Mapping[str, str] | None):
@@ -85,9 +85,30 @@ def _get_client(region: str, profile: str | None, extra_env: Mapping[str, str] |
     access_key = env.get("AWS_ACCESS_KEY_ID")
     secret_key = env.get("AWS_SECRET_ACCESS_KEY")
     session_token = env.get("AWS_SESSION_TOKEN")
+    # Bedrock API-key (bearer-token) auth. Mirrors the AsyncAnthropicBedrock
+    # path in foreman.llm, which feeds AWS_BEARER_TOKEN_BEDROCK to the SDK's
+    # `api_key`. boto3 can only pick a bearer token up from os.environ (its
+    # token provider ignores any per-client env overlay), but the guild's token
+    # arrives here in `extra_env`, not the process env — so we can't rely on
+    # boto3's automatic resolution. Instead we force the bearer signer and hand
+    # it the token directly, keeping the token per-guild rather than leaking it
+    # into the shared process environment.
+    bearer_token = env.get("AWS_BEARER_TOKEN_BEDROCK")
 
-    cache_key = (region, profile, access_key, secret_key)
+    cache_key = (region, profile, access_key, secret_key, bearer_token)
     if cache_key not in _clients:
+        if bearer_token:
+            from botocore.config import Config
+            from botocore.tokens import FrozenAuthToken
+
+            session = boto3.Session(region_name=region)
+            client = session.client(
+                "bedrock-runtime", config=Config(signature_version="bearer")
+            )
+            client._request_signer._auth_token = FrozenAuthToken(bearer_token)
+            _clients[cache_key] = client
+            return _clients[cache_key]
+
         session_kwargs: dict[str, Any] = {"region_name": region}
         if access_key and secret_key:
             session_kwargs["aws_access_key_id"] = access_key

--- a/backend/tests/test_bedrock_provider.py
+++ b/backend/tests/test_bedrock_provider.py
@@ -205,6 +205,39 @@ async def test_bedrock_native_client_create_success(monkeypatch):
     assert call_kwargs["inferenceConfig"] == {"maxTokens": 100}
 
 
+async def test_bedrock_native_client_uses_bearer_token(monkeypatch):
+    """A bearer token in extra_env forces the bearer signer and is handed to
+    the client directly — boto3's own token provider only reads os.environ,
+    which never carries the guild-supplied token."""
+    fake_boto_client = MagicMock()
+    fake_boto_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "ok"}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 1, "outputTokens": 1},
+        "ResponseMetadata": {"HTTPStatusCode": 200, "RequestId": "req-1"},
+    }
+    fake_session = MagicMock()
+    fake_session.client.return_value = fake_boto_client
+
+    with patch("foreman.providers.bedrock.boto3") as fake_boto3:
+        fake_boto3.Session.return_value = fake_session
+        client = BedrockNativeClient(
+            region="us-east-1", extra_env={"AWS_BEARER_TOKEN_BEDROCK": "tok-abc"}
+        )
+        await client.messages.with_raw_response.create(
+            model="moonshotai.kimi-k2.5",
+            max_tokens=100,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    # Client built with the bearer signature version, and the token injected.
+    config = fake_session.client.call_args.kwargs["config"]
+    assert config.signature_version == "bearer"
+    assert fake_boto_client._request_signer._auth_token.token == "tok-abc"
+    # No AWS keys/profile passed on the session when using a bearer token.
+    assert fake_boto3.Session.call_args.kwargs == {"region_name": "us-east-1"}
+
+
 async def test_bedrock_native_client_create_without_boto3_raises():
     with (
         patch("foreman.providers.bedrock.HAS_BOTO3", False),


### PR DESCRIPTION
## Problem

Running the foreman with a native Bedrock model (Kimi K2, Nova, …) failed immediately:

```
foreman.llm  - Foreman using Amazon Bedrock Converse API (region=us-east-1, model=moonshotai.kimi-k2.5)
api.latency  - WARNING - provider=bedrock endpoint=moonshotai.kimi-k2.5 method=Converse       status=error error='NoCredentialsError: Unable to locate credentials'
```

Native models route through the Bedrock **Converse API** via boto3 (`BedrockNativeClient`), which only knew how to authenticate with SigV4 keys/profile. The guild's Bedrock API key (`AWS_BEARER_TOKEN_BEDROCK`) arrives in the **per-guild env overlay**, not the container's `os.environ` — and boto3's own bearer-token provider (`get_token_from_environment`) reads **only `os.environ`**. So Converse calls never saw the token, fell back to SigV4, and died with `NoCredentialsError`.

The Claude-on-Bedrock path (`AsyncAnthropicBedrock`) was unaffected because it feeds the token straight to the SDK's `api_key`.

## Fix

When a bearer token is present in the env overlay, build the `bedrock-runtime` client with `signature_version="bearer"` and inject the token into the request signer directly (`FrozenAuthToken`). This:

- bypasses boto3's `os.environ`-only token detection, and
- keeps the token **per-guild** rather than leaking it into the shared process environment (mirroring how the `AsyncAnthropicBedrock` path already handles it via `api_key`).

Also adds `auth=<mode>` to the Converse-path log line (parity with the Claude-on-Bedrock path) so this is diagnosable from the logs next time.

## Verification

- Rebuilt and ran the real foreman against `moonshotai.kimi-k2.5`: Converse calls now return `status=200` (was `NoCredentialsError`), and the model produces normal `end_turn` responses.
- Verified on the wire that forcing the bearer signer + injecting the token yields `Authorization: Bearer <token>`.
- New unit test `test_bedrock_native_client_uses_bearer_token`; `test_bedrock_provider.py` + `test_foreman_llm.py` → **64 passed**.

## Scope / not included

During testing I also saw the Kimi foreman occasionally spin through the 10-round `get_task_status` safety cap. I investigated the Anthropic↔Converse tool-result round-tripping (translation, duplicate `toolUseId`s, `strip_orphaned_tool_results`) and found all of them correct in controlled tests against live Kimi — the loop was not reproducible in isolation and has no confirmed root cause, so no speculative fix is included here. This PR is scoped to the verified credential fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)