### PR TITLE
Add guild-level cooldown for worker spawns

### DIFF
--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import random
 import string
@@ -657,6 +658,11 @@ async def _cmd_worker_spawn(interaction: dict) -> None:
     ``/connect-account`` first — spawning a worker starts a container and
     consumes credentials, so it's gated on the same account link used to
     resolve identity elsewhere (see ``discord/router.py::_resolve_identity``).
+
+    Also rejects the request if the guild spawned a worker within the last
+    ``worker_lifecycle.WORKER_SPAWN_COOLDOWN`` (default 5 min), to guard
+    against accidental spam and the resource waste of repeated container
+    starts — see ``worker_lifecycle.check_worker_spawn_cooldown``.
     """
     token = interaction.get("token", "")
     data = interaction.get("data", {})
@@ -701,6 +707,20 @@ async def _cmd_worker_spawn(interaction: dict) -> None:
             guild = guild_result.one_or_none()
             if not guild:
                 await _send_followup(token, content=f"Pioneer guild `{guild_slug}` not found.")
+                return
+
+            from worker_lifecycle import check_worker_spawn_cooldown  # noqa: PLC0415
+
+            remaining = await check_worker_spawn_cooldown(db, guild.id)
+            if remaining is not None:
+                minutes = max(1, math.ceil(remaining.total_seconds() / 60))
+                await _send_followup(
+                    token,
+                    content=(
+                        "Worker spawn cooldown active. Try again in "
+                        f"{minutes} minute{'s' if minutes != 1 else ''}."
+                    ),
+                )
                 return
 
             result_text, is_error = await spawn_worker(

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -604,11 +605,13 @@ async def test_cmd_worker_spawn_success(monkeypatch):
     fake_spawn_worker = AsyncMock(
         return_value=(json.dumps({"worker_id": "w-abc123", "repos": ["org/repo"]}), False)
     )
+    fake_cooldown = AsyncMock(return_value=None)
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
         patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.spawn_worker", new=fake_spawn_worker),
+        patch("worker_lifecycle.check_worker_spawn_cooldown", new=fake_cooldown),
     ):
         from routes.discord import _cmd_worker_spawn
 
@@ -656,11 +659,13 @@ async def test_cmd_worker_spawn_reports_queued_status(monkeypatch):
     fake_spawn_worker = AsyncMock(
         return_value=(json.dumps({"worker_id": "w-abc123", "repos": ["org/repo"]}), False)
     )
+    fake_cooldown = AsyncMock(return_value=None)
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
         patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.spawn_worker", new=fake_spawn_worker),
+        patch("worker_lifecycle.check_worker_spawn_cooldown", new=fake_cooldown),
     ):
         from routes.discord import _cmd_worker_spawn
 
@@ -768,11 +773,13 @@ async def test_cmd_worker_spawn_reports_tool_error(monkeypatch):
     fake_spawn_worker = AsyncMock(
         return_value=("spawn_worker requires at least one repo in the 'repos' list.", True)
     )
+    fake_cooldown = AsyncMock(return_value=None)
 
     with (
         patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
         patch("discord_notifier.patch", new=fake_patch),
         patch("routes.discord.spawn_worker", new=fake_spawn_worker),
+        patch("worker_lifecycle.check_worker_spawn_cooldown", new=fake_cooldown),
     ):
         from routes.discord import _cmd_worker_spawn
 
@@ -781,6 +788,50 @@ async def test_cmd_worker_spawn_reports_tool_error(monkeypatch):
     assert sent
     assert "Failed to spawn worker" in sent[0]["content"]
     assert "at least one repo" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cmd_worker_spawn_cooldown_active(monkeypatch):
+    """_cmd_worker_spawn refuses (without calling spawn_worker) when the guild is in cooldown."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+    monkeypatch.setenv("DISCORD_PIONEER_GUILD_SLUG", "test-guild")
+
+    guild = MagicMock()
+    guild.id = 1
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value="ps-user-1")),  # account link lookup
+            MagicMock(one_or_none=MagicMock(return_value=guild)),  # guild lookup
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    fake_spawn_worker = AsyncMock()
+    fake_cooldown = AsyncMock(return_value=timedelta(seconds=150))
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("discord_notifier.patch", new=fake_patch),
+        patch("routes.discord.spawn_worker", new=fake_spawn_worker),
+        patch("worker_lifecycle.check_worker_spawn_cooldown", new=fake_cooldown),
+    ):
+        from routes.discord import _cmd_worker_spawn
+
+        await _cmd_worker_spawn(_worker_spawn_interaction())
+
+    fake_spawn_worker.assert_not_called()
+    assert sent
+    assert "cooldown" in sent[0]["content"].lower()
+    assert "3 minutes" in sent[0]["content"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_worker_lifecycle.py
+++ b/backend/tests/test_worker_lifecycle.py
@@ -16,6 +16,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from worker_lifecycle import (  # noqa: E402
     SHUTDOWN_FORCE_KILL_TIMEOUT,
+    WORKER_SPAWN_COOLDOWN,
+    check_worker_spawn_cooldown,
     drain_stale_workers_on_startup,
     force_kill_worker_if_unresponsive,
     generate_worker_id,
@@ -296,6 +298,49 @@ async def test_record_worker_spawn_skips_defaults_without_repos():
 
     mock_db.exec.assert_called_once()
     mock_db.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# check_worker_spawn_cooldown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_worker_spawn_cooldown_no_prior_spawn():
+    """A guild with no recorded spawn defaults is never in cooldown."""
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=None)))
+
+    remaining = await check_worker_spawn_cooldown(mock_db, 42)
+
+    assert remaining is None
+
+
+@pytest.mark.asyncio
+async def test_check_worker_spawn_cooldown_recent_spawn_still_active():
+    """A spawn 1 minute ago is still within the 5-minute cooldown."""
+    defaults = MagicMock(updated_at=datetime.now(UTC) - timedelta(minutes=1))
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=defaults)))
+
+    remaining = await check_worker_spawn_cooldown(mock_db, 42)
+
+    assert remaining is not None
+    assert timedelta(minutes=3) < remaining <= timedelta(minutes=4)
+
+
+@pytest.mark.asyncio
+async def test_check_worker_spawn_cooldown_expired():
+    """A spawn from longer ago than the cooldown window is not in cooldown."""
+    defaults = MagicMock(
+        updated_at=datetime.now(UTC) - WORKER_SPAWN_COOLDOWN - timedelta(seconds=1)
+    )
+    mock_db = AsyncMock()
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value=defaults)))
+
+    remaining = await check_worker_spawn_cooldown(mock_db, 42)
+
+    assert remaining is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -62,6 +62,15 @@ WORKER_IDLE_SWEEP_INTERVAL = float(os.environ.get("PIONEER_WORKER_IDLE_SWEEP_INT
 # there is no in-progress task to wait for.
 IDLE_REAP_FORCE_KILL_TIMEOUT = float(os.environ.get("PIONEER_IDLE_REAP_KILL_TIMEOUT", "300"))
 
+# Minimum time a guild must wait between successful worker spawns, to guard
+# against accidental spam (e.g. a user mashing /worker-spawn) and the resource
+# waste of repeatedly starting containers. Enforced by callers that check
+# check_worker_spawn_cooldown() before invoking spawn_worker() — currently just
+# the Discord /worker-spawn command.
+WORKER_SPAWN_COOLDOWN = timedelta(
+    seconds=float(os.environ.get("PIONEER_WORKER_SPAWN_COOLDOWN", "300"))
+)
+
 # Grace period before a version-stale worker is drained. A worker spawned by the
 # *previous* backend during a rolling deploy is still cold-starting on Fargate
 # (image pull + per-guild credential fetch) when the new backend takes over; its
@@ -182,6 +191,21 @@ async def get_guild_spawn_defaults(db, guild_pk: int) -> GuildSpawnDefaults | No
             select(GuildSpawnDefaults).where(col(GuildSpawnDefaults.guild_id) == guild_pk)
         )
     ).one_or_none()
