### PR TITLE
feat(infra): run alembic migrations as a separate release task

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,12 +41,93 @@ jobs:
           docker build --target "${{ matrix.service }}" --build-arg "PIONEER_VERSION=${{ github.sha }}" -t "$IMAGE" .
           docker push "$IMAGE"
 
+  # Run alembic migrations as a one-off ECS task BEFORE terraform rolls the
+  # services. The backend container is a plain `pioneer serve` (no startup
+  # migration), so during the rolling deploy the new backend can come up
+  # alongside the old one — ECS tears the old task down only after the new
+  # one passes health checks, and neither of them races a schema upgrade.
+  #
+  # The targeted apply registers only the migrate task-definition revision at
+  # the new image tag; the services keep their previous revisions until the
+  # full apply below.
+  migrate:
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          # Unwrapped binary so `terraform output -raw` below yields clean values.
+          terraform_wrapper: false
+
+      - name: Terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -backend-config="region=${{ secrets.AWS_REGION }}"
+
+      - name: Register migrate task definition
+        run: |
+          terraform apply -auto-approve \
+            -target=aws_ecs_task_definition.migrate \
+            -var="container_image_tag=${{ github.sha }}"
+
+      - name: Run migration task and wait for completion
+        run: |
+          CLUSTER=$(terraform output -raw ecs_cluster_name)
+          FAMILY=$(terraform output -raw ecs_migrate_task_definition_family)
+          SUBNETS=$(terraform output -json private_subnet_ids | jq -r 'join(",")')
+          SG=$(terraform output -raw ecs_tasks_security_group_id)
+
+          RESULT=$(aws ecs run-task \
+            --cluster "$CLUSTER" \
+            --task-definition "$FAMILY" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}")
+
+          TASK_ARN=$(echo "$RESULT" | jq -r '.tasks[0].taskArn // empty')
+          if [ -z "$TASK_ARN" ]; then
+            echo "run-task failed:"
+            echo "$RESULT" | jq '.failures'
+            exit 1
+          fi
+          echo "Migration task: $TASK_ARN"
+
+          aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK_ARN"
+
+          TASK=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN")
+          EXIT_CODE=$(echo "$TASK" | jq -r '.tasks[0].containers[0].exitCode // empty')
+          STOP_REASON=$(echo "$TASK" | jq -r '.tasks[0].stoppedReason // empty')
+
+          echo "--- migration logs ---"
+          LOG_GROUP=$(terraform output -raw ecs_migrate_log_group)
+          aws logs get-log-events \
+            --log-group-name "$LOG_GROUP" \
+            --log-stream-name "migrate/migrate/${TASK_ARN##*/}" \
+            --start-from-head \
+            --query 'events[].message' --output text || true
+          echo "----------------------"
+
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "Migration failed (exit code: ${EXIT_CODE:-none}, stopped reason: $STOP_REASON)"
+            exit 1
+          fi
+
   # terraform apply is the single source of truth for the running task
   # definitions: it renders env (subnets, SGs, config) AND the image tag in one
   # revision and rolls the services. Replaces the old per-service
   # render/deploy-task-definition steps + the services' ignore_changes.
   apply:
-    needs: build
+    needs: migrate
     runs-on: ubuntu-latest
     # No `environment:` gate — that would change the OIDC subject to
     # environment:<name>, which var.github_oidc_allowed_refs (ref:refs/heads/*)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,9 +250,11 @@ Core tables include `guilds`, `agents`, `workers`, `tasks`, `task_logs`, `messag
 `github_tokens`, `claude_credentials`, `user_sessions`; the schema has grown well beyond this list
 (Discord integration, GitHub issue/PR caching, usage tracking, etc.) — `backend/models.py`
 (SQLModel ORM) is the authoritative source. Migrated by Alembic — see
