### PR TITLE
chore(infra): hardcode tfstate bucket in backend block

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,10 +66,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
 
       - name: Terraform init
-        run: |
-          terraform init \
-            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
-            -backend-config="region=${{ secrets.AWS_REGION }}"
+        run: terraform init # bucket/region are hardcoded in main.tf's backend block
 
       - name: Terraform apply
         run: terraform apply -auto-approve -var="container_image_tag=${{ github.sha }}"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -211,7 +211,8 @@ doesn't permit — to add one, also add `"environment:terraform-apply"` to that 
 | --- | --- |
 | `AWS_DEPLOY_ROLE_ARN` | The `github_actions_deploy_role_arn` Terraform output — the OIDC role the deploy workflow assumes. |
 | `AWS_REGION` | Region to operate in (matches `var.aws_region`). |
-| `TF_STATE_BUCKET` | S3 bucket used for `terraform init -backend-config=bucket=...`. |
+
+(The tfstate bucket/region are hardcoded in `main.tf`'s `backend "s3"` block, so `deploy.yml` runs a bare `terraform init` — no `TF_STATE_BUCKET` secret needed. If you fork to another account, edit that block.)
 
 No `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are used — the workflow authenticates via
 OIDC (`aws-actions/configure-aws-credentials` + `role-to-assume`), which is why `iam.tf`

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,10 +22,10 @@ terraform {
   # Remote state in S3. Bootstrap the bucket (and, on Terraform < 1.10, a
   # DynamoDB lock table named the same as the bucket with a "-locks" suffix)
   # out of band before running `terraform init` — see README.md "Backend
-  # setup". Backend blocks cannot interpolate variables, so fill in the
-  # placeholders below (or pass them via `terraform init -backend-config=...`).
+  # setup". Backend blocks cannot interpolate variables; forking to another
+  # account means editing bucket/region here (or passing `-backend-config=...`).
   backend "s3" {
-    bucket       = "REPLACE_WITH_YOUR_TFSTATE_BUCKET"
+    bucket       = "pioneer-square-tfstate-117217845094"
     key          = "pioneer-square/terraform.tfstate"
     region       = "us-east-1"
     encrypt      = true


### PR DESCRIPTION
Follow-up to #982. That PR's `apply` job failed at `terraform init` because the `TF_STATE_BUCKET` secret was documented but never created, so CI ran `terraform init -backend-config="bucket="` (empty → "value cannot be empty or all whitespace").

I set the secret to unblock the deploy (it's green now), but the bucket name isn't sensitive and `main.tf`'s backend block already hardcodes `region` and `key`. This puts `bucket` there too and simplifies `deploy.yml` to a bare `terraform init` — no out-of-band secret to forget.

- `main.tf`: `bucket = "pioneer-square-tfstate-117217845094"`
- `deploy.yml`: drop both `-backend-config` flags
- README: drop `TF_STATE_BUCKET` from required secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)