### PR TITLE
Strip think blocks from Foreman responses before DB storage

### DIFF
--- a/backend/foreman/message_utils.py
+++ b/backend/foreman/message_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 from datetime import date, datetime
 from typing import Any
 
@@ -13,6 +14,16 @@ from .constants import (
     MAX_HISTORY_MESSAGES,
     MAX_TOOL_RESULT_CHARS,
 )
+
+# Some providers (e.g. Kimi K2, reached either directly via Bedrock or through
+# the foreman API proxy) emit their chain-of-thought inline in the response
+# text as a <think>...</think> block instead of a separate reasoning field.
+# foreman.providers.bedrock strips this for direct Bedrock calls, but that
+# module is never in the path for proxied providers, so any leftover block
+# would otherwise be persisted verbatim to foreman_turns. Strip again here,
+# right before assistant content is persisted, as a provider-agnostic last
+# line of defense.
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
 
 
 def _json_default(obj: Any) -> Any:
@@ -220,3 +231,20 @@ def _serialize_content(content) -> str:
                     blocks.append({"type": str(getattr(b, "type", "unknown")), "raw": str(b)})
         return json.dumps(blocks)
     return json.dumps(str(content))
+
+
+def strip_think_blocks_json(content_json: str) -> str:
+    """Strip <think>...</think> reasoning blocks from `_serialize_content` output.
+
+    Operates on the already-serialized JSON string so it works uniformly on
+    both shapes `_serialize_content` can produce: a bare string, or a list of
+    content-block dicts (only "text" blocks can carry a think block).
+    """
+    parsed = json.loads(content_json)
+    if isinstance(parsed, str):
+        parsed = _THINK_BLOCK_RE.sub("", parsed)
+    elif isinstance(parsed, list):
+        for block in parsed:
+            if isinstance(block, dict) and isinstance(block.get("text"), str):
+                block["text"] = _THINK_BLOCK_RE.sub("", block["text"])
+    return json.dumps(parsed)

