### PR TITLE
fix(discord): auto-provision bots that @-mention from unwired channels

### DIFF
--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from datetime import UTC, datetime
 
 from discord.auth import (
@@ -316,6 +317,51 @@ async def _resolve_user_guild_slugs(ps_user_id: str) -> list[str]:
         return []
 
 
+def _default_guild_slug() -> str | None:
+    """Return this instance's default guild slug (``GUILD_ID``), or None.
+
+    A last resort, not a preference: it applies only where an inbound event
+    carries no project of its own to resolve from — a bot @-mention in a DM,
+    or in a Discord server wired to nothing. Anywhere a channel or server
+    binding exists, that binding wins, so a multi-project server is never
+    funnelled into the instance default.
+
+    Shared with the ``foreman`` service, which reads the same var to pick the
+    single guild it manages; the backend must be passed it explicitly in
+    ``docker-compose.yml`` (it is not inherited).
+    """
+    return os.environ.get("GUILD_ID") or None
+
+
+async def resolve_guild_slug(
+    channel_id: str | None, discord_guild_id: str | None = None
+) -> str | None:
+    """Return the Pioneer Square guild a Discord interaction targets, or None.
+
+    The same narrowing the inbound chat path applies, in the same order —
+    most specific context first, instance default last:
+
+        1. the channel/thread it came from, if bound (``resolve_session``)
+        2. any project the Discord *server* is wired to, newest first
+        3. this instance's default guild (``GUILD_ID``)
+
+    Exists so slash commands resolve their target the way a bot @-mention
+    does, instead of being pinned to a single env var: ``/ps status`` typed in
+    a channel wired to a project should report on *that* project. Never raises
+    — each step is individually fault-tolerant, so a lookup failure degrades
+    to the next step rather than failing the command.
+    """
+    if channel_id:
+        session = await resolve_session(str(channel_id))
+        if session:
+            return session[0]
+    if discord_guild_id:
+        bound = await _resolve_discord_guild_slugs(str(discord_guild_id))
+        if bound:
+            return bound[0]
+    return _default_guild_slug()
+
+
 async def _resolve_discord_guild_slugs(discord_guild_id: str) -> list[str]:
     """Return every Pioneer Square guild slug bound to *any* channel of the
     Discord server *discord_guild_id*, most-recently-created first.
@@ -364,10 +410,17 @@ async def _dispatch_author_scoped(message: dict, content: str, reply_channel_id:
     Every other inbound path resolves a Foreman session from the *channel*
     a message landed in (see ``resolve_session``). This one can't, so it
     falls back to the author's own projects. The author has to resolve to a
-    linked Pioneer Square user (``_resolve_identity``) with at least one
-    accessible project (``_resolve_user_guild_slugs``) — an author that
-    fails either check has nowhere well-defined to route to and is silently
-    ignored, same as an unresolvable channel elsewhere in this module.
+    Pioneer Square user (``_resolve_identity``) with at least one accessible
+    project (``_resolve_user_guild_slugs``) — an author that fails either
+    check has nowhere well-defined to route to and is silently ignored, same
+    as an unresolvable channel elsewhere in this module.
+
+    A *bot* author resolves by being auto-provisioned rather than by having
+    linked an account, exactly as on the channel-scoped path — see the
+    ``guild_pk`` note below for where its parent comes from. Dropping the
+    ``is_bot`` flag here is what made bot @-mentions from unwired channels
+    resolve to nobody and get ignored (they reach this path at all only since
+    the bot-mention bypass in #969).
 
     Candidates are the author's accessible projects, but ones bound to the
     Discord server the mention came from are preferred: a mention typed in an
@@ -385,7 +438,22 @@ async def _dispatch_author_scoped(message: dict, content: str, reply_channel_id:
     rather than just the one it's replying from. Never raises.
     """
     author = message.get("author") or {}
-    ps_user_id, label = await _resolve_identity(author.get("id"), author.get("username"))
+    discord_guild_id = message.get("guild_id")
+    # Resolved before the identity lookup, not after, because an unlinked *bot*
+    # author gets provisioned during that lookup and needs a guild to parent
+    # into. Unlike the channel-scoped path there is no binding to read it from,
+    # so the server's own bindings stand in: the most-recently-created project
+    # the mention's Discord server is wired to, falling back to the instance
+    # default only when the server is wired to nothing (or it's a DM). Humans
+    # are unaffected either way — guild_pk is read only when provisioning a bot.
+    bound = await _resolve_discord_guild_slugs(str(discord_guild_id)) if discord_guild_id else []
+    provision_slug = bound[0] if bound else _default_guild_slug()
+    ps_user_id, label = await _resolve_identity(
+        author.get("id"),
+        author.get("username"),
+        is_bot=bool(author.get("bot")),
+        guild_pk=await _guild_pk_for_slug(provision_slug) if provision_slug else None,
+    )
     if not ps_user_id:
         logger.info(
             "discord router: mention from unlinked discord_user=%s — ignoring",
@@ -401,9 +469,7 @@ async def _dispatch_author_scoped(message: dict, content: str, reply_channel_id:
         )
         return
 
-    discord_guild_id = message.get("guild_id")
     if discord_guild_id:
-        bound = await _resolve_discord_guild_slugs(str(discord_guild_id))
         # Intersect rather than replace: server bindings narrow the choice,
         # but must never route someone into a project they aren't a member of.
         accessible = set(guild_slugs)

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -6,9 +6,14 @@ Required env vars:
     DISCORD_PUBLIC_KEY          Ed25519 public key (hex) from Discord developer portal
     DISCORD_APPLICATION_ID      Discord application/bot ID (used for followup URLs)
     DISCORD_BOT_TOKEN           Discord bot token (reuses Phase 2 var)
-    DISCORD_PIONEER_GUILD_SLUG  Pioneer Square guild slug to target for /ps commands
 
 Optional env vars:
+    DISCORD_PIONEER_GUILD_SLUG  Pins every /ps command to one Pioneer Square guild.
+                                Deprecated: when unset, a command resolves its own
+                                target the way an inbound bot @-mention does —
+                                channel binding, then Discord-server binding, then
+                                GUILD_ID (see discord.router.resolve_guild_slug).
+    GUILD_ID                    Instance default guild, used as the last resort above.
     DISCORD_ALLOWED_ROLE_IDS    Comma-separated Discord role IDs; empty = allow all
     DISCORD_OPERATOR_ROLE_NAME  Discord role name allowed to run /join-channel and
                                 /leave-channel (in addition to Manage Channels
@@ -100,7 +105,35 @@ def _application_id() -> str | None:
 
 
 def _pioneer_guild_slug() -> str | None:
+    """Explicit, instance-wide override for the guild ``/ps`` commands target.
+
+    Deprecated in favour of letting the command resolve its own context — see
+    ``_resolve_command_guild_slug``. Kept because it is the documented way to
+    pin an instance to one project, and unsetting it silently would change
+    behaviour for deployments relying on it.
+    """
     return os.environ.get("DISCORD_PIONEER_GUILD_SLUG") or None
+
+
+async def _resolve_command_guild_slug(interaction: dict) -> str:
+    """Return the Pioneer Square guild slug a slash command should operate on.
+
+    Resolves the same way an inbound bot @-mention does — channel binding,
+    then Discord-server binding, then the instance default (``GUILD_ID``) —
+    so ``/ps status`` in a channel wired to a project reports on that project
+    rather than on whatever one env var names. ``DISCORD_PIONEER_GUILD_SLUG``
+    still wins when explicitly set, preserving the pinned-instance setup.
+
+    Returns ``""`` when nothing resolves, matching what the call sites
+    previously produced for an unset env var.
+    """
+    explicit = _pioneer_guild_slug()
+    if explicit:
+        return explicit
+    from discord.router import resolve_guild_slug  # noqa: PLC0415
+
+    slug = await resolve_guild_slug(interaction.get("channel_id"), interaction.get("guild_id"))
+    return slug or ""
 
 
 def _operator_role_name() -> str:
@@ -644,7 +677,7 @@ async def _cmd_worker_spawn(interaction: dict) -> None:
         [t.strip() for t in str(tools_opt["value"]).split(",") if t.strip()] if tools_opt else []
     )
 
-    guild_slug = _pioneer_guild_slug() or ""
+    guild_slug = await _resolve_command_guild_slug(interaction)
 
     try:
         async with AsyncSessionLocal() as db:
@@ -884,7 +917,7 @@ async def _dispatch_command(interaction: dict) -> None:
         await _cmd_worker_spawn(interaction)
         return
 
-    guild_slug = _pioneer_guild_slug() or ""
+    guild_slug = await _resolve_command_guild_slug(interaction)
 
     options: list[dict] = data.get("options", [])
     if not options:

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -1230,3 +1230,58 @@ async def test_cmd_leave_channel_denies_without_permission(monkeypatch):
 
     assert sent
     assert "Manage Channels" in sent[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Slash-command guild resolution (shares discord.router.resolve_guild_slug)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_command_guild_slug_env_override_wins(monkeypatch):
+    """An explicitly set DISCORD_PIONEER_GUILD_SLUG still pins the instance,
+    without consulting the channel/server bindings at all."""
+    monkeypatch.setenv("DISCORD_PIONEER_GUILD_SLUG", "pinned-guild")
+
+    from routes.discord import _resolve_command_guild_slug
+
+    resolver = AsyncMock(return_value="context-guild")
+    with patch("discord.router.resolve_guild_slug", new=resolver):
+        slug = await _resolve_command_guild_slug(
+            {"channel_id": "chan-1", "guild_id": "dg-1", "data": {}}
+        )
+
+    assert slug == "pinned-guild"
+    assert resolver.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_command_guild_slug_resolves_from_context_when_unset(monkeypatch):
+    """With the env var unset the command resolves its own target from the
+    channel/server it was invoked in, like an inbound bot @-mention."""
+    monkeypatch.delenv("DISCORD_PIONEER_GUILD_SLUG", raising=False)
+
+    from routes.discord import _resolve_command_guild_slug
+
+    resolver = AsyncMock(return_value="context-guild")
+    with patch("discord.router.resolve_guild_slug", new=resolver):
+        slug = await _resolve_command_guild_slug(
+            {"channel_id": "chan-1", "guild_id": "dg-1", "data": {}}
+        )
+
+    assert slug == "context-guild"
+    resolver.assert_awaited_once_with("chan-1", "dg-1")
+
+
+@pytest.mark.asyncio
+async def test_command_guild_slug_empty_when_nothing_resolves(monkeypatch):
+    """Nothing bound and no default — callers get "" exactly as they did for an
+    unset env var before, so downstream handling is unchanged."""
+    monkeypatch.delenv("DISCORD_PIONEER_GUILD_SLUG", raising=False)
+
+    from routes.discord import _resolve_command_guild_slug
+
+    with patch("discord.router.resolve_guild_slug", new=AsyncMock(return_value=None)):
+        slug = await _resolve_command_guild_slug({"channel_id": None, "data": {}})
+
+    assert slug == ""

--- a/backend/tests/test_discord_router.py
+++ b/backend/tests/test_discord_router.py
@@ -455,3 +455,200 @@ async def test_route_inbound_message_reuses_existing_bot_user(client):
     with _sync_session(db_url) as session:
         count = len(session.execute(select(User).where(col(User.id) == first_id)).scalars().all())
         assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_bot_mention_in_unwired_channel_provisions_via_server_binding(client):
+    """Regression: a *bot* @-mention reaching the author-scoped path was resolved
+    without ``is_bot``, so it never auto-provisioned and was dropped as "unlinked".
+
+    The mention bypass (#969) is what lets a bot reach this path at all, from a
+    channel that is wired to nothing. The parent comes from the Discord
+    *server's* other bindings, since there is no channel binding to read.
+
+    Deliberately does not patch ``_resolve_identity`` — every other mention test
+    stubs it out, which is exactly how the missing flag went unnoticed.
+    """
+    _test_client, db_url = client
+    insert_guild(db_url, "g-router-bot3", owner_user_id="gh-owner-bot3")
+    _insert_channel_guild(
+        db_url, "channel-wired-bot3", "g-router-bot3", discord_guild_id="discord-server-bot3"
+    )
+
+    with (
+        patch.dict(os.environ, {"DISCORD_APPLICATION_ID": "bot-id-1"}),
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "<@bot-id-1> deploy finished",
+                # Wired to nothing — only the *server* has a binding, elsewhere.
+                "channel_id": "channel-unwired-bot3",
+                "guild_id": "discord-server-bot3",
+                "author": {"id": "d-bot-3", "username": "mecha", "bot": True},
+                "mentions": [{"id": "bot-id-1"}],
+            }
+        )
+
+    assert mock_trigger.await_count == 1
+    args, kwargs = mock_trigger.await_args
+    assert args[0] == "g-router-bot3"
+    assert kwargs["user_id"] == "discordbot:d-bot-3"
+
+    with _sync_session(db_url) as session:
+        bot_user = (
+            session.execute(select(User).where(col(User.id) == "discordbot:d-bot-3"))
+            .scalars()
+            .one()
+        )
+        assert bot_user.is_bot is True
+        assert bot_user.parent_user_id == "gh-owner-bot3"
+
+
+@pytest.mark.asyncio
+async def test_bot_mention_with_no_server_binding_falls_back_to_default_guild(client):
+    """With nothing bound to the mention's server (or in a DM), the bot parents
+    into the instance default (``GUILD_ID``) rather than being dropped."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-defalt", owner_user_id="gh-owner-bot4")
+
+    with (
+        patch.dict(os.environ, {"DISCORD_APPLICATION_ID": "bot-id-1", "GUILD_ID": "g-defalt"}),
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "<@bot-id-1> anyone home?",
+                "channel_id": "dm-channel-bot4",
+                "author": {"id": "d-bot-4", "username": "mecha", "bot": True},
+                "mentions": [{"id": "bot-id-1"}],
+            }
+        )
+
+    assert mock_trigger.await_count == 1
+    args, _kwargs = mock_trigger.await_args
+    assert args[0] == "g-defalt"
+
+    with _sync_session(db_url) as session:
+        bot_user = (
+            session.execute(select(User).where(col(User.id) == "discordbot:d-bot-4"))
+            .scalars()
+            .one()
+        )
+        assert bot_user.parent_user_id == "gh-owner-bot4"
+
+
+@pytest.mark.asyncio
+async def test_server_binding_beats_default_guild_for_bot_mention(client):
+    """``GUILD_ID`` is a last resort, not a preference — a server wired to a
+    project parents the bot there even when the default points elsewhere."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-defalt", owner_user_id="gh-owner-default")
+    insert_guild(db_url, "g-wired5", owner_user_id="gh-owner-bot5")
+    _insert_channel_guild(
+        db_url, "channel-wired-bot5", "g-wired5", discord_guild_id="discord-server-bot5"
+    )
+
+    with (
+        patch.dict(os.environ, {"DISCORD_APPLICATION_ID": "bot-id-1", "GUILD_ID": "g-defalt"}),
+        patch.object(router, "_persist_inbound_message", new=AsyncMock()),
+        patch("ws_handlers._trigger_foreman", new=AsyncMock()) as mock_trigger,
+        patch("foreman.runner.reset_foreman_poll"),
+    ):
+        await router._route_inbound_message(
+            {
+                "content": "<@bot-id-1> status?",
+                "channel_id": "channel-unwired-bot5",
+                "guild_id": "discord-server-bot5",
+                "author": {"id": "d-bot-5", "username": "mecha", "bot": True},
+                "mentions": [{"id": "bot-id-1"}],
+            }
+        )
+
+    assert mock_trigger.await_count == 1
+    args, _kwargs = mock_trigger.await_args
+    assert args[0] == "g-wired5"
+
+    with _sync_session(db_url) as session:
+        bot_user = (
+            session.execute(select(User).where(col(User.id) == "discordbot:d-bot-5"))
+            .scalars()
+            .one()
+        )
+        assert bot_user.parent_user_id == "gh-owner-bot5"
+
+
+# ---------------------------------------------------------------------------
+# resolve_guild_slug — shared by slash commands (routes/discord.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_slug_prefers_the_channel_binding(client):
+    """The channel a command was typed in wins over the server and the default."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-channel")
+    insert_guild(db_url, "g-server")
+    _insert_channel_guild(db_url, "channel-cmd-1", "g-channel", discord_guild_id="discord-cmd-1")
+    _insert_channel_guild(db_url, "channel-cmd-other", "g-server", discord_guild_id="discord-cmd-1")
+
+    with patch.dict(os.environ, {"GUILD_ID": "g-defalt"}):
+        slug = await router.resolve_guild_slug("channel-cmd-1", "discord-cmd-1")
+
+    assert slug == "g-channel"
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_slug_falls_back_to_server_binding(client):
+    """An unbound channel falls back to a project the Discord server is wired to."""
+    _test_client, db_url = client
+    # The server-binding lookup joins Guild, so the project row must exist —
+    # unlike the channel-binding lookup, which reads ps_guild_id directly.
+    insert_guild(db_url, "g-server2")
+    _insert_channel_guild(db_url, "channel-cmd-2", "g-server2", discord_guild_id="discord-cmd-2")
+
+    with patch.dict(os.environ, {"GUILD_ID": "g-defalt"}):
+        slug = await router.resolve_guild_slug("channel-cmd-unbound", "discord-cmd-2")
+
+    assert slug == "g-server2"
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_slug_falls_back_to_instance_default(client):
+    """Nothing bound anywhere — the instance default is the last resort."""
+    _test_client, _db_url = client
+
+    with patch.dict(os.environ, {"GUILD_ID": "g-defalt"}):
+        slug = await router.resolve_guild_slug("channel-cmd-nowhere", "discord-cmd-nowhere")
+
+    assert slug == "g-defalt"
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_slug_returns_none_when_nothing_resolves(client):
+    """No binding and no GUILD_ID — the caller decides what to do with None."""
+    _test_client, _db_url = client
+
+    with patch.dict(os.environ, {"GUILD_ID": ""}):
+        slug = await router.resolve_guild_slug("channel-cmd-nowhere", "discord-cmd-nowhere")
+
+    assert slug is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_slug_routes_a_thread_to_its_task_guild(client):
+    """A command typed in a task's thread resolves to that task's guild — the
+    thread bindings the chat path uses, not just /join-channel wiring."""
+    _test_client, db_url = client
+    insert_guild(db_url, "g-thread")
+    insert_task(db_url, "g-thread", "t-thread-cmd", state="working")
+    _insert_binding(db_url, "task_stream", "t-thread-cmd", "thread-cmd-1")
+
+    with patch.dict(os.environ, {"GUILD_ID": "g-defalt"}):
+        slug = await router.resolve_guild_slug("thread-cmd-1", "discord-cmd-3")
+
+    assert slug == "g-thread"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,12 @@ services:
       # and, when set, is forwarded into worker containers this backend spawns
       # (build_spawn_worker_env) so the worker's debug-query skill can use it too.
       DEBUG_TOKEN: ${DEBUG_TOKEN:-}
+      # Default Pioneer Square guild (6-char slug) for this instance — used
+      # where an inbound event has no project of its own to resolve from, e.g.
+      # a Discord @-mention in an unwired channel (discord/router.py). Shared
+      # with the foreman service below, which reads the same var to pick the
+      # single guild it manages.
+      GUILD_ID: ${GUILD_ID:-}
       # S3 session-log sync — forwarded to spawned worker containers.
       PIONEER_S3_BUCKET: ${PIONEER_S3_BUCKET:-}
       PIONEER_S3_PREFIX: ${PIONEER_S3_PREFIX:-}


### PR DESCRIPTION
## Problem

mecha-wolfgang @-mentioned the bot and got silently dropped:

```
discord gateway: queueing @-mention channel=1528707144227225631 guild=... author=1528548276943458357
discord router:  mention from unlinked discord_user=1528548276943458357 — ignoring
```

No `users` row was ever created for it, despite #965 adding bot auto-provisioning.

`_dispatch_author_scoped` called `_resolve_identity` **without** `is_bot`, so the
auto-provisioning branch never ran and it returned `None` → "unlinked" → dropped.
The channel-scoped path (`_dispatch_channel_scoped`) passed the flag correctly;
this one didn't.

This path is only reachable since #969 added the bot-mention bypass, which is what
lets a bot's mention through from a channel wired to nothing. Every pre-existing
mention test patches `_resolve_identity` wholesale, so nothing caught it.

## Fix

`_dispatch_author_scoped` now resolves the Discord-server binding *before* the
identity lookup and passes both `is_bot=` and `guild_pk=` through.

The parent guild has to come from somewhere and there's no channel binding here,
so it mirrors the chat path: **server bindings (newest first) → `GUILD_ID`**.
`GUILD_ID` is a last resort, not a preference — a multi-project server is never
funnelled into the instance default. Humans are unaffected; `guild_pk` is read
only when provisioning a bot.

## GUILD_ID plumbing

`GUILD_ID` already existed but `docker-compose.yml` passed it **only** to the
profile-gated `foreman` service, so the backend read it as unset regardless of
`.env`. Now forwarded to `backend` too.

## Slash commands

Per review discussion, `/ps` commands now resolve their target the same way,
via the new public `router.resolve_guild_slug()`:

1. `DISCORD_PIONEER_GUILD_SLUG` if explicitly set (unchanged, pins an instance)
2. the channel/thread the command was typed in (covers task threads, not just `/join-channel`)
3. any project the Discord server is wired to, newest first
4. `GUILD_ID`
5. `""` — same value the call sites got from an unset env var before

So `/ps status` in a `dnsid`-wired channel reports on `dnsid` instead of whatever
one env var names.

## Tests

8 added; 121 discord tests pass; `ruff check backend/` clean.

The three regression tests fail against the pre-fix code with the exact production
symptom (`mention from unlinked discord_user=... — ignoring`) and **deliberately do
not patch `_resolve_identity`** — stubbing it out is how the original bug went
unnoticed.

## Notes

- Verified live: backend rebuilt and restarted, `GUILD_ID=dnsid` present in the
  container, gateway `READY`.
- Not in this PR — `DISCORD_PIONEER_GUILD_SLUG` was set to the placeholder
  `abc123` (not a real slug) in local `.env`, which is gitignored. I commented it
  out locally so commands fall through to context resolution; **any other
  deployment with that placeholder set needs the same change**, or `/ps` keeps
  targeting a guild that doesn't exist.
- `_resolve_discord_guild_slugs` inner-joins `Guild`, so a `discord_channel_guilds`
  row pointing at a deleted project silently falls through to the next step rather
  than erroring. Pre-existing behavior, just now load-bearing for step 3 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)