### PR TITLE
feat: ECS worker dispatch, foreman spawn_worker tool, idle-worker reaper

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -27,6 +27,11 @@ the branch from GitHub. Pass preferred_worker_id to force a specific worker.
 - Cancel tasks that are going wrong or are no longer needed via cancel_task
 - Shut down a misbehaving or no-longer-needed worker process via shutdown_worker \
 (graceful: idle agents exit immediately, busy agents finish their current task)
+- Spawn a new worker via spawn_worker when no online worker covers the repos a task \
+needs, or when all capable workers are busy and work is queueing. Never spawn a \
+duplicate for repos an online (or currently starting) worker already covers. Spawned \
+workers shut down automatically after a period of inactivity, so don't spawn \
+speculatively and don't worry about cleaning up idle ones
 - Summarise status and outcomes when asked
 - Escalate to the human only when genuinely stuck
 

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -21,6 +21,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import discord_notifier
+import worker_runtime
 from database import get_db
 from db import github_cache
 from events import broadcast, broadcast_msg, emit_terminal_line
@@ -72,17 +73,6 @@ DEFAULT_FINALIZE_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
 # event loop indefinitely.
 EXTERNAL_CALL_TIMEOUT = 30
 
-# Separate, larger timeout for docker_client.containers.run (detach=True).
-# The Docker API call itself should complete once the daemon confirms the container
-# started, but can legitimately take longer than a GitHub REST call on a loaded host.
-CONTAINER_RUN_TIMEOUT = 600
-
-# Module-level Docker client — created once per process to reuse the Unix-socket
-# connection across repeated spawn_worker calls instead of opening a new socket
-# each time.  None until first successful from_env(); tests can patch
-# _get_docker_client() directly to avoid touching sys.modules.
-_docker_client: Any = None
-
 # Per-tool-call collector for GitHub API response metadata (request IDs, status codes).
 # Each _exec_one_tool invocation sets a fresh list via _api_calls_ctx.set([]) using the
 # token-reset pattern so concurrent coroutines never share a list.  asyncio.to_thread
@@ -106,20 +96,6 @@ def _record_api_call(path: str, status: int, headers: Any) -> None:
         if ghrid:
             entry["x_github_request_id"] = ghrid
     calls.append(entry)
-
-
-async def _get_docker_client() -> Any:
-    """Return the cached Docker client, importing the SDK and calling from_env() once.
-
-    Skips the thread hop on subsequent calls once the client is cached.
-    """
-    global _docker_client
-    if _docker_client is not None:
-        return _docker_client
-    import docker  # ImportError propagated to caller if SDK not installed
-
-    _docker_client = await _to_thread(docker.from_env)
-    return _docker_client
 
 
 async def _to_thread(fn, /, *args, **kwargs):
@@ -1133,8 +1109,10 @@ def _post_agent_task(task_url: str, body: bytes) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# spawn_worker implementation (intentionally excluded from FOREMAN_TOOLS until
-# async/lock fixes in #551, #564, #566 are merged and tested — see #567)
+# spawn_worker implementation — exposed to the parent foreman via FOREMAN_TOOLS
+# and invoked directly by worker_lifecycle.spawn_replacement_workers(). Spawned
+# workers are auto-reaped by worker_lifecycle.idle_worker_reaper() after a
+# period of inactivity.
 # ---------------------------------------------------------------------------
 
 
@@ -1213,54 +1191,28 @@ async def spawn_worker(
     )
 
     try:
-        docker_client = await _get_docker_client()
-        image = os.environ.get("WORKER_IMAGE", "pioneer-square-worker")
-
-        network = None
-        try:
-            me = docker_client.containers.get(os.environ.get("HOSTNAME", ""))
-            network = next(iter(me.attrs["NetworkSettings"]["Networks"].keys()), None)
-        except Exception as e:
-            logger.warning(
-                "Docker network detection failed, starting without explicit network: %s",
-                e,
-            )
-
-        labels = {
-            "com.pioneer.kind": "worker",
-            "com.pioneer.guild": guild_id,
-        }
-        container_name = f"pioneer-worker-{guild_id}-{secrets.token_hex(3)}"
-        run_kwargs: dict = dict(
-            image=image,
-            environment=env,
-            detach=True,
-            remove=True,
-            labels=labels,
-            name=container_name,
-        )
-        if network:
-            run_kwargs["network"] = network
-
-        container = await asyncio.to_thread(docker_client.containers.run, **run_kwargs)
-        # Persist container id and version so the lifecycle module can force-kill
-        # this container if the backend is redeployed with a different version.
+        spawned = await worker_runtime.start_worker_container(env=env, guild_id=guild_id)
+        # Persist the spawn handle and version so the lifecycle module can
+        # force-kill this container/task if the backend is redeployed with a
+        # different version (or the worker idles past the reap timeout).
         from worker_lifecycle import record_worker_spawn as _record_worker_spawn  # noqa: PLC0415
 
-        await _record_worker_spawn(db, worker_id, container.id)
+        await _record_worker_spawn(db, worker_id, spawned.handle)
         result_text = json.dumps(
             {
                 "worker_id": worker_id,
-                "container_id": container.id[:12],
+                "container_id": spawned.short_id,
+                "runtime": spawned.runtime,
                 "repos": repos,
                 "name": worker_name,
             }
         )
         logger.info(
-            "spawn_worker: guild=%s worker_id=%s container=%s repos=%s",
+            "spawn_worker: guild=%s worker_id=%s runtime=%s container=%s repos=%s",
             guild_id,
             worker_id,
-            container.id[:12],
+            spawned.runtime,
+            spawned.short_id,
             repos,
         )
         return result_text, False
@@ -1269,8 +1221,9 @@ async def spawn_worker(
             update(Worker).where(col(Worker.id) == worker_id).values(state="spawn_failed")
         )
         await db.commit()
+        sdk = "boto3" if worker_runtime.ecs_enabled() else "Docker SDK"
         return (
-            f"Worker pre-registered as {worker_id} but the Docker SDK is not "
+            f"Worker pre-registered as {worker_id} but the {sdk} is not "
             "installed on the backend — container was NOT started. "
             f"To start manually: PIONEER_WORKER_ID={worker_id} "
             f"PIONEER_AUTH_TOKEN={auth_token} "

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -649,13 +649,53 @@ FOREMAN_TOOLS = [
             "required": ["bot_user_id", "message"],
         },
     },
-    # spawn_worker intentionally disabled — see issues #551, #564, #566, #567
+    {
+        "name": "spawn_worker",
+        "description": (
+            "Start a new worker process to run tasks. Use when no worker is online for the "
+            "repos a task needs, or when every capable worker is busy and work is queueing up. "
+            "The worker is pre-registered and its container/ECS task is started immediately; it "
+            "comes online within a minute or so and then picks up assigned tasks. Do not spawn "
+            "a duplicate if a worker for the same repos is already online or currently starting. "
+            "Spawned workers are automatically shut down after a period of inactivity, so there "
+            "is no need to clean up idle workers yourself (shutdown_worker still works for an "
+            "immediate stop)."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repos": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Repos the worker should serve, as 'owner/repo'. At least one.",
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Optional tool runners to enable on the worker "
+                        "(e.g. ['claude', 'codex']). Default: claude only."
+                    ),
+                },
+                "agent_count": {
+                    "type": "integer",
+                    "description": "Optional number of concurrent agent slots (default 4).",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional human-readable worker name.",
+                },
+            },
+            "required": ["repos"],
+        },
+    },
 ]
 
 # Tools excluded from per-task child contexts. Child contexts manage a single,
