### PR TITLE
Fix: honor AWS_BEARER_TOKEN_BEDROCK in startup Bedrock model enrichment

### DIFF
--- a/backend/tests/test_bedrock_enricher.py
+++ b/backend/tests/test_bedrock_enricher.py
@@ -157,6 +157,36 @@ def test_build_bedrock_model_map_inference_profiles_fail_gracefully():
     assert result["claude-sonnet-4-6"] == "anthropic.claude-sonnet-4-6-20251001-v1:0"
 
 
+# ---------------------------------------------------------------------------
+# build_bedrock_model_map — AWS_BEARER_TOKEN_BEDROCK (issue #943)
+# ---------------------------------------------------------------------------
+
+
+def test_build_bedrock_model_map_uses_bearer_token(monkeypatch):
+    """When AWS_BEARER_TOKEN_BEDROCK is set, the client must be built with the
+    bearer signature version and the token injected directly — a plain
+    boto3.client("bedrock") does not auto-negotiate bearer auth and would
+    otherwise raise NoCredentialsError and log the "no AWS credentials
+    configured" warning even though a valid token is configured.
+    """
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "tok-abc")
+
+    client = _make_client(
+        foundation_models=[
+            {"modelId": "anthropic.claude-sonnet-4-6-20251001-v1:0"},
+        ]
+    )
+
+    with patch("boto3.client", return_value=client) as mock_client_ctor:
+        result = build_bedrock_model_map()
+
+    assert result["claude-sonnet-4-6"] == "anthropic.claude-sonnet-4-6-20251001-v1:0"
+
+    _, kwargs = mock_client_ctor.call_args
+    assert kwargs["config"].signature_version == "bearer"
+    assert client._request_signer._auth_token.token == "tok-abc"
+
+
 def test_build_bedrock_model_map_boto3_import_error():
     """ImportError for boto3 must return an empty dict."""
     import builtins

--- a/backend/util/bedrock_enricher.py
+++ b/backend/util/bedrock_enricher.py
@@ -20,6 +20,7 @@ as a fallback (which may fail at inference time).
 from __future__ import annotations
 
 import logging
+import os
 import re
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,28 @@ def _extract_short_id(model_id: str) -> str | None:
     if m:
         return m.group(1)
     return None
+
+
+def _make_bedrock_client(boto3_mod):
+    """Build the boto3 ``bedrock`` (control-plane) client used to list models.
+
+    Mirrors ``foreman.providers.bedrock._get_client``'s bearer-token handling:
+    a plain ``boto3.client("bedrock")`` does not auto-negotiate the
+    ``httpBearerAuth`` scheme just because ``AWS_BEARER_TOKEN_BEDROCK`` is set
+    in the environment — it still resolves SigV4 credentials and fails with
+    ``NoCredentialsError`` when none are configured. The signature version
+    must be forced to ``"bearer"`` and the token injected directly.
+    """
+    bearer_token = os.environ.get("AWS_BEARER_TOKEN_BEDROCK")
+    if not bearer_token:
+        return boto3_mod.client("bedrock")
+
+    from botocore.config import Config
+    from botocore.tokens import FrozenAuthToken
+
+    client = boto3_mod.client("bedrock", config=Config(signature_version="bearer"))
+    client._request_signer._auth_token = FrozenAuthToken(bearer_token)
+    return client
 
 
 def build_bedrock_model_map() -> dict[str, str]:
@@ -71,7 +94,7 @@ def build_bedrock_model_map() -> dict[str, str]:
         return {}
 
     try:
-        client = boto3.client("bedrock")
+        client = _make_bedrock_client(boto3)
     except Exception as exc:
         logger.warning("bedrock_enricher: failed to create Bedrock client (%s) — skipping", exc)
         return {}


### PR DESCRIPTION
## Summary

Fixes #943. The startup catalog refresh (`refresh_model_catalog_if_stale` →
`build_bedrock_model_map()` in `backend/util/bedrock_enricher.py`) built a
plain `boto3.client("bedrock")`. boto3 does not auto-negotiate the
`httpBearerAuth` scheme just because `AWS_BEARER_TOKEN_BEDROCK` is present in
the environment — the client still resolves SigV4 credentials and raises
`NoCredentialsError` when none are configured, which this module then logs as
"no AWS credentials configured".

This is exactly the pitfall `foreman/providers/bedrock.py::_get_client` (used
by regular Bedrock calls) already works around: force the signature version
to `"bearer"` and inject the token directly via `FrozenAuthToken` rather than
relying on boto3's default credential chain.

`build_bedrock_model_map()` now goes through a new `_make_bedrock_client()`
helper that applies the same bearer-token handling when
`AWS_BEARER_TOKEN_BEDROCK` is set, falling back to the previous plain-client
behavior otherwise.

## Test plan

- [x] `pytest tests/test_bedrock_enricher.py` — 14 passed, including a new
  regression test asserting the client is constructed with
  `signature_version="bearer"` and the token injected when
  `AWS_BEARER_TOKEN_BEDROCK` is set.
- [x] `pytest tests/test_bedrock_provider.py tests/test_foreman_llm.py tests/test_models_dev.py` — all pass, no regressions.
- [x] Manually verified: with only `AWS_BEARER_TOKEN_BEDROCK` set (no AWS
  keys/profile), the client built by `_make_bedrock_client()` no longer
  raises `NoCredentialsError` on `list_foundation_models` — it proceeds to
  the actual API call (confirmed via a live call, which failed only on token
  format, not on missing credentials).
- [x] `ruff check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)