### PR TITLE
feat: Add Discord @mention response handler for channel #1528707144227225631

### DIFF
--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -23,6 +23,11 @@ table, keyed on ``(subject_type, subject_key)``):
       ``task_id=None``, so the reply is posted directly to the guild's main
       configured channel. ``notify_foreman_chat`` never creates a new dated
       thread; that fallback has been removed.
+    - one exception to the above: ``_MENTION_ONLY_CHANNEL_ID`` (#962) is a
+      wired channel that only forwards a message when it explicitly
+      @mentions the bot — every other message posted there is ignored. The
+      mention token is stripped before the content is forwarded as ad-hoc
+      chat (``task_id=None``), same as any other wired channel.
     - anything else has nowhere to route to and is silently ignored.
 
 Consumes ``discord.gateway.gateway_message_queue``. Enable with the same
@@ -33,12 +38,34 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import re
 from datetime import UTC, datetime
 
 from discord.auth import is_member_authorized
 from discord.gateway import gateway_message_queue
 
 logger = logging.getLogger(__name__)
+
+# #962 — see the routing-model exception in the module docstring above.
+# Override via env for testing/ops without a code change.
+_MENTION_ONLY_CHANNEL_ID = os.environ.get("DISCORD_MENTION_CHANNEL_ID") or "1528707144227225631"
+
+
+def _bot_user_id() -> str | None:
+    return os.environ.get("DISCORD_APPLICATION_ID") or None
+
+
+def _is_bot_mentioned(message: dict, bot_id: str) -> bool:
+    """Return True if *bot_id* appears in the message's ``mentions`` array."""
+    mentions = message.get("mentions") or []
+    return any(str(user.get("id")) == bot_id for user in mentions if isinstance(user, dict))
+
+
+def _strip_mention(content: str, bot_id: str) -> str:
+    """Remove every ``<@bot_id>``/``<@!bot_id>`` mention token from *content*."""
+    pattern = re.compile(rf"<@!?{re.escape(bot_id)}>")
+    return pattern.sub("", content).strip()
 
 
 async def _lookup_binding(thread_id: str) -> tuple[str, str] | None:
@@ -264,6 +291,17 @@ async def _route_inbound_message(message: dict) -> None:
     channel_id = message.get("channel_id")
     if not channel_id:
         return
+
+    if channel_id == _MENTION_ONLY_CHANNEL_ID:
+        bot_id = _bot_user_id()
+        if not bot_id or not _is_bot_mentioned(message, bot_id):
+            logger.debug(
+                "discord router: channel=%s only responds to @mentions — ignoring", channel_id
+            )
+            return
+        content = _strip_mention(content, bot_id)
+        if not content:
+            return
 
     session = await resolve_session(channel_id)
     if session is None:

--- a/backend/tests/test_discord_router.py
+++ b/backend/tests/test_discord_router.py
@@ -177,3 +177,88 @@ async def test_route_inbound_message_no_tag_for_general_chat(client):
     human_message = _args[2]
     assert not human_message.startswith("[discord-thread-reply]")
     assert human_message.startswith("[Discord]")
+
+
+# ---------------------------------------------------------------------------
+# #962 — mention-only channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mention_channel_ignores_message_without_mention(client):
+    """A plain message (no @mention) in the mention-only channel is ignored."""
+    _test_client, db_url = client
+    _insert_channel_guild(db_url, "1528707144227225631", "g-router7")
+
+    with (
+        patch.dict(os.environ, {"DISCORD_APPLICATION_ID": "bot-id-1"}),
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "just chatting, not pinging anyone",
+                "channel_id": "1528707144227225631",
+                "author": {"id": "d-user-3", "username": "carol"},
+                "mentions": [],
+            }
+        )
+
+    assert mock_trigger.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_mention_channel_responds_when_bot_mentioned(client):
+    """A message that @mentions the bot in the mention-only channel is forwarded,
+    with the mention token stripped from the content (#962)."""
+    _test_client, db_url = client
+    _insert_channel_guild(db_url, "1528707144227225631", "g-router8")
+
+    with (
+        patch.dict(os.environ, {"DISCORD_APPLICATION_ID": "bot-id-1"}),
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "<@bot-id-1> what's the status of the release?",
+                "channel_id": "1528707144227225631",
+                "author": {"id": "d-user-4", "username": "dave"},
+                "mentions": [{"id": "bot-id-1", "username": "pioneer-bot"}],
+            }
+        )
+
+    assert mock_trigger.await_count == 1
+    _args, kwargs = mock_trigger.await_args
+    assert kwargs["task_id"] is None
+    human_message = _args[2]
+    assert "<@bot-id-1>" not in human_message
+    assert "what's the status of the release?" in human_message
+
+
+@pytest.mark.asyncio
+async def test_mention_channel_ignores_when_application_id_unset(client):
+    """With DISCORD_APPLICATION_ID unset, the bot can't identify its own mentions
+    and safely ignores messages in the mention-only channel rather than guessing."""
+    _test_client, db_url = client
+    _insert_channel_guild(db_url, "1528707144227225631", "g-router9")
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch.object(router, "_bot_user_id", return_value=None),
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "<@bot-id-1> hello?",
+                "channel_id": "1528707144227225631",
+                "author": {"id": "d-user-5", "username": "erin"},
+                "mentions": [{"id": "bot-id-1"}],
+            }
+        )
+
+    assert mock_trigger.await_count == 0

