### PR TITLE
Fix backend: treat placeholder Anthropic API key as unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,9 @@ ANTHROPIC_API_KEY=
 # Claude OAuth token for the `claude` CLI inside workers. Generate with
 # `claude setup-token` on a machine where you've logged in. When set, workers
 # skip the interactive auth flow and the backend credentials-fetch path.
-# Forwarded to backend-spawned worker containers automatically.
+# Worker-only: read directly from each worker container's own environment
+# (docker-compose.yml's `worker` service) — the backend does not read or
+# forward this value to spawned workers.
 CLAUDE_CODE_OAUTH_TOKEN=
 
 # Worker-only: GitHub token for cloning private repos and opening PRs.

--- a/backend/foreman/llm_providers/anthropic_provider.py
+++ b/backend/foreman/llm_providers/anthropic_provider.py
@@ -18,6 +18,22 @@ from .errors import normalize_error
 
 logger = logging.getLogger(__name__)
 
+# Deployments sometimes set ANTHROPIC_API_KEY=placeholder as a non-empty
+# stand-in (e.g. to satisfy tooling that requires the var to be present)
+# without intending it as a real credential. Passing it to the SDK produces a
+# confusing 401 instead of the "no key configured" fallback callers expect.
+_PLACEHOLDER_KEY_VALUES = {"placeholder"}
+
+
+def _real_api_key(value: str | None) -> str | None:
+    """Return *value* unless it's blank or a known placeholder string."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped or stripped.lower() in _PLACEHOLDER_KEY_VALUES:
+        return None
+    return stripped
+
 
 class AnthropicProvider(LLMProvider):
     """Adapter for the direct Anthropic Messages API."""
@@ -53,7 +69,9 @@ class AnthropicProvider(LLMProvider):
         if env.get("ANTHROPIC_AUTH_TOKEN"):
             kwargs["auth_token"] = env["ANTHROPIC_AUTH_TOKEN"]
         else:
-            resolved_api_key = api_key or env.get("ANTHROPIC_API_KEY")
+            resolved_api_key = _real_api_key(api_key) or _real_api_key(
+                env.get("ANTHROPIC_API_KEY")
+            )
             if resolved_api_key:
                 kwargs["api_key"] = resolved_api_key
         if env.get("ANTHROPIC_BASE_URL"):

--- a/backend/foreman/llm_providers/anthropic_provider.py
+++ b/backend/foreman/llm_providers/anthropic_provider.py
@@ -69,9 +69,7 @@ class AnthropicProvider(LLMProvider):
         if env.get("ANTHROPIC_AUTH_TOKEN"):
             kwargs["auth_token"] = env["ANTHROPIC_AUTH_TOKEN"]
         else:
-            resolved_api_key = _real_api_key(api_key) or _real_api_key(
-                env.get("ANTHROPIC_API_KEY")
-            )
+            resolved_api_key = _real_api_key(api_key) or _real_api_key(env.get("ANTHROPIC_API_KEY"))
             if resolved_api_key:
                 kwargs["api_key"] = resolved_api_key
         if env.get("ANTHROPIC_BASE_URL"):

--- a/backend/tests/test_foreman_llm.py
+++ b/backend/tests/test_foreman_llm.py
@@ -345,6 +345,42 @@ class TestMakeAnthropicClient:
         )
         mock_mod.AsyncAnthropic.assert_called_once_with(api_key="sk-explicit")
 
+    @pytest.mark.parametrize("placeholder", ["placeholder", "Placeholder", " placeholder ", ""])
+    def test_placeholder_env_api_key_omitted_from_kwargs(self, monkeypatch, placeholder):
+        """ANTHROPIC_API_KEY=placeholder (any case/whitespace) must not reach the SDK."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(extra_env={"ANTHROPIC_API_KEY": placeholder})
+        mock_mod.AsyncAnthropic.assert_called_once_with()
+
+    def test_placeholder_explicit_api_key_omitted_from_kwargs(self, monkeypatch):
+        """An explicit api_key of "placeholder" must not reach the SDK either."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(api_key="placeholder")
+        mock_mod.AsyncAnthropic.assert_called_once_with()
+
+    def test_placeholder_env_falls_back_to_real_explicit_api_key(self, monkeypatch):
+        """A real explicit api_key must still be used when ANTHROPIC_API_KEY is a placeholder."""
+        monkeypatch.delenv("FOREMAN_PROVIDER", raising=False)
+        import foreman.llm as llm_mod
+
+        mock_mod = _make_mock_anthropic()
+        monkeypatch.setattr(llm_mod, "_anthropic_mod", mock_mod)
+        monkeypatch.setattr(llm_mod, "HAS_ANTHROPIC", True)
+        llm_mod.make_anthropic_client(
+            api_key="sk-explicit", extra_env={"ANTHROPIC_API_KEY": "placeholder"}
+        )
+        mock_mod.AsyncAnthropic.assert_called_once_with(api_key="sk-explicit")
+
     def test_auth_token_wins_over_process_api_key(self, monkeypatch):
         """Regression for #660: ANTHROPIC_AUTH_TOKEN in guild env_vars must win over a
         process-level ANTHROPIC_API_KEY so the SDK never receives both (it raises ValueError

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,9 +56,6 @@ services:
       GITHUB_REDIRECT_URI: ${GITHUB_REDIRECT_URI:-https://pioneer-square.melloy.life/auth/github/callback}
       FRONTEND_URL: ${FRONTEND_URL:-https://pioneer-square.melloy.life}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      # Forwarded to spawned worker containers so they skip the interactive
-      # `claude setup-token` flow. Generate one with `claude setup-token`.
-      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       WORKER_IMAGE: ${WORKER_IMAGE:-pioneer-square-worker}
       WORKER_BACKEND_URL: ${WORKER_BACKEND_URL:-http://backend:8000}


### PR DESCRIPTION
## Summary
- `ANTHROPIC_API_KEY=placeholder` (or blank/whitespace, any case) is now normalized to `None` in `AnthropicProvider`, for both the explicit `api_key` argument and the env var, so a placeholder value falls back to "no key configured" instead of being sent to the SDK and producing a confusing 401.
- Removed `CLAUDE_CODE_OAUTH_TOKEN` from the `backend` service in `docker-compose.yml` — it's a worker-only credential; workers already read it from their own environment, and the backend never consumed it.
- No "OpenAI Ali key" configuration exists anywhere in this backend (checked the whole repo), so there was nothing to remove for that item.

## Test plan
- [x] `uv run pytest tests/test_foreman_llm.py -q` — 46 passed (includes 3 new placeholder-handling tests)
- [x] `uv run pytest -q` (full backend suite) — 730 passed, 2 skipped, 0 failed; 456 errors are pre-existing `ConnectionRefusedError`s from integration tests needing a live Postgres instance, which isn't available in this sandbox (unrelated to this change)