+
+
+async def check_worker_spawn_cooldown(db, guild_pk: int) -> timedelta | None:
+    """Return the remaining cooldown if *guild_pk* spawned a worker too recently, else None.
+
+    Reads ``guild_spawn_defaults.updated_at``, which record_worker_spawn()
+    refreshes on every successful spawn — so this reflects the guild's last
+    successful spawn regardless of which caller (Discord, foreman AI, REST)
+    triggered it.
+    """
+    defaults = await get_guild_spawn_defaults(db, guild_pk)
+    if defaults is None:
+        return None
+    remaining = WORKER_SPAWN_COOLDOWN - (datetime.now(UTC) - defaults.updated_at)
+    return remaining if remaining > timedelta(0) else None
 
 
 async def signal_stale_worker_on_join(


### PR DESCRIPTION
## Summary
- Adds a 5-minute (configurable via `PIONEER_WORKER_SPAWN_COOLDOWN`) cooldown per guild between successful worker spawns via the Discord `/worker-spawn` command.
- Prevents accidental spam and the resource waste of repeatedly starting containers.
- `check_worker_spawn_cooldown()` reads `guild_spawn_defaults.updated_at` (refreshed by `record_worker_spawn()` on every successful spawn), so it reflects the guild's last spawn regardless of trigger source.

## Test plan
- [x] `cd backend && python -m pytest tests/test_discord_interactions.py tests/test_worker_lifecycle.py -q` — 83 passed (7 pre-existing errors unrelated to this change, due to no local Postgres on 5433; confirmed identical failures on `main`)
- [x] `ruff check` on changed files — clean