### PR TITLE
Broaden foreman mention scope to user level

### DIFF
--- a/backend/discord/auth.py
+++ b/backend/discord/auth.py
@@ -1,14 +1,18 @@
-"""Shared Discord role-allowlist authorization check.
+"""Shared Discord role-ID logic: member authorization plus foreman-role mention
+detection.
 
 Both the slash-command interaction handler (``routes/discord.py``) and the
 inbound chat router (Phase 5, ``discord/router.py``) gate cost-incurring
 actions on the same ``DISCORD_ALLOWED_ROLE_IDS`` allowlist, so the check
-lives here once instead of being duplicated.
+lives here once instead of being duplicated. The Gateway transport
+(``discord/router.py``) and consumer share the foreman-role mention check the
+same way.
 """
 
 from __future__ import annotations
 
 import os
+import re
 
 
 def allowed_role_ids() -> set[str]:
@@ -30,3 +34,32 @@ def is_member_authorized(member: dict | None) -> bool:
         return False
     user_roles: list[str] = member.get("roles", [])
     return bool(set(user_roles) & allowed)
+
+
+# The foreman role: a message that @-mentions this role always gets a
+# response, regardless of channel/guild wiring — see the routing-model
+# exception in ``discord/router.py``'s module docstring. Override via env for
+# testing/ops without a code change.
+FOREMAN_ROLE_ID = os.environ.get("DISCORD_FOREMAN_ROLE_ID") or "1522965022836396178"
+
+_FOREMAN_ROLE_MENTION_RE = re.compile(rf"<@&{re.escape(FOREMAN_ROLE_ID)}>")
+
+
+def mentions_foreman_role(message: dict) -> bool:
+    """Return True if *message* @-mentions the foreman role.
+
+    Checks Discord's structured ``mention_roles`` array first (populated on
+    guild messages), then falls back to a literal ``<@&role_id>`` scan of the
+    raw content — ``mention_roles`` is absent/empty on DMs (Discord has no
+    guild there to resolve a role mention against) even when a user pastes
+    the raw mention token directly.
+    """
+    mention_roles = message.get("mention_roles") or []
+    if any(str(role_id) == FOREMAN_ROLE_ID for role_id in mention_roles):
+        return True
+    return bool(_FOREMAN_ROLE_MENTION_RE.search(message.get("content") or ""))
+
+
+def strip_foreman_role_mention(content: str) -> str:
+    """Remove every ``<@&role_id>`` foreman-role mention token from *content*."""
+    return _FOREMAN_ROLE_MENTION_RE.sub("", content).strip()

--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -28,6 +28,7 @@ Protocol handled, per https://discord.com/developers/docs/topics/gateway:
 
 Filtering applied to ``MESSAGE_CREATE`` before anything is queued:
     - ``author.bot is True``      -> discarded (avoids echoing discord_notifier)
+    - foreman role @-mentioned    -> queued unconditionally (see below)
     - no ``guild_id`` (a DM)      -> discarded
     - channel/thread not "wired"  -> discarded (see ``_is_channel_wired``)
 
@@ -41,6 +42,14 @@ threads of a wired channel but carry their own ``channel_id`` in Discord's
 model, so they need their own lookup; the routing/reply layer (#744) does its
 own, more specific, reverse-lookup against that same table to decide *which*
 Foreman session a message belongs to.
+
+One exception to the "wired" requirement: a message that @-mentions the
+foreman role (``discord.auth.mentions_foreman_role``) is queued regardless of
+guild/DM/wiring — this is a *user*-scoped path, not a channel-scoped one, so
+the router (not this transport layer) is what decides which Foreman session
+it belongs to (see ``discord/router.py``'s module docstring). The Gateway
+must carry the ``DIRECT_MESSAGES`` intent (folded into ``_INTENTS`` below) for
+a DM's ``MESSAGE_CREATE`` to reach this handler at all.
 """
 
 from __future__ import annotations
@@ -53,6 +62,7 @@ import random
 import time
 
 import websockets
+from discord.auth import mentions_foreman_role
 from discord_notifier import send_welcome_dm
 
 logger = logging.getLogger(__name__)
@@ -60,8 +70,10 @@ logger = logging.getLogger(__name__)
 _GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
 
 # GUILDS (1 << 0) | GUILD_MEMBERS (1 << 1) | GUILD_MESSAGES (1 << 9)
