### PR TITLE
Auto-create user entries for bots with parent user

### DIFF
--- a/backend/alembic/versions/20260715_000000_add_bot_fields_to_users.py
+++ b/backend/alembic/versions/20260715_000000_add_bot_fields_to_users.py
@@ -1,0 +1,47 @@
+"""add_bot_fields_to_users
+
+Adds ``is_bot`` and ``parent_user_id`` to ``users`` so a Discord bot account
+can be auto-provisioned its own row (for audit trails / message attribution)
+while its guild permissions and ownership are traced back to a real human via
+``parent_user_id`` (self-referential FK). See ``discord/bot_users.py``.
+
+Revision ID: 20260715_000000_add_bot_fields_to_users
+Revises: 20260714_000000_add_task_logs_worker_agent_indexes
+Create Date: 2026-07-15
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260715_000000_add_bot_fields_to_users"
+down_revision: str | Sequence[str] | None = "20260714_000000_add_task_logs_worker_agent_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_bot", sa.Boolean(), nullable=False, server_default=sa.text("false")
+            )
+        )
+        batch_op.add_column(sa.Column("parent_user_id", sa.Text(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_users_parent_user_id_users", "users", ["parent_user_id"], ["id"]
+        )
+
+    op.create_index("ix_users_parent_user_id", "users", ["parent_user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_parent_user_id", table_name="users")
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_constraint("fk_users_parent_user_id_users", type_="foreignkey")
+        batch_op.drop_column("parent_user_id")
+        batch_op.drop_column("is_bot")

--- a/backend/discord/bot_users.py
+++ b/backend/discord/bot_users.py
@@ -1,0 +1,139 @@
+"""Auto-provisioning of ``users`` rows for Discord bot accounts.
+
+Discord bots (other applications' bot users, not this application's own bot —
+see ``gateway._handle_message_create``'s self-message filter) can post in wired
+channels/threads and today have no Pioneer Square identity: ``router._resolve_identity``
+only *looks up* an existing mapping and returns ``None`` for anything unmapped,
+which means a bot's messages get attributed to nobody (no audit trail) and
+inherit no permissions.
+
+``ensure_bot_user`` fills that gap the first time a given Discord bot is seen in
+a guild: it creates a ``users`` row (``is_bot=True``), points ``parent_user_id``
+at a real human — the guild's earliest owner, standing in for "whoever is
+responsible for what's installed in this guild" since Discord's API does not
+expose who invited a given bot — and mirrors the parent's ``guild_members`` role
+onto the new bot row so the bot inherits the same guild permissions. A
+``discord_account_links`` row is also written so subsequent messages from the
+same Discord bot resolve instantly via the existing lookup path in
+``router._resolve_identity`` without re-running this provisioning logic.
+
+A bot is never chosen as a parent (guarded via ``User.is_bot == False`` on the
+owner query), so bot->bot parent chains cannot form.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from models import DiscordAccountLink, GuildMember, User
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import col, select
+
+logger = logging.getLogger(__name__)
+
+
+def _bot_ps_user_id(discord_user_id: str) -> str:
+    """Deterministic, stable ps_user_id for a Discord bot — never collides with
+    a GitHub numeric id (`users.id` for humans), so the two id spaces can share
+    the same column safely."""
+    return f"discordbot:{discord_user_id}"
+
+
+async def _find_parent_owner(db, guild_pk: int) -> tuple[str | None, str]:
+    """Return ``(user_id, role)`` for the guild's earliest human owner, or
+    ``(None, "member")`` if the guild has no human owner on record."""
+    result = await db.exec(
+        select(GuildMember.user_id, GuildMember.role)
+        .join(User, col(User.id) == col(GuildMember.user_id))
+        .where(
+            col(GuildMember.guild_id) == guild_pk,
+            col(GuildMember.role) == "owner",
+            col(User.is_bot).is_(False),
+        )
+        .order_by(col(GuildMember.created_at).asc())
+        .limit(1)
+    )
+    row = result.first()
+    if row is None:
+        return None, "member"
+    return row[0], row[1]
+
+
+async def ensure_bot_user(discord_user_id: str, username: str | None, guild_pk: int | None) -> str:
+    """Find-or-create the Pioneer Square user row for a Discord bot account.
+
+    Idempotent — safe to call for a bot that already has a row (returns the
+    existing id without writing anything). ``guild_pk`` is used only to pick a
+    parent/inherited role for a *new* row; pass ``None`` when unknown (the bot
+    row is still created, just with no parent).
+    """
+    from database import AsyncSessionLocal  # noqa: PLC0415
+
+    ps_user_id = _bot_ps_user_id(discord_user_id)
+
+    async with AsyncSessionLocal() as db:
+        existing = await db.exec(select(User.id).where(col(User.id) == ps_user_id))
+        if existing.first():
+            return ps_user_id
+
+        now = datetime.now(UTC)
+        parent_user_id: str | None = None
+        parent_role = "member"
+        if guild_pk is not None:
+            parent_user_id, parent_role = await _find_parent_owner(db, guild_pk)
+            if parent_user_id is None:
+                logger.warning(
+                    "discord bot_users: no human owner found for guild_pk=%s — "
+                    "provisioning bot=%s with no parent",
+                    guild_pk,
+                    discord_user_id,
+                )
+
+        label = username or discord_user_id
+        user_stmt = pg_insert(User).values(
+            id=ps_user_id,
+            github_id=ps_user_id,
+            github_login=f"discordbot:{label}",
+            display_name=label,
+            is_bot=True,
+            parent_user_id=parent_user_id,
+            created_at=now,
+            updated_at=now,
+        )
+        user_stmt = user_stmt.on_conflict_do_nothing(index_elements=["id"])
+        await db.exec(user_stmt)
+
+        link_stmt = pg_insert(DiscordAccountLink).values(
+            ps_user_id=ps_user_id,
+            discord_user_id=discord_user_id,
+            discord_username=username or "",
+            created_at=now,
+        )
+        link_stmt = link_stmt.on_conflict_do_update(
+            index_elements=["discord_user_id"],
+            set_={
+                "ps_user_id": link_stmt.excluded.ps_user_id,
+                "discord_username": link_stmt.excluded.discord_username,
+            },
+        )
+        await db.exec(link_stmt)
+
+        if guild_pk is not None and parent_user_id is not None:
+            member_stmt = pg_insert(GuildMember).values(
+                guild_id=guild_pk,
+                user_id=ps_user_id,
+                role=parent_role,
+                created_at=now,
+            )
+            member_stmt = member_stmt.on_conflict_do_nothing(index_elements=["guild_id", "user_id"])
+            await db.exec(member_stmt)
+
+        await db.commit()
+        logger.info(
+            "discord bot_users: provisioned bot user %s (discord_id=%s parent=%s)",
+            ps_user_id,
+            discord_user_id,
+            parent_user_id,
+        )
+        return ps_user_id

--- a/backend/discord/gateway.py
+++ b/backend/discord/gateway.py
@@ -27,7 +27,12 @@ Protocol handled, per https://discord.com/developers/docs/topics/gateway:
     INVALID_SESSION (op 9)   -> RESUME if resumable, otherwise fresh IDENTIFY
 
 Filtering applied to ``MESSAGE_CREATE`` before anything is queued:
-    - ``author.bot is True``      -> discarded (avoids echoing discord_notifier)
+    - ``author.bot is True`` and either this is our own application's bot user
+      (``DISCORD_APPLICATION_ID``) or that env var isn't set at all -> discarded
+      (avoids echoing discord_notifier; see ``_is_own_bot_or_unconfigured``).
+      Other bots' messages pass through once ``DISCORD_APPLICATION_ID`` is
+      configured, and get their own auto-provisioned ``users`` row on first
+      contact (``discord/bot_users.py``) instead of being dropped outright.
     - foreman role @-mentioned    -> queued unconditionally (see below)
     - no ``guild_id`` (a DM)      -> discarded
     - channel/thread not "wired"  -> discarded (see ``_is_channel_wired``)
@@ -95,6 +100,20 @@ def _bot_token() -> str | None:
 
 def _gateway_enabled() -> bool:
     return os.environ.get("DISCORD_GATEWAY_ENABLED", "false").strip().lower() == "true"
+
+
+def _is_own_bot_or_unconfigured(author_id: str | None) -> bool:
+    """Return True if *author_id* is this application's own bot user, or if
+    ``DISCORD_APPLICATION_ID`` isn't set (in which case we can't tell, so we
+    conservatively treat every bot as "our own" to preserve the pre-existing,
+    echo-safe default of dropping all bot messages).
+
+    Set ``DISCORD_APPLICATION_ID`` to opt in to processing *other* bots'
+    messages (auto-provisioned as their own ``users`` row — see
+    ``discord/bot_users.py``) while still never reacting to our own messages.
+    """
+    own_id = os.environ.get("DISCORD_APPLICATION_ID")
+    return not own_id or str(author_id) == own_id
 
 
 def _backoff_delay(attempt: int, base: float = 2.0, cap: float = 60.0) -> float:
@@ -409,7 +428,7 @@ class GatewayClient:
 
     async def _handle_message_create(self, message: dict) -> None:
         author = message.get("author") or {}
-        if author.get("bot"):
+        if author.get("bot") and _is_own_bot_or_unconfigured(author.get("id")):
             return
         if mentions_foreman_role(message):
             # User-scoped, not channel-scoped — bypass the DM/wiring filters

--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -192,6 +192,19 @@ async def _resolve_channel_guild(channel_id: str) -> str | None:
         return None
 
 
+async def _guild_pk_for_slug(guild_slug: str) -> int | None:
+    """Return the integer ``guilds.id`` for *guild_slug*, or None. Never raises."""
+    try:
+        from auth_deps import get_guild_pk  # noqa: PLC0415
+        from database import AsyncSessionLocal  # noqa: PLC0415
+
+        async with AsyncSessionLocal() as db:
+            return await get_guild_pk(db, guild_slug)
+    except Exception:
+        logger.warning("discord router: guild pk lookup failed slug=%s", guild_slug, exc_info=True)
+        return None
+
+
 async def resolve_session(channel_id: str) -> tuple[str, str | None] | None:
     """Return ``(ps_guild_slug, task_id)`` for *channel_id*, or None if unresolvable.
 
@@ -222,7 +235,11 @@ async def resolve_session(channel_id: str) -> tuple[str, str | None] | None:
 
 
 async def _resolve_identity(
-    discord_user_id: str | None, username: str | None
+    discord_user_id: str | None,
+    username: str | None,
+    *,
+    is_bot: bool = False,
+    guild_pk: int | None = None,
 ) -> tuple[str | None, str]:
     """Return ``(ps_user_id, label)`` for a Discord author.
 
@@ -230,7 +247,11 @@ async def _resolve_identity(
     the older ``discord_users`` mapping (also used by ``mention_or_login``,
     reversed here: Discord user ID -> GitHub login -> Pioneer Square user).
     Falls back to ``(None, "a Discord user")`` — or the Discord username, if
-    known — when neither mapping exists. Never raises.
+    known — when neither mapping exists, *unless* ``is_bot`` is set: an
+    unmapped bot author is auto-provisioned its own ``users`` row (see
+    ``discord.bot_users.ensure_bot_user``) so its actions get an audit trail
+    and inherited guild permissions instead of resolving to nobody. Never
+    raises.
     """
     generic = f"Discord user @{username}" if username else "a Discord user"
     if not discord_user_id:
@@ -268,6 +289,20 @@ async def _resolve_identity(
         logger.warning(
             "discord router: identity lookup failed discord_user=%s", discord_user_id, exc_info=True
         )
+        return None, generic
+
+    if is_bot:
+        try:
+            from discord.bot_users import ensure_bot_user  # noqa: PLC0415
+
+            ps_user_id = await ensure_bot_user(discord_user_id, username, guild_pk)
+            return ps_user_id, f"🤖 {username}" if username else f"🤖 {discord_user_id}"
+        except Exception:
+            logger.warning(
+                "discord router: bot auto-provisioning failed discord_user=%s",
+                discord_user_id,
+                exc_info=True,
+            )
 
     return None, generic
 
@@ -429,7 +464,13 @@ async def _route_inbound_message(message: dict) -> None:
         return
 
     author = message.get("author") or {}
-    ps_user_id, label = await _resolve_identity(author.get("id"), author.get("username"))
+    guild_pk = await _guild_pk_for_slug(guild_slug)
+    ps_user_id, label = await _resolve_identity(
+        author.get("id"),
+        author.get("username"),
+        is_bot=bool(author.get("bot")),
+        guild_pk=guild_pk,
+    )
     discord_line = f"[Discord] {label}: {content}"
     # A resolved task_id means this message landed in a thread already bound to a task
     # (an "issue" or "task_stream" subject binding) — tag it so the Foreman can route

--- a/backend/models.py
+++ b/backend/models.py
@@ -262,6 +262,16 @@ class User(SQLModel, table=True):
     avatar_url: str | None = None
     created_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+    # True for auto-provisioned Discord bot accounts (see discord/bot_users.py).
+    # False for real GitHub-authenticated humans.
+    is_bot: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default=text("false")),
+    )
+    # For a bot user (is_bot=True), the real human user it is provisioned under —
+    # typically the guild's owner at the time the bot first interacted. NULL for
+    # human users. Self-referential FK; never chains bot -> bot.
+    parent_user_id: str | None = Field(default=None, foreign_key="users.id", index=True)
 
 
 class GuildMember(SQLModel, table=True):

--- a/backend/tests/test_discord_bot_users.py
+++ b/backend/tests/test_discord_bot_users.py
@@ -1,0 +1,140 @@
+"""Unit tests for Discord bot user auto-provisioning (discord/bot_users.py).
+
+Exercises ``ensure_bot_user`` against a real DB: a bot's first message creates
+a ``users`` row parented to the guild's human owner and inherits that owner's
+guild role (permission inheritance); later messages from the same bot reuse
+the row; multiple distinct bots in the same guild share the same parent.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from discord.bot_users import ensure_bot_user  # noqa: E402
+from helpers import _sync_session, insert_guild, insert_member  # noqa: E402
+from models import Guild, GuildMember  # noqa: E402
+from sqlmodel import col, select  # noqa: E402
+
+
+def _guild_pk(db_url: str, slug: str) -> int:
+    with _sync_session(db_url) as session:
+        return session.execute(select(Guild.id).where(col(Guild.slug) == slug)).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_ensure_bot_user_creates_row_parented_to_guild_owner(client):
+    _test_client, db_url = client
+    insert_guild(db_url, "g-bot-users1", owner_user_id="gh-owner-1")
+    guild_pk = _guild_pk(db_url, "g-bot-users1")
+
+    ps_user_id = await ensure_bot_user("discord-bot-1", "CIBot", guild_pk)
+
+    assert ps_user_id == "discordbot:discord-bot-1"
+    with _sync_session(db_url) as session:
+        from models import User
+
+        user = session.get(User, ps_user_id)
+        assert user is not None
+        assert user.is_bot is True
+        assert user.parent_user_id == "gh-owner-1"
+
+        # Permission inheritance: the bot inherits the parent's guild role.
+        member = session.execute(
+            select(GuildMember).where(
+                col(GuildMember.guild_id) == guild_pk,
+                col(GuildMember.user_id) == ps_user_id,
+            )
+        ).scalars().one()
+        assert member.role == "owner"
+
+
+@pytest.mark.asyncio
+async def test_ensure_bot_user_is_idempotent(client):
+    _test_client, db_url = client
+    insert_guild(db_url, "g-bot-users2", owner_user_id="gh-owner-2")
+    guild_pk = _guild_pk(db_url, "g-bot-users2")
+
+    first = await ensure_bot_user("discord-bot-2", "CIBot", guild_pk)
+    second = await ensure_bot_user("discord-bot-2", "CIBot", guild_pk)
+
+    assert first == second
+    with _sync_session(db_url) as session:
+        from models import User
+
+        rows = session.execute(select(User).where(col(User.id) == first)).scalars().all()
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_bot_user_multiple_bots_share_parent(client):
+    _test_client, db_url = client
+    insert_guild(db_url, "g-bot-users3", owner_user_id="gh-owner-3")
+    guild_pk = _guild_pk(db_url, "g-bot-users3")
+
+    bot_a = await ensure_bot_user("discord-bot-3a", "BotA", guild_pk)
+    bot_b = await ensure_bot_user("discord-bot-3b", "BotB", guild_pk)
+
+    assert bot_a != bot_b
+    with _sync_session(db_url) as session:
+        from models import User
+
+        user_a = session.get(User, bot_a)
+        user_b = session.get(User, bot_b)
+        assert user_a.parent_user_id == user_b.parent_user_id == "gh-owner-3"
+
+
+@pytest.mark.asyncio
+async def test_ensure_bot_user_inherits_non_owner_role(client):
+    """The bot inherits whatever role the resolved parent actually has — a
+    guild whose only human is a plain member, not an owner, still resolves a
+    parent-owner (a real guild always has ≥1 owner), but a bot's inherited
+    role tracks that owner's own role rather than being hardcoded."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-bot-users4", owner_user_id="gh-owner-4")
+    insert_member(db_url, "g-bot-users4", "gh-member-4", role="member")
+    guild_pk = _guild_pk(db_url, "g-bot-users4")
+
+    ps_user_id = await ensure_bot_user("discord-bot-4", "CIBot", guild_pk)
+
+    with _sync_session(db_url) as session:
+        member = session.execute(
+            select(GuildMember).where(
+                col(GuildMember.guild_id) == guild_pk,
+                col(GuildMember.user_id) == ps_user_id,
+            )
+        ).scalars().one()
+        # Parent is still the owner (gh-owner-4) since that's who owns the guild.
+        assert member.role == "owner"
+
+
+@pytest.mark.asyncio
+async def test_ensure_bot_user_with_no_guild_context_has_no_parent(client):
+    """When guild_pk is unknown, the bot row is still created (so its actions
+    still get an audit trail) but with no parent to inherit from."""
+    ps_user_id = await ensure_bot_user("discord-bot-5", "LonelyBot", None)
+
+    assert ps_user_id == "discordbot:discord-bot-5"
+
+
+@pytest.mark.asyncio
+async def test_ensure_bot_user_never_parents_to_another_bot(client):
+    """A bot can never become another bot's parent — only a real human owner
+    qualifies, guarded by the is_bot=False filter in _find_parent_owner."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-bot-users6", owner_user_id="gh-owner-6")
+    guild_pk = _guild_pk(db_url, "g-bot-users6")
+
+    first_bot = await ensure_bot_user("discord-bot-6a", "BotA", guild_pk)
+    second_bot = await ensure_bot_user("discord-bot-6b", "BotB", guild_pk)
+
+    with _sync_session(db_url) as session:
+        from models import User
+
+        assert session.get(User, second_bot).parent_user_id != first_bot
+        assert session.get(User, second_bot).parent_user_id == "gh-owner-6"

--- a/backend/tests/test_discord_bot_users.py
+++ b/backend/tests/test_discord_bot_users.py
@@ -45,12 +45,16 @@ async def test_ensure_bot_user_creates_row_parented_to_guild_owner(client):
         assert user.parent_user_id == "gh-owner-1"
 
         # Permission inheritance: the bot inherits the parent's guild role.
-        member = session.execute(
-            select(GuildMember).where(
-                col(GuildMember.guild_id) == guild_pk,
-                col(GuildMember.user_id) == ps_user_id,
+        member = (
+            session.execute(
+                select(GuildMember).where(
+                    col(GuildMember.guild_id) == guild_pk,
+                    col(GuildMember.user_id) == ps_user_id,
+                )
             )
-        ).scalars().one()
+            .scalars()
+            .one()
+        )
         assert member.role == "owner"
 
 
@@ -103,12 +107,16 @@ async def test_ensure_bot_user_inherits_non_owner_role(client):
     ps_user_id = await ensure_bot_user("discord-bot-4", "CIBot", guild_pk)
 
     with _sync_session(db_url) as session:
-        member = session.execute(
-            select(GuildMember).where(
-                col(GuildMember.guild_id) == guild_pk,
-                col(GuildMember.user_id) == ps_user_id,
+        member = (
+            session.execute(
+                select(GuildMember).where(
+                    col(GuildMember.guild_id) == guild_pk,
+                    col(GuildMember.user_id) == ps_user_id,
+                )
             )
-        ).scalars().one()
+            .scalars()
+            .one()
+        )
         # Parent is still the owner (gh-owner-4) since that's who owns the guild.
         assert member.role == "owner"
 

--- a/backend/tests/test_discord_gateway.py
+++ b/backend/tests/test_discord_gateway.py
@@ -302,6 +302,39 @@ async def test_message_create_filters_bot_author():
 
 
 @pytest.mark.asyncio
+async def test_message_create_allows_other_bot_when_application_id_configured(monkeypatch):
+    """A different application's bot message passes through once
+    DISCORD_APPLICATION_ID is set, so it can be auto-provisioned/routed
+    instead of being dropped outright."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "own-bot-id")
+    client = gateway.GatewayClient("token", queue=asyncio.Queue())
+    message = {
+        "author": {"bot": True, "id": "other-bot-id"},
+        "guild_id": "g1",
+        "channel_id": "c1",
+    }
+    with patch("discord.gateway._is_channel_wired", new=AsyncMock(return_value=True)):
+        await client._handle_message_create(message)
+    assert client._queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_message_create_still_filters_own_bot_when_application_id_configured(monkeypatch):
+    """Even with DISCORD_APPLICATION_ID configured, our own bot's messages are
+    still dropped to avoid echoing discord_notifier."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "own-bot-id")
+    client = gateway.GatewayClient("token", queue=asyncio.Queue())
+    message = {
+        "author": {"bot": True, "id": "own-bot-id"},
+        "guild_id": "g1",
+        "channel_id": "c1",
+    }
+    with patch("discord.gateway._is_channel_wired", new=AsyncMock(return_value=True)):
+        await client._handle_message_create(message)
+    assert client._queue.empty()
+
+
+@pytest.mark.asyncio
 async def test_message_create_filters_dm_with_no_guild_id():
     client = gateway.GatewayClient("token", queue=asyncio.Queue())
     message = {"author": {"bot": False}, "channel_id": "c1"}

--- a/backend/tests/test_discord_router.py
+++ b/backend/tests/test_discord_router.py
@@ -21,7 +21,8 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 from discord import router  # noqa: E402
 from helpers import _sync_session, insert_guild, insert_task  # noqa: E402
-from models import DiscordChannelGuild, DiscordThreadBinding  # noqa: E402
+from models import DiscordChannelGuild, DiscordThreadBinding, User  # noqa: E402
+from sqlmodel import col, select  # noqa: E402
 
 
 def _insert_binding(db_url: str, subject_type: str, subject_key: str, thread_id: str) -> None:
@@ -270,3 +271,71 @@ async def test_mention_channel_ignores_when_application_id_unset(client):
         )
 
     assert mock_trigger.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Bot auto-provisioning (parent_user_id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_message_auto_provisions_bot_author(client):
+    """An unmapped bot author gets its own users row, parented to the guild owner,
+    instead of resolving to no ps_user_id at all."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-router-bot1", owner_user_id="gh-owner-bot1")
+    _insert_channel_guild(db_url, "channel-bot-1", "g-router-bot1")
+
+    with (
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "build finished",
+                "channel_id": "channel-bot-1",
+                "author": {"id": "d-bot-1", "username": "ci-bot", "bot": True},
+            }
+        )
+
+    assert mock_trigger.await_count == 1
+    _args, kwargs = mock_trigger.await_args
+    ps_user_id = kwargs["user_id"]
+    assert ps_user_id == "discordbot:d-bot-1"
+
+    with _sync_session(db_url) as session:
+        bot_user = session.execute(select(User).where(col(User.id) == ps_user_id)).scalars().one()
+        assert bot_user.is_bot is True
+        assert bot_user.parent_user_id == "gh-owner-bot1"
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_message_reuses_existing_bot_user(client):
+    """A second message from the same bot reuses its already-provisioned row."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-router-bot2", owner_user_id="gh-owner-bot2")
+    _insert_channel_guild(db_url, "channel-bot-2", "g-router-bot2")
+
+    async def _send():
+        with (
+            patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+            patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+            patch("foreman.runner.reset_foreman_poll"),
+        ):
+            await router._route_inbound_message(
+                {
+                    "content": "status update",
+                    "channel_id": "channel-bot-2",
+                    "author": {"id": "d-bot-2", "username": "ci-bot", "bot": True},
+                }
+            )
+            return mock_trigger.await_args[1]["user_id"]
+
+    first_id = await _send()
+    second_id = await _send()
+    assert first_id == second_id == "discordbot:d-bot-2"
+
+    with _sync_session(db_url) as session:
+        count = len(session.execute(select(User).where(col(User.id) == first_id)).scalars().all())
+        assert count == 1


### PR DESCRIPTION
## Summary
- Adds `is_bot` and `parent_user_id` columns to `users` (self-referential FK) via a new Alembic migration, so a Discord bot account can be auto-provisioned its own row while its permissions/ownership trace back to a real human.
- Adds `discord/bot_users.py::ensure_bot_user`, which find-or-creates a `users` row for a Discord bot (`discordbot:<discord_id>` id), parents it to the guild's earliest human owner, and mirrors that owner's `guild_members` role onto the bot so it inherits the same guild permissions. A bot can never become another bot's parent (`is_bot == False` guard on the owner lookup), preventing bot→bot parent chains.
- `discord/router.py::_resolve_identity` now auto-provisions an unmapped bot author via `ensure_bot_user` instead of resolving to `None` (no audit trail). A `discord_account_links` row is written so later messages from the same bot resolve instantly through the existing lookup path.
- `discord/gateway.py` no longer blanket-drops all bot messages: when `DISCORD_APPLICATION_ID` is configured, only messages from *this app's own* bot user are filtered (to avoid echo loops); other bots' messages pass through and get auto-provisioned. Without that env var set, behavior is unchanged (all bot messages dropped) to preserve the safe default.
- Idempotent: repeat messages from an already-provisioned bot reuse its existing row; multiple distinct bots in the same guild share the same parent.

## Test plan
- [x] `pip install pytest-asyncio` (needed for `@pytest.mark.asyncio` tests; `requirements-test.txt` only carries `psycopg2-binary` — `pytest-asyncio` is declared in `requirements.txt`)
- [x] `python -m pytest backend/tests/test_discord_bot_users.py backend/tests/test_discord_gateway.py backend/tests/test_discord_router.py -q` — 46 passed
- [x] Full backend suite: `python -m pytest -q` — 1111 passed, 2 skipped
- Fixed a bug in the new tests where `_sync_session` (plain SQLAlchemy `Session`) was called with sqlmodel's `.exec()`, which doesn't exist on it — switched to `.execute()` + `.scalars()` to match every other test file's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)