### PR TITLE
fix: read __version__ from installed package metadata

### DIFF
--- a/cli/pioneer_cli/__init__.py
+++ b/cli/pioneer_cli/__init__.py
@@ -12,4 +12,9 @@ The three runtimes still live in their own source trees (``backend/``,
 ``sys.path`` for the selected mode and hands off to the existing entry point.
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pioneer-square")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0"

--- a/worker/pioneer_worker/__init__.py
+++ b/worker/pioneer_worker/__init__.py
@@ -6,4 +6,9 @@ runs `claude --dangerously-skip-permissions` on each task, and pushes the
 result as a GitHub pull request.
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pioneer-square")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0"


### PR DESCRIPTION
## Summary
- `pioneer worker --version` always printed the hardcoded `0.1.0` from `pioneer_worker/__init__.py`, no matter what version was in `pyproject.toml` or installed.
- Both `pioneer_cli` and `pioneer_worker` now read `__version__` from the installed `pioneer-square` dist via `importlib.metadata`, falling back to `0.0.0.dev0` when not installed.

## Test plan
- `uv pip install -e cli && pioneer worker --version` → `pioneer-worker 2026.7.17+cef28ee` (matches pyproject; `07`→`7` is PEP 440 normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)