-`backend/alembic/versions/`. `init_db()` runs `alembic upgrade head`
-on startup; pre-Alembic databases are stamped to `head` so the upgrade is a no-op. On every
-backend startup, all workers and worker agents are reset to `offline`.
+`backend/alembic/versions/`. In docker-compose the backend container command runs
+`alembic upgrade head` before `pioneer serve`; on ECS, migrations run as a dedicated
+one-off `migrate` task during deploy (before the services roll — see `terraform/ecs.tf`
+and `.github/workflows/deploy.yml`), so backend startup itself never runs migrations. On
+every backend startup, all workers and worker agents are reset to `offline`.
 
 ### Worker internals
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -14,6 +14,7 @@ Amazon Bedrock access.
 | `worker` | ECS task definition only, **no service** — see "Worker dispatch" below |
 | `pgweb` (Metabase, `profiles: [tools]`) | Not migrated; run locally against the RDS endpoint if needed |
 | `postgres-test` (`profiles: [test]`) | Not migrated; test-only |
+| (backend's inline `alembic upgrade head`) | One-off `*-migrate` task definition, run at deploy time — see "Database migrations" below |
 
 ### Worker dispatch
 
@@ -33,6 +34,34 @@ carry per-spawn configuration as container env overrides (static secrets like
 (`backend/worker_lifecycle.py`, `PIONEER_WORKER_IDLE_TIMEOUT`, default 30 min) shuts
 spawned workers down after a period of inactivity so idle Fargate tasks don't accrue
 cost indefinitely.
+
+### Database migrations
+
+In docker-compose the backend container runs `alembic upgrade head` inline before
+`pioneer serve`. On ECS that would couple schema upgrades to backend startup, forcing the
+old task down before the new one could safely come up. Instead, `ecs.tf` registers a
+dedicated `*-migrate` task definition (backend image, `alembic upgrade head` only,
+`DATABASE_URL` as its single secret) with no service, and the backend container command is
+a plain `pioneer serve`.
+
+At deploy time, `deploy.yml`'s `migrate` job registers the migrate task definition at the
+new image tag (a `-target`ed apply that leaves the services untouched), runs it via
+`ecs:RunTask`, streams its CloudWatch output into the job log, and fails the deploy if the
+task exits non-zero — the services only roll after the schema is at `head`. Because the
+backend no longer migrates at startup, ECS's default rolling deployment (min healthy 100% /
+max 200%) brings the new backend up alongside the old one and tears the old one down only
+once the new one passes health checks.
+
+Running a migration out-of-band (without deploying) is the same call the workflow makes:
+
+```bash
+aws ecs run-task --cluster <cluster_name> \
+  --task-definition <name_prefix>-migrate \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[<private_subnet_ids>],securityGroups=[<ecs_tasks_security_group_id>],assignPublicIp=DISABLED}"
+```
+
+(all values available as Terraform outputs).
 
 ## Prerequisites
 
@@ -185,12 +214,16 @@ Nova, etc.) also requires access to be enabled per-account in the Bedrock consol
 
 ### `deploy.yml`
 
-Triggered on push to `main` (or manually via `workflow_dispatch`). Two stages:
+Triggered on push to `main` (or manually via `workflow_dispatch`). Three stages:
 
 1. **build** (one job per service, backend/foreman/worker): assumes the
    `github_actions_deploy_role_arn` role via OIDC, logs in to ECR, and builds/pushes
    the image tagged with the commit SHA (also stamped into the image as `PIONEER_VERSION`).
-2. **apply**: `terraform init` + `terraform apply -auto-approve -var container_image_tag=<sha>`.
+2. **migrate**: registers the `*-migrate` task definition at the new image tag
+   (`terraform apply -target=aws_ecs_task_definition.migrate`, services untouched), runs it
+   as a one-off Fargate task, and fails the deploy if `alembic upgrade head` exits non-zero
+   — see "Database migrations" above.
+3. **apply**: `terraform init` + `terraform apply -auto-approve -var container_image_tag=<sha>`.
    Terraform is the single source of truth for the running task definitions — it renders
    env (subnets, security groups, config) **and** the image tag into one revision and rolls
    the services. There is no separate `amazon-ecs-deploy-task-definition` step and the

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -54,7 +54,10 @@ resource "aws_ecs_task_definition" "backend" {
         }
       ]
 