--- a/backend/tests/test_discord_router.py
+++ b/backend/tests/test_discord_router.py
@@ -37,11 +37,13 @@ def _insert_binding(db_url: str, subject_type: str, subject_key: str, thread_id:
         session.commit()
 
 
-def _insert_channel_guild(db_url: str, channel_id: str, guild_id: str) -> None:
+def _insert_channel_guild(
+    db_url: str, channel_id: str, guild_id: str, discord_guild_id: str = "discord-guild-1"
+) -> None:
     with _sync_session(db_url) as session:
         session.add(
             DiscordChannelGuild(
-                discord_guild_id="discord-guild-1",
+                discord_guild_id=discord_guild_id,
                 discord_channel_id=channel_id,
                 ps_guild_id=guild_id,
                 created_at=datetime.now(UTC),
@@ -188,7 +190,9 @@ async def test_route_inbound_message_no_tag_for_general_chat(client):
 async def test_mention_channel_ignores_message_without_mention(client):
     """A plain message (no @mention) in the mention-only channel is ignored."""
     _test_client, db_url = client
-    _insert_channel_guild(db_url, "1528707144227225631", "g-router7")
+    _insert_channel_guild(
+        db_url, "1528707144227225631", "g-router7", discord_guild_id="discord-guild-mention-1"
+    )
 
     with (
         patch.dict(os.environ, {"DISCORD_APPLICATION_ID": "bot-id-1"}),
@@ -213,7 +217,9 @@ async def test_mention_channel_responds_when_bot_mentioned(client):
     """A message that @mentions the bot in the mention-only channel is forwarded,
     with the mention token stripped from the content (#962)."""
     _test_client, db_url = client
-    _insert_channel_guild(db_url, "1528707144227225631", "g-router8")
+    _insert_channel_guild(
+        db_url, "1528707144227225631", "g-router8", discord_guild_id="discord-guild-mention-2"
+    )
 
     with (
         patch.dict(os.environ, {"DISCORD_APPLICATION_ID": "bot-id-1"}),
@@ -243,7 +249,9 @@ async def test_mention_channel_ignores_when_application_id_unset(client):
     """With DISCORD_APPLICATION_ID unset, the bot can't identify its own mentions
     and safely ignores messages in the mention-only channel rather than guessing."""
     _test_client, db_url = client
-    _insert_channel_guild(db_url, "1528707144227225631", "g-router9")
+    _insert_channel_guild(
+        db_url, "1528707144227225631", "g-router9", discord_guild_id="discord-guild-mention-3"
+    )
 
     with (
         patch.dict(os.environ, {}, clear=False),


### PR DESCRIPTION
## Summary

Closes #962.

The bot's inbound Discord chat router (`backend/discord/router.py`) already forwards every message posted in a *wired* channel (one bound via `/join-channel`) to the Foreman AI as ad-hoc chat. Channel `1528707144227225631` is a general/shared channel where forwarding every message would be noisy, so this adds a gate specific to that channel: only a message that explicitly `@mentions` the bot is forwarded — every other message is ignored.

- Added `_MENTION_ONLY_CHANNEL_ID` (defaults to `1528707144227225631`, overridable via `DISCORD_MENTION_CHANNEL_ID` for ops/testing).
- Added `_is_bot_mentioned` / `_strip_mention`, which check Discord's `mentions` array against `DISCORD_APPLICATION_ID` (the bot's own user id) and strip the `<@id>`/`<@!id>` mention token before the content is forwarded.
- `_route_inbound_message` now short-circuits for this channel: no mention (or no `DISCORD_APPLICATION_ID` configured) → ignored; mentioned → content is stripped and processed exactly like any other wired channel's ad-hoc chat (`task_id=None`), so it replies in the same channel via the existing `notify_foreman_chat` mirror.
- Updated the module's routing-model docstring to document this as an explicit exception.

Note: this channel still needs to be wired to a Pioneer Square guild via the existing `/join-channel` command for routing to succeed — this PR only changes what's forwarded once wired, not how a channel gets associated with a guild.

## Test plan

- [x] `ruff check` on the touched files
- [x] Added unit tests in `backend/tests/test_discord_router.py`: ignores a non-mention message in the channel, forwards + strips content when mentioned, and ignores when `DISCORD_APPLICATION_ID` isn't configured
- [ ] Full `pytest` suite (requires a live Postgres instance not available in this sandbox — CI will run it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)