### PR TITLE
fix(worker): stop killing freshly-spawned workers on launch

### DIFF
--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import os
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -364,6 +364,40 @@ async def test_signal_stale_worker_on_join_skips_when_version_unknown():
 
     assert signalled is False
     broadcast.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_signal_stale_worker_on_join_spares_freshly_spawned():
+    """A stale-version worker spawned seconds ago (deploy overlap) is not killed."""
+    broadcast = AsyncMock()
+    just_now = datetime.now(UTC) - timedelta(seconds=5)
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="v-new"),
+        patch("worker_lifecycle.broadcast_msg", broadcast),
+    ):
+        signalled = await signal_stale_worker_on_join("g-guild", "w-newborn", "v-old", just_now)
+
+    assert signalled is False
+    broadcast.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_signal_stale_worker_on_join_kills_old_stale_worker():
+    """A stale-version worker spawned long ago (real zombie) is still signalled."""
+    broadcasts = []
+
+    async def fake_broadcast(guild_slug, msg, *a, **kw):
+        broadcasts.append((guild_slug, msg))
+
+    long_ago = datetime.now(UTC) - timedelta(hours=1)
+    with (
+        patch("worker_lifecycle.get_current_version", return_value="v-new"),
+        patch("worker_lifecycle.broadcast_msg", fake_broadcast),
+    ):
+        signalled = await signal_stale_worker_on_join("g-guild", "w-zombie", "v-old", long_ago)
+
+    assert signalled is True
+    assert len(broadcasts) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -62,6 +62,16 @@ WORKER_IDLE_SWEEP_INTERVAL = float(os.environ.get("PIONEER_WORKER_IDLE_SWEEP_INT
 # there is no in-progress task to wait for.
 IDLE_REAP_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_IDLE_REAP_KILL_TIMEOUT", "300"))
 
+# Grace period before a version-stale worker is drained. A worker spawned by the
+# *previous* backend during a rolling deploy is still cold-starting on Fargate
+# (image pull + per-guild credential fetch) when the new backend takes over; its
+# version legitimately differs but it is a healthy newborn, not a zombie. Without
+# this, every worker that boots slower than the gap between deploys is killed the
+# instant it connects and reaped 30 min later having done zero work. Genuinely
+# old zombies are older than this and still get reaped by the idle reaper.
+# ponytail: 5 min covers Fargate cold-start; bump via env if boots run longer.
+STALE_DRAIN_MIN_AGE = timedelta(seconds=float(os.environ.get("PIONEER_STALE_DRAIN_MIN_AGE", "300")))
+
 # Task states that hold a worker alive: queued or actively-running work.
 # "awaiting-review" deliberately does NOT hold a worker alive — a PR can sit in
 # review for days, and send_followup routes to any idle worker (which pulls the
@@ -175,7 +185,10 @@ async def get_guild_spawn_defaults(db, guild_pk: int) -> GuildSpawnDefaults | No
 
 
 async def signal_stale_worker_on_join(
-    guild_slug: str, worker_id: str, spawned_version: str | None
+    guild_slug: str,
+    worker_id: str,
+    spawned_version: str | None,
+    started_at: datetime | None = None,
 ) -> bool:
     """Tell a version-stale backend-spawned worker to shut down as it (re)connects.
 
@@ -186,12 +199,26 @@ async def signal_stale_worker_on_join(
     on demand from the guild's spawn defaults, and the idle reaper force-kills
     the container if the worker never acts on the signal.
 
+    A worker spawned within STALE_DRAIN_MIN_AGE is spared: during a rolling
+    deploy it was spawned by the previous backend and is only now finishing its
+    cold-start, so its version differs but it is a healthy newborn, not a zombie.
+
     Returns True when a shutdown signal was sent.
     """
     if not spawned_version:
         return False
     current = get_current_version()
     if current is None or spawned_version == current:
+        return False
+    if started_at is not None and datetime.now(UTC) - started_at < STALE_DRAIN_MIN_AGE:
+        logger.info(
+            "worker_lifecycle: worker %s joined with stale version %s (current %s) but was "
+            "spawned %ds ago — sparing it (deploy overlap, not a zombie)",
+            worker_id,
+            spawned_version,
+            current,
+            int((datetime.now(UTC) - started_at).total_seconds()),
+        )
         return False
     logger.info(
         "worker_lifecycle: worker %s joined with stale version %s (current %s) — "
@@ -242,6 +269,12 @@ async def drain_stale_workers_on_startup() -> list[str]:
             # with NULL spawned_version (pre-migration rows from before version tracking
             # was introduced). NULL means we cannot confirm they match the current version,
             # so we conservatively treat them as stale.
+            #
+            # But spare workers spawned within STALE_DRAIN_MIN_AGE: during a rolling deploy
+            # the previous backend just spawned them and they are still cold-starting, so
+            # their version differs yet they are healthy newborns. NULL started_at (never
+            # recorded a spawn time) is treated as old and still drained.
+            spawn_cutoff = datetime.now(UTC) - STALE_DRAIN_MIN_AGE
             rows = (
                 await db.exec(
                     select(Worker, col(Guild.slug).label("guild_slug"))
@@ -250,6 +283,8 @@ async def drain_stale_workers_on_startup() -> list[str]:
                         col(Worker.spawned_version) != current_version,
                         col(Worker.state) != "offline",
                         col(Worker.disabled).is_(False),
+                        (col(Worker.started_at).is_(None))
+                        | (col(Worker.started_at) < spawn_cutoff),
                     )
                 )
             ).all()

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -283,9 +283,10 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     # WebSocket; without this check it would create agent rows and broadcast
     # events into a guild it doesn't belong to.
     worker_spawned_version: str | None = None
+    worker_started_at = None
     if agent_type == "worker" and worker_id:
         member_res = await ctx.db.exec(
-            select(col(Worker.id), col(Worker.spawned_version)).where(
+            select(col(Worker.id), col(Worker.spawned_version), col(Worker.started_at)).where(
                 col(Worker.id) == worker_id,
                 col(Worker.guild_id) == ctx.guild_pk,
             )
@@ -299,6 +300,7 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
             )
             return
         worker_spawned_version = member_row[1]
+        worker_started_at = member_row[2]
         # Guard against two live connections claiming the same worker_id (e.g. a
         # container that reconnects with a fresh agent_id while its previous
         # socket is still lingering after a restart). Evict the older agent so
@@ -400,7 +402,9 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
     # exits, the idle reaper force-kills it if it never complies, and the
     # foreman respawns on demand from the guild's spawn defaults.
     if agent_type == "worker" and worker_id:
-        await signal_stale_worker_on_join(ctx.guild_id, worker_id, worker_spawned_version)
+        await signal_stale_worker_on_join(
+            ctx.guild_id, worker_id, worker_spawned_version, worker_started_at
+        )
     # Only an explicit external Foreman API proxy may claim the proxy seat —
     # the legacy browser join still carries agentType="foreman" but must NOT
     # be registered in foreman_connections. The external client signals its

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -56,6 +56,11 @@ def _slug(text: str, max_len: int = 60) -> str:
 _CANCEL_SENTINEL = object()  # placed in redirect queue to signal task cancellation
 _SHUTDOWN_SENTINEL = object()  # placed in task queue to wake idle agents during shutdown
 
+# How long a dispatched Claude task waits for a background login to finish
+# before failing. Matches the 300s setup-token code-entry window in
+# _run_claude_login — no point waiting past when the login itself gives up.
+CLAUDE_AUTH_WAIT_SECONDS = float(os.environ.get("PIONEER_CLAUDE_AUTH_WAIT", "300"))
+
 _PR_PHASES = frozenset({"execute", "followup"})
 
 
@@ -125,6 +130,16 @@ class Worker:
         )
         self.ws = WSClient(cfg.ws_url, sleep_monitor=self.sleep_monitor)
         self._shutdown_event = asyncio.Event()
+        # "Claude is ready to run tasks." Starts set (the common case: creds in
+        # env or restored, or a tool that isn't claude) and is CLEARED only when
+        # _check_claude_auth kicks off a background login, then set again when the
+        # login completes. Claude tasks wait on it; pi/codex tasks ignore it.
+        # Startup never blocks on it — the worker joins first and auths in the
+        # background (see _check_claude_auth).
+        self._claude_authed = asyncio.Event()
+        self._claude_authed.set()
+        # Handle to the background login coroutine so it isn't GC'd mid-flight.
+        self._claude_login_task: asyncio.Task | None = None
         self._worker_name: str = ""
         # Captured at run() start so the optional control API's handler thread
         # can schedule coroutines onto the worker's loop. Stays None when no
@@ -510,7 +525,21 @@ class Worker:
         return logged_in
 
     async def _check_claude_auth(self) -> None:
-        """Ensure Claude is authenticated. Restores stored credentials or runs login flow."""
+        """Make Claude credentials usable without blocking the worker's startup.
+
+        The synchronous part is cheap: check the env, check an existing local
+        login, and try to restore a stored blob from the backend. Any of those
+        succeeding sets ``_claude_authed`` and returns.
+
+        If none do, we do NOT run the interactive ``claude setup-token`` login
+        inline — that blocks up to 300s waiting for a human to paste an OAuth
+        code, which on an unattended ECS worker means the worker never joins the
+        guild (and pi/codex workers that don't even use Claude get stuck too).
+        Instead the login runs in the background: the worker joins immediately,
+        emits ``claude-auth-required`` so the UI can drive the OAuth flow, and
+        Claude tasks wait on ``_claude_authed`` only when one is actually
+        dispatched.
+        """
         import base64
         import io
         import json
@@ -519,14 +548,17 @@ class Worker:
 
         if os.environ.get("ANTHROPIC_API_KEY"):
             logger.info("ANTHROPIC_API_KEY set — skipping Claude login flow")
+            self._claude_authed.set()
             return
 
         if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
             logger.info("CLAUDE_CODE_OAUTH_TOKEN already in env — skipping login")
+            self._claude_authed.set()
             return
 
         if await self._claude_is_authenticated():
             logger.info("Claude credentials already present")
+            self._claude_authed.set()
             return
 
         # Try restoring credentials stored in the backend. Two formats are
@@ -555,6 +587,7 @@ class Worker:
                             # The env var is inherited by every spawned claude;
                             # no need to re-verify with `claude auth status`,
                             # which can spuriously fail on macOS keychain hosts.
+                            self._claude_authed.set()
                             return
                     except (json.JSONDecodeError, UnicodeDecodeError):
                         pass  # fall through to legacy tarball path
@@ -564,13 +597,23 @@ class Worker:
                         tar.extractall(path=Path.home())
                     logger.info("Restored Claude credentials tarball from backend (legacy)")
                     if await self._claude_is_authenticated():
+                        self._claude_authed.set()
                         return
                     logger.warning("Restored credentials blob but auth status still fails")
         except Exception as exc:
             logger.warning("Could not fetch Claude credentials from backend: %s", exc)
 
-        await self._emit("No Claude credentials found — starting login...", level=LEVEL_AUTH)
-        await self._run_claude_login()
+        # No usable credentials. Claude tasks must now wait, so clear the ready
+        # flag, then run the interactive login in the BACKGROUND — the worker
+        # still joins the guild immediately; _run_claude_login emits
+        # claude-auth-required and re-sets _claude_authed if a human completes it.
+        self._claude_authed.clear()
+        logger.info("No Claude credentials found — starting login in background (non-blocking)")
+        await self._emit(
+            "No Claude credentials found — starting login (worker stays online)...",
+            level=LEVEL_AUTH,
+        )
+        self._claude_login_task = asyncio.create_task(self._run_claude_login())
 
     async def _run_claude_login(self) -> None:
         """Drive `claude setup-token` to completion and persist the resulting OAuth token.
@@ -764,6 +807,7 @@ class Worker:
             return
 
         os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = token
+        self._claude_authed.set()
         logger.info("Captured CLAUDE_CODE_OAUTH_TOKEN (len=%d) and set in env", len(token))
         await self._emit(
             "Token captured — saving to backend so future workers can reuse it",
@@ -1235,8 +1279,11 @@ class Worker:
         await self.ws.connect()
 
         # Start listener before auth so it can relay auth codes from the UI.
-        # _join() is intentionally delayed until after auth — agents must not
-        # be visible to the foreman until Claude is ready to accept tasks.
+        # _check_claude_auth is non-blocking: it restores stored creds if it can
+        # and otherwise kicks off the login in the background. The worker joins
+        # right away — Claude tasks wait on _claude_authed when dispatched (see
+        # _execute_task); pi/codex workers never need it. Blocking the join on an
+        # interactive login stalled every unattended worker for 300s.
         listener = asyncio.create_task(self._listen())
         await self._check_claude_auth()
         self._detect_available_tools()
@@ -2221,6 +2268,22 @@ class Worker:
             success = False
             stop_reason = "no_events"
             last_msg = ""
+
+            # Claude tasks need credentials; startup no longer blocks the join on
+            # them (see _check_claude_auth), so a claude task dispatched before
+            # login completes waits here instead of launching un-authed. pi/codex
+            # tasks skip this entirely. Bounded so a slot can't hang forever.
+            if tool == "claude" and not self._claude_authed.is_set():
+                logger.info("Task %s: waiting for Claude auth before launch", task_id)
+                await emit("Waiting for Claude authentication to complete...")
+                try:
+                    await asyncio.wait_for(
+                        self._claude_authed.wait(), timeout=CLAUDE_AUTH_WAIT_SECONDS
+                    )
+                except TimeoutError:
+                    raise RuntimeError(
+                        "Claude is not authenticated — complete the login in the UI, then retry"
+                    ) from None
 
             while True:
                 if tool == "codex":

--- a/worker/tests/test_disconnect.py
+++ b/worker/tests/test_disconnect.py
@@ -146,6 +146,54 @@ async def test_on_ws_reconnect_skips_join_before_auth():
     assert sent == [], f"No messages should be sent before auth, got: {sent}"
 
 
+async def test_check_claude_auth_sets_event_from_env():
+    """Credentials already in env mark Claude ready synchronously — no login."""
+    worker = Worker(_make_cfg())
+    worker._run_claude_login = AsyncMock()
+    import os
+
+    os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = "tok-abc"
+    try:
+        await worker._check_claude_auth()
+    finally:
+        del os.environ["CLAUDE_CODE_OAUTH_TOKEN"]
+
+    assert worker._claude_authed.is_set()
+    worker._run_claude_login.assert_not_awaited()
+
+
+async def test_check_claude_auth_does_not_block_when_unauthenticated(monkeypatch):
+    """With no creds, _check_claude_auth returns immediately and runs login in the
+    background — it must not block the join, and _claude_authed stays unset until
+    the login actually completes."""
+    worker = Worker(_make_cfg())
+    worker._send = AsyncMock()
+    worker._emit = AsyncMock()
+    monkeypatch.setattr(worker, "_claude_is_authenticated", AsyncMock(return_value=False))
+
+    login_started = asyncio.Event()
+    login_release = asyncio.Event()
+
+    async def fake_login():
+        login_started.set()
+        await login_release.wait()  # simulate the 300s human-paste wait
+
+    monkeypatch.setattr(worker, "_run_claude_login", fake_login)
+    # Make the backend credential fetch fail fast so we hit the login path.
+    monkeypatch.setattr(worker, "_http", AsyncMock(side_effect=OSError("no backend")))
+
+    # Must return promptly despite the login "blocking" indefinitely.
+    await asyncio.wait_for(worker._check_claude_auth(), timeout=2.0)
+
+    assert not worker._claude_authed.is_set(), (
+        "auth must not be marked ready before login completes"
+    )
+    await asyncio.wait_for(login_started.wait(), timeout=2.0)  # login runs in background
+    login_release.set()
+    if worker._claude_login_task:
+        await worker._claude_login_task
+
+
 async def test_on_ws_reconnect_resends_non_idle_agent_state():
     """A reconnect during an active task must restore the slot's actual state
     so the backend doesn't leave the agent stuck at idle."""


### PR DESCRIPTION
## Problem

Workers were failing the instant they launched in ECS (staging). Diagnosed from CloudWatch: every worker sat **exactly 5 minutes** between `WebSocket connected` and `Joined guild`, and many were shut down on join with `Graceful shutdown initiated: worker-shutdown message`.

Two independent causes, both exposed by #988 (which stopped injecting `CLAUDE_CODE_OAUTH_TOKEN` into spawned workers):

### 1. Version-stale drain killed newborns
`signal_stale_worker_on_join` / `drain_stale_workers_on_startup` treat any `spawned_version` mismatch as a zombie from an old deploy. A worker spawned by the *previous* backend during a rolling deploy is still cold-starting on Fargate when the new backend takes over — so it was killed the instant it connected and reaped 30 min later having done zero work.

```
worker w-9d01d5 joined with stale version 63ee8e6... (current 0c4db83...) — sending graceful shutdown
```

The version stamping itself was **correct** (full commit SHAs end to end); the drain logic just couldn't tell a newborn from a zombie.

### 2. Startup blocked the guild join on an interactive Claude login
`run()` called `_check_claude_auth()` **before** `_join()`. With no stored creds it runs `claude setup-token`, which blocks up to 300s waiting for a human to paste an OAuth code — on an unattended ECS task the worker never joins. It ran even for **pi/codex** workers that never use Claude (a pi worker was being gated on a Claude login it would never use).

## Fix

1. **Grace window** — `STALE_DRAIN_MIN_AGE` (300s, `PIONEER_STALE_DRAIN_MIN_AGE`) so both drain paths spare recently-spawned workers. Genuine zombies are older and still get reaped by the idle reaper.
2. **Non-blocking auth** — `_check_claude_auth` restores stored creds synchronously and, when there are none, runs the login in the **background**; the worker joins immediately. A `_claude_authed` event (default **set**, cleared only while a background login is pending) gates Claude tasks via `CLAUDE_AUTH_WAIT_SECONDS`; pi/codex tasks ignore it.

## Tests
- backend: lifecycle grace window (young stale worker spared, old zombie still signalled).
- worker: auth marks ready from env; `_check_claude_auth` returns promptly while login runs in the background without setting the ready flag early.
- Full suites green: backend lifecycle/join 49 passed, worker 275 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)