### PR TITLE
fix: Kimi/Nova Converse tool loop — preserve content blocks through serialization

### DIFF
--- a/backend/foreman/providers/bedrock.py
+++ b/backend/foreman/providers/bedrock.py
@@ -284,7 +284,16 @@ class _RawConverseResponse:
 
 
 def _response_dict_to_namespace(raw: dict[str, Any]) -> SimpleNamespace:
-    content = [SimpleNamespace(**block) for block in raw.get("content") or []]
+    # Each content block carries its own ``model_dump()`` returning the original
+    # dict, so ``message_utils._serialize_content`` round-trips it losslessly.
+    # Without it, that helper falls back to ``{"type": ..., "raw": str(block)}``,
+    # dropping ``id``/``name``/``input`` from tool_use blocks — which then get
+    # stripped as orphans and the model never sees its tool results (infinite
+    # tool loop for Kimi/Nova on the Converse path).
+    content = [
+        SimpleNamespace(**block, model_dump=lambda block=block: block)
+        for block in raw.get("content") or []
+    ]
     usage = SimpleNamespace(**(raw.get("usage") or {}))
     return SimpleNamespace(
         id=raw.get("id"),

--- a/backend/tests/test_bedrock_provider.py
+++ b/backend/tests/test_bedrock_provider.py
@@ -156,6 +156,51 @@ def test_converse_response_to_anthropic_tool_use():
     assert result["stop_reason"] == "tool_use"
 
 
+def test_response_namespace_blocks_serialize_losslessly():
+    """Regression: content blocks from the Converse path must survive
+    ``_serialize_content`` with their fields intact. Before, they were bare
+    SimpleNamespaces with no ``model_dump()``, so a tool_use block collapsed to
+    ``{"type": "tool_use", "raw": "namespace(...)"}`` — losing id/name/input.
+    ``strip_orphaned_tool_results`` then dropped the tool_use (id=None) and its
+    tool_result, so Kimi/Nova never saw the result and looped forever.
+    """
+    import json
+
+    from foreman.message_utils import _serialize_content, strip_orphaned_tool_results
+    from foreman.providers.bedrock import _response_dict_to_namespace
+
+    adict = converse_response_to_anthropic(
+        {
+            "output": {
+                "message": {
+                    "content": [
+                        {"text": " Let me check the task."},
+                        {"toolUse": {"toolUseId": "tu-1", "name": "get_task_status", "input": {"task_id": "t-1"}}},
+                    ]
+                }
+            },
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 10, "outputTokens": 2},
+        },
+        "moonshotai.kimi-k2.5",
+    )
+    ns = _response_dict_to_namespace(adict)
+
+    blocks = json.loads(_serialize_content(ns.content))
+    assert blocks == [
+        {"type": "text", "text": " Let me check the task."},
+        {"type": "tool_use", "id": "tu-1", "name": "get_task_status", "input": {"task_id": "t-1"}},
+    ]
+
+    # The tool_result must survive orphan-stripping (i.e. its tool_use is intact).
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "state"}]},
+        {"role": "assistant", "content": blocks},
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu-1", "content": "pending"}]},
+    ]
+    assert len(strip_orphaned_tool_results(messages)) == 3
+
+
 # ---------------------------------------------------------------------------
 # BedrockNativeClient.create — mocked boto3
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Recent `moonshotai.kimi-k2.5` foreman turns were getting stuck in an infinite tool loop. The `api_request_log` table showed every round returning `stop_reason=tool_use`, input tokens frozen at ~11382, and the same `get_task_status` call repeated indefinitely until the round cap.

Inspecting the stored request `messages` revealed corrupted assistant blocks:

```json
{"raw": "namespace(type='text', text=\" I'll check on the pending task...\")", "type": "text"}
```

The `tool_use` blocks were **gone entirely**, and no `tool_result` messages appeared at all — so Kimi never saw the outcome of its tool call and kept re-issuing it.

## Root cause

The native-Bedrock Converse path (Kimi/Nova only) built content blocks as bare `SimpleNamespace` objects with no `model_dump()` (`bedrock.py`). That tripped the lossy fallback in `_serialize_content` (`message_utils.py`), which stringifies each block into `{"type": ..., "raw": str(b)}`, **discarding `id`/`name`/`input`** from tool_use blocks.

With the tool_use `id` now `None`, `strip_orphaned_tool_results` treated both the tool_use and its matching tool_result as orphans and deleted them. The model only ever received its own text-only narration, never a tool result → infinite loop.

The Anthropic SDK path was unaffected (its blocks are real pydantic objects with `.model_dump()`).

## Fix

Give each Converse content block its own `model_dump()` returning the original dict, so `_serialize_content` round-trips it losslessly.

Adds a regression test asserting a Converse tool_use block serializes with all fields intact and survives orphan-stripping.

## Testing

- `pytest tests/test_bedrock_provider.py` — 25 passed (24 existing + 1 new regression test)
- Verified end-to-end with a round-trip reproduction against the real `converse_response_to_anthropic` → `_serialize_content` → `strip_orphaned_tool_results` code path.

Note: the running foreman process needs a restart to pick up the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)