### PR TITLE
Prevent Dependabot from bumping TypeScript to 7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,12 @@ updates:
       frontend-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: typescript
+        # TypeScript 7 is a peer-dependency conflict with typescript-eslint (<6.1.0)
+        # and @vue/eslint-config-typescript. Re-enable once those packages support TS 7.
+        # See: https://github.com/jmelloy/pioneer-square/issues/950
+        versions: [">=7.0.0"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
- TypeScript 7.0.2 was proposed in PR #948 but conflicts with `typescript-eslint@8.64.0` (requires `typescript <6.1.0`) and `@vue/eslint-config-typescript` peer dependencies.
- Adds an `ignore` rule to `.github/dependabot.yml` for the `typescript` package (`>=7.0.0`) on the `/frontend` npm ecosystem, with a comment explaining the constraint and linking to the issue.
- Re-enable once `typescript-eslint` / `@vue/eslint-config-typescript` support TypeScript 7.

Fixes #950

## Test plan
- [x] Validated `.github/dependabot.yml` parses as valid YAML