### PR TITLE
feat: install pi-subagents extension in worker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,13 @@ RUN useradd --create-home --shell /bin/bash worker \
     && mkdir -p /work/repos /work/worktrees /config /home/worker/go \
     && chown -R worker:worker /work /config /home/worker
 
+# Pi extension for delegating tasks to subagents (#938), giving pi-coding-agent
+# a subagent/delegation tool. Installed as the `worker` user (not root) since
+# `pi install` writes into $HOME/.pi, and the container runs as `worker`.
+USER worker
+RUN pi install npm:pi-subagents
+USER root
+
 # PGDATA gives the coding agent a sensible default cluster location to
 # initialise with `initdb`/`pg_ctl` when a repo's tests need a real Postgres.
 # TEST_DATABASE_URL is picked up by backend/tests/_test_config.py with zero


### PR DESCRIPTION
## Summary

- Installs the `pi-subagents` extension for the `pi` coding agent CLI in the worker image, so workers have subagent delegation (review, scout, planner, oracle, parallel audits, etc.) available out of the box instead of requiring manual per-instance setup.
- `pi-subagents` is a **Pi extension**, not a standalone pip or npm-global package — it's installed with `pi install npm:pi-subagents` rather than `pip install` or `npm install -g`. (There is no `pi-subagents` package on PyPI; the pip-based approach suggested in the issue doesn't apply here.)
- The install runs as the `worker` user, after `useradd`, because `pi install` writes extension state to `$HOME/.pi`, and the container runs as `worker` at runtime (root's `$HOME/.pi` would be invisible to it).
- Placed right after the existing AI coding CLI installs (`claude-code`, `codex`, `pi-coding-agent`) since `pi` must exist first and this is already the Dockerfile's "layer most likely to update" section — new layers here don't invalidate the more stable system-package layers above.

## Why

Refs #938 — currently `pi-subagents` isn't pre-installed, so workers either lack subagent delegation or need it installed manually/out-of-band, which drifts across worker instances. Baking it into the image keeps every worker container consistent at deploy time.

## Test plan

- [x] Reviewed the Dockerfile change for syntax correctness (balanced `RUN`/`USER` blocks, matches existing multi-line `RUN` style in the file)
- [ ] Docker wasn't available in this sandbox, so a live `docker build --target worker` wasn't run — recommend building once in CI/locally to confirm `pi install npm:pi-subagents` succeeds and `pi-subagents` is picked up for the `worker` user at runtime (e.g. `docker run --rm <image> pi --help` or checking `/home/worker/.pi`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)