-      command = ["sh", "-c", "cd backend && alembic upgrade head && cd .. && pioneer serve"]
+      # Migrations run in the separate one-off migrate task below (before the
+      # services roll), so backend startup never gates on `alembic upgrade` and
+      # a new task can come up alongside the old one during a deploy.
+      command = ["pioneer", "serve"]
 
       environment = [
         { name = "GITHUB_REDIRECT_URI", value = var.frontend_url != "" ? "${var.frontend_url}/auth/github/callback" : "" },
@@ -147,6 +150,62 @@ resource "aws_ecs_service" "backend" {
   tags = {
     Name    = "${local.name_prefix}-backend"
     Service = "backend"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Migrate — one-off release task (no service). deploy.yml registers this at
+# the new image tag and runs it to completion via ecs:RunTask BEFORE the full
+# terraform apply rolls the services: the schema is upgraded first, then the
+# new backend comes up next to the old one and ECS tears the old one down
+# only once the new one is healthy.
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "migrate" {
+  name              = "/ecs/${local.name_prefix}/migrate"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    Name    = "${local.name_prefix}-migrate-logs"
+    Service = "migrate"
+  }
+}
+
+resource "aws_ecs_task_definition" "migrate" {
+  family                   = "${local.name_prefix}-migrate"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "migrate"
+      image     = "${aws_ecr_repository.service["backend"].repository_url}:${var.container_image_tag}"
+      essential = true
+
+      command = ["sh", "-c", "cd backend && alembic upgrade head"]
+
+      secrets = [
+        { name = "DATABASE_URL", valueFrom = aws_ssm_parameter.database_url.arn }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.migrate.name
+          "awslogs-region"        = local.region
+          "awslogs-stream-prefix" = "migrate"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    Name    = "${local.name_prefix}-migrate"
+    Service = "migrate"
   }
 }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -277,6 +277,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "ecs:DescribeTaskDefinition",
       "ecs:DescribeTasks",
       "ecs:RegisterTaskDefinition",
+      "ecs:RunTask", # deploy.yml runs the one-off migrate task before rolling the services
       "ecs:UpdateService",
     ]
     resources = ["*"] # ecs:RegisterTaskDefinition does not support resource-level scoping.

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -36,6 +36,26 @@ output "ecs_worker_task_definition_family" {
   value       = aws_ecs_task_definition.worker.family
 }
 
+output "ecs_migrate_task_definition_family" {
+  description = "Task definition family for the one-off alembic migration release task, run via ecs:RunTask by deploy.yml before rolling the services."
+  value       = aws_ecs_task_definition.migrate.family
+}
+
+output "ecs_migrate_log_group" {
+  description = "CloudWatch log group of the migrate task, used by deploy.yml to surface migration output."
+  value       = aws_cloudwatch_log_group.migrate.name
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs, the awsvpc network configuration for one-off ECS tasks (migrate)."
+  value       = aws_subnet.private[*].id
+}
+
+output "ecs_tasks_security_group_id" {
+  description = "Security group shared by ECS tasks, used when launching one-off tasks (migrate)."
+  value       = aws_security_group.ecs_tasks.id
+}
+
 output "rds_endpoint" {
   description = "RDS Postgres connection endpoint (host:port)."
   value       = aws_db_instance.postgres.endpoint


### PR DESCRIPTION
Move `alembic upgrade head` out of the ECS backend container command into
a dedicated one-off migrate task definition, run by a new deploy.yml
`migrate` job between build and apply:

- terraform/ecs.tf: new `*-migrate` task definition (backend image,
  alembic-only command, DATABASE_URL as its single secret, own log
  group); backend command is now a plain `pioneer serve`.
- deploy.yml: the migrate job registers the migrate task definition at
  the new image tag with a targeted apply (services untouched), runs it
  via ecs:RunTask, surfaces the CloudWatch logs, and fails the deploy on
  a non-zero exit. The full apply that rolls the services only runs
  after the schema is at head.
- iam.tf: add ecs:RunTask to the deploy role's scoped ECS statement.
- outputs.tf: expose the migrate task family/log group and the
  subnets/security group the workflow needs for run-task.

With backend startup no longer gated on migrations, ECS's rolling
deploy (min 100% / max 200%) brings the new backend up alongside the
old one and tears the old one down only once the new one is healthy —
and concurrent backend tasks never race a schema upgrade.

Also corrects the stale AGENTS.md claim that init_db() runs migrations
on startup (migrations only run via the compose command / migrate task).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R1axaDgaXZLArjT6kMECrY