### PR TITLE
feat(frontend): pre-fill spawn form from guild spawn defaults

### DIFF
--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -21,7 +21,15 @@ from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg, emit_terminal_line, pending_claude_auth
 from fastapi import APIRouter, Depends, HTTPException
-from models import ClaudeCredentials, Guild, Task, UserSpawnSettings, Worker, live_tasks_filter
+from models import (
+    ClaudeCredentials,
+    Guild,
+    GuildSpawnDefaults,
+    Task,
+    UserSpawnSettings,
+    Worker,
+    live_tasks_filter,
+)
 from pydantic import BaseModel, field_validator
 from sqlalchemy import update
 from sqlmodel import col, select
@@ -263,6 +271,36 @@ async def spawn_worker_container(
         "worker_id": worker_id,
         "container_id": spawned.short_id,
         "runtime": spawned.runtime,
+    }
+
+
+@router.get("/guilds/{guild_id}/spawn-defaults")
+async def get_spawn_defaults(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Return the guild's last-successful-spawn parameters (repos, tools, agent_count).
+
+    This is the guild-wide default the foreman falls back to when a
+    ``spawn_worker`` call omits parameters; the spawn form uses it to pre-fill
+    when the current user has no personal saved settings. Returns an empty
+    object when the guild has never recorded a successful spawn.
+    """
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    row = (
+        await db.exec(
+            select(GuildSpawnDefaults).where(col(GuildSpawnDefaults.guild_id) == guild_pk)
+        )
+    ).one_or_none()
+    if row is None:
+        return {}
+    return {
+        "repos": json.loads(row.repos or "[]"),
+        "tools": json.loads(row.tools or "[]"),
+        "agent_count": row.agent_count,
     }
 
 

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -234,6 +234,61 @@ def test_shutdown_unknown_worker_returns_404(client):
     assert resp.status_code == 404
 
 
+# ---------------------------------------------------------------------------
+# Guild spawn defaults
+# ---------------------------------------------------------------------------
+
+
+def _insert_spawn_defaults(
+    db_url: str, guild_id: str, repos: str, tools: str, agent_count: int | None
+) -> None:
+    from datetime import UTC, datetime
+
+    from models import GuildSpawnDefaults
+
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == guild_id))
+        session.add(
+            GuildSpawnDefaults(
+                guild_id=guild_pk,
+                repos=repos,
+                tools=tools,
+                agent_count=agent_count,
+                updated_at=datetime.now(UTC),
+            )
+        )
+        session.commit()
+
+
+def test_get_spawn_defaults_empty_when_none(client):
+    """A guild that has never recorded a successful spawn returns an empty object."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-def-empty")
+    resp = test_client.get("/guilds/guild-def-empty/spawn-defaults", headers=_auth(db_url))
+    assert resp.status_code == 200
+    assert resp.json() == {}
+
+
+def test_get_spawn_defaults_returns_recorded(client):
+    """The endpoint parses the JSON columns and returns repos/tools/agent_count."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-def-set")
+    _insert_spawn_defaults(db_url, "guild-def-set", '["acme/widgets"]', '["claude", "codex"]', 2)
+    resp = test_client.get("/guilds/guild-def-set/spawn-defaults", headers=_auth(db_url))
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "repos": ["acme/widgets"],
+        "tools": ["claude", "codex"],
+        "agent_count": 2,
+    }
+
+
+def test_get_spawn_defaults_unknown_guild_404(client):
+    test_client, db_url = client
+    resp = test_client.get("/guilds/guild-def-nope/spawn-defaults", headers=_auth(db_url))
+    assert resp.status_code == 404
+
+
 def test_spawn_worker_env_forwards_claude_oauth_token():
     """CLAUDE_CODE_OAUTH_TOKEN must reach the spawned container so it skips setup-token."""
     from main import _build_spawn_worker_env

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -6,6 +6,9 @@
     </div>
     <template v-else>
       <label class="spawn-label">Repos</label>
+      <div v-if="prefilledFromGuild" class="spawn-prefill-note">
+        Pre-filled from this guild's last spawn — adjust as needed.
+      </div>
       <div v-if="loadingRepos" class="spawn-hint-text">Loading repos…</div>
       <div v-else-if="repoFetchFailed" class="spawn-error">
         Failed to load repos — saved selection cleared.
@@ -136,6 +139,12 @@ interface SpawnSettings {
   envVars?: EnvPair[]
 }
 
+interface GuildSpawnDefaults {
+  repos?: string[]
+  tools?: string[]
+  agent_count?: number | null
+}
+
 const selectedRepos = ref<string[]>([])
 const name = ref('')
 const selectedTools = ref<string[]>([])
@@ -147,12 +156,21 @@ const loadingRepos = ref(false)
 const repoFetchFailed = ref(false)
 const launched = ref(false)
 const launchedWorkerId = ref('')
+const prefilledFromGuild = ref(false)
 
 const groupedRepos = computed(() => groupAndSortRepos(ghStore.repos))
 
 async function loadSavedSettings(guildId: string): Promise<SpawnSettings | null> {
   try {
     return await api<SpawnSettings>(`/guilds/${guildId}/spawn-settings`)
+  } catch {
+    return null
+  }
+}
+
+async function loadGuildDefaults(guildId: string): Promise<GuildSpawnDefaults | null> {
+  try {
+    return await api<GuildSpawnDefaults>(`/guilds/${guildId}/spawn-defaults`)
   } catch {
     return null
   }
@@ -190,24 +208,44 @@ onMounted(async () => {
   const saved = guild ? await loadSavedSettings(guild.id) : null
 
   if (saved && (saved.repos?.length || saved.tools?.length || saved.envVars?.length)) {
-    if (saved.repos?.length) {
-      if (repoFetchFailed.value) {
-        // Fetch failed — cannot validate saved repos against available ones.
-        selectedRepos.value = []
-      } else {
-        const availableRepoNames = new Set(ghStore.repos.map((r) => r.full_name))
-        // If fetch succeeded but returned no repos, the filter yields [] — correct.
-        selectedRepos.value = saved.repos.filter((r) => availableRepoNames.has(r))
-      }
-    }
+    // Tier 1: this user's own saved settings win.
+    if (saved.repos?.length) selectedRepos.value = validateRepos(saved.repos)
     if (saved.tools?.length) selectedTools.value = saved.tools
     if (saved.envVars?.length) envVars.value = saved.envVars
-  } else {
-    selectedRepos.value = repoFetchFailed.value ? [] : [...ghStore.selectedRepos]
+    return
   }
+
+  // Tier 2: no personal settings — fall back to the guild's last successful
+  // spawn (the same defaults the foreman uses), so a new user sees the guild's
+  // usual configuration instead of a blank form.
+  const guildDefaults = guild ? await loadGuildDefaults(guild.id) : null
+  if (
+    guildDefaults &&
+    (guildDefaults.repos?.length ||
+      guildDefaults.tools?.length ||
+      guildDefaults.agent_count != null)
+  ) {
+    if (guildDefaults.repos?.length) selectedRepos.value = validateRepos(guildDefaults.repos)
+    if (guildDefaults.tools?.length) selectedTools.value = [...guildDefaults.tools]
+    if (guildDefaults.agent_count != null) agentCount.value = guildDefaults.agent_count
+    prefilledFromGuild.value = selectedRepos.value.length > 0
+    return
+  }
+
+  // Tier 3: nothing recorded — mirror the repos already selected in the GitHub sidebar.
+  selectedRepos.value = repoFetchFailed.value ? [] : [...ghStore.selectedRepos]
 })
 
+// Keep only repos that exist in the fetched list; on a fetch failure we can't
+// validate, so drop everything rather than send unknown repos to the backend.
+function validateRepos(repos: string[]): string[] {
+  if (repoFetchFailed.value) return []
+  const available = new Set(ghStore.repos.map((r) => r.full_name))
+  return repos.filter((r) => available.has(r))
+}
+
 function toggleRepo(fullName: string) {
+  prefilledFromGuild.value = false
   const idx = selectedRepos.value.indexOf(fullName)
   if (idx >= 0) {
     selectedRepos.value.splice(idx, 1)
@@ -227,6 +265,7 @@ function orgSomeSelected(owner: string): boolean {
 }
 
 function toggleOrg(owner: string) {
+  prefilledFromGuild.value = false
   const repos = groupedRepos.value.find((g) => g.owner === owner)?.repos ?? []
   if (orgAllSelected(owner)) {
     const names = new Set(repos.map((r) => r.full_name))
@@ -391,6 +430,14 @@ async function launch() {
   color: var(--color-text-dim);
   padding: 4px 0;
   font-style: italic;
+}
+
+.spawn-prefill-note {
+  font-size: 9px;
+  color: var(--color-teal);
+  font-style: italic;
+  line-height: 1.4;
+  margin: 0 0 2px;
 }
 
 .spawn-repo-list {

--- a/frontend/src/components/sidebar/__tests__/SpawnWorkerForm.spec.ts
+++ b/frontend/src/components/sidebar/__tests__/SpawnWorkerForm.spec.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { flushPromises, mount } from '@vue/test-utils'
+import SpawnWorkerForm from '../SpawnWorkerForm.vue'
+import { useGuildStore } from '../../../stores/guild'
+import { useGitHubStore } from '../../../stores/github'
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+interface Routes {
+  spawnSettings?: unknown
+  spawnDefaults?: unknown
+}
+
+// Route the two GETs the form issues on mount by URL, so the test does not
+// depend on call ordering.
+function mockFetch(routes: Routes) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/spawn-settings')) {
+      return Promise.resolve(jsonResponse(routes.spawnSettings ?? {}))
+    }
+    if (url.includes('/spawn-defaults')) {
+      return Promise.resolve(jsonResponse(routes.spawnDefaults ?? {}))
+    }
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+function primeStores() {
+  const guild = useGuildStore()
+  guild.currentGuild = { id: 'g1', name: 'Test Guild' }
+  const gh = useGitHubStore()
+  gh.token = 'gh-tok'
+  // Pre-set repos so the form skips its GH-API fetch on mount.
+  gh.repos = [{ full_name: 'acme/widgets' }, { full_name: 'acme/gears' }] as never
+}
+
+async function mountForm(routes: Routes) {
+  mockFetch(routes)
+  primeStores()
+  const wrapper = mount(SpawnWorkerForm)
+  await flushPromises()
+  return wrapper
+}
+
+describe('SpawnWorkerForm guild-default pre-fill', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('pre-fills repos, tools, and agent count from guild spawn defaults', async () => {
+    const wrapper = await mountForm({
+      spawnSettings: {},
+      spawnDefaults: { repos: ['acme/widgets'], tools: ['claude', 'codex'], agent_count: 2 },
+    })
+
+    // The guild default repo is selected and its row is rendered as selected.
+    const widgetsRow = wrapper.findAll('.spawn-repo-row').find((r) => r.text().includes('widgets'))
+    expect(widgetsRow?.classes()).toContain('selected')
+
+    // Tools from the guild default are selected.
+    const claudeRow = wrapper.findAll('.spawn-repo-row').find((r) => r.text() === 'claude')
+    const codexRow = wrapper.findAll('.spawn-repo-row').find((r) => r.text() === 'codex')
+    expect(claudeRow?.classes()).toContain('selected')
+    expect(codexRow?.classes()).toContain('selected')
+
+    // Agent count is pre-filled.
+    const agentInput = wrapper.find('input[type="number"]').element as HTMLInputElement
+    expect(agentInput.value).toBe('2')
+
+    // The explanatory note is shown and Launch is enabled.
+    expect(wrapper.find('.spawn-prefill-note').exists()).toBe(true)
+    const launchBtn = wrapper.find('.spawn-launch-btn').element as HTMLButtonElement
+    expect(launchBtn.disabled).toBe(false)
+  })
+
+  it('drops guild-default repos that are not in the available list', async () => {
+    const wrapper = await mountForm({
+      spawnSettings: {},
+      spawnDefaults: { repos: ['acme/widgets', 'ghost/removed'], tools: [] },
+    })
+
+    const selectedNames = wrapper.findAll('.spawn-repo-row.selected').map((r) => r.text())
+    expect(selectedNames.some((n) => n.includes('widgets'))).toBe(true)
+    expect(selectedNames.some((n) => n.includes('removed'))).toBe(false)
+  })
+
+  it('prefers the user’s personal saved settings over guild defaults', async () => {
+    const fetchSpy = await mountForm({
+      spawnSettings: { repos: ['acme/gears'], tools: ['pi'] },
+      spawnDefaults: { repos: ['acme/widgets'], tools: ['claude'] },
+    }).then((w) => w)
+
+    const gearsRow = fetchSpy.findAll('.spawn-repo-row').find((r) => r.text().includes('gears'))
+    const widgetsRow = fetchSpy.findAll('.spawn-repo-row').find((r) => r.text().includes('widgets'))
+    expect(gearsRow?.classes()).toContain('selected')
+    expect(widgetsRow?.classes()).not.toContain('selected')
+    // Guild defaults did not apply, so no pre-fill note.
+    expect(fetchSpy.find('.spawn-prefill-note').exists()).toBe(false)
+  })
+
+  it('dismisses the pre-fill note once the user edits the repo selection', async () => {
+    const wrapper = await mountForm({
+      spawnSettings: {},
+      spawnDefaults: { repos: ['acme/widgets'], tools: [] },
+    })
+    expect(wrapper.find('.spawn-prefill-note').exists()).toBe(true)
+
+    // Toggle a different repo → the note should disappear.
+    const gearsCheckbox = wrapper
+      .findAll('.spawn-repo-row')
+      .find((r) => r.text().includes('gears'))!
+      .find('input[type="checkbox"]')
+    await gearsCheckbox.setValue(true)
+    await flushPromises()
+    expect(wrapper.find('.spawn-prefill-note').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

The backend branch this is stacked on (`claude/worker-spawn-data-migration-gp323a`) moved worker spawn parameters into a guild-level `guild_spawn_defaults` table that tracks the guild's last successful spawn, and taught the foreman `spawn_worker` tool to fall back to it. The human-driven spawn form in the sidebar didn't benefit — a user with no personal saved settings still got a blank form.

## Solution

The spawn-worker form now resolves its initial values in three tiers:

1. **The user's personal saved settings** (`user_spawn_settings`) — unchanged, still highest priority.
2. **The guild's spawn defaults** (`guild_spawn_defaults`) — new fallback, the same defaults the foreman uses, so a new user sees the guild's usual repos/tools/agent-count.
3. **The repos already selected in the GitHub sidebar** — unchanged final fallback.

Guild-default repos are validated against the fetched repo list (unknown repos dropped), matching the existing personal-settings behaviour. A note tells the user when the form was pre-filled from the guild default, and it's dismissed as soon as they edit the repo selection.

### Changes
- **Backend:** `GET /guilds/{id}/spawn-defaults` returns the guild's recorded spawn parameters (`repos`, `tools`, `agent_count`), or `{}` when none exist. Member-gated like the other spawn endpoints.
- **Frontend:** `SpawnWorkerForm.vue` fetches guild defaults as the tier-2 fallback and surfaces the pre-fill note.

## Tests
- Backend: `cd backend && python -m pytest tests/test_worker_api.py` — 32 passed (3 new for the endpoint: empty, recorded, unknown-guild 404).
- Frontend: `cd frontend && npm test` — new `SpawnWorkerForm.spec.ts` covers pre-fill, unknown-repo dropping, personal-settings precedence, and note dismissal (4 passed); `npm run type-check` clean. (The one failing e2e smoke test needs a running dev server and is unrelated.)

## Note
This is **stacked** on `claude/worker-spawn-data-migration-gp323a` — the base branch is that backend branch, so this diff shows only the frontend changes. Merge the backend PR first; GitHub will then automatically retarget this PR at the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSqASQptEbYeb1EfkF4bMC)_