-# already-assigned task; creating or assigning new tasks remains the parent
-# foreman's responsibility. See docs/foreman-per-task-context.md.
-_CHILD_EXCLUDED_TOOLS = frozenset({"create_task", "assign_task"})
+# already-assigned task; creating or assigning new tasks — and standing up new
+# workers — remains the parent foreman's responsibility.
+# See docs/foreman-per-task-context.md.
+_CHILD_EXCLUDED_TOOLS = frozenset({"create_task", "assign_task", "spawn_worker"})
 
 # Tool set handed to a per-task child context (FOREMAN_TOOLS minus the
 # create/assign pair). Same JSON schemas, narrowed scope.

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,11 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from util.tasks import spawn
-from worker_lifecycle import drain_stale_workers_on_startup, reconcile_stale_workers
+from worker_lifecycle import (
+    drain_stale_workers_on_startup,
+    idle_worker_reaper,
+    reconcile_stale_workers,
+)
 from ws_types import WorkerPingMsg
 
 # Load .env (looked up from CWD upward, then alongside this file) before any
@@ -387,6 +391,9 @@ async def lifespan(app: FastAPI):
 
     asyncio.ensure_future(_startup_refresh_catalog())
     sweeper = spawn(_stale_worker_sweeper(), name="stale-worker-sweeper")
+    # Reap backend-spawned workers that have been idle past the configured
+    # timeout (PIONEER_WORKER_IDLE_TIMEOUT) — see worker_lifecycle.
+    idle_reaper = spawn(idle_worker_reaper(), name="idle-worker-reaper")
 
     # Discord Gateway (Phase 4): persistent websocket for inbound messages.
     # No-op unless DISCORD_GATEWAY_ENABLED=true and DISCORD_BOT_TOKEN are set.
@@ -401,12 +408,17 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         sweeper.cancel()
+        idle_reaper.cancel()
         if reconcile_bg is not None:
             reconcile_bg.cancel()
         if discord_gw_task is not None:
             discord_gw_task.cancel()
         try:
             await sweeper
+        except (asyncio.CancelledError, Exception):
+            pass
+        try:
+            await idle_reaper
         except (asyncio.CancelledError, Exception):
             pass
         if reconcile_bg is not None:

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -16,6 +16,7 @@ import secrets
 import string
 from datetime import UTC, datetime
 
+import worker_runtime
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg, emit_terminal_line, pending_claude_auth
@@ -160,18 +161,16 @@ async def spawn_worker_container(
     github_user_id: str = Depends(require_member()),
     db: AsyncSession = Depends(get_db_dep),
 ):
-    """Start a new worker container via Docker. Requires the Docker socket to be mounted."""
-    try:
-        import docker as docker_sdk
-    except ImportError:
-        raise HTTPException(status_code=503, detail="Docker SDK not installed in backend")
+    """Start a new worker container.
 
+    Uses the runtime selected by ``worker_runtime``: the mounted Docker socket
+    in docker-compose/local dev, or ECS RunTask when the backend runs on
+    Fargate (ECS_CLUSTER_NAME + ECS_WORKER_TASK_DEFINITION set).
+    """
     try:
-        client = docker_sdk.from_env()
-    except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Docker socket unavailable: {e}")
-
-    image = os.environ.get("WORKER_IMAGE", "pioneer-square-worker")
+        await worker_runtime.check_runtime_available()
+    except worker_runtime.WorkerSpawnError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
 
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
@@ -231,45 +230,14 @@ async def spawn_worker_container(
         extra_env=extra_env or None,
     )
 
-    # Join the same Docker network as the backend so the worker can reach it.
-    network = None
     try:
-        me = client.containers.get(os.environ.get("HOSTNAME", ""))
-        network = next(iter(me.attrs["NetworkSettings"]["Networks"].keys()), None)
-    except Exception:
-        pass
-
-    # Pioneer-owned labels — these containers are spawned and lifecycle-managed
-    # by the backend, not compose, so we don't tag them with com.docker.compose.*.
-    # List them with: docker ps --filter label=com.pioneer.kind=worker
-    labels = {
-        "com.pioneer.kind": "worker",
-        "com.pioneer.guild": guild_id,
-    }
-
-    container_name = f"pioneer-worker-{guild_id}-{secrets.token_hex(3)}"
-
-    try:
-        run_kwargs: dict = dict(
-            image=image,
-            environment=env,
-            detach=True,
-            remove=True,
-            labels=labels,
-            name=container_name,
-        )
-        if network:
-            run_kwargs["network"] = network
-        container = client.containers.run(**run_kwargs)
-    except docker_sdk.errors.ImageNotFound:
+        spawned = await worker_runtime.start_worker_container(env=env, guild_id=guild_id)
+    except worker_runtime.WorkerSpawnError as e:
         await db.exec(
             update(Worker).where(col(Worker.id) == worker_id).values(state="spawn_failed")
         )
         await db.commit()
