### PR TITLE
Strip <think> blocks from Kimi model responses

### DIFF
--- a/backend/foreman/providers/bedrock.py
+++ b/backend/foreman/providers/bedrock.py
@@ -221,6 +221,25 @@ _STOP_REASON_MAP = {
     "stop_sequence": "stop_sequence",
 }
 
+# Kimi K2 emits its chain-of-thought inline in the text output as a
+# <think>...</think> block ahead of the actual response, rather than in a
+# separate reasoning field the Converse API could surface on its own. Left
+# in place, that reasoning leaks into task history, worker prompts, and chat
+# display. Other Bedrock models (Nova, Titan, Claude) don't emit this tag, so
+# stripping is scoped to Kimi models only via `_is_kimi_model`.
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
+
+
+def _is_kimi_model(model: str) -> bool:
+    return "kimi" in model.lower()
+
+
+def _strip_think_block(text: str, model: str) -> str:
+    """Strip a leading <think>...</think> reasoning block from Kimi output."""
+    if not text or not _is_kimi_model(model):
+        return text
+    return _THINK_BLOCK_RE.sub("", text)
+
 
 def converse_response_to_anthropic(response: dict[str, Any], model: str) -> dict[str, Any]:
     """Convert a Bedrock Converse API response into an Anthropic Messages API
@@ -229,7 +248,9 @@ def converse_response_to_anthropic(response: dict[str, Any], model: str) -> dict
     content_blocks: list[dict[str, Any]] = []
     for block in output_message.get("content") or []:
         if "text" in block:
-            content_blocks.append({"type": "text", "text": block["text"]})
+            content_blocks.append(
+                {"type": "text", "text": _strip_think_block(block["text"], model)}
+            )
         elif "toolUse" in block:
             tool_use = block["toolUse"]
             content_blocks.append(

--- a/backend/tests/test_bedrock_provider.py
+++ b/backend/tests/test_bedrock_provider.py
@@ -139,6 +139,62 @@ def test_converse_response_to_anthropic_text():
     }
 
 
+def test_converse_response_to_anthropic_strips_kimi_think_block():
+    response = {
+        "output": {
+            "message": {
+                "content": [
+                    {
+                        "text": "<think>\nSome reasoning here...\n</think>\nActual generated content here"
+                    }
+                ]
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 5},
+    }
+    result = converse_response_to_anthropic(response, "moonshotai.kimi-k2-instruct")
+    assert result["content"] == [{"type": "text", "text": "Actual generated content here"}]
+
+
+def test_converse_response_to_anthropic_strips_multiple_kimi_think_blocks():
+    response = {
+        "output": {
+            "message": {
+                "content": [
+                    {"text": "<think>first</think>middle<think>second</think>end"},
+                ]
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 1, "outputTokens": 1},
+    }
+    result = converse_response_to_anthropic(response, "moonshot.kimi-k2-instruct")
+    assert result["content"] == [{"type": "text", "text": "middleend"}]
+
+
+def test_converse_response_to_anthropic_leaves_non_kimi_text_untouched():
+    """A <think> tag literally present in a non-Kimi model's own output must
+    survive untouched — the strip is scoped to Kimi models only."""
+    response = {
+        "output": {"message": {"content": [{"text": "<think>not reasoning</think>real text"}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 1, "outputTokens": 1},
+    }
+    result = converse_response_to_anthropic(response, "amazon.nova-pro-v1:0")
+    assert result["content"] == [{"type": "text", "text": "<think>not reasoning</think>real text"}]
+
+
+def test_converse_response_to_anthropic_kimi_no_think_block_untouched():
+    response = {
+        "output": {"message": {"content": [{"text": "plain answer, no reasoning tag"}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 1, "outputTokens": 1},
+    }
+    result = converse_response_to_anthropic(response, "moonshotai.kimi-k2-instruct")
+    assert result["content"] == [{"type": "text", "text": "plain answer, no reasoning tag"}]
+
+
 def test_converse_response_to_anthropic_tool_use():
     response = {
         "output": {


### PR DESCRIPTION
## Summary
- Adds `_is_kimi_model()` and `_strip_think_block()` helpers to `backend/foreman/providers/bedrock.py`, scoped to Kimi K2 models served via Bedrock's Converse API.
- `<think>...</think>` reasoning blocks are stripped from Kimi text output before it's converted to the Anthropic Messages shape, so callers downstream (history storage, worker/task display) never see the raw reasoning.
- Other Bedrock models (Nova, Titan, Claude) are unaffected — the strip only applies when the model name contains `kimi`.

## Test plan
- [x] `cd backend && python -m pytest tests/test_bedrock_provider.py -q` (29 passed, includes 4 new tests: single think-block strip, multiple think-blocks strip, non-Kimi model left untouched, Kimi output with no think block left untouched)
- [x] `cd backend && python -m pytest tests/test_foreman_llm.py -q` (40 passed, no regressions)
- [x] `ruff check` / `ruff format` clean

Fixes #945