### PR TITLE
ci: push release commits via deploy key (ruleset bypass)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Push via the release-workflow deploy key: github-actions[bot] can't
+          # be added to a user-repo ruleset bypass list, but "Deploy keys" can.
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Compute version
         id: version


### PR DESCRIPTION
`github-actions[bot]` can't be added to a ruleset bypass list on a user-owned repo, but **Deploy keys** can. This switches `release.yml`'s checkout to an SSH deploy key so its push-to-main authenticates as the key.

Already configured (no action needed): the `release-workflow` deploy key (write access) and the `RELEASE_DEPLOY_KEY` repo secret.

**One manual step**: in your main ruleset → Bypass list → add **Deploy keys**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)