### PR TITLE
fix: strip Kimi think block when opening <think> tag is missing

### DIFF
--- a/backend/foreman/providers/bedrock.py
+++ b/backend/foreman/providers/bedrock.py
@@ -227,7 +227,15 @@ _STOP_REASON_MAP = {
 # in place, that reasoning leaks into task history, worker prompts, and chat
 # display. Other Bedrock models (Nova, Titan, Claude) don't emit this tag, so
 # stripping is scoped to Kimi models only via `_is_kimi_model`.
+#
+# In practice the opening <think> tag is frequently missing from the actual
+# Converse response even though the closing </think> is present — observed
+# live via DEBUG_TOKEN task_logs, e.g. a response body of "...assign it to
+# w-d04281.  </think>            Claiming the issue and assigning...". Only
+# matching the paired form left that leading reasoning text in the stored
+# completion, so an unpaired closing tag must also strip everything before it.
 _THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
+_UNPAIRED_THINK_CLOSE_RE = re.compile(r"^.*?</think>\s*", re.DOTALL | re.IGNORECASE)
 
 
 def _is_kimi_model(model: str) -> bool:
@@ -235,10 +243,12 @@ def _is_kimi_model(model: str) -> bool:
 
 
 def _strip_think_block(text: str, model: str) -> str:
-    """Strip a leading <think>...</think> reasoning block from Kimi output."""
+    """Strip <think>...</think> reasoning block(s) from Kimi output, including
+    a bare closing </think> with no matching opening tag."""
     if not text or not _is_kimi_model(model):
         return text
-    return _THINK_BLOCK_RE.sub("", text)
+    stripped = _THINK_BLOCK_RE.sub("", text)
+    return _UNPAIRED_THINK_CLOSE_RE.sub("", stripped)
 
 
 def converse_response_to_anthropic(response: dict[str, Any], model: str) -> dict[str, Any]:

--- a/backend/tests/test_bedrock_provider.py
+++ b/backend/tests/test_bedrock_provider.py
@@ -185,6 +185,30 @@ def test_converse_response_to_anthropic_leaves_non_kimi_text_untouched():
     assert result["content"] == [{"type": "text", "text": "<think>not reasoning</think>real text"}]
 
 
+def test_converse_response_to_anthropic_strips_unpaired_kimi_think_close():
+    """Real Bedrock responses sometimes omit the opening <think> tag while
+    still emitting the closing </think> — everything before it is reasoning
+    text that must still be stripped."""
+    response = {
+        "output": {
+            "message": {
+                "content": [
+                    {
+                        "text": "Let me claim the issue and assign it to w-d04281.  </think>"
+                        "            Claiming the issue and assigning **w-d04281**"
+                    }
+                ]
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 5},
+    }
+    result = converse_response_to_anthropic(response, "moonshotai.kimi-k2-instruct")
+    assert result["content"] == [
+        {"type": "text", "text": "Claiming the issue and assigning **w-d04281**"}
+    ]
+
+
 def test_converse_response_to_anthropic_kimi_no_think_block_untouched():
     response = {
         "output": {"message": {"content": [{"text": "plain answer, no reasoning tag"}]}},


### PR DESCRIPTION
## Summary

DEBUG_TOKEN investigation into task_logs (per the debug-token-kimi-think-token-investigation task) found real Bedrock Kimi responses where the model emits only a closing `</think>` tag with **no** opening `<think>` — e.g. a logged completion body of:

```
Let me claim the issue and assign it to w-d04281.  </think>            Claiming the issue and assigning **w-d04281** to fix the Kimi response parsing:
```

`_strip_think_block()` in `backend/foreman/providers/bedrock.py` (added by #946, closing #945) only matched the paired `<think>...</think>` form, so this leading reasoning text was left in the stored completion, task history, and worker prompts.

## Fix

- Added `_UNPAIRED_THINK_CLOSE_RE`, a second pass applied after the paired-tag strip that removes everything up to a bare `</think>` when no matching opening tag was present.
- Scoped to Kimi models only, same as before (`_is_kimi_model`).
- Added `test_converse_response_to_anthropic_strips_unpaired_kimi_think_close` reproducing the exact logged case; all existing paired/multi-block/non-Kimi tests still pass unchanged.

## Test plan

- [x] `python -m pytest backend/tests/test_bedrock_provider.py -v` — 30/30 passed
- [x] `ruff check` / `ruff format --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)