### PR TITLE
feat(backend): guild-level spawn defaults; simplify stale-worker lifecycle

### DIFF
--- a/backend/alembic/versions/20260723_000000_add_guild_spawn_defaults.py
+++ b/backend/alembic/versions/20260723_000000_add_guild_spawn_defaults.py
@@ -1,0 +1,82 @@
+"""add_guild_spawn_defaults
+
+Creates ``guild_spawn_defaults`` — one row per guild holding the default
+spawn-worker parameters (repos, tools, agent_count) the foreman uses when a
+``spawn_worker`` call doesn't specify them. The row tracks the *last
+successful spawn* for the guild and is upserted on every worker spawn.
+
+Data migration: seeds each guild's row from its most recent worker row,
+preferring workers that were actually spawned by the backend (``container_id``
+is recorded only after a successful container/ECS start) over plain
+registrations, newest first. Guilds with no worker carrying a non-empty repos
+list get no row — the foreman then requires explicit repos until the first
+spawn records defaults.
+
+Revision ID: 20260723_000000_add_guild_spawn_defaults
+Revises: 20260722_000000_add_discord_bot_fields_to_users
+Create Date: 2026-07-23
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260723_000000_add_guild_spawn_defaults"
+down_revision: str | Sequence[str] | None = "20260722_000000_add_discord_bot_fields_to_users"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "guild_spawn_defaults",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("repos", sa.Text(), nullable=False, server_default="'[]'"),
+        sa.Column("tools", sa.Text(), nullable=False, server_default="'[]'"),
+        sa.Column("agent_count", sa.Integer(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "uq_guild_spawn_defaults_guild_id",
+        "guild_spawn_defaults",
+        ["guild_id"],
+        unique=True,
+    )
+
+    # Seed each guild from its most recent worker with a non-empty repos list,
+    # preferring backend-spawned workers (container_id recorded on successful
+    # start) over plain registrations. Portable across Postgres and SQLite:
+    # window functions and CASE ordering work on both.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO guild_spawn_defaults (guild_id, repos, tools, agent_count, updated_at)
+            SELECT guild_id, repos, tools, NULL, CURRENT_TIMESTAMP
+            FROM (
+                SELECT
+                    w.guild_id,
+                    w.repos,
+                    COALESCE(w.tools, '[]') AS tools,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY w.guild_id
+                        ORDER BY
+                            CASE WHEN w.container_id IS NOT NULL THEN 0 ELSE 1 END,
+                            w.created_at DESC
+                    ) AS rn
+                FROM workers w
+                WHERE w.repos IS NOT NULL AND w.repos != '[]' AND w.repos != ''
+            ) latest
+            WHERE latest.rn = 1
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_guild_spawn_defaults_guild_id", table_name="guild_spawn_defaults")
+    op.drop_table("guild_spawn_defaults")

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1110,9 +1110,10 @@ def _post_agent_task(task_url: str, body: bytes) -> dict:
 
 # ---------------------------------------------------------------------------
 # spawn_worker implementation — exposed to the parent foreman via FOREMAN_TOOLS
-# and invoked directly by worker_lifecycle.spawn_replacement_workers(). Spawned
-# workers are auto-reaped by worker_lifecycle.idle_worker_reaper() after a
-# period of inactivity.
+# and invoked by the Discord /worker-spawn command. Spawned workers are
+# auto-reaped by worker_lifecycle.idle_worker_reaper() after a period of
+# inactivity; parameters omitted from the call fall back to the guild's
+# last-successful-spawn defaults (guild_spawn_defaults).
 # ---------------------------------------------------------------------------
 
 
@@ -1132,12 +1133,30 @@ async def spawn_worker(
 
     Returns (result_text, is_error).
     """
+    from worker_lifecycle import get_guild_spawn_defaults  # noqa: PLC0415
+
     repos: list = inp.get("repos") or []
     tools_list: list[str] = inp.get("tools") or []
     agent_count: int | None = inp.get("agent_count")
     custom_name: str | None = inp.get("name")
+
+    # Fall back to the guild's last-successful-spawn defaults for anything the
+    # call didn't specify, so "spawn a worker" works without restating the
+    # guild's usual configuration.
+    if guild_pk is not None and (not repos or not tools_list or agent_count is None):
+        defaults = await get_guild_spawn_defaults(db, guild_pk)
+        if defaults is not None:
+            if not repos:
+                repos = json.loads(defaults.repos or "[]")
+            if not tools_list:
+                tools_list = json.loads(defaults.tools or "[]")
+            if agent_count is None:
+                agent_count = defaults.agent_count
     if not repos:
-        return "spawn_worker requires at least one repo in the 'repos' list.", True
+        return (
+            "spawn_worker requires at least one repo in the 'repos' list — this guild has "
+            "no recorded spawn defaults to fall back on."
+        ), True
 
     worker_id = "w-" + secrets.token_hex(3)
     auth_token = secrets.token_urlsafe(32)
