### PR TITLE
fix(logging): disable colored logs automatically on ECS (#983)

### DIFF
--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import UTC, datetime
 from typing import Any
 
@@ -94,6 +95,34 @@ _SUPPRESSED_LOGGERS = [
     "websockets",
     "urllib3",
 ]
+
+
+def running_on_ecs() -> bool:
+    """Detect whether the process is running inside an ECS task.
+
+    ECS (Fargate or EC2-backed) always sets a task metadata endpoint and,
+    for Fargate, injects task-role credentials via a relative URI; both are
+    reliable signals that we're in a container with no interactive
+    terminal, so ANSI color codes would just show up as garbage in the log
+    output (CloudWatch Logs et al.).
+    """
+    if "ECS_CONTAINER_METADATA_URI" in os.environ:
+        return True
+    if "ECS_CONTAINER_METADATA_URI_V4" in os.environ:
+        return True
+    if "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" in os.environ:
+        return True
+    if "ECS" in os.environ.get("AWS_EXECUTION_ENV", ""):
+        return True
+    return False
+
+
+def default_log_format() -> str:
+    """Return the log format to use when ``LOG_FORMAT`` isn't set explicitly.
+
+    Plain (uncolored) output on ECS; colored output for local development.
+    """
+    return "plain" if running_on_ecs() else "colored"
 
 
 def get_logging_config(

--- a/backend/main.py
+++ b/backend/main.py
@@ -55,10 +55,11 @@ except ImportError:
 # the lifespan hook fires.  uvicorn will later call dictConfig with its own
 # defaults; our lifespan re-applies it (with force-equivalent disable_existing
 # behaviour) to ensure consistent formatting after uvicorn starts.
+from logging_config import default_log_format as _default_log_format
 from logging_config import get_logging_config as _get_logging_config
 
 _early_log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
-_early_log_format = os.environ.get("LOG_FORMAT", "colored")
+_early_log_format = os.environ.get("LOG_FORMAT", _default_log_format())
 logging.config.dictConfig(_get_logging_config(_early_log_level, _early_log_format))
 
 logger = logging.getLogger(__name__)
@@ -338,7 +339,7 @@ async def lifespan(app: FastAPI):
     # Re-apply our logging config after uvicorn has set up its own handlers so
     # the format remains consistent for the lifetime of the server.
     _log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
-    _log_format = os.environ.get("LOG_FORMAT", "colored")
+    _log_format = os.environ.get("LOG_FORMAT", _default_log_format())
     logging.config.dictConfig(_get_logging_config(_log_level, _log_format))
 
     # A configured public guild identity is a startup invariant. Failing here
@@ -577,7 +578,7 @@ if __name__ == "__main__":
     import uvicorn
 
     _main_log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
-    _main_log_format = os.environ.get("LOG_FORMAT", "colored")
+    _main_log_format = os.environ.get("LOG_FORMAT", _default_log_format())
     uvicorn.run(
         "main:app",
         host="0.0.0.0",

--- a/backend/tests/test_logging_config.py
+++ b/backend/tests/test_logging_config.py
@@ -1,0 +1,54 @@
+"""Unit tests for ECS detection in logging_config."""
+
+from __future__ import annotations
+
+import logging_config
+
+_ECS_ENV_VARS = [
+    "ECS_CONTAINER_METADATA_URI",
+    "ECS_CONTAINER_METADATA_URI_V4",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_EXECUTION_ENV",
+]
+
+
+def _clear_ecs_env(monkeypatch):
+    for name in _ECS_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_running_on_ecs_false_when_no_env_vars(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    assert logging_config.running_on_ecs() is False
+    assert logging_config.default_log_format() == "colored"
+
+
+def test_running_on_ecs_true_for_metadata_uri(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    monkeypatch.setenv("ECS_CONTAINER_METADATA_URI", "http://169.254.170.2/v3/x")
+    assert logging_config.running_on_ecs() is True
+    assert logging_config.default_log_format() == "plain"
+
+
+def test_running_on_ecs_true_for_metadata_uri_v4(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    monkeypatch.setenv("ECS_CONTAINER_METADATA_URI_V4", "http://169.254.170.2/v4/x")
+    assert logging_config.running_on_ecs() is True
+
+
+def test_running_on_ecs_true_for_container_credentials(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    monkeypatch.setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/x")
+    assert logging_config.running_on_ecs() is True
+
+
+def test_running_on_ecs_true_for_execution_env(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    monkeypatch.setenv("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE")
+    assert logging_config.running_on_ecs() is True
+
+
+def test_running_on_ecs_false_for_unrelated_execution_env(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    monkeypatch.setenv("AWS_EXECUTION_ENV", "AWS_Lambda_python3.11")
+    assert logging_config.running_on_ecs() is False

--- a/cli/pioneer_cli/main.py
+++ b/cli/pioneer_cli/main.py
@@ -68,10 +68,10 @@ def _run_serve(argv: list[str]) -> int:
     os.chdir(backend_dir)
 
     import uvicorn  # noqa: PLC0415
-    from logging_config import get_logging_config  # noqa: PLC0415
+    from logging_config import default_log_format, get_logging_config  # noqa: PLC0415
 
     log_level = args.log_level.upper()
-    log_format = os.environ.get("LOG_FORMAT", "colored")
+    log_format = os.environ.get("LOG_FORMAT", default_log_format())
     uvicorn.run(
         "main:app",
         host=args.host,

--- a/worker/pioneer_worker/cli.py
+++ b/worker/pioneer_worker/cli.py
@@ -11,7 +11,7 @@ import sys
 
 from . import __version__
 from . import config as config_mod
-from .logging_config import get_logging_config
+from .logging_config import default_log_format, get_logging_config
 from .mock_worker import MockWorker
 from .worker import Worker
 
@@ -147,7 +147,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    log_format = os.environ.get("LOG_FORMAT", "colored")
+    log_format = os.environ.get("LOG_FORMAT", default_log_format())
     logging.config.dictConfig(get_logging_config(log_level=args.log_level, log_format=log_format))
     log = logging.getLogger("pioneer_worker.cli")
     log.info("pioneer-worker CLI starting (log_level=%s)", args.log_level)

--- a/worker/pioneer_worker/logging_config.py
+++ b/worker/pioneer_worker/logging_config.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import UTC, datetime
 from typing import Any
 
@@ -86,6 +87,34 @@ _SUPPRESSED_LOGGERS = [
     "websockets",
     "urllib3",
 ]
+
+
+def running_on_ecs() -> bool:
+    """Detect whether the process is running inside an ECS task.
+
+    ECS (Fargate or EC2-backed) always sets a task metadata endpoint and,
+    for Fargate, injects task-role credentials via a relative URI; both are
+    reliable signals that we're in a container with no interactive
+    terminal, so ANSI color codes would just show up as garbage in the log
+    output (CloudWatch Logs et al.).
+    """
+    if "ECS_CONTAINER_METADATA_URI" in os.environ:
+        return True
+    if "ECS_CONTAINER_METADATA_URI_V4" in os.environ:
+        return True
+    if "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" in os.environ:
+        return True
+    if "ECS" in os.environ.get("AWS_EXECUTION_ENV", ""):
+        return True
+    return False
+
+
+def default_log_format() -> str:
+    """Return the log format to use when ``LOG_FORMAT`` isn't set explicitly.
+
+    Plain (uncolored) output on ECS; colored output for local development.
+    """
+    return "plain" if running_on_ecs() else "colored"
 
 
 def get_logging_config(

--- a/worker/tests/test_logging_config.py
+++ b/worker/tests/test_logging_config.py
@@ -1,0 +1,42 @@
+"""Unit tests for ECS detection in pioneer_worker.logging_config."""
+
+from __future__ import annotations
+
+from pioneer_worker import logging_config
+
+_ECS_ENV_VARS = [
+    "ECS_CONTAINER_METADATA_URI",
+    "ECS_CONTAINER_METADATA_URI_V4",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_EXECUTION_ENV",
+]
+
+
+def _clear_ecs_env(monkeypatch):
+    for name in _ECS_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_running_on_ecs_false_when_no_env_vars(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    assert logging_config.running_on_ecs() is False
+    assert logging_config.default_log_format() == "colored"
+
+
+def test_running_on_ecs_true_for_metadata_uri(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    monkeypatch.setenv("ECS_CONTAINER_METADATA_URI", "http://169.254.170.2/v3/x")
+    assert logging_config.running_on_ecs() is True
+    assert logging_config.default_log_format() == "plain"
+
+
+def test_running_on_ecs_true_for_execution_env(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    monkeypatch.setenv("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE")
+    assert logging_config.running_on_ecs() is True
+
+
+def test_running_on_ecs_false_for_unrelated_execution_env(monkeypatch):
+    _clear_ecs_env(monkeypatch)
+    monkeypatch.setenv("AWS_EXECUTION_ENV", "AWS_Lambda_python3.11")
+    assert logging_config.running_on_ecs() is False


### PR DESCRIPTION
## Summary
- Add `running_on_ecs()` (backend and worker `logging_config.py`) to detect ECS deployment by checking `ECS_CONTAINER_METADATA_URI`, `ECS_CONTAINER_METADATA_URI_V4`, `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, and `AWS_EXECUTION_ENV` (for an "ECS" substring)
- Add `default_log_format()` returning `"plain"` when ECS is detected, `"colored"` otherwise
- Wire `default_log_format()` in as the fallback for the `LOG_FORMAT` env var in `backend/main.py`, `cli/pioneer_cli/main.py`, and `worker/pioneer_worker/cli.py`, so ECS deployments default to uncolored CloudWatch-friendly logs while local dev keeps colored output
- Add unit tests (`backend/tests/test_logging_config.py`, `worker/tests/test_logging_config.py`) covering each detection signal and the false-positive case (e.g. `AWS_EXECUTION_ENV=AWS_Lambda_python3.11`)

Closes #983

## Test plan
- [x] `pytest backend/tests/test_logging_config.py`
- [x] `pytest worker/tests/test_logging_config.py`
- [ ] Deploy to ECS and confirm CloudWatch logs are free of ANSI codes
- [ ] Confirm local `pioneer serve` / `pioneer-worker` still show colored logs by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)