-# | MESSAGE_CONTENT (1 << 15)
-_INTENTS = 33283
+# | DIRECT_MESSAGES (1 << 12) | MESSAGE_CONTENT (1 << 15)
+# DIRECT_MESSAGES is required so a DM's MESSAGE_CREATE reaches the bot at
+# all — otherwise a foreman-role mention typed into a DM would never arrive.
+_INTENTS = 33283 | 4096
 
 # Gateway opcodes.
 _OP_DISPATCH = 0
@@ -398,6 +410,11 @@ class GatewayClient:
     async def _handle_message_create(self, message: dict) -> None:
         author = message.get("author") or {}
         if author.get("bot"):
+            return
+        if mentions_foreman_role(message):
+            # User-scoped, not channel-scoped — bypass the DM/wiring filters
+            # below entirely; the router decides how to handle it from here.
+            await self._queue.put(message)
             return
         if not message.get("guild_id"):
             return  # DM — no guild_id on the message

--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -352,9 +352,7 @@ async def _route_foreman_mention(message: dict, content: str) -> None:
 
     guild_slug, *other_projects = guild_slugs
     context_note = f" (also has access to: {', '.join(other_projects)})" if other_projects else ""
-    human_message = (
-        f"[discord-foreman-mention] project={guild_slug}{context_note}\n[Discord] {label}: {content}"
-    )
+    human_message = f"[discord-foreman-mention] project={guild_slug}{context_note}\n[Discord] {label}: {content}"
 
     try:
         await _persist_inbound_message(guild_slug, content, user_id=ps_user_id, task_id=None)

--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -28,6 +28,13 @@ table, keyed on ``(subject_type, subject_key)``):
       @mentions the bot — every other message posted there is ignored. The
       mention token is stripped before the content is forwarded as ad-hoc
       chat (``task_id=None``), same as any other wired channel.
+    - a second, higher-priority exception: a message that @-mentions the
+      foreman role (``discord.auth.mentions_foreman_role``) is routed by
+      *author*, not by channel — see ``_route_foreman_mention``. It is
+      checked first, before any of the channel-scoped logic above, so it
+      always gets a response in any channel or DM the Gateway forwards it
+      from (see ``discord/gateway.py``), independent of whether that channel
+      is wired to any particular guild.
     - anything else has nowhere to route to and is silently ignored.
 
 Consumes ``discord.gateway.gateway_message_queue``. Enable with the same
@@ -42,7 +49,7 @@ import os
 import re
 from datetime import UTC, datetime
 
-from discord.auth import is_member_authorized
+from discord.auth import is_member_authorized, mentions_foreman_role, strip_foreman_role_mention
 from discord.gateway import gateway_message_queue
 
 logger = logging.getLogger(__name__)
@@ -269,6 +276,110 @@ def _is_authorized(message: dict) -> bool:
     return is_member_authorized(message.get("member"))
 
 