@@ -1194,10 +1213,19 @@ async def spawn_worker(
         spawned = await worker_runtime.start_worker_container(env=env, guild_id=guild_id)
         # Persist the spawn handle and version so the lifecycle module can
         # force-kill this container/task if the backend is redeployed with a
-        # different version (or the worker idles past the reap timeout).
+        # different version (or the worker idles past the reap timeout), and
+        # refresh the guild's spawn defaults with this successful spawn.
         from worker_lifecycle import record_worker_spawn as _record_worker_spawn  # noqa: PLC0415
 
-        await _record_worker_spawn(db, worker_id, spawned.handle)
+        await _record_worker_spawn(
+            db,
+            worker_id,
+            spawned.handle,
+            guild_pk=guild_pk,
+            repos=repos,
+            tools=tools_list,
+            agent_count=agent_count,
+        )
         result_text = json.dumps(
             {
                 "worker_id": worker_id,

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -659,7 +659,8 @@ FOREMAN_TOOLS = [
             "a duplicate if a worker for the same repos is already online or currently starting. "
             "Spawned workers are automatically shut down after a period of inactivity, so there "
             "is no need to clean up idle workers yourself (shutdown_worker still works for an "
-            "immediate stop)."
+            "immediate stop). Parameters you omit default to the guild's last successful spawn "
+            "configuration; a guild that has never spawned a worker requires explicit repos."
         ),
         "input_schema": {
             "type": "object",
@@ -667,14 +668,18 @@ FOREMAN_TOOLS = [
                 "repos": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Repos the worker should serve, as 'owner/repo'. At least one.",
+                    "description": (
+                        "Repos the worker should serve, as 'owner/repo'. Optional: defaults to "
+                        "the repos of the guild's last successful spawn."
+                    ),
                 },
                 "tools": {
                     "type": "array",
                     "items": {"type": "string"},
                     "description": (
                         "Optional tool runners to enable on the worker "
-                        "(e.g. ['claude', 'codex']). Default: claude only."
+                        "(e.g. ['claude', 'codex']). Defaults to the guild's last spawn, "
+                        "else claude only."
                     ),
                 },
                 "agent_count": {
@@ -686,7 +691,7 @@ FOREMAN_TOOLS = [
                     "description": "Optional human-readable worker name.",
                 },
             },
-            "required": ["repos"],
+            "required": [],
         },
     },
 ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,7 +38,6 @@ from util.tasks import spawn
 from worker_lifecycle import (
     drain_stale_workers_on_startup,
     idle_worker_reaper,
-    reconcile_stale_workers,
 )
 from ws_types import WorkerPingMsg
 
@@ -363,22 +362,15 @@ async def lifespan(app: FastAPI):
             dnsid_runtime.guild_slug,
         )
 
-    # Phase 1: detect stale workers and send graceful-shutdown signals.
-    # Must be awaited directly before reset_connection_state() so the DB still
-    # holds the non-offline state that identifies which workers were stale.
-    stale_ids = await drain_stale_workers_on_startup()
+    # Detect stale workers and send graceful-shutdown signals. Must be awaited
+    # directly before reset_connection_state() so the DB still holds the
+    # non-offline state that identifies which workers were stale. Stale workers
+    # that reconnect later are signalled from the WS join handler; the idle
+    # reaper cleans up anything that never complies, and the foreman respawns
+    # workers on demand from the guild's spawn defaults.
+    await drain_stale_workers_on_startup()
 
     await reset_connection_state()
-
-    # Phase 2: drain each stale worker (wait for it to reconnect, soft-kill it,
-    # let it finish its task and go offline) and spawn a fresh replacement once
-    # it's down. Runs in the background so it doesn't block startup or the first
-    # request.
-    reconcile_bg = (
-        spawn(reconcile_stale_workers(stale_ids), name="stale-worker-reconcile")
-        if stale_ids
-        else None
-    )
     # Refresh the models.dev catalog on startup: persist to DB and warm the
     # in-memory cache so the first /api/models request is fast.
     from util.models_dev import refresh_model_catalog_if_stale as _refresh_catalog  # noqa: PLC0415
@@ -409,8 +401,6 @@ async def lifespan(app: FastAPI):
     finally:
         sweeper.cancel()
         idle_reaper.cancel()
-        if reconcile_bg is not None:
-            reconcile_bg.cancel()
         if discord_gw_task is not None:
             discord_gw_task.cancel()
         try:
@@ -421,11 +411,6 @@ async def lifespan(app: FastAPI):
             await idle_reaper
         except (asyncio.CancelledError, Exception):
             pass
-        if reconcile_bg is not None:
-            try:
-                await reconcile_bg
-            except (asyncio.CancelledError, Exception):
-                pass
         if discord_gw_task is not None:
             try:
                 await discord_gw_task

--- a/backend/models.py
+++ b/backend/models.py
@@ -656,6 +656,30 @@ class UserSpawnSettings(SQLModel, table=True):
     )
 
 