-        raise HTTPException(
-            status_code=404,
-            detail=f"Worker image '{image}' not found — run: docker compose build worker",
-        )
+        raise HTTPException(status_code=e.status_code, detail=str(e))
     except Exception as e:
         await db.exec(
             update(Worker).where(col(Worker.id) == worker_id).values(state="spawn_failed")
@@ -277,11 +245,16 @@ async def spawn_worker_container(
         await db.commit()
         raise HTTPException(status_code=500, detail=f"Failed to start container: {e}")
 
-    # Persist container id and spawned version so the lifecycle module can
-    # force-kill this container if the backend is redeployed at a different version.
-    await record_worker_spawn(db, worker_id, container.id)
+    # Persist the spawn handle and version so the lifecycle module can
+    # force-kill this container/task if the backend is redeployed at a
+    # different version (or the worker idles past the reap timeout).
+    await record_worker_spawn(db, worker_id, spawned.handle)
 
-    return {"worker_id": worker_id, "container_id": container.id[:12], "image": image}
+    return {
+        "worker_id": worker_id,
+        "container_id": spawned.short_id,
+        "runtime": spawned.runtime,
+    }
 
 
 @router.get("/guilds/{guild_id}/pending-auth")

--- a/backend/tests/test_child_prompt.py
+++ b/backend/tests/test_child_prompt.py
@@ -10,12 +10,17 @@ from backend.foreman.prompt import (
 from backend.foreman.tools_schema import CHILD_FOREMAN_TOOLS, FOREMAN_TOOLS
 
 
-def test_child_tools_exclude_create_and_assign():
+def test_child_tools_exclude_create_assign_and_spawn():
     names = {t["name"] for t in CHILD_FOREMAN_TOOLS}
     assert "create_task" not in names
     assert "assign_task" not in names
+    assert "spawn_worker" not in names
     # Everything else carries over.
-    assert names == {t["name"] for t in FOREMAN_TOOLS} - {"create_task", "assign_task"}
+    assert names == {t["name"] for t in FOREMAN_TOOLS} - {
+        "create_task",
+        "assign_task",
+        "spawn_worker",
+    }
 
 
 def test_child_tools_keep_lifecycle_tools():

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -2053,10 +2053,10 @@ class TestFinalizeClosedIssueAtomicity:
 
 
 class TestSpawnWorker:
-    """spawn_worker() is not in FOREMAN_TOOLS (see #567) but is still invoked
-    directly by worker_lifecycle.spawn_replacement_workers() on backend startup.
-    Regression test for a missing ``await`` on ``_get_docker_client()`` that
-    made every real invocation of this path fail (see #725).
+    """spawn_worker() is invoked by the foreman tool executor and directly by
+    worker_lifecycle.spawn_replacement_workers() on backend startup. Container
+    start goes through the worker_runtime abstraction (Docker socket locally,
+    ECS RunTask on Fargate).
     """
 
     async def test_spawn_worker_starts_container(self, db_session):
@@ -2068,7 +2068,7 @@ class TestSpawnWorker:
         fake_docker_client.containers.run.return_value = fake_container
 
         with (
-            patch("foreman.tools._get_docker_client", AsyncMock(return_value=fake_docker_client)),
+            patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_docker_client)),
             patch("foreman.tools.broadcast", new_callable=AsyncMock),
         ):
             results = await exec_tools(
@@ -2081,6 +2081,56 @@ class TestSpawnWorker:
         assert r.get("is_error") is not True, f"spawn_worker failed: {r['content']}"
         assert "abcdef012345" in r["content"]
         fake_docker_client.containers.run.assert_called_once()
+
+    async def test_spawn_worker_uses_ecs_when_configured(self, db_session, monkeypatch):
+        insert_guild(db_session, "g-spawn-ecs")
+
+        monkeypatch.setenv("ECS_CLUSTER_NAME", "ps-test-cluster")
+        monkeypatch.setenv("ECS_WORKER_TASK_DEFINITION", "ps-test-worker")
+        monkeypatch.setenv("ECS_WORKER_SUBNETS", "subnet-aaa, subnet-bbb")
+        monkeypatch.setenv("ECS_WORKER_SECURITY_GROUPS", "sg-ccc")
+
+        task_arn = (
+            "arn:aws:ecs:us-east-1:123456789012:task/ps-test-cluster/"
+            "0123456789abcdef0123456789abcdef"
+        )
+        fake_ecs = MagicMock()
+        fake_ecs.run_task.return_value = {"tasks": [{"taskArn": task_arn}], "failures": []}
+
+        with (
+            patch("worker_runtime._get_ecs_client", return_value=fake_ecs),
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        ):
+            results = await exec_tools(
+                "g-spawn-ecs",
+                [_fake_tool_use("spawn_worker", {"repos": ["acme/widgets"]})],
+            )
+
+        r = results[0]
+        assert r.get("is_error") is not True, f"spawn_worker failed: {r['content']}"
+        assert "0123456789ab" in r["content"]
+        fake_ecs.run_task.assert_called_once()
+        kwargs = fake_ecs.run_task.call_args.kwargs
+        assert kwargs["cluster"] == "ps-test-cluster"
+        assert kwargs["taskDefinition"] == "ps-test-worker"
+        assert kwargs["launchType"] == "FARGATE"
+        net = kwargs["networkConfiguration"]["awsvpcConfiguration"]
+        assert net["subnets"] == ["subnet-aaa", "subnet-bbb"]
+        assert net["securityGroups"] == ["sg-ccc"]
+        assert net["assignPublicIp"] == "DISABLED"
+        env_override = kwargs["overrides"]["containerOverrides"][0]
+        assert env_override["name"] == "worker"
+        env_map = {e["name"]: e["value"] for e in env_override["environment"]}
+        assert env_map["PIONEER_GUILD_ID"] == "g-spawn-ecs"
+        assert env_map["PIONEER_REPOS"] == "acme/widgets"
+
+        # The worker row records the full task ARN so the lifecycle module can
+        # StopTask it later.
+        from models import Worker as WorkerModel  # noqa: PLC0415
+
+        with _sync_session(db_session) as session:
+            container_ids = session.execute(select(col(WorkerModel.container_id))).scalars().all()
+        assert task_arn in container_ids
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tools_dedup.py
+++ b/backend/tests/test_tools_dedup.py
@@ -18,12 +18,13 @@ def test_foreman_tools_canonical_is_list():
     assert "assign_task" in names
 
 
-def test_spawn_worker_not_in_foreman_tools():
-    """spawn_worker must stay out of FOREMAN_TOOLS until async/lock fixes land (#567)."""
-    from backend.foreman.tools_schema import FOREMAN_TOOLS
+def test_spawn_worker_in_foreman_tools_but_not_child_contexts():
+    """spawn_worker is exposed to the parent foreman only — child contexts manage a
+    single already-assigned task and must not stand up new workers."""
+    from backend.foreman.tools_schema import CHILD_FOREMAN_TOOLS, FOREMAN_TOOLS
 
     names = [t["name"] for t in FOREMAN_TOOLS]
-    assert "spawn_worker" not in names, (
-        "spawn_worker must not be exposed to the foreman AI until issues #551, #564, #566 "
-        "are merged and tested (see #567)"
-    )
+    assert "spawn_worker" in names
+
+    child_names = [t["name"] for t in CHILD_FOREMAN_TOOLS]
+    assert "spawn_worker" not in child_names

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -746,3 +746,214 @@ async def test_force_kill_if_unresponsive_polls_across_multiple_iterations():
 
     assert fake_db.call_count == 3
     mock_kill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# reap_idle_workers_once
+# ---------------------------------------------------------------------------
+
+
+class _FakeReapDB:
+    """Sequenced fake session: each exec() pops the next canned result."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.commit = AsyncMock()
+        self.exec_count = 0
+
+    async def exec(self, *a, **kw):
+        self.exec_count += 1
+        if self._results:
+            return self._results.pop(0)
+        return MagicMock()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _rows_result(rows):
+    return MagicMock(all=MagicMock(return_value=rows))
+
+
+def _first_result(value):
+    return MagicMock(first=MagicMock(return_value=value))
+
+
+def _scalar_result(value):
+    return MagicMock(one_or_none=MagicMock(return_value=value))
+
+
+def _old(seconds: float = 7200):
+    from datetime import timedelta
+
+    return datetime.now(UTC) - timedelta(seconds=seconds)
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_worker_shuts_down_and_escalates():
+    """An online spawned worker with no live work and no recent task-log activity is
+    gracefully shut down, disabled, and given a force-kill backstop."""
+    from worker_lifecycle import reap_idle_workers_once
+
+    # Session 1: candidates. Session 2: inactivity checks (no active task, no
+    # busy agent, stale last log) + the disabled update.
+    sessions = [
+        _FakeReapDB([_rows_result([("w-idle", "idle", _old(60), "g-guild")])]),
+        _FakeReapDB(
+            [_first_result(None), _first_result(None), _scalar_result(_old()), MagicMock()]
+        ),
+    ]
+    session_iter = iter(sessions)
+    broadcast = AsyncMock()
+    terminal = AsyncMock()
+
+    def _swallow_coro(coro, **kw):
+        coro.close()  # avoid "coroutine never awaited" warnings
+        return MagicMock()
+
+    escalate = MagicMock(side_effect=_swallow_coro)
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+        patch("worker_lifecycle.emit_terminal_line", terminal),
+        patch("util.tasks.spawn", escalate),
+    ):
+        reaped = await reap_idle_workers_once()
+
+    assert reaped == ["w-idle"]
+    broadcast.assert_called_once()
+    guild_slug, msg = broadcast.call_args.args
+    assert guild_slug == "g-guild"
+    assert msg.workerId == "w-idle"
+    assert "idle" in (msg.reason or "")
+    sessions[1].commit.assert_called_once()
+    escalate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reap_skips_worker_with_active_task():
+    from worker_lifecycle import reap_idle_workers_once
+
+    sessions = [
+        _FakeReapDB([_rows_result([("w-busy", "idle", _old(60), "g-guild")])]),
+        _FakeReapDB([_first_result("t-live")]),  # active pending/working task found
+    ]
+    session_iter = iter(sessions)
+    broadcast = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+    ):
+        reaped = await reap_idle_workers_once()
+
+    assert reaped == []
+    broadcast.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reap_skips_worker_with_busy_agent():
+    from worker_lifecycle import reap_idle_workers_once
+
+    sessions = [
+        _FakeReapDB([_rows_result([("w-agent", "online", None, "g-guild")])]),
+        _FakeReapDB([_first_result(None), _first_result("a-busy")]),
+    ]
+    session_iter = iter(sessions)
+    broadcast = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+    ):
+        reaped = await reap_idle_workers_once()
+
+    assert reaped == []
+    broadcast.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reap_skips_worker_with_recent_task_log():
+    from worker_lifecycle import reap_idle_workers_once
+
+    sessions = [
+        _FakeReapDB([_rows_result([("w-recent", "idle", _old(60), "g-guild")])]),
+        _FakeReapDB([_first_result(None), _first_result(None), _scalar_result(_old(seconds=30))]),
+    ]
+    session_iter = iter(sessions)
+    broadcast = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+    ):
+        reaped = await reap_idle_workers_once()
+
+    assert reaped == []
+    broadcast.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reap_offline_zombie_force_kills_directly():
+    """An offline spawned worker whose last_seen is past the cutoff (or NULL) gets its
+    container/ECS task force-killed without the graceful-drain dance."""
+    from worker_lifecycle import reap_idle_workers_once
+
+    sessions = [
+        _FakeReapDB([_rows_result([("w-zombie", "offline", None, "g-guild")])]),
+        _FakeReapDB([MagicMock()]),  # disabled update
+    ]
+    session_iter = iter(sessions)
+    mock_kill = AsyncMock()
+    broadcast = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+    ):
+        reaped = await reap_idle_workers_once()
+
+    assert reaped == ["w-zombie"]
+    mock_kill.assert_called_once_with({"w-zombie"})
+    broadcast.assert_not_called()  # nothing to signal — it never connected
+
+
+@pytest.mark.asyncio
+async def test_reap_skips_offline_worker_seen_recently():
+    """An offline worker seen recently may be mid-reconnect after a backend restart —
+    leave it alone."""
+    from worker_lifecycle import reap_idle_workers_once
+
+    sessions = [
+        _FakeReapDB([_rows_result([("w-reconnecting", "offline", _old(seconds=30), "g-g")])]),
+    ]
+    session_iter = iter(sessions)
+    mock_kill = AsyncMock()
+
+    with (
+        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
+        patch("worker_lifecycle._force_kill_containers", mock_kill),
+    ):
+        reaped = await reap_idle_workers_once()
+
+    assert reaped == []
+    mock_kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reap_disabled_when_timeout_zero():
+    from worker_lifecycle import reap_idle_workers_once
+
+    with (
+        patch("worker_lifecycle.WORKER_IDLE_TIMEOUT", 0),
+        patch("worker_lifecycle.AsyncSessionLocal") as mock_session,
+    ):
+        reaped = await reap_idle_workers_once()
+
+    assert reaped == []
+    mock_session.assert_not_called()

--- a/backend/tests/test_worker_runtime.py
+++ b/backend/tests/test_worker_runtime.py
@@ -1,0 +1,172 @@
+"""Tests for backend/worker_runtime.py — Docker vs ECS worker dispatch."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Make backend importable from tests/
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import worker_runtime  # noqa: E402
+
+TASK_ARN = "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/0123456789abcdef0123456789abcdef"
+
+
+@pytest.fixture
+def ecs_env(monkeypatch):
+    monkeypatch.setenv("ECS_CLUSTER_NAME", "my-cluster")
+    monkeypatch.setenv("ECS_WORKER_TASK_DEFINITION", "my-worker-taskdef")
+    monkeypatch.setenv("ECS_WORKER_SUBNETS", "subnet-1,subnet-2")
+    monkeypatch.setenv("ECS_WORKER_SECURITY_GROUPS", "sg-1")
+
+
+# ---------------------------------------------------------------------------
+# Runtime selection
+# ---------------------------------------------------------------------------
+
+
+def test_ecs_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("ECS_CLUSTER_NAME", raising=False)
+    monkeypatch.delenv("ECS_WORKER_TASK_DEFINITION", raising=False)
+    assert worker_runtime.ecs_enabled() is False
+    assert worker_runtime.runtime_name() == "docker"
+
+
+def test_ecs_requires_both_vars(monkeypatch):
+    monkeypatch.setenv("ECS_CLUSTER_NAME", "c")
+    monkeypatch.delenv("ECS_WORKER_TASK_DEFINITION", raising=False)
+    assert worker_runtime.ecs_enabled() is False
+
+
+def test_ecs_enabled_with_both_vars(ecs_env):
+    assert worker_runtime.ecs_enabled() is True
+    assert worker_runtime.runtime_name() == "ecs"
+
+
+# ---------------------------------------------------------------------------
+# Docker start
+# ---------------------------------------------------------------------------
+
+
+async def test_start_worker_docker(monkeypatch):
+    monkeypatch.delenv("ECS_CLUSTER_NAME", raising=False)
+    fake_container = MagicMock(id="abcdef0123456789deadbeef")
+    fake_client = MagicMock()
+    fake_client.containers.get.side_effect = Exception("no self container")
+    fake_client.containers.run.return_value = fake_container
+
+    with patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_client)):
+        spawned = await worker_runtime.start_worker_container(
+            env={"PIONEER_GUILD_ID": "g1"}, guild_id="g1"
+        )
+
+    assert spawned.runtime == "docker"
+    assert spawned.handle == "abcdef0123456789deadbeef"
+    assert spawned.short_id == "abcdef012345"
+    run_kwargs = fake_client.containers.run.call_args.kwargs
+    assert run_kwargs["environment"] == {"PIONEER_GUILD_ID": "g1"}
+    assert run_kwargs["labels"]["com.pioneer.kind"] == "worker"
+    assert run_kwargs["detach"] is True
+
+
+# ---------------------------------------------------------------------------
+# ECS start
+# ---------------------------------------------------------------------------
+
+
+async def test_start_worker_ecs(ecs_env):
+    fake_ecs = MagicMock()
+    fake_ecs.run_task.return_value = {"tasks": [{"taskArn": TASK_ARN}], "failures": []}
+
+    with patch("worker_runtime._get_ecs_client", return_value=fake_ecs):
+        spawned = await worker_runtime.start_worker_container(
+            env={"PIONEER_GUILD_ID": "g1"}, guild_id="g1"
+        )
+
+    assert spawned.runtime == "ecs"
+    assert spawned.handle == TASK_ARN
+    assert spawned.short_id == "0123456789ab"
+    kwargs = fake_ecs.run_task.call_args.kwargs
+    assert kwargs["cluster"] == "my-cluster"
+    assert kwargs["taskDefinition"] == "my-worker-taskdef"
+    assert kwargs["count"] == 1
+    net = kwargs["networkConfiguration"]["awsvpcConfiguration"]
+    assert net["subnets"] == ["subnet-1", "subnet-2"]
+    assert net["securityGroups"] == ["sg-1"]
+    assert net["assignPublicIp"] == "DISABLED"
+    override = kwargs["overrides"]["containerOverrides"][0]
+    assert override["name"] == "worker"
+    assert {"name": "PIONEER_GUILD_ID", "value": "g1"} in override["environment"]
+
+
+async def test_start_worker_ecs_public_ip_opt_in(ecs_env, monkeypatch):
+    monkeypatch.setenv("ECS_WORKER_ASSIGN_PUBLIC_IP", "true")
+    fake_ecs = MagicMock()
+    fake_ecs.run_task.return_value = {"tasks": [{"taskArn": TASK_ARN}], "failures": []}
+
+    with patch("worker_runtime._get_ecs_client", return_value=fake_ecs):
+        await worker_runtime.start_worker_container(env={}, guild_id="g1")
+
+    net = fake_ecs.run_task.call_args.kwargs["networkConfiguration"]["awsvpcConfiguration"]
+    assert net["assignPublicIp"] == "ENABLED"
+
+
+async def test_start_worker_ecs_requires_subnets(ecs_env, monkeypatch):
+    monkeypatch.delenv("ECS_WORKER_SUBNETS", raising=False)
+    fake_ecs = MagicMock()
+
+    with (
+        patch("worker_runtime._get_ecs_client", return_value=fake_ecs),
+        pytest.raises(worker_runtime.WorkerSpawnError, match="ECS_WORKER_SUBNETS"),
+    ):
+        await worker_runtime.start_worker_container(env={}, guild_id="g1")
+
+    fake_ecs.run_task.assert_not_called()
+
+
+async def test_start_worker_ecs_surfaces_failures(ecs_env):
+    fake_ecs = MagicMock()
+    fake_ecs.run_task.return_value = {
+        "tasks": [],
+        "failures": [{"reason": "RESOURCE:MEMORY", "detail": "no capacity"}],
+    }
+
+    with (
+        patch("worker_runtime._get_ecs_client", return_value=fake_ecs),
+        pytest.raises(worker_runtime.WorkerSpawnError, match="RESOURCE:MEMORY"),
+    ):
+        await worker_runtime.start_worker_container(env={}, guild_id="g1")
+
+
+# ---------------------------------------------------------------------------
+# Stop dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_dispatches_ecs_for_task_arns(monkeypatch):
+    # No ECS env needed: the cluster is parsed out of the task ARN itself.
+    monkeypatch.delenv("ECS_CLUSTER_NAME", raising=False)
+    fake_ecs = MagicMock()
+
+    with patch("worker_runtime._get_ecs_client", return_value=fake_ecs):
+        await worker_runtime.stop_worker_container(TASK_ARN, reason="test kill")
+
+    fake_ecs.stop_task.assert_called_once_with(
+        cluster="my-cluster", task=TASK_ARN, reason="test kill"
+    )
+
+
+async def test_stop_dispatches_docker_for_container_ids():
+    fake_container = MagicMock()
+    fake_client = MagicMock()
+    fake_client.containers.get.return_value = fake_container
+
+    with patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_client)):
+        await worker_runtime.stop_worker_container("abcdef012345")
+
+    fake_client.containers.get.assert_called_once_with("abcdef012345")
+    fake_container.kill.assert_called_once()

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -42,12 +42,13 @@ import logging
 import os
 import secrets
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
+import worker_runtime
 from database import AsyncSessionLocal
