### PR TITLE
fix(webhooks): only notify CI on main when it fails

### DIFF
--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -447,6 +447,29 @@ def _extract_pr_info(payload: dict) -> tuple[int | None, str | None, str | None]
     return None, None, repo
 
 
+def _check_run_head_branch(event_type: str, node: dict) -> str | None:
+    """Return the head branch a ``check_run``/``check_suite`` event ran against.
+
+    ``check_suite`` payloads carry ``head_branch`` directly; ``check_run``
+    payloads nest it under their embedded (minimal) ``check_suite`` object.
+    """
+    if event_type == "check_suite":
+        return node.get("head_branch")
+    return (node.get("check_suite") or {}).get("head_branch")
+
+
+def _should_notify_ci_result(head_branch: str | None, conclusion: str | None) -> bool:
+    """Decide whether a ``check_run``/``check_suite`` conclusion should notify Discord.
+
+    ``main`` has no PR review gate left to act on, so a passing/cancelled/etc.
+    result there is just noise — only failures are worth paging on. PR branches
+    keep the full pass/fail signal since that's what review depends on.
+    """
+    if conclusion not in {"success", "failure", "cancelled", "timed_out", "action_required"}:
+        return False
+    return head_branch != "main" or conclusion == "failure"
+
+
 async def _find_task(db, guild_pk: int, repo: str | None, pr_number: int | None):
     """Match a webhook to one of this guild's tasks by (repo, pr_number).
 
@@ -1086,10 +1109,11 @@ async def github_webhook(
             if isinstance(node, dict)
             else "CI"
         )
+        head_branch = _check_run_head_branch(event_type, node) if isinstance(node, dict) else None
         # Buffered per-PR and combined into one Discord message (see
         # discord_notifier.notify_ci_check) instead of one message per check —
         # a CI matrix can complete several of these within seconds of each other.
-        if conclusion in {"success", "failure", "cancelled", "timed_out", "action_required"}:
+        if _should_notify_ci_result(head_branch, conclusion):
             spawn(
                 discord_notifier.notify_ci_check(
                     check_name,

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -52,9 +52,11 @@ from models import (
 )
 from routes.webhooks import (  # noqa: E402
     _build_foreman_summary,
+    _check_run_head_branch,
     _devready_issue_trigger,
     _get_guild_owner_github_login,
     _should_dispatch_to_foreman,
+    _should_notify_ci_result,
 )
 from sqlalchemy import update  # noqa: E402
 from sqlmodel import col, select  # noqa: E402
@@ -172,6 +174,47 @@ class TestShouldDispatch:
             "pull_request_review", "submitted", {}, "human-reviewer", "t-1"
         )
         assert ok
+
+
+class TestCheckRunHeadBranch:
+    """``_check_run_head_branch`` pulls the head branch out of either event shape."""
+
+    def test_check_suite_carries_head_branch_directly(self):
+        node = {"head_branch": "main"}
+        assert _check_run_head_branch("check_suite", node) == "main"
+
+    def test_check_run_nests_head_branch_under_check_suite(self):
+        node = {"check_suite": {"head_branch": "feature/x"}}
+        assert _check_run_head_branch("check_run", node) == "feature/x"
+
+    def test_check_run_missing_check_suite_returns_none(self):
+        assert _check_run_head_branch("check_run", {}) is None
+
+
+class TestShouldNotifyCiResult:
+    """Main only notifies on failure; PR branches notify on every conclusion."""
+
+    def test_main_failure_notifies(self):
+        assert _should_notify_ci_result("main", "failure") is True
+
+    def test_main_success_suppressed(self):
+        assert _should_notify_ci_result("main", "success") is False
+
+    def test_main_cancelled_suppressed(self):
+        assert _should_notify_ci_result("main", "cancelled") is False
+
+    def test_pr_branch_success_notifies(self):
+        assert _should_notify_ci_result("feature/x", "success") is True
+
+    def test_pr_branch_failure_notifies(self):
+        assert _should_notify_ci_result("feature/x", "failure") is True
+
+    def test_unknown_branch_defaults_to_notifying(self):
+        assert _should_notify_ci_result(None, "success") is True
+
+    def test_irrelevant_conclusion_is_never_notified(self):
+        assert _should_notify_ci_result("feature/x", "neutral") is False
+        assert _should_notify_ci_result("main", "neutral") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #971.

Previously, every CI conclusion (success, failure, cancelled, timed out, action required) on `main` triggered a Discord notification, which was pure noise once a build passed — there's no PR review gate left on `main` for a routine green build to matter to. PR branches still need every conclusion since that's what review depends on.

- Added `_check_run_head_branch(event_type, node)` in `backend/routes/webhooks.py`, which extracts the head branch from either payload shape: `check_suite` events carry `head_branch` directly, `check_run` events nest it under their embedded `check_suite` object.
- Added `_should_notify_ci_result(head_branch, conclusion)`, which gates the existing Discord notify call: on `main`, only `failure` notifies; on any other branch, all relevant conclusions (`success`, `failure`, `cancelled`, `timed_out`, `action_required`) notify as before.
- Wired both into the `github_webhook` handler in place of the old unconditional conclusion check.

## Test plan

- [x] Added `TestCheckRunHeadBranch` and `TestShouldNotifyCiResult` unit tests covering both event shapes and the main-vs-PR-branch notification gating (including edge cases: unknown branch defaults to notifying, irrelevant conclusions like `neutral` never notify).
- [x] `pytest tests/test_github_webhooks_phase2.py` — all non-DB-dependent tests pass (DB-backed tests fail locally only due to no Postgres fixture available in this sandbox, unrelated to this change).