+async def _resolve_user_guild_slugs(ps_user_id: str) -> list[str]:
+    """Return every Pioneer Square guild slug *ps_user_id* is a member of.
+
+    Ordered most-recently-created first — the closest available proxy for
+    "most relevant," since there is no per-user "last active project" field
+    to prefer instead (see ``routes/guilds.py:list_guilds``, which orders the
+    same way for the same reason). Never raises.
+    """
+    try:
+        from database import AsyncSessionLocal  # noqa: PLC0415
+        from models import Guild, GuildMember  # noqa: PLC0415
+        from sqlmodel import col, select  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            result = await db.exec(
+                select(Guild.slug)
+                .join(GuildMember, col(GuildMember.guild_id) == col(Guild.id))
+                .where(col(GuildMember.user_id) == ps_user_id)
+                .order_by(col(Guild.created_at).desc())
+            )
+            return [slug for slug in result.all() if slug]
+    except Exception:
+        logger.warning(
+            "discord router: accessible-guilds lookup failed user=%s", ps_user_id, exc_info=True
+        )
+        return []
+
+
+async def _route_foreman_mention(message: dict, content: str) -> None:
+    """Route a foreman-role @-mention to the Foreman, scoped by *author*
+    rather than by the channel the message landed in.
+
+    Every other inbound path resolves a Foreman session from the *channel*
+    a message landed in (see ``resolve_session``) — this path ignores that
+    entirely, so a foreman-role mention always gets a response in any
+    channel or DM the bot can see, regardless of which (if any) guild
+    project that channel happens to be wired to. The author still has to be
+    role-authorized (``_is_authorized``) and resolve to a linked Pioneer
+    Square user (``_resolve_identity``) with at least one accessible
+    project (``_resolve_user_guild_slugs``) — an author that fails any of
+    those checks has nowhere well-defined to route to and is silently
+    ignored, same as an unresolvable channel elsewhere in this module.
+
+    When the author has more than one accessible project, the most recently
+    created one is used as the trigger target (a single Foreman trigger is
+    inherently scoped to one project — see ``_trigger_foreman``), with the
+    rest listed in the forwarded message so the Foreman can answer with
+    context spanning all of the author's projects rather than just the one
+    it's replying from. Never raises.
+    """
+    if not content:
+        return
+    if not _is_authorized(message):
+        logger.info("discord router: unauthorized author — ignoring foreman-role mention")
+        return
+
+    author = message.get("author") or {}
+    ps_user_id, label = await _resolve_identity(author.get("id"), author.get("username"))
+    if not ps_user_id:
+        logger.info(
+            "discord router: foreman-role mention from unlinked discord_user=%s — ignoring",
+            author.get("id"),
+        )
+        return
+
+    guild_slugs = await _resolve_user_guild_slugs(ps_user_id)
+    if not guild_slugs:
+        logger.info(
+            "discord router: foreman-role mention from user=%s with no accessible projects "
+            "— ignoring",
+            ps_user_id,
+        )
+        return
+
+    guild_slug, *other_projects = guild_slugs
+    context_note = f" (also has access to: {', '.join(other_projects)})" if other_projects else ""
+    human_message = (
+        f"[discord-foreman-mention] project={guild_slug}{context_note}\n[Discord] {label}: {content}"
+    )
+
+    try:
+        await _persist_inbound_message(guild_slug, content, user_id=ps_user_id, task_id=None)
+    except Exception:
+        logger.warning(
+            "discord router: failed to persist foreman-role mention guild=%s — forwarding to "
+            "Foreman anyway",
+            guild_slug,
+            exc_info=True,
+        )
+
+    from foreman.runner import reset_foreman_poll  # noqa: PLC0415
+    from ws_handlers import _trigger_foreman  # noqa: PLC0415
+
+    await _trigger_foreman(
+        guild_slug,
+        "chat",
+        human_message,
+        user_id=ps_user_id,
+        task_id=None,
+        task_name=f"foreman.discord-mention:{guild_slug}",
+    )
+    reset_foreman_poll(guild_slug)
+
+
 async def route_inbound_message(message: dict) -> bool:
     """Route one inbound Discord ``MESSAGE_CREATE`` payload to the Foreman AI.
 
@@ -290,6 +401,10 @@ async def _route_inbound_message(message: dict) -> None:
         return
     channel_id = message.get("channel_id")
     if not channel_id:
+        return
+
+    if mentions_foreman_role(message):
+        await _route_foreman_mention(message, strip_foreman_role_mention(content))
         return
 
     if channel_id == _MENTION_ONLY_CHANNEL_ID:

--- a/backend/tests/test_discord_auth.py
+++ b/backend/tests/test_discord_auth.py
@@ -1,0 +1,52 @@
+"""Unit tests for the foreman-role mention helpers in discord/auth.py."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from discord import auth  # noqa: E402
+
+
+def test_mentions_foreman_role_via_mention_roles_array():
+    """Guild messages carry a structured mention_roles array — the primary signal."""
+    message = {"content": "hey <@&1522965022836396178> got a sec?", "mention_roles": ["1522965022836396178"]}
+    assert auth.mentions_foreman_role(message) is True
+
+
+def test_mentions_foreman_role_via_raw_content_fallback():
+    """DMs carry no mention_roles (no guild to resolve a role against) — fall back to content."""
+    message = {"content": "<@&1522965022836396178> ping", "mention_roles": []}
+    assert auth.mentions_foreman_role(message) is True
+
+
+def test_mentions_foreman_role_false_when_absent():
+    message = {"content": "just chatting", "mention_roles": []}
+    assert auth.mentions_foreman_role(message) is False
+
+
+def test_mentions_foreman_role_ignores_unrelated_role_mentions():
+    message = {"content": "<@&999999999999999999> different role", "mention_roles": ["999999999999999999"]}
+    assert auth.mentions_foreman_role(message) is False
+
+
+def test_strip_foreman_role_mention_removes_token():
+    content = auth.strip_foreman_role_mention("<@&1522965022836396178> what's the status?")
+    assert content == "what's the status?"
+    assert "1522965022836396178" not in content
+
+
+def test_foreman_role_id_overridable_via_env(monkeypatch):
+    monkeypatch.setenv("DISCORD_FOREMAN_ROLE_ID", "42")
+    reloaded = importlib.reload(auth)
+    try:
+        assert reloaded.mentions_foreman_role({"content": "<@&42> hi", "mention_roles": []}) is True
+        assert reloaded.mentions_foreman_role(
+            {"content": "<@&1522965022836396178> hi", "mention_roles": []}
+        ) is False
+    finally:
+        monkeypatch.delenv("DISCORD_FOREMAN_ROLE_ID", raising=False)
+        importlib.reload(auth)