-from events import broadcast_msg
-from models import Guild, Worker
-from sqlalchemy import update
+from events import broadcast_msg, emit_terminal_line
+from models import Agent, Guild, Task, TaskLog, Worker, live_tasks_filter
+from sqlalchemy import func, update
 from sqlmodel import col, select
 from ws_types import WorkerShutdownMsg
 
@@ -68,6 +69,28 @@ WORKER_RECONNECT_GRACE = float(os.environ.get("PIONEER_WORKER_RECONNECT_GRACE", 
 # guards the startup version-mismatch drain) since this is the window the foreman
 # AI waits on every ordinary "stop this worker" request.
 SHUTDOWN_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_SHUTDOWN_TIMEOUT", "1800"))
+
+# How long a backend-spawned worker may sit with no live work before the idle
+# reaper shuts it down (and stops its container/ECS task). 0 disables reaping.
+WORKER_IDLE_TIMEOUT = float(os.environ.get("PIONEER_WORKER_IDLE_TIMEOUT", "1800"))
+
+# How often the idle reaper wakes up to look for idle spawned workers.
+WORKER_IDLE_SWEEP_INTERVAL = float(os.environ.get("PIONEER_WORKER_IDLE_SWEEP_INTERVAL", "60"))
+
+# Escalation window for the idle reaper's graceful shutdown. Much shorter than
+# SHUTDOWN_FORCE_KILL_TIMEOUT because a reaped worker is by definition idle —
+# there is no in-progress task to wait for.
+IDLE_REAP_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_IDLE_REAP_KILL_TIMEOUT", "300"))
+
+# Task states that hold a worker alive: queued or actively-running work.
+# "awaiting-review" deliberately does NOT hold a worker alive — a PR can sit in
+# review for days, and send_followup routes to any idle worker (which pulls the
+# branch from GitHub), so keeping the original worker running would defeat the
+# reaper entirely.
+_ACTIVE_TASK_STATES = ("pending", "working")
+
+# Agent states that mean the worker is actively doing something right now.
+_BUSY_AGENT_STATES = ("working", "thinking", "busy")
 
 
 def get_current_version() -> str | None:
@@ -268,25 +291,19 @@ async def drain_stale_workers_on_startup() -> list[str]:
 
 
 async def _force_kill_containers(worker_ids: set[str]) -> None:
-    """Force-kill the Docker containers backing the given worker IDs, if any."""
+    """Force-kill the containers/ECS tasks backing the given worker IDs, if any."""
     async with AsyncSessionLocal() as db:
         workers = (await db.exec(select(Worker).where(col(Worker.id).in_(worker_ids)))).all()
 
-    # Create the Docker client once; avoids per-container connection overhead and
-    # ensures consistent failure behaviour across all kills in this batch.
-    docker_client = None
     for worker in workers:
         if worker.container_id:
             try:
-                import docker  # noqa: PLC0415
-
-                # Use asyncio.to_thread for all blocking Docker SDK calls.
-                if docker_client is None:
-                    docker_client = await asyncio.to_thread(docker.from_env)
-                container = await asyncio.to_thread(
-                    docker_client.containers.get, worker.container_id
+                # worker_runtime dispatches on the handle itself (Docker container
+                # id vs ECS task ARN), so handles recorded under either runtime
+                # remain killable after a deployment-model change.
+                await worker_runtime.stop_worker_container(
+                    worker.container_id, reason=f"force-kill of worker {worker.id}"
                 )
-                await asyncio.to_thread(container.kill)
                 logger.info(
                     "worker_lifecycle: force-killed container %s (worker %s)",
                     worker.container_id[:12],
@@ -299,7 +316,7 @@ async def _force_kill_containers(worker_ids: set[str]) -> None:
                     exc_info=True,
                 )
         else:
-            # Non-Docker worker (started via compose or manual CLI): cannot force-kill.
+            # Externally-started worker (compose or manual CLI): cannot force-kill.
             logger.warning(
                 "worker_lifecycle: stale worker %s has no container_id; "
                 "relying on graceful-shutdown signal only",
@@ -476,3 +493,182 @@ async def reconcile_stale_workers(stale_ids: list[str]) -> None:
             pending.discard(wid)
 
     logger.info("worker_lifecycle: all stale workers drained and replaced")
+
+
+# ---------------------------------------------------------------------------
+# Idle-worker reaper — automatic shutdown of backend-spawned workers that have
+# had nothing to do for WORKER_IDLE_TIMEOUT. Only workers with a recorded spawn
+# handle (container_id) are ever reaped: externally-started workers (compose,
+# manual CLI) belong to whoever started them.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_utc(dt: datetime | None) -> datetime | None:
+    """Attach UTC to naive datetimes read back from the DB (SQLite test runs)."""
+    if dt is not None and dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+async def _worker_is_inactive(db, worker_id: str, cutoff: datetime) -> bool:
+    """True when *worker_id* has no live work and no activity since *cutoff*."""
+    active_task = (
+        await db.exec(
+            select(col(Task.id))
+            .where(
+                col(Task.worker_id) == worker_id,
+                col(Task.state).in_(_ACTIVE_TASK_STATES),
+                live_tasks_filter(),
+            )
+            .limit(1)
+        )
+    ).first()
+    if active_task is not None:
+        return False
+
+    busy_agent = (
+        await db.exec(
+            select(col(Agent.id))
+            .where(
+                col(Agent.worker_id) == worker_id,
+                col(Agent.state).in_(_BUSY_AGENT_STATES),
+            )
+            .limit(1)
+        )
+    ).first()
+    if busy_agent is not None:
+        return False
+
+    # Last activity = the newest task-log line attributed to this worker.
+    # TaskLog rows are written throughout a run, so the newest one marks the
+    # end of the worker's most recent piece of work; a worker that never ran
+    # anything has no rows and falls back to its spawn time (already checked
+    # against the cutoff by the candidate query).
+    last_log = (
+        await db.exec(
+            select(func.max(col(TaskLog.timestamp))).where(col(TaskLog.worker_id) == worker_id)
+        )
+    ).one_or_none()
+    last_log = _ensure_utc(last_log)
+    return last_log is None or last_log < cutoff
+
+
+async def reap_idle_workers_once(now: datetime | None = None) -> list[str]:
+    """One idle-reap pass; returns the IDs of the workers that were shut down.
+
+    Two kinds of spawned workers are reaped once they pass the idle cutoff:
+
+    - **Online and idle** — no pending/working task, no busy agent, and no
+      task-log activity within the window. Gets the graceful shutdown signal
+      (same path as shutdown_worker) plus a short force-kill backstop.
+    - **Offline zombies** — spawned but never (re)connected, or long dead. The
+      container/ECS task is force-killed directly (a no-op if it already
+      exited). Gated on ``last_seen`` also being past the cutoff so workers
+      that are merely reconnecting after a backend restart are left alone.
+
+    Both kinds are marked ``disabled`` so they are neither respawned on the
+    next backend restart nor re-examined on the next sweep.
+    """
+    if WORKER_IDLE_TIMEOUT <= 0:
+        return []
+    if now is None:
+        now = datetime.now(UTC)
+    cutoff = now - timedelta(seconds=WORKER_IDLE_TIMEOUT)
+
+    async with AsyncSessionLocal() as db:
+        candidates = (
+            await db.exec(
+                select(
+                    col(Worker.id),
+                    col(Worker.state),
+                    col(Worker.last_seen),
+                    col(Guild.slug).label("guild_slug"),
+                )
+                .join(Guild, col(Guild.id) == col(Worker.guild_id))
+                .where(
+                    col(Worker.container_id).isnot(None),
+                    col(Worker.disabled).is_(False),
+                    col(Worker.started_at).isnot(None),
+                    col(Worker.started_at) < cutoff,
+                )
+            )
+        ).all()
+
+    reaped: list[str] = []
+    for worker_id, state, last_seen, guild_slug in candidates:
+        try:
+            if state == "offline":
+                # Never-connected zombie or already-dead container. Skip if it
+                # was alive recently — it may be mid-reconnect after a restart.
+                last_seen = _ensure_utc(last_seen)
+                if last_seen is not None and last_seen >= cutoff:
+                    continue
+                async with AsyncSessionLocal() as db:
+                    await db.exec(
+                        update(Worker)
+                        .where(col(Worker.id) == worker_id)
+                        .values(disabled=True, drain_requested_at=now)
+                    )
+                    await db.commit()
+                logger.info(
+                    "worker_lifecycle: reaping offline spawned worker %s "
+                    "(no connection since spawn or last activity > %.0fs ago)",
+                    worker_id,
+                    WORKER_IDLE_TIMEOUT,
+                )
+                await _force_kill_containers({worker_id})
+                reaped.append(worker_id)
+                continue
+
+            async with AsyncSessionLocal() as db:
+                inactive = await _worker_is_inactive(db, worker_id, cutoff)
+                if not inactive:
+                    continue
+                await db.exec(
+                    update(Worker)
+                    .where(col(Worker.id) == worker_id)
+                    .values(disabled=True, drain_requested_at=now)
+                )
+                await db.commit()
+
+            reason = (
+                f"idle for over {int(WORKER_IDLE_TIMEOUT)}s — automatic shutdown of spawned worker"
+            )
+            logger.info("worker_lifecycle: reaping idle worker %s (%s)", worker_id, reason)
+            await broadcast_msg(guild_slug, WorkerShutdownMsg(workerId=worker_id, reason=reason))
+            await emit_terminal_line(guild_slug, worker_id, f"[lifecycle] {reason}")
+
+            # Backstop: the worker is idle, so it should exit within seconds of
+            # the signal; force-kill its container/ECS task if it doesn't.
+            from util.tasks import spawn  # noqa: PLC0415
+
+            spawn(
+                force_kill_worker_if_unresponsive(worker_id, timeout=IDLE_REAP_FORCE_KILL_TIMEOUT),
+                name=f"idle-reap-escalate:{worker_id}",
+            )
+            reaped.append(worker_id)
+        except Exception:
+            logger.warning(
+                "worker_lifecycle: idle-reap failed for worker %s", worker_id, exc_info=True
+            )
+    return reaped
+
+
+async def idle_worker_reaper() -> None:
+    """Background task: periodically reap spawned workers idle past the timeout."""
+    if WORKER_IDLE_TIMEOUT <= 0:
+        logger.info("worker_lifecycle: idle-worker reaper disabled (PIONEER_WORKER_IDLE_TIMEOUT=0)")
+        return
+    logger.info(
+        "worker_lifecycle: idle-worker reaper started: timeout=%.0fs interval=%.0fs",
+        WORKER_IDLE_TIMEOUT,
+        WORKER_IDLE_SWEEP_INTERVAL,
+    )
+    while True:
+        try:
+            await asyncio.sleep(WORKER_IDLE_SWEEP_INTERVAL)
+            await reap_idle_workers_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("worker_lifecycle: idle-worker reaper iteration failed")

--- a/backend/worker_runtime.py
+++ b/backend/worker_runtime.py
@@ -1,0 +1,305 @@
+"""Container runtime abstraction for spawning and killing worker processes.
+
+Two runtimes are supported, selected automatically from the environment:
+
+- **docker** — the docker-compose / local-dev model: the backend talks to the
+  mounted Docker socket (``docker.from_env()``) and runs one worker container
+  per spawn on its own network.
+- **ecs** — the AWS Fargate model: the backend calls ``ecs.run_task`` against
+  the pre-registered worker task definition family. Fargate tasks have no
+  shared Docker socket, so this is the only way to launch workers there. The
+  Terraform module in ``terraform/`` registers the task definition, grants the
+  backend's task role ``ecs:RunTask``/``ecs:StopTask``/``ecs:DescribeTasks``,
+  and injects the env vars below into the backend service.
+
+ECS mode is enabled when both ``ECS_CLUSTER_NAME`` and
+``ECS_WORKER_TASK_DEFINITION`` are set (as they are in the ECS task definition
+rendered by terraform/ecs.tf). Additional ECS configuration:
+
+- ``ECS_WORKER_SUBNETS`` — comma-separated subnet IDs for the worker task's
+  awsvpc network interface (required to run on Fargate).
+- ``ECS_WORKER_SECURITY_GROUPS`` — comma-separated security group IDs.
+- ``ECS_WORKER_ASSIGN_PUBLIC_IP`` — "true" to give worker tasks a public IP
+  (default false; private subnets with a NAT gateway don't need one).
+- ``ECS_WORKER_CONTAINER_NAME`` — container name inside the worker task
+  definition to apply env overrides to (default "worker").
+
+The spawn *handle* persisted in ``workers.container_id`` is the Docker
+container ID in docker mode and the full ECS task ARN in ECS mode;
+``stop_worker_container`` dispatches on the ``arn:`` prefix so either kind of
+handle can be force-killed after a redeploy regardless of the current mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import secrets
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Hard cap on a single spawn call. The Docker/ECS API call should return as
+# soon as the runtime accepts the task, but can legitimately take a while on a
+# loaded host (image pull, capacity placement).
+CONTAINER_RUN_TIMEOUT = 600
+
+# Hard cap on a single force-kill call.
+CONTAINER_STOP_TIMEOUT = 60
+
+# Module-level clients — created once per process to reuse connections across
+# repeated spawn calls. Tests patch _get_docker_client / _get_ecs_client.
+_docker_client: Any = None
+_ecs_client: Any = None
+
+
+class WorkerSpawnError(Exception):
+    """Raised when the runtime accepted our request but could not start a worker.
+
+    ``status_code`` is a hint for HTTP callers (404 for a missing image,
+    503 for an unavailable runtime, 500 otherwise).
+    """
+
+    def __init__(self, message: str, status_code: int = 500):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass
+class SpawnedWorker:
+    """Result of a successful spawn."""
+
+    handle: str  # Docker container ID or ECS task ARN — persist in workers.container_id
+    short_id: str  # 12-char display form for logs / tool results
+    runtime: str  # "docker" | "ecs"
+
+
+def ecs_enabled() -> bool:
+    """True when the backend should dispatch workers via ECS RunTask."""
+    return bool(os.environ.get("ECS_CLUSTER_NAME") and os.environ.get("ECS_WORKER_TASK_DEFINITION"))
+
+
+def runtime_name() -> str:
+    return "ecs" if ecs_enabled() else "docker"
+
+
+async def check_runtime_available() -> None:
+    """Raise WorkerSpawnError(503) if the selected runtime cannot spawn workers."""
+    if ecs_enabled():
+        try:
+            _get_ecs_client()
+        except ImportError:
+            raise WorkerSpawnError("boto3 not installed in backend", status_code=503)
+        except Exception as e:
+            raise WorkerSpawnError(f"ECS client unavailable: {e}", status_code=503)
+        return
+    try:
+        await _get_docker_client()
+    except ImportError:
+        raise WorkerSpawnError("Docker SDK not installed in backend", status_code=503)
+    except Exception as e:
+        raise WorkerSpawnError(f"Docker socket unavailable: {e}", status_code=503)
+
+
+async def _get_docker_client() -> Any:
+    """Return the cached Docker client, importing the SDK and calling from_env() once."""
+    global _docker_client
+    if _docker_client is not None:
+        return _docker_client
+    import docker  # noqa: PLC0415 — ImportError propagated to caller if SDK not installed
+
+    _docker_client = await asyncio.to_thread(docker.from_env)
+    return _docker_client
+
+
+def _get_ecs_client() -> Any:
+    """Return the cached boto3 ECS client (region from the usual AWS env/config chain)."""
+    global _ecs_client
+    if _ecs_client is not None:
+        return _ecs_client
+    import boto3  # noqa: PLC0415 — ImportError propagated to caller if SDK not installed
+
+    _ecs_client = boto3.client("ecs")
+    return _ecs_client
+
+
+def _csv_env(name: str) -> list[str]:
+    return [item.strip() for item in os.environ.get(name, "").split(",") if item.strip()]
+
+
+async def start_worker_container(*, env: dict[str, str], guild_id: str) -> SpawnedWorker:
+    """Start one worker with the given environment; returns its runtime handle.
+
+    Raises WorkerSpawnError on failure (including a friendly message for a
+    missing local image) and ImportError if the runtime SDK isn't installed.
+    """
+    if ecs_enabled():
+        return await _start_worker_ecs(env=env, guild_id=guild_id)
+    return await _start_worker_docker(env=env, guild_id=guild_id)
+
+
+async def stop_worker_container(handle: str, *, reason: str = "killed by backend") -> None:
+    """Force-kill the container/task behind *handle* (best effort, raises on API errors).
+
+    Dispatches on the handle itself rather than the current runtime so ECS task
+    ARNs recorded before a config change are still stoppable, and vice versa.
+    """
+    if handle.startswith("arn:"):
+        await _stop_worker_ecs(handle, reason=reason)
+    else:
+        await _stop_worker_docker(handle)
+
+
+# ---------------------------------------------------------------------------
+# Docker
+# ---------------------------------------------------------------------------
+
+
+async def _start_worker_docker(*, env: dict[str, str], guild_id: str) -> SpawnedWorker:
+    client = await _get_docker_client()
+    image = os.environ.get("WORKER_IMAGE", "pioneer-square-worker")
+
+    # Join the same Docker network as the backend so the worker can reach it.
+    network = None
+    try:
+        me = await asyncio.to_thread(client.containers.get, os.environ.get("HOSTNAME", ""))
+        network = next(iter(me.attrs["NetworkSettings"]["Networks"].keys()), None)
+    except Exception as e:
+        logger.warning("Docker network detection failed, starting without explicit network: %s", e)
+
+    # Pioneer-owned labels — these containers are spawned and lifecycle-managed
+    # by the backend, not compose. List with:
+    # docker ps --filter label=com.pioneer.kind=worker
+    run_kwargs: dict = dict(
+        image=image,
+        environment=env,
+        detach=True,
+        remove=True,
+        labels={"com.pioneer.kind": "worker", "com.pioneer.guild": guild_id},
+        name=f"pioneer-worker-{guild_id}-{secrets.token_hex(3)}",
+    )
+    if network:
+        run_kwargs["network"] = network
+
+    try:
+        container = await asyncio.wait_for(
+            asyncio.to_thread(client.containers.run, **run_kwargs),
+            timeout=CONTAINER_RUN_TIMEOUT,
+        )
+    except Exception as exc:
+        # Import lazily inside the handler: the docker SDK is only guaranteed
+        # importable when the (possibly test-patched) client above is real.
+        try:
+            import docker as docker_sdk  # noqa: PLC0415
+
+            image_not_found = isinstance(exc, docker_sdk.errors.ImageNotFound)
+        except ImportError:
+            image_not_found = False
+        if image_not_found:
+            raise WorkerSpawnError(
+                f"Worker image '{image}' not found — run: docker compose build worker",
+                status_code=404,
+            )
+        raise
+    return SpawnedWorker(handle=container.id, short_id=container.id[:12], runtime="docker")
+
+
+async def _stop_worker_docker(container_id: str) -> None:
+    client = await _get_docker_client()
+    container = await asyncio.wait_for(
+        asyncio.to_thread(client.containers.get, container_id),
+        timeout=CONTAINER_STOP_TIMEOUT,
+    )
+    await asyncio.wait_for(asyncio.to_thread(container.kill), timeout=CONTAINER_STOP_TIMEOUT)
+
+
+# ---------------------------------------------------------------------------
+# ECS
+# ---------------------------------------------------------------------------
+
+
+async def _start_worker_ecs(*, env: dict[str, str], guild_id: str) -> SpawnedWorker:
+    client = _get_ecs_client()
+    cluster = os.environ["ECS_CLUSTER_NAME"]
+    task_definition = os.environ["ECS_WORKER_TASK_DEFINITION"]
+    container_name = os.environ.get("ECS_WORKER_CONTAINER_NAME", "worker")
+
+    run_kwargs: dict = dict(
+        cluster=cluster,
+        taskDefinition=task_definition,
+        launchType="FARGATE",
+        count=1,
+        # startedBy is capped at 36 chars; guild slugs are 6 chars.
+        startedBy=f"pioneer-backend/{guild_id}"[:36],
+        group=f"pioneer-worker:{guild_id}",
+        overrides={
+            "containerOverrides": [
+                {
+                    "name": container_name,
+                    # NOTE: the RunTask overrides payload is limited to 8 KiB.
+                    # Static secrets (GITHUB_TOKEN, CLAUDE_CODE_OAUTH_TOKEN, …)
+                    # already ride in the task definition's `secrets` block, so
+                    # this override only needs the per-spawn PIONEER_* vars,
+                    # but a huge extra_env from the UI could still exceed it.
+                    "environment": [{"name": k, "value": v} for k, v in env.items()],
+                }
+            ]
+        },
+    )
+    subnets = _csv_env("ECS_WORKER_SUBNETS")
+    if subnets:
+        assign_public_ip = os.environ.get("ECS_WORKER_ASSIGN_PUBLIC_IP", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        vpc_config: dict = {
+            "subnets": subnets,
+            "assignPublicIp": "ENABLED" if assign_public_ip else "DISABLED",
+        }
+        security_groups = _csv_env("ECS_WORKER_SECURITY_GROUPS")
+        if security_groups:
+            vpc_config["securityGroups"] = security_groups
+        run_kwargs["networkConfiguration"] = {"awsvpcConfiguration": vpc_config}
+    else:
+        # awsvpc-mode task definitions (all Fargate ones) can't launch without
+        # a network configuration — fail with a pointer at the missing config
+        # rather than an opaque boto3 ClientError.
+        raise WorkerSpawnError(
+            "ECS worker dispatch is enabled but ECS_WORKER_SUBNETS is not set — "
+            "the Fargate worker task needs at least one subnet ID"
+        )
+
+    response = await asyncio.wait_for(
+        asyncio.to_thread(client.run_task, **run_kwargs),
+        timeout=CONTAINER_RUN_TIMEOUT,
+    )
+
+    failures = response.get("failures") or []
+    tasks = response.get("tasks") or []
+    if not tasks:
+        detail = "; ".join(
+            f"{f.get('reason', 'unknown')}" + (f" ({f['detail']})" if f.get("detail") else "")
+            for f in failures
+        )
+        raise WorkerSpawnError(f"ECS RunTask returned no task: {detail or 'no failure detail'}")
+
+    task_arn: str = tasks[0]["taskArn"]
+    # The last ARN path segment is the 32-hex task ID — use its head as the display id.
+    return SpawnedWorker(handle=task_arn, short_id=task_arn.rsplit("/", 1)[-1][:12], runtime="ecs")
+
+
+async def _stop_worker_ecs(task_arn: str, *, reason: str) -> None:
+    client = _get_ecs_client()
+    # StopTask needs the cluster the task runs in; the cluster name is the
+    # second-to-last ARN segment (task ARN format:
+    # arn:aws:ecs:<region>:<acct>:task/<cluster>/<task-id>).
+    parts = task_arn.rsplit("/", 2)
+    cluster = parts[1] if len(parts) == 3 else os.environ.get("ECS_CLUSTER_NAME", "")
+    await asyncio.wait_for(
+        # ECS StopTask sends SIGTERM then SIGKILL after the task's stopTimeout.
+        asyncio.to_thread(client.stop_task, cluster=cluster, task=task_arn, reason=reason[:255]),
+        timeout=CONTAINER_STOP_TIMEOUT,
+    )

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -15,16 +15,24 @@ Amazon Bedrock access.
 | `pgweb` (Metabase, `profiles: [tools]`) | Not migrated; run locally against the RDS endpoint if needed |
 | `postgres-test` (`profiles: [test]`) | Not migrated; test-only |
 
-### Worker dispatch — a known gap
+### Worker dispatch
 
-In docker-compose, the `backend` container spawns one `worker` container per task via the
-Docker socket (`docker.from_env()` in `backend/foreman/tools.py` and
-`backend/routes/workers.py`). Fargate tasks have no shared Docker socket, so this repo's
-application code still assumes the old model. This Terraform module registers a `worker`
-task definition and grants the backend's task role `ecs:RunTask`/`ecs:StopTask`/
-`ecs:DescribeTasks` scoped to this cluster (see `iam.tf`), so the infrastructure is ready —
-but switching `backend` to call `ecs.run_task(...)` instead of `docker.containers.run(...)`
-is an application-code change tracked separately, not part of this module.
+In docker-compose, the `backend` container spawns one `worker` container per spawn request
+via the Docker socket. Fargate tasks have no shared Docker socket, so on ECS the backend
+dispatches workers with `ecs:RunTask` instead: `backend/worker_runtime.py` switches to ECS
+mode automatically when `ECS_CLUSTER_NAME` and `ECS_WORKER_TASK_DEFINITION` are set (both
+injected into the backend task definition by `ecs.tf`, alongside `ECS_WORKER_SUBNETS` and
+`ECS_WORKER_SECURITY_GROUPS` for the worker task's awsvpc network interface). This module
+registers the `worker` task definition and grants the backend's task role
+`ecs:RunTask`/`ecs:StopTask`/`ecs:DescribeTasks` scoped to this cluster (see `iam.tf`).
+
+Spawned worker tasks connect back to the backend through the ALB (`WORKER_BACKEND_URL`),
+carry per-spawn configuration as container env overrides (static secrets like
+`GITHUB_TOKEN` ride in the task definition's `secrets` block), and are stopped with
+`ecs:StopTask` when force-killed. The backend's idle reaper
+(`backend/worker_lifecycle.py`, `PIONEER_WORKER_IDLE_TIMEOUT`, default 30 min) shuts
+spawned workers down after a period of inactivity so idle Fargate tasks don't accrue
+cost indefinitely.
 
 ## Prerequisites
 

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -59,13 +59,20 @@ resource "aws_ecs_task_definition" "backend" {
       environment = [
         { name = "GITHUB_REDIRECT_URI", value = var.frontend_url != "" ? "${var.frontend_url}/auth/github/callback" : "" },
         { name = "FRONTEND_URL", value = var.frontend_url },
-        { name = "WORKER_BACKEND_URL", value = "http://localhost:${var.backend_container_port}" },
+        # Spawned workers run as separate Fargate tasks, so "localhost" would
+        # never reach the backend — they connect back through the ALB.
+        { name = "WORKER_BACKEND_URL", value = "${local.has_certificate ? "https" : "http"}://${var.domain_name != "" ? var.domain_name : aws_lb.main.dns_name}" },
         { name = "LOG_LEVEL", value = var.log_level },
         { name = "PIONEER_S3_BUCKET", value = aws_s3_bucket.assets.bucket },
         { name = "PIONEER_S3_PREFIX", value = "worker-sessions" },
         { name = "AWS_DEFAULT_REGION", value = local.region },
+        # Worker dispatch via ECS RunTask (backend/worker_runtime.py): the
+        # first two select ECS mode; the subnet/SG pair is the awsvpc network
+        # configuration each spawned worker task launches with.
         { name = "ECS_CLUSTER_NAME", value = aws_ecs_cluster.main.name },
         { name = "ECS_WORKER_TASK_DEFINITION", value = "${local.name_prefix}-worker" },
+        { name = "ECS_WORKER_SUBNETS", value = join(",", aws_subnet.private[*].id) },
+        { name = "ECS_WORKER_SECURITY_GROUPS", value = aws_security_group.ecs_tasks.id },
         # The embedded foreman (backend/foreman/runner.py) makes LLM calls from
         # this process whenever no standalone foreman proxy is connected for a
         # guild — it needs the same provider config as the foreman task below.


### PR DESCRIPTION
Closes the worker-dispatch gap from terraform/README.md: on Fargate the
backend has no Docker socket, so spawning workers via docker.containers.run
could never work. Worker spawning now goes through a runtime abstraction
(backend/worker_runtime.py) that picks ECS RunTask when ECS_CLUSTER_NAME +
ECS_WORKER_TASK_DEFINITION are set (injected by terraform/ecs.tf, along with
the worker task's subnets/security group) and the Docker socket otherwise.
The spawn handle stored in workers.container_id is the ECS task ARN or the
Docker container id; force-kill dispatches on the handle so either kind stays
stoppable. WORKER_BACKEND_URL on ECS now points at the ALB instead of
localhost so spawned worker tasks can actually reach the backend.

The foreman can now spawn workers itself: spawn_worker is exposed in
FOREMAN_TOOLS (parent contexts only — per-task child contexts stay excluded),
with prompt guidance to spawn only when no online worker covers the needed
repos and never to duplicate one that is starting.

To keep spawned workers from running (and costing) forever, a new idle reaper
(worker_lifecycle.idle_worker_reaper, wired into the app lifespan) gracefully
shuts down backend-spawned workers with no pending/working task, no busy
agent, and no task-log activity for PIONEER_WORKER_IDLE_TIMEOUT (default 30
min), with a short force-kill backstop; offline zombies that never connected
are stopped directly. Reaped workers are marked disabled so they are not
respawned on the next deploy.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EaS2PWrsvEqN9to1A8PYU3