+class GuildSpawnDefaults(SQLModel, table=True):
+    """Per-guild default spawn-worker parameters, tracking the last successful spawn.
+
+    One row per guild, upserted every time a worker container is successfully
+    started with explicit parameters (foreman spawn_worker tool, REST
+    spawn-worker endpoint, Discord /worker-spawn). The foreman's spawn_worker
+    tool falls back to this row when a call omits repos/tools/agent_count, so
+    "spawn me a worker" works without restating the guild's usual configuration.
+    """
+
+    __tablename__ = "guild_spawn_defaults"  # type: ignore[assignment]
+    __table_args__ = (Index("uq_guild_spawn_defaults_guild_id", "guild_id", unique=True),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    guild_id: int = Field(foreign_key="guilds.id")
+    # JSON-serialised list of "owner/repo" strings (same encoding as workers.repos).
+    repos: str = Field(default="[]", sa_column=Column(Text, nullable=False, server_default="'[]'"))
+    # JSON-serialised list of tool runner names (same encoding as workers.tools).
+    tools: str = Field(default="[]", sa_column=Column(Text, nullable=False, server_default="'[]'"))
+    # Concurrent agent slots requested at spawn; NULL = worker default.
+    agent_count: int | None = None
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
 class PushToken(SQLModel, table=True):
     """APNs (or, in the future, FCM) device token registered by the iOS app.
 

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -247,8 +247,17 @@ async def spawn_worker_container(
 
     # Persist the spawn handle and version so the lifecycle module can
     # force-kill this container/task if the backend is redeployed at a
-    # different version (or the worker idles past the reap timeout).
-    await record_worker_spawn(db, worker_id, spawned.handle)
+    # different version (or the worker idles past the reap timeout), and
+    # refresh the guild's spawn defaults with this successful spawn.
+    await record_worker_spawn(
+        db,
+        worker_id,
+        spawned.handle,
+        guild_pk=guild_pk,
+        repos=data.repos,
+        tools=data.tools,
+        agent_count=data.agent_count,
+    )
 
     return {
         "worker_id": worker_id,

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -2053,10 +2053,11 @@ class TestFinalizeClosedIssueAtomicity:
 
 
 class TestSpawnWorker:
-    """spawn_worker() is invoked by the foreman tool executor and directly by
-    worker_lifecycle.spawn_replacement_workers() on backend startup. Container
-    start goes through the worker_runtime abstraction (Docker socket locally,
-    ECS RunTask on Fargate).
+    """spawn_worker() is invoked by the foreman tool executor and the Discord
+    /worker-spawn command. Container start goes through the worker_runtime
+    abstraction (Docker socket locally, ECS RunTask on Fargate). Parameters
+    omitted from a call fall back to the guild's last-successful-spawn
+    defaults (guild_spawn_defaults), which every successful spawn refreshes.
     """
 
     async def test_spawn_worker_starts_container(self, db_session):
@@ -2131,6 +2132,107 @@ class TestSpawnWorker:
         with _sync_session(db_session) as session:
             container_ids = session.execute(select(col(WorkerModel.container_id))).scalars().all()
         assert task_arn in container_ids
+
+    async def test_spawn_worker_records_guild_defaults(self, db_session):
+        """A successful spawn upserts the guild's last-successful-spawn defaults."""
+        from models import GuildSpawnDefaults  # noqa: PLC0415
+
+        insert_guild(db_session, "g-spawn-rec")
+
+        fake_container = SimpleNamespace(id="abcdef0123456789")
+        fake_docker_client = MagicMock()
+        fake_docker_client.containers.get.side_effect = Exception("not found")
+        fake_docker_client.containers.run.return_value = fake_container
+
+        with (
+            patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_docker_client)),
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        ):
+            results = await exec_tools(
+                "g-spawn-rec",
+                [
+                    _fake_tool_use(
+                        "spawn_worker",
+                        {"repos": ["acme/widgets"], "tools": ["claude", "codex"], "agent_count": 2},
+                    )
+                ],
+            )
+        assert results[0].get("is_error") is not True, results[0]["content"]
+
+        with _sync_session(db_session) as session:
+            row = session.execute(select(GuildSpawnDefaults)).scalars().one()
+        assert json.loads(row.repos) == ["acme/widgets"]
+        assert json.loads(row.tools) == ["claude", "codex"]
+        assert row.agent_count == 2
+
+        # A second spawn with different parameters replaces (not duplicates) the row.
+        with (
+            patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_docker_client)),
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        ):
+            results = await exec_tools(
+                "g-spawn-rec",
+                [_fake_tool_use("spawn_worker", {"repos": ["acme/gears"]})],
+            )
+        assert results[0].get("is_error") is not True, results[0]["content"]
+
+        with _sync_session(db_session) as session:
+            row = session.execute(select(GuildSpawnDefaults)).scalars().one()
+        assert json.loads(row.repos) == ["acme/gears"]
+
+    async def test_spawn_worker_falls_back_to_guild_defaults(self, db_session):
+        """spawn_worker with no repos uses the guild's recorded spawn defaults."""
+        from models import GuildSpawnDefaults  # noqa: PLC0415
+
+        insert_guild(db_session, "g-spawn-def")
+        with _sync_session(db_session) as session:
+            guild_pk = session.execute(
+                select(col(Guild.id)).where(col(Guild.slug) == "g-spawn-def")
+            ).scalar_one()
+            session.add(
+                GuildSpawnDefaults(
+                    guild_id=guild_pk,
+                    repos='["acme/widgets"]',
+                    tools='["claude"]',
+                    agent_count=3,
+                    updated_at=datetime.now(UTC),
+                )
+            )
+            session.commit()
+
+        fake_container = SimpleNamespace(id="abcdef0123456789")
+        fake_docker_client = MagicMock()
+        fake_docker_client.containers.get.side_effect = Exception("not found")
+        fake_docker_client.containers.run.return_value = fake_container
+
+        with (
+            patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_docker_client)),
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        ):
+            results = await exec_tools("g-spawn-def", [_fake_tool_use("spawn_worker", {})])
+
+        r = results[0]
+        assert r.get("is_error") is not True, f"spawn_worker failed: {r['content']}"
+        assert "acme/widgets" in r["content"]
+        env = fake_docker_client.containers.run.call_args.kwargs["environment"]
+        assert env["PIONEER_REPOS"] == "acme/widgets"
+        assert env["PIONEER_MAX_AGENTS"] == "3"
+
+    async def test_spawn_worker_errors_without_repos_or_defaults(self, db_session):
+        """No repos in the call and no recorded defaults → clear error, no container."""
+        insert_guild(db_session, "g-spawn-none")
+
+        fake_docker_client = MagicMock()
+        with (
+            patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_docker_client)),
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        ):
+            results = await exec_tools("g-spawn-none", [_fake_tool_use("spawn_worker", {})])
+
+        r = results[0]
+        assert r.get("is_error") is True
+        assert "no recorded spawn defaults" in r["content"]
+        fake_docker_client.containers.run.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -16,15 +16,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from worker_lifecycle import (  # noqa: E402
     SHUTDOWN_FORCE_KILL_TIMEOUT,
-    WORKER_DRAIN_TIMEOUT,
-    WORKER_RECONNECT_GRACE,
     drain_stale_workers_on_startup,
     force_kill_worker_if_unresponsive,
     generate_worker_id,
     get_current_version,
-    reconcile_stale_workers,
     record_worker_spawn,
-    spawn_replacement_workers,
+    signal_stale_worker_on_join,
 )
 
 # ---------------------------------------------------------------------------
@@ -245,25 +242,6 @@ async def test_drain_sends_shutdown_and_records_timestamp(monkeypatch):
     assert stale_ids == ["w-stale1"]
 
 
-def test_drain_timeout_default():
-    assert WORKER_DRAIN_TIMEOUT == 1800.0
-
-
-def test_drain_timeout_env_override(monkeypatch):
-    monkeypatch.setenv("PIONEER_WORKER_DRAIN_TIMEOUT", "120")
-    import importlib
-
-    import worker_lifecycle as wl
-
-    try:
-        importlib.reload(wl)
-        assert wl.WORKER_DRAIN_TIMEOUT == 120.0
-    finally:
-        # Always restore module state so later tests see the default value.
-        monkeypatch.delenv("PIONEER_WORKER_DRAIN_TIMEOUT", raising=False)
-        importlib.reload(wl)
-
-
 # ---------------------------------------------------------------------------
 # record_worker_spawn
 # ---------------------------------------------------------------------------
@@ -283,72 +261,113 @@ async def test_record_worker_spawn_writes_fields():
     mock_db.commit.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_record_worker_spawn_upserts_guild_defaults():
+    """With guild_pk and repos, the guild's spawn defaults are upserted in the same commit."""
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock()
+    mock_db.commit = AsyncMock()
+
+    with patch("worker_lifecycle.get_current_version", return_value="v-test"):
+        await record_worker_spawn(
+            mock_db,
+            "w-abc123",
+            "container-deadbeef",
+            guild_pk=42,
+            repos=["acme/widgets"],
+            tools=["claude"],
+            agent_count=2,
+        )
+
+    # Worker update + guild_spawn_defaults upsert, one commit.
+    assert mock_db.exec.call_count == 2
+    mock_db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_record_worker_spawn_skips_defaults_without_repos():
+    """No repos recorded (or no guild_pk) → the defaults row is left untouched."""
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock()
+    mock_db.commit = AsyncMock()
+
+    with patch("worker_lifecycle.get_current_version", return_value="v-test"):
+        await record_worker_spawn(mock_db, "w-abc123", "container-deadbeef", guild_pk=42, repos=[])
+
+    mock_db.exec.assert_called_once()
+    mock_db.commit.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
-# _spawn_replacement_workers
+# signal_stale_worker_on_join
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_spawn_replacement_workers_no_op_on_empty():
-    """Empty stale_ids list → no DB or spawn calls."""
-    with patch("worker_lifecycle.AsyncSessionLocal") as mock_session:
-        await spawn_replacement_workers([])
-    mock_session.assert_not_called()
+async def test_signal_stale_worker_on_join_sends_shutdown():
+    """A worker joining with a version stamp that differs from the backend's is signalled."""
+    broadcasts = []
 
