### PR TITLE
fix: ruff format fixes for bedrock files

### DIFF
--- a/backend/foreman/providers/bedrock.py
+++ b/backend/foreman/providers/bedrock.py
@@ -102,9 +102,7 @@ def _get_client(region: str, profile: str | None, extra_env: Mapping[str, str] |
             from botocore.tokens import FrozenAuthToken
 
             session = boto3.Session(region_name=region)
-            client = session.client(
-                "bedrock-runtime", config=Config(signature_version="bearer")
-            )
+            client = session.client("bedrock-runtime", config=Config(signature_version="bearer"))
             client._request_signer._auth_token = FrozenAuthToken(bearer_token)
             _clients[cache_key] = client
             return _clients[cache_key]

--- a/backend/tests/test_bedrock_provider.py
+++ b/backend/tests/test_bedrock_provider.py
@@ -175,7 +175,13 @@ def test_response_namespace_blocks_serialize_losslessly():
                 "message": {
                     "content": [
                         {"text": " Let me check the task."},
-                        {"toolUse": {"toolUseId": "tu-1", "name": "get_task_status", "input": {"task_id": "t-1"}}},
+                        {
+                            "toolUse": {
+                                "toolUseId": "tu-1",
+                                "name": "get_task_status",
+                                "input": {"task_id": "t-1"},
+                            }
+                        },
                     ]
                 }
             },
@@ -196,7 +202,10 @@ def test_response_namespace_blocks_serialize_losslessly():
     messages = [
         {"role": "user", "content": [{"type": "text", "text": "state"}]},
         {"role": "assistant", "content": blocks},
-        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu-1", "content": "pending"}]},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "tu-1", "content": "pending"}],
+        },
     ]
     assert len(strip_orphaned_tool_results(messages)) == 3
 


### PR DESCRIPTION
## Summary
- `ruff format --check .` on `main` fails: `backend/foreman/providers/bedrock.py` and `backend/tests/test_bedrock_provider.py` are not formatted per the repo's ruff config, which would fail the `python-lint` CI job.
- Ran `ruff format backend/foreman/providers/bedrock.py backend/tests/test_bedrock_provider.py` to fix both files.

## Test plan
- [x] `ruff check .` — all checks passed
- [x] `ruff format --check .` — 190 files already formatted, no diffs remaining