### PR TITLE
Add DEBUG_TOKEN flow and worker debug-query skill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,16 @@ RUN useradd --create-home --shell /bin/bash worker \
     && mkdir -p /work/repos /work/worktrees /config /home/worker/go \
     && chown -R worker:worker /work /config /home/worker
 
+# Personal skills (~/.claude/skills) are discovered by the claude CLI regardless
+# of which target repo's worktree it's run in as cwd, so this is where
+# worker-wide skills belong. debug-query lets a task's Claude session inspect
+# backend operational tables via /debug/query when DEBUG_TOKEN is set (see
+# worker/skills/debug-query/SKILL.md and docker-compose.yml).
+COPY worker/skills/ /home/worker/.claude/skills/
+RUN chmod +x /home/worker/.claude/skills/*/scripts/*.sh \
+    && chown -R worker:worker /home/worker/.claude
+ENV PIONEER_SKILL_DIR=/home/worker/.claude/skills/debug-query
+
 # Pi extension for delegating tasks to subagents (#938), giving pi-coding-agent
 # a subagent/delegation tool. Installed as the `worker` user (not root) since
 # `pi install` writes into $HOME/.pi, and the container runs as `worker`.

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -369,6 +369,26 @@ def test_spawn_worker_env_falls_back_to_host_env_when_db_empty():
     assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "host-token"
 
 
+def test_spawn_worker_env_forwards_debug_token():
+    """DEBUG_TOKEN lets the worker's debug-query skill call /debug/query."""
+    from main import _build_spawn_worker_env
+
+    env = _build_spawn_worker_env(
+        guild_id="g1",
+        repos=[],
+        worker_name=None,
+        source_env={"DEBUG_TOKEN": "operator-secret"},
+    )
+    assert env["DEBUG_TOKEN"] == "operator-secret"
+
+
+def test_spawn_worker_env_omits_debug_token_when_unset():
+    from main import _build_spawn_worker_env
+
+    env = _build_spawn_worker_env(guild_id="g1", repos=[], worker_name=None, source_env={})
+    assert "DEBUG_TOKEN" not in env
+
+
 def test_decode_claude_oauth_token_modern_format():
     """base64(json({'oauth_token': '...'})) is the format setup-token writes."""
     import base64

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -301,6 +301,12 @@ def build_spawn_worker_env(
         env["PIONEER_MAX_AGENTS"] = str(agent_count)
     if tools:
         env["PIONEER_TOOLS"] = ",".join(tools)
+    # Forwarded so the worker's debug-query skill (worker/skills/debug-query)
+    # can call the backend's DEBUG_TOKEN-gated /debug/query endpoint. Absent
+    # unless the backend itself has DEBUG_TOKEN set.
+    debug_token = source_env.get("DEBUG_TOKEN", "")
+    if debug_token:
+        env["DEBUG_TOKEN"] = debug_token
     # S3 session-log sync — forward bucket, prefix, interval, and AWS creds so
     # spawned workers can upload without needing their own config file entries.
     for _key in (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,10 @@ services:
       WORKER_LOG_LEVEL: ${WORKER_LOG_LEVEL:-}
       TEST_MODE: ${TEST_MODE:-}
       PIONEER_FOREMAN_KEY: ${PIONEER_FOREMAN_KEY:-}
+      # Gates the /debug/query read-only SQL endpoint (see backend/routes/debug_query.py)
+      # and, when set, is forwarded into worker containers this backend spawns
+      # (build_spawn_worker_env) so the worker's debug-query skill can use it too.
+      DEBUG_TOKEN: ${DEBUG_TOKEN:-}
       # S3 session-log sync — forwarded to spawned worker containers.
       PIONEER_S3_BUCKET: ${PIONEER_S3_BUCKET:-}
       PIONEER_S3_PREFIX: ${PIONEER_S3_PREFIX:-}
@@ -156,6 +160,12 @@ services:
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       WORKER_LOG_LEVEL: ${WORKER_LOG_LEVEL:-INFO}
+      # Backend URL the debug-query skill posts to (see worker/skills/debug-query).
+      PIONEER_BACKEND_URL: ${WORKER_BACKEND_URL:-http://backend:8000}
+      # Same operator credential as the backend's DEBUG_TOKEN (see above) — set
+      # this to the same value so the worker's debug-query skill can call
+      # /debug/query. Leave unset to disable the skill.
+      DEBUG_TOKEN: ${DEBUG_TOKEN:-}
       PIONEER_S3_BUCKET: ${PIONEER_S3_BUCKET:-}
       PIONEER_S3_PREFIX: ${PIONEER_S3_PREFIX:-}
       PIONEER_S3_SYNC_INTERVAL: ${PIONEER_S3_SYNC_INTERVAL:-}

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1217,6 +1217,12 @@ class Worker:
         await self._register()
         assert self.cfg.worker_id, "worker_id must be set after registration"
 
+        # Guarantee PIONEER_BACKEND_URL is in the environment even when
+        # backend_url came from the config file rather than the env var —
+        # skills (e.g. worker/skills/debug-query) rely on it being set for
+        # every spawned claude subprocess.
+        os.environ.setdefault("PIONEER_BACKEND_URL", self.cfg.backend_url)
+
         await self._fetch_github_token_if_needed()
         await self._fetch_guild_env_vars()
         await self._refresh_github_repos()

--- a/worker/skills/debug-query/SKILL.md
+++ b/worker/skills/debug-query/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: debug-query
+description: Run read-only SQL against the Pioneer Square backend's operational tables (tasks, task_logs, task_events, workers, agents, github_events, llm_usage, foreman_turns) via its DEBUG_TOKEN-gated /debug/query endpoint. Use this when debugging a task/worker/agent issue and you need to inspect live backend state instead of guessing from logs alone. Only available when DEBUG_TOKEN is set in the environment.
+---
+
+# Debug query
+
+Lets you run a read-only `SELECT` against the backend's operational tables over
+HTTP, without shelling into the database. Backed by `backend/routes/debug_query.py`.
+
+## Before using
+
+Check `DEBUG_TOKEN` is set:
+
+```bash
+test -n "$DEBUG_TOKEN" && echo available
+```
+
+If it's empty, this skill is not usable in this environment — don't attempt the
+query, and don't ask the user for the token.
+
+## Usage
+
+```bash
+"$PIONEER_SKILL_DIR/scripts/query.sh" "SELECT id, state, worker_id FROM tasks WHERE state = 'working' LIMIT 10"
+```
+
+`PIONEER_SKILL_DIR` is set in the worker image to this skill's own directory, so
+it resolves correctly no matter which repo's worktree is the current working
+directory. If it's unset (e.g. running this skill outside the worker image),
+use the path relative to this file instead: `scripts/query.sh "..."`.
+
+Prints the JSON array of matching rows on success, or a JSON error body (with a
+non-zero exit code) on failure.
+
+## Constraints (enforced server-side, not by this script)
+
+- Single `SELECT` statement only — no `INSERT`/`UPDATE`/`DELETE`/DDL, no
+  comments, no semicolon-chained statements.
+- Only these tables: `tasks`, `task_logs`, `task_events`, `workers`, `agents`,
+  `github_events`, `llm_usage`, `foreman_turns`. No credential-bearing tables
+  (`github_tokens`, `user_sessions`, etc.) are exposed.
+- Results are capped at 500 rows and the query is capped at 2 seconds.
+- Not guild-scoped — a query can return rows across every guild.
+
+## Example
+
+```bash
+"$PIONEER_SKILL_DIR/scripts/query.sh" \
+  "SELECT id, subtype, created_at FROM task_events WHERE task_id = 't-abc123' ORDER BY created_at DESC LIMIT 20"
+```

--- a/worker/skills/debug-query/scripts/query.sh
+++ b/worker/skills/debug-query/scripts/query.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Post a single read-only SELECT to the backend's DEBUG_TOKEN-gated
+# /debug/query endpoint (backend/routes/debug_query.py) and print the result.
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $(basename "$0") '<SELECT statement>'" >&2
+  exit 2
+fi
+
+if [ -z "${DEBUG_TOKEN:-}" ]; then
+  echo "DEBUG_TOKEN is not set in this environment; the debug-query skill is unavailable." >&2
+  exit 1
+fi
+
+backend_url="${PIONEER_BACKEND_URL:-http://backend:8000}"
+sql="$1"
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+status=$(curl -sS -o "$body_file" -w '%{http_code}' -X POST "${backend_url%/}/debug/query" \
+  -H "X-Debug-Token: ${DEBUG_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg sql "$sql" '{sql: $sql}')")
+
+cat "$body_file"
+echo
+
+if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Adds DEBUG_TOKEN support to enable the debug-query worker skill (the `/debug/query` backend endpoint itself already landed on `main` in a prior merge).

- Forwards DEBUG_TOKEN through `build_spawn_worker_env()` with tests
- Guarantees `PIONEER_BACKEND_URL` in worker environment for spawned claude processes
- Creates new worker skill: `debug-query` with `SKILL.md` documentation
- Wires `DEBUG_TOKEN` and `PIONEER_BACKEND_URL` through `docker-compose.yml` and the worker `Dockerfile`

Closes #953