--- a/backend/foreman/message_utils.py
+++ b/backend/foreman/message_utils.py
@@ -25,6 +25,29 @@ from .constants import (
 # line of defense.
 _THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
 
+# Kimi K2's chat template pre-fills the <think> opening tag as part of the
+# prompt, so the model's own completion text often contains only the closing
+# </think> with no opening tag at all — confirmed via a foreman_turns DB
+# investigation (t-fgcgq4): production rows had 206 bare "</think>" closes
+# vs. only 11 real "<think>...</think>" pairs. Treat a lone </think> as
+# closing an implicit reasoning span that began at the very start of the
+# text. Only strip it when real content follows the tag, so a message that
+# merely *mentions* "</think>" in prose (no reasoning ahead of it) can't have
+# its entire body wiped out.
+_ORPHANED_THINK_CLOSE_RE = re.compile(r"\A.*?</think>\s*", re.DOTALL | re.IGNORECASE)
+
+
+def _strip_think_text(text: str) -> str:
+    """Strip both think-block shapes seen in production: a matched
+    <think>...</think> pair, and Kimi's common bare-</think> shape where the
+    opening tag was swallowed by the model's chat template.
+    """
+    text = _THINK_BLOCK_RE.sub("", text)
+    match = _ORPHANED_THINK_CLOSE_RE.match(text)
+    if match and text[match.end() :].strip():
+        text = text[match.end() :]
+    return text
+
 
 def _json_default(obj: Any) -> Any:
     """JSON encoder fallback: serialize datetime/date objects as ISO strings."""
@@ -242,9 +265,9 @@ def strip_think_blocks_json(content_json: str) -> str:
     """
     parsed = json.loads(content_json)
     if isinstance(parsed, str):
-        parsed = _THINK_BLOCK_RE.sub("", parsed)
+        parsed = _strip_think_text(parsed)
     elif isinstance(parsed, list):
         for block in parsed:
             if isinstance(block, dict) and isinstance(block.get("text"), str):
-                block["text"] = _THINK_BLOCK_RE.sub("", block["text"])
+                block["text"] = _strip_think_text(block["text"])
     return json.dumps(parsed)

--- a/backend/foreman/providers/bedrock.py
+++ b/backend/foreman/providers/bedrock.py
@@ -229,16 +229,33 @@ _STOP_REASON_MAP = {
 # stripping is scoped to Kimi models only via `_is_kimi_model`.
 _THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
 
+# In practice Kimi K2's chat template pre-fills the <think> opening tag as
+# part of the prompt, so the completion text itself usually contains only
+# the closing </think> with no opening tag (confirmed via a foreman_turns DB
+# investigation, t-fgcgq4: 206 bare "</think>" closes vs. only 11 real
+# "<think>...</think>" pairs). `_THINK_BLOCK_RE` alone never matches that
+# shape, so it silently strips nothing for the common case. Treat a lone
+# </think> as closing an implicit reasoning span that began at the very
+# start of the text — but only when real content follows the tag, so a
+# response that never reaches a real answer isn't reduced to nothing.
+_ORPHANED_THINK_CLOSE_RE = re.compile(r"\A.*?</think>\s*", re.DOTALL | re.IGNORECASE)
+
 
 def _is_kimi_model(model: str) -> bool:
     return "kimi" in model.lower()
 
 
 def _strip_think_block(text: str, model: str) -> str:
-    """Strip a leading <think>...</think> reasoning block from Kimi output."""
+    """Strip a <think>...</think> reasoning block — including the common
+    bare-</think> shape where the opening tag was swallowed by the chat
+    template — from Kimi output."""
     if not text or not _is_kimi_model(model):
         return text
-    return _THINK_BLOCK_RE.sub("", text)
+    text = _THINK_BLOCK_RE.sub("", text)
+    match = _ORPHANED_THINK_CLOSE_RE.match(text)
+    if match and text[match.end() :].strip():
+        text = text[match.end() :]
+    return text
 
 
 def converse_response_to_anthropic(response: dict[str, Any], model: str) -> dict[str, Any]:

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -38,6 +38,7 @@ from foreman.message_utils import (
     _summarize_task,
     prune_history,
     strip_orphaned_tool_results,
+    strip_think_blocks_json,
     truncate_tool_result,
 )
 from foreman.prompt import (
@@ -489,7 +490,7 @@ async def _save_turn(
             guild_id=guild_pk_val or 0,
             user_id=user_id,
             role=role,
-            content_json=_serialize_content(content),
+            content_json=strip_think_blocks_json(_serialize_content(content)),
             is_tool_response=1 if is_tool_response else 0,
             parent_id=parent_id,
             created_at=datetime.now(UTC),

--- a/backend/tests/test_bedrock_provider.py
+++ b/backend/tests/test_bedrock_provider.py
@@ -195,6 +195,25 @@ def test_converse_response_to_anthropic_kimi_no_think_block_untouched():
     assert result["content"] == [{"type": "text", "text": "plain answer, no reasoning tag"}]
 
 
+def test_converse_response_to_anthropic_strips_kimi_orphaned_closing_tag():
+    """Real production shape (confirmed via foreman_turns DB investigation,
+    t-fgcgq4): Kimi's chat template pre-fills the <think> opening tag, so the
+    completion text contains only the closing </think> with no opener."""
+    response = {
+        "output": {
+            "message": {
+                "content": [
+                    {"text": "I should check the task status first. </think> Task is on track."}
+                ]
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 5},
+    }
+    result = converse_response_to_anthropic(response, "moonshotai.kimi-k2-instruct")
+    assert result["content"] == [{"type": "text", "text": "Task is on track."}]
+
+
 def test_converse_response_to_anthropic_tool_use():
     response = {
         "output": {

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -34,6 +34,7 @@ from foreman.message_utils import (
     _serialize_content,
     _summarize_task,
     prune_history,
+    strip_think_blocks_json,
     truncate_tool_result,
 )
 from foreman.prompt import FOREMAN_SYSTEM, build_state_preamble, build_system_prompt
@@ -359,6 +360,46 @@ class TestSerializeContent:
     def test_empty_list(self):
         result = _serialize_content([])
         assert json.loads(result) == []
+
+
+# ---------------------------------------------------------------------------
+# 2b. strip_think_blocks_json (runner helper)
+# ---------------------------------------------------------------------------
+
+
+class TestStripThinkBlocksJson:
+    def test_strips_think_block_from_bare_string(self):
+        content = _serialize_content("<think>reasoning here</think>Hello there")
+        result = strip_think_blocks_json(content)
+        assert json.loads(result) == "Hello there"
+
+    def test_strips_think_block_from_text_block(self):
+        content = _serialize_content(
+            [{"type": "text", "text": "<think>secret plan</think>Final answer"}]
+        )
+        result = strip_think_blocks_json(content)
+        assert json.loads(result) == [{"type": "text", "text": "Final answer"}]
+
+    def test_leaves_tool_use_blocks_untouched(self):
+        blocks = [
+            {"type": "text", "text": "<think>hmm</think>Doing it now."},
+            {"type": "tool_use", "id": "tu-1", "name": "create_task", "input": {"name": "T"}},
+        ]
+        content = _serialize_content(blocks)
+        result = strip_think_blocks_json(content)
+        parsed = json.loads(result)
+        assert parsed[0] == {"type": "text", "text": "Doing it now."}
+        assert parsed[1] == blocks[1]
+
+    def test_no_think_block_is_unaffected(self):
+        content = _serialize_content("Nothing to strip here")
+        result = strip_think_blocks_json(content)
+        assert json.loads(result) == "Nothing to strip here"
+
+    def test_multiple_think_blocks_all_stripped(self):
+        content = _serialize_content("<think>a</think>Text one<think>b</think>Text two")
+        result = strip_think_blocks_json(content)
+        assert json.loads(result) == "Text oneText two"
 
 
 # ---------------------------------------------------------------------------
@@ -2538,6 +2579,45 @@ class TestForemanHistory:
             turn = session.scalar(select(ForemanTurn).order_by(col(ForemanTurn.id).desc()).limit(1))
         assert turn is not None
         assert turn.task_id is None
+
+    async def test_save_turn_strips_think_block_from_string_content(self, db_session):
+        """A leaked <think>...</think> block in a plain-string assistant turn
+        must never reach the foreman_turns row — regression test for the bug
+        where unstripped reasoning was persisted verbatim (see row 122861)."""
+        insert_guild(db_session, "g-hist-think-str")
+        await _save_turn(
+            "g-hist-think-str",
+            "u-1",
+            "assistant",
+            "<think>internal reasoning the user should never see</think>Here's the answer.",
+        )
+        with _sync_session(db_session) as session:
+            turn = session.scalar(select(ForemanTurn).order_by(col(ForemanTurn.id).desc()).limit(1))
+        assert turn is not None
+        assert "<think>" not in turn.content_json
+        assert json.loads(turn.content_json) == "Here's the answer."
+
+    async def test_save_turn_strips_think_block_from_text_blocks(self, db_session):
+        """A leaked <think>...</think> block inside a text content block must
+        be stripped before persistence, while sibling tool_use blocks are
+        left untouched."""
+        insert_guild(db_session, "g-hist-think-blocks")
+        await _save_turn(
+            "g-hist-think-blocks",
+            "u-1",
+            "assistant",
+            [
+                {"type": "text", "text": "<think>plan the task creation</think>Creating it now."},
+                {"type": "tool_use", "id": "tu-1", "name": "create_task", "input": {"name": "T"}},
+            ],
+        )
+        with _sync_session(db_session) as session:
+            turn = session.scalar(select(ForemanTurn).order_by(col(ForemanTurn.id).desc()).limit(1))
+        assert turn is not None
+        assert "<think>" not in turn.content_json
+        parsed = json.loads(turn.content_json)
+        assert parsed[0] == {"type": "text", "text": "Creating it now."}
+        assert parsed[1] == {"type": "tool_use", "id": "tu-1", "name": "create_task", "input": {"name": "T"}}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -401,6 +401,30 @@ class TestStripThinkBlocksJson:
         result = strip_think_blocks_json(content)
         assert json.loads(result) == "Text oneText two"
 
+    def test_strips_orphaned_closing_tag_with_no_opening_tag(self):
+        # The pattern actually observed in foreman_turns (t-fgcgq4): Kimi's
+        # chat template pre-fills <think>, so only the closing tag survives
+        # in the completion text.
+        content = _serialize_content(
+            "I should check the task status first. </think> Task is on track."
+        )
+        result = strip_think_blocks_json(content)
+        assert json.loads(result) == "Task is on track."
+
+    def test_orphaned_closing_tag_in_text_block(self):
+        content = _serialize_content(
+            [{"type": "text", "text": "Let me plan this out. </think> Here's the plan."}]
+        )
+        result = strip_think_blocks_json(content)
+        assert json.loads(result) == [{"type": "text", "text": "Here's the plan."}]
+
+    def test_orphaned_closing_tag_with_nothing_after_is_left_alone(self):
+        # No real content follows the tag — leave the text untouched rather
+        # than collapsing a response down to nothing.
+        content = _serialize_content("Just reasoning, no answer yet </think>")
+        result = strip_think_blocks_json(content)
+        assert json.loads(result) == "Just reasoning, no answer yet </think>"
+
 
 # ---------------------------------------------------------------------------
 # 3. Tool dispatching — correct handler invoked, result format

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -2617,7 +2617,12 @@ class TestForemanHistory:
         assert "<think>" not in turn.content_json
         parsed = json.loads(turn.content_json)
         assert parsed[0] == {"type": "text", "text": "Creating it now."}
-        assert parsed[1] == {"type": "tool_use", "id": "tu-1", "name": "create_task", "input": {"name": "T"}}
+        assert parsed[1] == {
+            "type": "tool_use",
+            "id": "tu-1",
+            "name": "create_task",
+            "input": {"name": "T"},
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the issue where `<think>...</think>` blocks were being stored in foreman_turns.

- Strips think blocks from assistant responses before DB persistence
- Uses existing _THINK_BLOCK_RE-style pattern from bedrock.py
- Handles both string content and JSON text blocks gracefully

All 62 non-DB tests pass. DB tests error due to test environment limitation (no Postgres available in this sandbox).