### PR TITLE
Terraform buildout fixes + ECS deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main, "release/**"]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to deploy"
+        type: choice
+        options: [staging, prod]
+        default: staging
+
+permissions:
+  id-token: write # OIDC — assumes the terraform-created deploy role, no static keys
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.ref }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [backend, foreman, worker]
+    env:
+      # main -> staging, release/** -> prod, manual dispatch -> input
+      ENVIRONMENT: ${{ inputs.environment || (startsWith(github.ref, 'refs/heads/release/') && 'prod' || 'staging') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        id: image
+        run: |
+          IMAGE="${{ steps.ecr.outputs.registry }}/pioneer-square-${ENVIRONMENT}/${{ matrix.service }}:${{ github.sha }}"
+          docker build --target "${{ matrix.service }}" -t "$IMAGE" .
+          docker push "$IMAGE"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch current task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition "pioneer-square-${ENVIRONMENT}-${{ matrix.service }}" \
+            --query taskDefinition > taskdef.json
+
+      - name: Render task definition with new image
+        id: render
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: taskdef.json
+          container-name: ${{ matrix.service }}
+          image: ${{ steps.image.outputs.image }}
+
+      # The worker has no ECS service (launched on demand via RunTask), so this
+      # step only registers a new task definition revision for it.
+      - name: Deploy
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render.outputs.task-definition }}
+          cluster: pioneer-square-${{ env.ENVIRONMENT }}-cluster
+          service: ${{ matrix.service != 'worker' && format('pioneer-square-{0}-{1}', env.ENVIRONMENT, matrix.service) || '' }}
+          wait-for-service-stability: ${{ matrix.service == 'backend' }}

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.3.0"
   constraints = "~> 4.0"
   hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
     "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -66,18 +66,34 @@ resource "aws_ecs_task_definition" "backend" {
         { name = "AWS_DEFAULT_REGION", value = local.region },
         { name = "ECS_CLUSTER_NAME", value = aws_ecs_cluster.main.name },
         { name = "ECS_WORKER_TASK_DEFINITION", value = "${local.name_prefix}-worker" },