--- a/backend/tests/test_discord_auth.py
+++ b/backend/tests/test_discord_auth.py
@@ -13,7 +13,10 @@ from discord import auth  # noqa: E402
 
 def test_mentions_foreman_role_via_mention_roles_array():
     """Guild messages carry a structured mention_roles array — the primary signal."""
-    message = {"content": "hey <@&1522965022836396178> got a sec?", "mention_roles": ["1522965022836396178"]}
+    message = {
+        "content": "hey <@&1522965022836396178> got a sec?",
+        "mention_roles": ["1522965022836396178"],
+    }
     assert auth.mentions_foreman_role(message) is True
 
 
@@ -29,7 +32,10 @@ def test_mentions_foreman_role_false_when_absent():
 
 
 def test_mentions_foreman_role_ignores_unrelated_role_mentions():
-    message = {"content": "<@&999999999999999999> different role", "mention_roles": ["999999999999999999"]}
+    message = {
+        "content": "<@&999999999999999999> different role",
+        "mention_roles": ["999999999999999999"],
+    }
     assert auth.mentions_foreman_role(message) is False
 
 
@@ -44,9 +50,12 @@ def test_foreman_role_id_overridable_via_env(monkeypatch):
     reloaded = importlib.reload(auth)
     try:
         assert reloaded.mentions_foreman_role({"content": "<@&42> hi", "mention_roles": []}) is True
-        assert reloaded.mentions_foreman_role(
-            {"content": "<@&1522965022836396178> hi", "mention_roles": []}
-        ) is False
+        assert (
+            reloaded.mentions_foreman_role(
+                {"content": "<@&1522965022836396178> hi", "mention_roles": []}
+            )
+            is False
+        )
     finally:
         monkeypatch.delenv("DISCORD_FOREMAN_ROLE_ID", raising=False)
         importlib.reload(auth)

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -94,7 +94,7 @@ async def test_identify_sent_after_hello_with_no_prior_session():
     identify = [m for m in ws.sent if m["op"] == gateway._OP_IDENTIFY]
     assert len(identify) == 1
     assert identify[0]["d"]["token"] == "test-token"
-    assert identify[0]["d"]["intents"] == 33283
+    assert identify[0]["d"]["intents"] == gateway._INTENTS
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Any message containing `<@&1522965022836396178>` (the foreman role) now always gets a response, regardless of which guild/channel it lands in or whether it's a DM.
- Routing switches from channel-scoped to user-scoped for this path: the author's Pioneer Square identity is resolved, along with every guild project they have access to, so the reply is contextual to the user and can reference all their accessible projects (not just whichever project the channel happens to be wired to).
- `discord/gateway.py` now carries the `DIRECT_MESSAGES` intent so a DM's `MESSAGE_CREATE` reaches the bot at all, and queues foreman-role mentions unconditionally ahead of the existing DM/wiring filters.
- `discord/router.py` checks for a foreman-role mention first, before any channel-scoped logic, and routes it via a new author-scoped path (`_route_foreman_mention`) instead of the per-channel session resolver.

## Test plan
- [x] `pytest backend/tests/test_discord_auth.py` — 6 passed (mention detection via structured `mention_roles`, raw-content fallback for DMs, negative cases, mention stripping, env-var override).
- [ ] Manual verification in a live Discord server: mention the foreman role in an unwired channel and in a DM, confirm a response is received.