### PR TITLE
Discord env vars for backend task + commit terraform.tfvars

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -10,10 +10,13 @@
 crash.log
 crash.*.log
 
-# Variable files likely to contain real secrets.
+# Variable files likely to contain real secrets. terraform.tfvars is the
+# exception: secrets live in SSM (seeded from .env), so it holds only
+# non-secret environment config and is committed. Keep secrets out of it.
 *.tfvars
 *.tfvars.json
 !example.tfvars
+!terraform.tfvars
 
 # Override files, used only for local overrides.
 override.tf

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -81,6 +81,8 @@ resource "aws_ecs_task_definition" "backend" {
         { name = "DISCORD_PIONEER_GUILD_SLUG", value = var.discord_pioneer_guild_slug },
         { name = "DISCORD_STREAM_TASKS", value = var.discord_stream_tasks },
         { name = "DISCORD_GATEWAY_ENABLED", value = var.discord_gateway_enabled },
+        { name = "DISCORD_DEV_GUILD_ID", value = var.discord_dev_guild_id },
+        { name = "DISCORD_PR_DEBOUNCE_SECONDS", value = var.discord_pr_debounce_seconds },
       ]
 
       secrets = [

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,16 @@
+domain_name  = "pioneer-square.melloy.life"
+frontend_url = "https://pioneer-square.melloy.life"
+
+guild_id              = "dnsid"
+foreman_provider      = "bedrock"
+foreman_bedrock_model = "arn:aws:bedrock:us-east-1:446872464738:inference-profile/us.anthropic.claude-sonnet-4-6"
+
+# Discord (bot token lives in SSM). channel_id / allowed_role_ids are not in
+# .env — defaults ("") leave those features off.
+discord_application_id      = "1522950582661283850"
+discord_public_key          = "0f580ff639cdcd2cf79d0d7f10935c034c03d24ea89ebc506416ee2c8cd4f034"
+discord_pioneer_guild_slug  = "abc123"
+discord_stream_tasks        = "true"
+discord_gateway_enabled     = "true"
+discord_dev_guild_id        = "1522752579157622876"
+discord_pr_debounce_seconds = "150"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -443,3 +443,15 @@ variable "discord_gateway_enabled" {
   type        = string
   default     = "true"
 }
+
+variable "discord_dev_guild_id" {
+  description = "Discord guild (server) ID for instant slash-command registration during development. Empty registers commands globally."
+  type        = string
+  default     = ""
+}
+
+variable "discord_pr_debounce_seconds" {
+  description = "Seconds to debounce PR-event Discord notifications."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
The two commits that missed the #972 merge window:

- **ecs/variables**: pass `DISCORD_DEV_GUILD_ID` and `DISCORD_PR_DEBOUNCE_SECONDS` to the backend task (both optional, empty defaults).
- **tfvars**: commit `terraform.tfvars` with the staging environment config (domain, guild ID, bedrock foreman, Discord app settings) and add a `!terraform.tfvars` gitignore exception. Nothing secret lives here — secrets are in SSM; the gitignore comment says to keep it that way.

Already applied to the staging stack (`terraform plan` is clean against this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)