+        # The embedded foreman (backend/foreman/runner.py) makes LLM calls from
+        # this process whenever no standalone foreman proxy is connected for a
+        # guild — it needs the same provider config as the foreman task below.
+        { name = "FOREMAN_MODEL", value = var.foreman_model },
+        { name = "FOREMAN_PROVIDER", value = var.foreman_provider },
+        { name = "FOREMAN_BEDROCK_MODEL", value = var.foreman_bedrock_model },
+        # Discord integration — mirrors the docker-compose backend service.
+        # DISCORD_BOT_TOKEN rides in `secrets` below.
+        { name = "DISCORD_CHANNEL_ID", value = var.discord_channel_id },
+        { name = "DISCORD_APPLICATION_ID", value = var.discord_application_id },
+        { name = "DISCORD_PUBLIC_KEY", value = var.discord_public_key },
+        { name = "DISCORD_ALLOWED_ROLE_IDS", value = var.discord_allowed_role_ids },
+        { name = "DISCORD_PIONEER_GUILD_SLUG", value = var.discord_pioneer_guild_slug },
+        { name = "DISCORD_STREAM_TASKS", value = var.discord_stream_tasks },
+        { name = "DISCORD_GATEWAY_ENABLED", value = var.discord_gateway_enabled },
       ]
 
       secrets = [
         for key, param in {
-          DATABASE_URL            = aws_ssm_parameter.database_url
-          GITHUB_CLIENT_ID        = aws_ssm_parameter.secret["github_client_id"]
-          GITHUB_CLIENT_SECRET    = aws_ssm_parameter.secret["github_client_secret"]
-          GITHUB_TOKEN            = aws_ssm_parameter.secret["github_token"]
-          ANTHROPIC_API_KEY       = aws_ssm_parameter.secret["anthropic_api_key"]
-          CLAUDE_CODE_OAUTH_TOKEN = aws_ssm_parameter.secret["claude_code_oauth_token"]
-          PIONEER_FOREMAN_KEY     = aws_ssm_parameter.secret["pioneer_foreman_key"]
-          DISCORD_BOT_TOKEN       = aws_ssm_parameter.secret["discord_bot_token"]
+          DATABASE_URL             = aws_ssm_parameter.database_url
+          GITHUB_CLIENT_ID         = aws_ssm_parameter.secret["github_client_id"]
+          GITHUB_CLIENT_SECRET     = aws_ssm_parameter.secret["github_client_secret"]
+          GITHUB_TOKEN             = aws_ssm_parameter.secret["github_token"]
+          ANTHROPIC_API_KEY        = aws_ssm_parameter.secret["anthropic_api_key"]
+          CLAUDE_CODE_OAUTH_TOKEN  = aws_ssm_parameter.secret["claude_code_oauth_token"]
+          PIONEER_FOREMAN_KEY      = aws_ssm_parameter.secret["pioneer_foreman_key"]
+          DISCORD_BOT_TOKEN        = aws_ssm_parameter.secret["discord_bot_token"]
+          AWS_BEARER_TOKEN_BEDROCK = aws_ssm_parameter.secret["aws_bearer_token_bedrock"]
         } : { name = key, valueFrom = param.arn }
       ]
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -17,8 +17,8 @@ resource "aws_db_subnet_group" "main" {
 }
 
 resource "aws_db_parameter_group" "postgres" {
-  name   = "${local.name_prefix}-pg16"
-  family = "postgres16"
+  name   = "${local.name_prefix}-pg18"
+  family = "postgres18"
 
   parameter {
     name         = "shared_preload_libraries"
@@ -27,8 +27,9 @@ resource "aws_db_parameter_group" "postgres" {
   }
 
   parameter {
-    name  = "pg_stat_statements.max"
-    value = "10000"
+    name         = "pg_stat_statements.max"
+    value        = "10000"
+    apply_method = "pending-reboot" # static parameter — immediate apply is rejected
   }
 
   parameter {
@@ -37,8 +38,9 @@ resource "aws_db_parameter_group" "postgres" {
   }
 
   parameter {
-    name  = "track_io_timing"
-    value = "1"
+    name         = "track_io_timing"
+    value        = "1"
+    apply_method = "pending-reboot" # matches what AWS records; avoids a perpetual plan diff
   }
 }
 

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -31,9 +31,12 @@ locals {
 resource "aws_ssm_parameter" "secret" {
   for_each = local.ssm_secrets
 
-  name  = "${local.ssm_path_prefix}/${each.key}"
-  type  = "SecureString"
-  value = each.value
+  name = "${local.ssm_path_prefix}/${each.key}"
+  type = "SecureString"
+  # SSM rejects empty values, and ecs.tf references every key in this map, so
+  # optional secrets left "" (discord_bot_token, aws_bearer_token_bedrock) are
+  # seeded with the same placeholder as the required ones.
+  value = coalesce(each.value, "CHANGE_ME_IN_SSM")
 
   tags = {
     Name = "${local.name_prefix}-${replace(each.key, "_", "-")}"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -202,7 +202,7 @@ variable "db_username" {
 variable "db_engine_version" {
   description = "Postgres engine version."
   type        = string
-  default     = "16.4"
+  default     = "18.4"
 }
 
 variable "db_instance_class" {
@@ -397,4 +397,49 @@ variable "log_level" {
   description = "Backend/foreman log level."
   type        = string
   default     = "INFO"
+}
+
+# Discord integration (see docs/discord.md). All optional — empty disables the
+# corresponding feature, matching the docker-compose defaults.
+
+variable "discord_channel_id" {
+  description = "Discord channel ID for flat-channel notification embeds. Required together with discord_bot_token for notifications."
+  type        = string
+  default     = ""
+}
+
+variable "discord_application_id" {
+  description = "Discord application ID — slash-command registration and the bot's own user ID for @mention detection."
+  type        = string
+  default     = ""
+}
+
+variable "discord_public_key" {
+  description = "Discord application public key for interaction signature verification."
+  type        = string
+  default     = ""
+}
+
+variable "discord_allowed_role_ids" {
+  description = "Comma-separated Discord role IDs authorized to control the bot."
+  type        = string
+  default     = ""
+}
+
+variable "discord_pioneer_guild_slug" {
+  description = "Pioneer Square guild slug the Discord integration is bound to."
+  type        = string
+  default     = ""
+}
+
+variable "discord_stream_tasks" {
+  description = "Mirror live task terminal output into per-task Discord threads (high volume)."
+  type        = string
+  default     = "false"
+}
+
+variable "discord_gateway_enabled" {
+  description = "Run the persistent Discord Gateway websocket for inbound messages (requires the Message Content Intent). No-op while discord_bot_token is unset."
+  type        = string
+  default     = "true"
 }


### PR DESCRIPTION
Fixes found while standing up the staging stack for real, plus the deploy pipeline.

## Terraform
- **RDS**: Postgres **18.4** (16.4 is no longer offered on RDS). Static parameters (`shared_preload_libraries`, `pg_stat_statements.max`, `track_io_timing`) marked `pending-reboot` — RDS rejects `immediate` for static params, and matching AWS's recorded `apply_method` avoids a perpetual plan diff.
- **SSM**: optional secrets left `""` (`discord_bot_token`, `aws_bearer_token_bedrock`) are seeded with the `CHANGE_ME_IN_SSM` placeholder — SSM rejects empty SecureString values, and the task definitions reference every parameter in the map.
- **ECS**: backend task now gets the foreman provider config (`FOREMAN_MODEL/PROVIDER/BEDROCK_MODEL`) for the embedded foreman, the Discord env vars (all optional, empty = disabled), and `AWS_BEARER_TOKEN_BEDROCK` in its secrets.

## CI
- **`.github/workflows/deploy.yml`** (new): on push to `main`/`release/**` or manual dispatch — builds each service image (`backend`/`foreman`/`worker`), pushes to ECR tagged with the commit SHA, and rolls the ECS task definitions via the OIDC deploy role. The worker only registers a new task-definition revision (no service — it's launched on demand via RunTask). `main` → staging, `release/**` → prod.
- Repo secrets `AWS_DEPLOY_ROLE_ARN` and `AWS_REGION` are already set.

## Already live (state, not in this diff)
The staging stack is applied and clean (`terraform plan`: no changes): VPC, ALB with HTTPS for `pioneer-square.melloy.life` (cert validated via Linode DNS), ECS cluster/services, RDS pg18.4 **with the production dump restored** (2.1 GB, 29 tables), SSM secrets seeded from `terraform/.env`. ECR repos are empty until this PR's workflow runs on merge — the backend service crash-loops on image pull until then, which is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)