+    async def fake_broadcast(guild_slug, msg, *a, **kw):
+        broadcasts.append((guild_slug, msg))
 
-@pytest.mark.asyncio
-async def test_spawn_replacement_workers_calls_spawn_for_each():
-    """One replacement worker is spawned per stale worker."""
-    fake_worker = MagicMock()
-    fake_worker.id = "w-old1"
-    fake_worker.guild_id = 42
-    fake_worker.repos = '["owner/repo"]'
-    fake_worker.tools = '["bash"]'
-    fake_worker.name = "old-worker"
-
-    class FakeDB:
-        def __init__(self, rows):
-            self._rows = rows
-            self.exec = AsyncMock(
-                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
-            )
-            self.commit = AsyncMock()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return False
-
-    # Session 1: query workers + guild slugs.
-    # Session 2: passed to spawn_worker call.
-    sessions = [FakeDB([(fake_worker, "g-myguild")]), FakeDB([])]
-    session_iter = iter(sessions)
-    spawn_calls: list[dict] = []
-
-    async def fake_spawn(inp, guild_id, guild_pk, db):
-        spawn_calls.append({"inp": inp, "guild_id": guild_id, "guild_pk": guild_pk})
-        return ("ok", False)
-
-    fake_tools = MagicMock()
-    fake_tools.spawn_worker = fake_spawn
     with (
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch.dict("sys.modules", {"foreman": MagicMock(), "foreman.tools": fake_tools}),
+        patch("worker_lifecycle.get_current_version", return_value="v-new"),
+        patch("worker_lifecycle.broadcast_msg", fake_broadcast),
     ):
-        await spawn_replacement_workers(["w-old1"])
+        signalled = await signal_stale_worker_on_join("g-guild", "w-stale", "v-old")
 
-    assert len(spawn_calls) == 1
-    assert spawn_calls[0]["guild_id"] == "g-myguild"
-    assert spawn_calls[0]["guild_pk"] == 42
-    assert spawn_calls[0]["inp"]["repos"] == ["owner/repo"]
-    assert spawn_calls[0]["inp"]["tools"] == ["bash"]
-    # The replacement must get a fresh identity, never the drained worker's name.
-    assert "name" not in spawn_calls[0]["inp"]
+    assert signalled is True
+    assert len(broadcasts) == 1
+    guild_slug, msg = broadcasts[0]
+    assert guild_slug == "g-guild"
+    assert msg.workerId == "w-stale"
+    assert "version mismatch" in (msg.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_signal_stale_worker_on_join_skips_matching_version():
+    broadcast = AsyncMock()
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="v-current"),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+    ):
+        signalled = await signal_stale_worker_on_join("g-guild", "w-fresh", "v-current")
+
+    assert signalled is False
+    broadcast.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_signal_stale_worker_on_join_skips_external_workers():
+    """Workers without a spawn version stamp (compose/manual CLI) are never signalled."""
+    broadcast = AsyncMock()
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="v-current"),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+    ):
+        signalled = await signal_stale_worker_on_join("g-guild", "w-external", None)
+
+    assert signalled is False
+    broadcast.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_signal_stale_worker_on_join_skips_when_version_unknown():
+    """An undetermined backend version can't be compared — no signal."""
+    broadcast = AsyncMock()
+    with (
+        patch("worker_lifecycle.get_current_version", return_value=None),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+    ):
+        signalled = await signal_stale_worker_on_join("g-guild", "w-any", "v-old")
+
+    assert signalled is False
+    broadcast.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# disabled worker — drain and re-spawn exclusion
+# disabled worker — drain exclusion
 # ---------------------------------------------------------------------------
 
 
@@ -392,51 +411,6 @@ async def test_drain_skips_disabled_workers():
     # Disabled worker is not drained — empty result, no broadcast.
     assert result == []
     assert broadcast_calls == []
-
-
-@pytest.mark.asyncio
-async def test_spawn_replacement_workers_skips_disabled():
-    """spawn_replacement_workers skips workers that have disabled=True in the DB."""
-    fake_worker = MagicMock()
-    fake_worker.id = "w-disabled-spawn"
-    fake_worker.guild_id = 7
-    fake_worker.repos = '["owner/repo"]'
-    fake_worker.name = "disabled-worker"
-    fake_worker.disabled = True
-
-    class FakeDB:
-        def __init__(self, rows):
-            self._rows = rows
-            self.exec = AsyncMock(
-                return_value=MagicMock(all=MagicMock(return_value=self._rows or []))
-            )
-            self.commit = AsyncMock()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return False
-
-    # The DB query returns no rows because the disabled filter excludes the worker.
-    sessions = [FakeDB([])]
-    session_iter = iter(sessions)
-    spawn_calls: list[dict] = []
-
-    async def fake_spawn(inp, guild_id, guild_pk, db):
-        spawn_calls.append({"inp": inp, "guild_id": guild_id})
-        return ("ok", False)
-
-    fake_tools = MagicMock()
-    fake_tools.spawn_worker = fake_spawn
-    with (
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch.dict("sys.modules", {"foreman": MagicMock(), "foreman.tools": fake_tools}),
-    ):
-        await spawn_replacement_workers(["w-disabled-spawn"])
-
-    # No spawn calls because the disabled worker was excluded by the DB query.
-    assert spawn_calls == []
 
 
 # ---------------------------------------------------------------------------
@@ -488,132 +462,6 @@ async def test_generate_worker_id_raises_after_max_attempts():
         await generate_worker_id(mock_db)
 
     assert mock_db.exec.call_count == 5
