### PR TITLE
Remove approval capability from review_pr_internal instructions

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -71,9 +71,11 @@ Always create_task first and finalize_task after — whether you use a worker or
 
 **Shallow/fallback review** (no worker available, or quick diff-only review):
 1. create_task(name="Review PR #N: <title>", phase="review", pr_number=N, pr_repo="owner/repo") → returns task_id
-2. review_pr_internal (or review_pr) — pass the PR details. Omit `action` to let the tool pick
-   the verdict itself from its own diff analysis (see "Review action policy" below); only pass
-   `action` explicitly to override that judgement.
+2. review_pr_internal (or review_pr) — pass the PR details. review_pr_internal never approves;
+   it posts COMMENT or REQUEST_CHANGES only. review_pr (the external MCP reviewer) may still
+   choose APPROVE per its own action parameter. Omit `action` to let the tool pick the verdict
+   itself from its own diff analysis (see "Review action policy" below); only pass `action`
+   explicitly to override that judgement.
 3. finalize_task(task_id=<task_id from step 1>) — call after the review returns. \
    Use expires_in_seconds=86400 for error/failed reviews; omit (default 3 days) otherwise.
 
@@ -83,7 +85,8 @@ forbidden from committing or opening a new PR. review_pr_internal and review_pr 
 directly via the GitHub Reviews API. In both paths, there is nothing to commit or push.
 
 ## Review action policy
-This applies to every PR review path — worker-driven `gh pr review` and review_pr_internal alike:
+This applies to worker-driven `gh pr review` and review_pr alike; review_pr_internal follows the
+same COMMENT vs. REQUEST_CHANGES judgement below but must never APPROVE:
 - **APPROVE** — the diff is functionally correct and any issues are minor nits (style, naming,
   formatting). Submit APPROVE with inline comments noting the nits; don't withhold approval over
   them.


### PR DESCRIPTION
## Summary
- `review_pr_internal` is a self-contained internal review tool with no external dependency; the foreman system prompt previously implied it could pick APPROVE as a verdict alongside COMMENT/REQUEST_CHANGES.
- Updated both places in `backend/foreman/prompt.py` that discuss `review_pr_internal` to state it never approves — only the worker-driven `gh pr review` path and the external `review_pr` MCP tool are described as able to APPROVE a PR.

## Test plan
- [x] Reviewed the full diff in `backend/foreman/prompt.py` to confirm no other stray mentions of `review_pr_internal` approving remain
- [x] Confirmed `review_pr` (external MCP reviewer) and worker-driven reviews retain their documented APPROVE capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)