-
-
-# ---------------------------------------------------------------------------
-# reconcile_stale_workers
-# ---------------------------------------------------------------------------
-
-
-class _FakeExecDB:
-    """Fake session whose exec().all() returns a fixed row list."""
-
-    def __init__(self, rows):
-        self.exec = AsyncMock(return_value=MagicMock(all=MagicMock(return_value=rows)))
-        self.commit = AsyncMock()
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *a):
-        return False
-
-
-@contextlib.contextmanager
-def _reconcile_patches(sessions, times, mock_kill, mock_spawn, broadcasts):
-    """Common patch set for driving reconcile_stale_workers deterministically.
-
-    ``sessions`` are consumed one AsyncSessionLocal() at a time: the first is the
-    guild-slug lookup, the rest are the per-poll online-worker queries. ``times``
-    feeds loop.time() (one call to seed phase_started, then one per poll). Real
-    sleeps are stubbed out so the loop runs instantly.
-    """
-    session_iter = iter(sessions)
-    fake_loop = MagicMock()
-    fake_loop.time = MagicMock(side_effect=times)
-
-    async def fake_broadcast(slug, msg, *a, **kw):
-        broadcasts.append((slug, msg))
-
-    with (
-        patch("worker_lifecycle.AsyncSessionLocal", lambda: next(session_iter)),
-        patch("worker_lifecycle.asyncio.sleep", AsyncMock()),
-        patch("worker_lifecycle.asyncio.get_event_loop", return_value=fake_loop),
-        patch("worker_lifecycle._force_kill_containers", mock_kill),
-        patch("worker_lifecycle.spawn_replacement_workers", mock_spawn),
-        patch("worker_lifecycle.broadcast_msg", fake_broadcast),
-    ):
-        yield
-
-
-@pytest.mark.asyncio
-async def test_reconcile_noop_on_empty_ids():
-    """Empty stale_ids list → no DB polling, no force-kill, no respawn."""
-    with (
-        patch("worker_lifecycle.AsyncSessionLocal") as mock_session,
-        patch("worker_lifecycle._force_kill_containers") as mock_kill,
-        patch("worker_lifecycle.spawn_replacement_workers") as mock_spawn,
-    ):
-        await reconcile_stale_workers([])
-
-    mock_session.assert_not_called()
-    mock_kill.assert_not_called()
-    mock_spawn.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_reconcile_drains_then_replaces_reconnected_worker():
-    """A worker that reconnects then drains is soft-killed and replaced, never force-killed."""
-    sessions = [
-        _FakeExecDB([("w-a", "g-guild")]),  # guild-slug lookup
-        _FakeExecDB(["w-a"]),  # poll 1: back online → begin draining
-        _FakeExecDB([]),  # poll 2: gone offline → drained
-    ]
-    mock_kill = AsyncMock()
-    mock_spawn = AsyncMock()
-    broadcasts: list = []
-    # loop.time(): seed + poll1 + poll2. Well under the drain timeout.
-    times = [0.0, 10.0, 20.0]
-
-    with _reconcile_patches(sessions, times, mock_kill, mock_spawn, broadcasts):
-        await reconcile_stale_workers(["w-a"])
-
-    # Soft-kill delivered on reconnect; drained cleanly so no force-kill.
-    assert any(msg.workerId == "w-a" for _, msg in broadcasts)
-    mock_kill.assert_not_called()
-    mock_spawn.assert_called_once_with(["w-a"])
-
-
-@pytest.mark.asyncio
-async def test_reconcile_force_kills_and_replaces_worker_that_never_reconnects():
-    """A worker that never comes back within the reconnect grace is killed and replaced."""
-    sessions = [
-        _FakeExecDB([("w-a", "g-guild")]),  # guild-slug lookup
-        _FakeExecDB([]),  # poll 1: still offline, within grace
-        _FakeExecDB([]),  # poll 2: still offline, grace exceeded → dead
-    ]
-    mock_kill = AsyncMock()
-    mock_spawn = AsyncMock()
-    broadcasts: list = []
-    # Seed at 0; poll1 within grace; poll2 past WORKER_RECONNECT_GRACE.
-    times = [0.0, 10.0, WORKER_RECONNECT_GRACE + 1.0]
-
-    with _reconcile_patches(sessions, times, mock_kill, mock_spawn, broadcasts):
-        await reconcile_stale_workers(["w-a"])
-
-    mock_kill.assert_called_once_with({"w-a"})
-    mock_spawn.assert_called_once_with(["w-a"])
-
-
-@pytest.mark.asyncio
-async def test_reconcile_force_kills_wedged_worker_that_never_drains():
-    """A worker that reconnects but never goes offline is force-killed after the drain timeout."""
-    sessions = [
-        _FakeExecDB([("w-a", "g-guild")]),  # guild-slug lookup
-        _FakeExecDB(["w-a"]),  # poll 1: online → begin draining
-        _FakeExecDB(["w-a"]),  # poll 2: still online past the drain timeout → wedged
-    ]
-    mock_kill = AsyncMock()
-    mock_spawn = AsyncMock()
-    broadcasts: list = []
-    # Seed=0; poll1 begins drain (phase_started=10); poll2 past drain timeout.
-    times = [0.0, 10.0, 10.0 + WORKER_DRAIN_TIMEOUT + 1.0]
-
-    with _reconcile_patches(sessions, times, mock_kill, mock_spawn, broadcasts):
-        await reconcile_stale_workers(["w-a"])
-
-    mock_kill.assert_called_once_with({"w-a"})
-    mock_spawn.assert_called_once_with(["w-a"])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -1,37 +1,26 @@
-"""Worker lifecycle: detect stale workers after a version change and cycle them.
+"""Worker lifecycle: version-stale detection, idle reaping, and spawn bookkeeping.
 
-A version bump means the running worker containers hold old code, so every stale
-worker must be drained (soft-killed, allowed to finish its in-progress task, then
-shut down) and replaced by a fresh container that picks up the new code. A stale
-worker reconnecting after the restart is *expected* (the backend restarts first,
-then the worker's reconnect loop brings its WebSocket back within seconds) — it is
-never a reason to spare the worker from replacement.
+Workers are disposable. Since the idle reaper shuts down every backend-spawned
+worker after PIONEER_WORKER_IDLE_TIMEOUT (default 30 min) of inactivity, and the
+foreman respawns workers on demand from the guild's spawn defaults
+(``guild_spawn_defaults``, refreshed on every successful spawn), there is no
+drain-and-replace choreography anymore. A version bump is handled with two
+lightweight nudges plus the reaper:
 
-Lifecycle steps on backend startup
-───────────────────────────────────
-1. get_current_version()         — PIONEER_VERSION env var, or "<YYYYMMDD>-<sha>"
-   from the current commit (date is the deterministic committer date, never
-   wall-clock/build time — versions are compared for exact equality, so a
-   nondeterministic date would mark every worker perpetually stale).
-2. drain_stale_workers_on_startup() — find workers whose spawned_version differs
-   from current; record drain_requested_at (informational) and best-effort
-   broadcast a shutdown. Returns the list of stale worker IDs.
-3. reset_connection_state()      — called by main.py AFTER step 2, sets all
-   workers offline in the DB.
-4. reconcile_stale_workers(ids)  — spawned as a background task AFTER step 3.
-   Per worker, two phases:
-     • Reconnect: reset_connection_state() just marked everyone offline, so
-       "offline" now means "not yet reconnected", not "drained". Wait up to
-       PIONEER_WORKER_RECONNECT_GRACE for the worker to come back online. If it
-       never does, its container died during the deploy — force-kill (best
-       effort) and replace it immediately.
-     • Drain: once it is back online, send the soft-kill and wait for it to
-       finish its task and go offline (its ack), up to PIONEER_WORKER_DRAIN_TIMEOUT.
-       If it never goes offline it is wedged — force-kill its container.
-   Either way, once the worker is down a replacement with a brand-new worker ID
-   and name (never the drained worker's identity) is spawned via
-   spawn_replacement_workers(). Replacing only after the old worker is confirmed
-   down means there is never a moment with two live workers for the same slot.
+1. drain_stale_workers_on_startup() — on backend startup (before
+   reset_connection_state()), find workers whose spawned_version differs from
+   get_current_version(), record drain_requested_at, and best-effort broadcast a
+   graceful shutdown (reaches workers still connected across a hot reload).
+2. signal_stale_worker_on_join() — when a worker (re)connects after the restart,
+   the join handler tells version-stale backend-spawned workers to shut down.
+   The worker finishes any in-progress task and exits on its own.
+3. The idle reaper force-kills whatever is left: containers that died during
+   the deploy (offline zombies) and workers that never processed the signal.
+
+get_current_version() prefers the PIONEER_VERSION env var, else
+"<YYYYMMDD>-<sha>" from the current commit (committer date, never wall-clock —
+versions are compared for exact equality, so a nondeterministic date would mark
+every worker perpetually stale).
 """
 
 from __future__ import annotations
@@ -47,27 +36,18 @@ from datetime import UTC, datetime, timedelta
 import worker_runtime
 from database import AsyncSessionLocal
 from events import broadcast_msg, emit_terminal_line
-from models import Agent, Guild, Task, TaskLog, Worker, live_tasks_filter
+from models import Agent, Guild, GuildSpawnDefaults, Task, TaskLog, Worker, live_tasks_filter
 from sqlalchemy import func, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col, select
 from ws_types import WorkerShutdownMsg
 
 logger = logging.getLogger(__name__)
 
-# How long to let a stale worker finish its in-progress task and exit gracefully
-# after the soft-kill before force-killing its container. Generous by default (30
-# min) because a busy worker may be mid-task when a deploy lands.
-WORKER_DRAIN_TIMEOUT = float(os.environ.get("PIONEER_WORKER_DRAIN_TIMEOUT", "1800"))
-
-# How long to wait for a stale worker to reconnect after a backend restart before
-# treating it as already dead (its container died during the deploy) and replacing
-# it without waiting for a drain. Workers normally reconnect within seconds.
-WORKER_RECONNECT_GRACE = float(os.environ.get("PIONEER_WORKER_RECONNECT_GRACE", "120"))
-
 # How long to wait after an explicit shutdown_worker request before force-killing
-# an unresponsive worker's container. Separate from WORKER_DRAIN_TIMEOUT (which
-# guards the startup version-mismatch drain) since this is the window the foreman
-# AI waits on every ordinary "stop this worker" request.
+# an unresponsive worker's container. Generous by default (30 min) because a busy
+# worker may be mid-task; this is the window the foreman AI waits on every
+# ordinary "stop this worker" request.
 SHUTDOWN_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_SHUTDOWN_TIMEOUT", "1800"))
 
 # How long a backend-spawned worker may sit with no live work before the idle
@@ -138,8 +118,23 @@ async def generate_worker_id(db) -> str:
     raise RuntimeError("could not generate a unique worker_id after 5 attempts")
 
 
-async def record_worker_spawn(db, worker_id: str, container_id: str) -> None:
-    """Persist container_id, spawned_version, and started_at after a successful worker spawn."""
+async def record_worker_spawn(
+    db,
+    worker_id: str,
+    container_id: str,
+    *,
+    guild_pk: int | None = None,
+    repos: list[str] | None = None,
+    tools: list[str] | None = None,
+    agent_count: int | None = None,
+) -> None:
+    """Persist container_id, spawned_version, and started_at after a successful worker spawn.
+
+    When *guild_pk* and a non-empty *repos* list are given, also upserts the
+    guild's ``guild_spawn_defaults`` row so it always reflects the last
+    successful spawn — the foreman's spawn_worker tool falls back to that row
+    when a call omits repos/tools/agent_count.
+    """
     await db.exec(
         update(Worker)
         .where(col(Worker.id) == worker_id)
@@ -149,58 +144,67 @@ async def record_worker_spawn(db, worker_id: str, container_id: str) -> None:
             started_at=datetime.now(UTC),
         )
     )
+    if guild_pk is not None and repos:
+        stmt = pg_insert(GuildSpawnDefaults).values(
+            guild_id=guild_pk,
+            repos=json.dumps(repos),
+            tools=json.dumps(tools or []),
+            agent_count=agent_count,
+            updated_at=datetime.now(UTC),
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["guild_id"],
+            set_={
+                "repos": stmt.excluded.repos,
+                "tools": stmt.excluded.tools,
+                "agent_count": stmt.excluded.agent_count,
+                "updated_at": stmt.excluded.updated_at,
+            },
+        )
+        await db.exec(stmt)
     await db.commit()
 
 
-async def spawn_replacement_workers(stale_ids: list[str]) -> None:
-    """Spawn one fresh replacement worker for each drained stale worker.
+async def get_guild_spawn_defaults(db, guild_pk: int) -> GuildSpawnDefaults | None:
+    """Return the guild's last-successful-spawn parameters, or None if never recorded."""
+    return (
+        await db.exec(
+            select(GuildSpawnDefaults).where(col(GuildSpawnDefaults.guild_id) == guild_pk)
+        )
+    ).one_or_none()
 
-    The replacement carries the same repos and tools but gets a brand-new worker
-    ID and name — spawn_worker() mints a fresh ``w-…`` id and derives the display
-    name from it, so we deliberately omit ``name`` here rather than reuse the
-    drained worker's identity (its name embeds the now-dead worker id).
+
+async def signal_stale_worker_on_join(
+    guild_slug: str, worker_id: str, spawned_version: str | None
+) -> bool:
+    """Tell a version-stale backend-spawned worker to shut down as it (re)connects.
+
+    Called from the WS join handler. Only workers with a recorded
+    spawned_version are ever signalled: externally-started workers (compose,
+    manual CLI) have no version stamp and belong to whoever started them.
+    The worker finishes any in-progress task and exits; the foreman respawns
+    on demand from the guild's spawn defaults, and the idle reaper force-kills
+    the container if the worker never acts on the signal.
+
+    Returns True when a shutdown signal was sent.
     """
-    if not stale_ids:
-        return
-
-    from foreman.tools import spawn_worker as _spawn_worker  # noqa: PLC0415
-
-    async with AsyncSessionLocal() as db:
-        rows = (
-            await db.exec(
-                select(Worker, col(Guild.slug).label("guild_slug"))
-                .join(Guild, col(Guild.id) == col(Worker.guild_id))
-                .where(col(Worker.id).in_(stale_ids), col(Worker.disabled).is_(False))
-            )
-        ).all()
-
-    for worker, guild_slug in rows:
-        try:
-            inp = {
-                "repos": json.loads(worker.repos or "[]"),
-                "tools": json.loads(worker.tools or "[]"),
-            }
-            async with AsyncSessionLocal() as db:
-                result_text, is_error = await _spawn_worker(
-                    inp=inp,
-                    guild_id=guild_slug,
-                    guild_pk=worker.guild_id,
-                    db=db,
-                )
-            if is_error:
-                logger.warning(
-                    "worker_lifecycle: failed to respawn replacement for guild %s: %s",
-                    guild_slug,
-                    result_text,
-                )
-            else:
-                logger.info("worker_lifecycle: spawned replacement worker for guild %s", guild_slug)
-        except Exception:
-            logger.warning(
-                "worker_lifecycle: exception respawning worker for guild %s",
-                guild_slug,
-                exc_info=True,
-            )
+    if not spawned_version:
+        return False
+    current = get_current_version()
+    if current is None or spawned_version == current:
+        return False
+    logger.info(
+        "worker_lifecycle: worker %s joined with stale version %s (current %s) — "
+        "sending graceful shutdown",
+        worker_id,
+        spawned_version,
+        current,
+    )
+    await broadcast_msg(
+        guild_slug,
+        WorkerShutdownMsg(workerId=worker_id, reason="backend restarted: version mismatch"),
+    )
+    return True
 
 
 async def drain_stale_workers_on_startup() -> list[str]:
@@ -208,10 +212,12 @@ async def drain_stale_workers_on_startup() -> list[str]:
 
     Must be awaited directly *before* reset_connection_state() so the DB still
     holds the non-offline state that identifies which workers were running before
-    this restart.
+    this restart. The broadcast only reaches workers still connected across a
+    hot reload; cold-restart stragglers are signalled by
+    signal_stale_worker_on_join() when they reconnect, and the idle reaper
+    cleans up anything that never complies.
 
-    Returns the list of stale worker IDs so the caller can pass them to
-    force_kill_stale_workers() as a background task after reset_connection_state().
+    Returns the list of stale worker IDs (for logging and tests).
     """
     current_version = get_current_version()
 
@@ -256,9 +262,8 @@ async def drain_stale_workers_on_startup() -> list[str]:
 
     logger.info(
         "worker_lifecycle: %d stale worker(s) from a previous deploy — "
-        "sending shutdown signals, force-kill in %.0fs (current version=%s)",
+        "sending shutdown signals (current version=%s)",
         len(rows),
-        WORKER_DRAIN_TIMEOUT,
         current_version,
     )
 
@@ -375,124 +380,6 @@ async def force_kill_worker_if_unresponsive(
         timeout,
     )
     await _force_kill_containers({worker_id})
-
-
-async def _guild_slugs_for_workers(worker_ids: set[str]) -> dict[str, str]:
-    """Map each worker id to its guild slug, for broadcasting shutdown messages."""
-    if not worker_ids:
-        return {}
-    async with AsyncSessionLocal() as db:
-        rows = (
-            await db.exec(
-                select(col(Worker.id), col(Guild.slug).label("guild_slug"))
-                .join(Guild, col(Guild.id) == col(Worker.guild_id))
-                .where(col(Worker.id).in_(worker_ids))
-            )
-        ).all()
-    return {wid: slug for wid, slug in rows}
-
-
-async def reconcile_stale_workers(stale_ids: list[str]) -> None:
-    """Drain every stale worker and replace it with a fresh one.
-
-    Spawned as a background task *after* reset_connection_state() has run. On a
-    version bump every stale worker holds old code and must be cycled, so a
-    reconnect is never a reason to skip replacement — it is exactly what we wait
-    for so the soft-kill can be delivered. Replacing only after the old worker is
-    confirmed offline means there is never a moment with two live workers for the
-    same slot, which is the double-spawn the previous spare-on-reconnect logic was
-    guarding against.
-
-    Per worker, two phases (see module docstring):
-      • "reconnect" — wait up to WORKER_RECONNECT_GRACE for the worker to come
-        back online. reset_connection_state() just marked everyone offline, so
-        "offline" here means "not yet reconnected", not "drained". A worker that
-        never reconnects had its container die during the deploy; force-kill (best
-        effort) and replace it.
-      • "drain" — once online, (re)send the soft-kill and wait up to
-        WORKER_DRAIN_TIMEOUT for the worker to finish its task and go offline. If
-        it never does it is wedged; force-kill its container. Either way, replace
-        it once it is down.
-    """
-    if not stale_ids:
-        return
-
-    poll_interval = 5.0
-    guild_slugs = await _guild_slugs_for_workers(set(stale_ids))
-    loop = asyncio.get_event_loop()
-    # Per-worker phase and the monotonic time that phase began (for timeouts).
-    phase = {wid: "reconnect" for wid in stale_ids}
-    phase_started = {wid: loop.time() for wid in stale_ids}
-    pending = set(stale_ids)
-
-    async def _send_soft_kill(wid: str) -> None:
-        slug = guild_slugs.get(wid)
-        if not slug:
-            return
-        try:
-            await broadcast_msg(
-                slug,
-                WorkerShutdownMsg(workerId=wid, reason="backend restarted: version mismatch"),
-            )
-        except Exception:
-            logger.warning(
-                "worker_lifecycle: could not send soft-kill to worker %s", wid, exc_info=True
-            )
-
-    while pending:
-        await asyncio.sleep(poll_interval)
-        now = loop.time()
-        async with AsyncSessionLocal() as db:
-            online = set(
-                (
-                    await db.exec(
-                        select(col(Worker.id)).where(
-                            col(Worker.id).in_(pending), col(Worker.state) != "offline"
-                        )
-                    )
-                ).all()
-            )
-
-        drained: list[str] = []  # went offline after draining → replace
-        dead: list[str] = []  # never reconnected / wedged → force-kill + replace
-        to_signal: list[str] = []  # online & stale → (re)send soft-kill
-
-        for wid in list(pending):
-            if phase[wid] == "reconnect":
-                if wid in online:
-                    # Back online — begin draining and deliver the soft-kill.
-                    phase[wid] = "drain"
-                    phase_started[wid] = now
-                    to_signal.append(wid)
-                elif now - phase_started[wid] >= WORKER_RECONNECT_GRACE:
-                    dead.append(wid)  # container died during the deploy
-            else:  # draining
-                if wid not in online:
-                    drained.append(wid)  # ack: finished its task and exited
-                elif now - phase_started[wid] >= WORKER_DRAIN_TIMEOUT:
-                    dead.append(wid)  # wedged: force-kill below
-                else:
-                    to_signal.append(wid)  # still draining — re-send (idempotent)
-
-        for wid in to_signal:
-            await _send_soft_kill(wid)
-
-        if dead:
-            logger.warning(
-                "worker_lifecycle: %d stale worker(s) did not drain in time — "
-                "force-killing their containers: %s",
-                len(dead),
-                sorted(dead),
-            )
-            await _force_kill_containers(set(dead))
-
-        # Replace every worker now confirmed down (drained cleanly or force-killed).
-        for wid in (*drained, *dead):
-            await spawn_replacement_workers([wid])
-            logger.info("worker_lifecycle: stale worker %s cycled — replacement spawned", wid)
-            pending.discard(wid)
-
-    logger.info("worker_lifecycle: all stale workers drained and replaced")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -44,6 +44,7 @@ from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from util.tasks import spawn
 from utils import worker_display_name
+from worker_lifecycle import signal_stale_worker_on_join
 from ws_types import (
     KNOWN_INBOUND_TYPES,
     AgentJoinedMsg,
@@ -281,20 +282,23 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     # A misconfigured or misbehaving worker could connect to the wrong guild's
     # WebSocket; without this check it would create agent rows and broadcast
     # events into a guild it doesn't belong to.
+    worker_spawned_version: str | None = None
     if agent_type == "worker" and worker_id:
         member_res = await ctx.db.exec(
-            select(col(Worker.id)).where(
+            select(col(Worker.id), col(Worker.spawned_version)).where(
                 col(Worker.id) == worker_id,
                 col(Worker.guild_id) == ctx.guild_pk,
             )
         )
-        if member_res.one_or_none() is None:
+        member_row = member_res.one_or_none()
+        if member_row is None:
             logger.warning(
                 "join: worker %s is not a member of guild %s — ignoring",
                 worker_id,
                 ctx.guild_id,
             )
             return
+        worker_spawned_version = member_row[1]
         # Guard against two live connections claiming the same worker_id (e.g. a
         # container that reconnects with a fresh agent_id while its previous
         # socket is still lingering after a restart). Evict the older agent so
@@ -391,6 +395,12 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
         # decide it owns the agent, and stamp the just-joined agent offline.
         async with agent_owner_lock(ctx.guild_id):
             agent_owners[agent_id] = ctx.websocket
+    # A backend-spawned worker holding code from a previous backend version is
+    # told to shut down as it (re)connects: it finishes any in-progress task and
+    # exits, the idle reaper force-kills it if it never complies, and the
+    # foreman respawns on demand from the guild's spawn defaults.
+    if agent_type == "worker" and worker_id:
+        await signal_stale_worker_on_join(ctx.guild_id, worker_id, worker_spawned_version)
     # Only an explicit external Foreman API proxy may claim the proxy seat —
     # the legacy browser join still carries agentType="foreman" but must NOT
     # be registered in foreman_connections. The external client signals its

--- a/docs/state-audit.md
+++ b/docs/state-audit.md
@@ -42,7 +42,7 @@ Relationship: `Guild → Workers → Agents` (one agent per live worker process;
 ### Notes
 
 - Worker state is coarse (online/offline/idle only); fine-grained "what is it doing" lives in agent state (below). The frontend has no separate worker vocabulary — `frontend/src/stores/agents.ts` derives a display state from the highest-priority agent state for that worker.
-- `backend/worker_lifecycle.py` (added after this audit) layers drain/reconcile behavior on top of the same three-value column, without adding new state values.
+- `backend/worker_lifecycle.py` (added after this audit) layers stale-version signalling and idle-reaping behavior on top of the same three-value column, without adding new state values.
 
 ---
 


### PR DESCRIPTION
Move worker spawn data off the workers table into a new guild-adjacent
guild_spawn_defaults table that always holds the guild's last successful
spawn parameters (repos, tools, agent_count):

- Alembic migration creates the table and backfills each guild from its
  most recent worker, preferring backend-spawned workers (container_id
  recorded) over plain registrations.
- record_worker_spawn() upserts the guild's defaults on every successful
  spawn (foreman tool, REST spawn-worker endpoint, Discord /worker-spawn).
- The foreman spawn_worker tool falls back to the guild defaults for any
  parameter the call omits, so repos is no longer required; the tool
  schema documents the fallback.

Rip out the drain-and-replace respawn machinery, now redundant since
spawned workers shut themselves down after ~30 min of inactivity (idle
reaper) and the foreman respawns on demand from the guild defaults:

- Delete reconcile_stale_workers(), spawn_replacement_workers(), and the
  PIONEER_WORKER_DRAIN_TIMEOUT / PIONEER_WORKER_RECONNECT_GRACE knobs
  (~200 lines plus their test scaffolding).
- Startup still broadcasts a graceful shutdown to version-stale workers;
  a new join-time check (signal_stale_worker_on_join) tells stale
  backend-spawned workers to exit when they reconnect after a deploy.
  Externally-started workers (no version stamp) are never signalled.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WSqASQptEbYeb1EfkF4bMC