### PR TITLE
feat(spawn): UI to manage guild spawn defaults; user spawn overrides them

### DIFF
--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -35,7 +35,9 @@ from utils import (
 from worker_lifecycle import (
     force_kill_worker_if_unresponsive,
     generate_worker_id,
+    get_guild_spawn_defaults,
     record_worker_spawn,
+    set_guild_spawn_defaults,
 )
 from ws_handlers import _resolve_user_identifier
 from ws_types import TaskAssignedMsg, WorkerMessageMsg, WorkerShutdownMsg
@@ -84,6 +86,21 @@ class SpawnWorkerRequest(BaseModel):
                 raise ValueError(
                     f"Env var value for {key!r} exceeds max length ({_MAX_ENV_VALUE_LEN} chars)"
                 )
+        return v
+
+
+class SaveSpawnDefaultsRequest(BaseModel):
+    """Guild-level spawn baseline. A full-replace PUT (no partial semantics)."""
+
+    repos: list[str] = []
+    tools: list[str] = []
+    agent_count: int | None = None
+
+    @field_validator("agent_count")
+    @classmethod
+    def validate_agent_count(cls, v: int | None) -> int | None:
+        if v is not None and not (1 <= v <= 16):
+            raise ValueError("agent_count must be between 1 and 16")
         return v
 
 
@@ -463,6 +480,64 @@ async def save_spawn_settings(
         row.updated_at = now
     await db.commit()
     return {"status": "saved"}
+
+
+def _spawn_defaults_payload(row) -> dict:
+    """Serialise a GuildSpawnDefaults row (or None) to the wire shape."""
+    if row is None:
+        return {"repos": [], "tools": [], "agent_count": None}
+    return {
+        "repos": json.loads(row.repos or "[]"),
+        "tools": json.loads(row.tools or "[]"),
+        "agent_count": row.agent_count,
+    }
+
+
+@router.get("/guilds/{guild_id}/spawn-defaults")
+async def get_spawn_defaults(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Return the guild's default spawn parameters (repos, tools, agent_count).
+
+    Readable by any guild member: the per-user spawn form uses these as the
+    baseline it lets the caller override. Returns empty defaults when the guild
+    has never recorded a spawn and no owner has set them explicitly.
+    """
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    row = await get_guild_spawn_defaults(db, guild_pk)
+    return _spawn_defaults_payload(row)
+
+
+@router.put("/guilds/{guild_id}/spawn-defaults")
+async def save_spawn_defaults(
+    guild_id: str,
+    data: SaveSpawnDefaultsRequest,
+    github_user_id: str = Depends(require_member("owner")),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Set the guild's default spawn parameters (owner only).
+
+    These become the baseline the foreman's ``spawn_worker`` tool falls back to
+    and the per-user spawn form pre-fills from. A successful worker spawn still
+    refreshes them afterward (``record_worker_spawn``) — this endpoint just lets
+    an owner curate the baseline directly instead of waiting for the next spawn.
+    """
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    await set_guild_spawn_defaults(
+        db,
+        guild_pk,
+        repos=data.repos,
+        tools=data.tools,
+        agent_count=data.agent_count,
+    )
+    row = await get_guild_spawn_defaults(db, guild_pk)
+    return _spawn_defaults_payload(row)
 
 
 @router.post("/guilds/{guild_id}/workers/{worker_id}/message")

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -234,6 +234,84 @@ def test_shutdown_unknown_worker_returns_404(client):
     assert resp.status_code == 404
 
 
+# ---------------------------------------------------------------------------
+# Guild spawn defaults
+# ---------------------------------------------------------------------------
+
+
+def test_get_spawn_defaults_empty(client):
+    """A guild with no recorded spawn returns empty defaults, not 404."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-sd1")
+    resp = test_client.get("/guilds/guild-sd1/spawn-defaults", headers=_auth(db_url))
+    assert resp.status_code == 200
+    assert resp.json() == {"repos": [], "tools": [], "agent_count": None}
+
+
+def test_put_spawn_defaults_roundtrips(client):
+    test_client, db_url = client
+    insert_guild(db_url, "guild-sd2")
+    resp = test_client.put(
+        "/guilds/guild-sd2/spawn-defaults",
+        headers=_auth(db_url),
+        json={"repos": ["a/b", "a/c"], "tools": ["claude"], "agent_count": 3},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"repos": ["a/b", "a/c"], "tools": ["claude"], "agent_count": 3}
+    # A subsequent GET reflects the saved baseline.
+    got = test_client.get("/guilds/guild-sd2/spawn-defaults", headers=_auth(db_url))
+    assert got.json() == {"repos": ["a/b", "a/c"], "tools": ["claude"], "agent_count": 3}
+
+
+def test_put_spawn_defaults_full_replace_clears_fields(client):
+    """PUT has full-replace semantics: an empty body wipes the previous baseline."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-sd3")
+    test_client.put(
+        "/guilds/guild-sd3/spawn-defaults",
+        headers=_auth(db_url),
+        json={"repos": ["a/b"], "tools": ["codex"], "agent_count": 5},
+    )
+    resp = test_client.put(
+        "/guilds/guild-sd3/spawn-defaults",
+        headers=_auth(db_url),
+        json={},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"repos": [], "tools": [], "agent_count": None}
+
+
+def test_put_spawn_defaults_rejects_bad_agent_count(client):
+    test_client, db_url = client
+    insert_guild(db_url, "guild-sd4")
+    resp = test_client.put(
+        "/guilds/guild-sd4/spawn-defaults",
+        headers=_auth(db_url),
+        json={"repos": [], "tools": [], "agent_count": 99},
+    )
+    assert resp.status_code == 422
+
+
+def test_put_spawn_defaults_requires_owner(client):
+    """Non-owner members can read defaults but not set them."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-sd5")
+    insert_member(db_url, "guild-sd5", "gh-member", role="member")
+    member_auth = {
+        "Authorization": f"Bearer {make_auth_token(db_url, user_id='gh-member', username='member1')}"
+    }
+    # Member can GET.
+    got = test_client.get("/guilds/guild-sd5/spawn-defaults", headers=member_auth)
+    assert got.status_code == 200
+    # But cannot PUT.
+    resp = test_client.put(
+        "/guilds/guild-sd5/spawn-defaults",
+        headers=member_auth,
+        json={"repos": ["a/b"], "tools": [], "agent_count": 2},
+    )
+    assert resp.status_code == 403
+
+
 def test_spawn_worker_env_does_not_inject_claude_oauth_token():
     """Claude credentials are per-guild: the worker fetches them from the backend
     (/auth/claude/credentials) on startup, so they are NOT injected at spawn.

--- a/backend/worker_lifecycle.py
+++ b/backend/worker_lifecycle.py
@@ -174,6 +174,43 @@ async def get_guild_spawn_defaults(db, guild_pk: int) -> GuildSpawnDefaults | No
     ).one_or_none()
 
 
+async def set_guild_spawn_defaults(
+    db,
+    guild_pk: int,
+    *,
+    repos: list[str],
+    tools: list[str],
+    agent_count: int | None,
+) -> None:
+    """Explicitly upsert a guild's ``guild_spawn_defaults`` row.
+
+    Unlike :func:`record_worker_spawn` (which only refreshes the row as a
+    side-effect of a successful spawn, and only when ``repos`` is non-empty),
+    this is the operator-facing write path: it always replaces the full row so
+    an owner can curate the guild's spawn baseline directly, including clearing
+    repos/tools. Callers are expected to have committed their own transaction
+    boundary; this commits before returning.
+    """
+    stmt = pg_insert(GuildSpawnDefaults).values(
+        guild_id=guild_pk,
+        repos=json.dumps(repos),
+        tools=json.dumps(tools),
+        agent_count=agent_count,
+        updated_at=datetime.now(UTC),
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["guild_id"],
+        set_={
+            "repos": stmt.excluded.repos,
+            "tools": stmt.excluded.tools,
+            "agent_count": stmt.excluded.agent_count,
+            "updated_at": stmt.excluded.updated_at,
+        },
+    )
+    await db.exec(stmt)
+    await db.commit()
+
+
 async def signal_stale_worker_on_join(
     guild_slug: str, worker_id: str, spawned_version: str | None
 ) -> bool:

--- a/frontend/src/components/GuildSpawnDefaults.vue
+++ b/frontend/src/components/GuildSpawnDefaults.vue
@@ -1,0 +1,429 @@
+<template>
+  <div class="gsd">
+    <div v-if="loading" class="gsd-hint">Loading…</div>
+    <template v-else>
+      <p class="gsd-intro">
+        The guild baseline used when the foreman spawns a worker and pre-filled into each member's
+        spawn form. Members can override it per launch.
+      </p>
+
+      <template v-if="canManage">
+        <label class="gsd-sublabel">Repos</label>
+        <div v-if="ghStore.repos.length === 0" class="gsd-hint">
+          No repos loaded — configure GitHub first.
+        </div>
+        <div v-else class="gsd-repo-list">
+          <template v-for="group in groupedRepos" :key="group.owner">
+            <label class="gsd-repo-row gsd-org-row" :class="{ selected: orgAllSelected(group.owner) }">
+              <input
+                type="checkbox"
+                :ref="(el) => setOrgCheckboxRef(el as HTMLInputElement | null, group.owner)"
+                :checked="orgAllSelected(group.owner)"
+                @change="toggleOrg(group.owner)"
+                class="gsd-check"
+              />
+              <span class="gsd-repo-name gsd-org-name">{{ group.owner }}</span>
+            </label>
+            <label
+              v-for="repo in group.repos"
+              :key="repo.full_name"
+              class="gsd-repo-row gsd-repo-indent"
+              :class="{ selected: repos.includes(repo.full_name) }"
+            >
+              <input
+                type="checkbox"
+                :checked="repos.includes(repo.full_name)"
+                @change="toggleRepo(repo.full_name)"
+                class="gsd-check"
+              />
+              <span class="gsd-repo-name">{{ repo.full_name.split('/')[1] }}</span>
+            </label>
+          </template>
+        </div>
+
+        <label class="gsd-sublabel">Tools</label>
+        <div class="gsd-tool-list">
+          <label
+            v-for="tool in AVAILABLE_TOOLS"
+            :key="tool"
+            class="gsd-repo-row"
+            :class="{ selected: tools.includes(tool) }"
+          >
+            <input
+              type="checkbox"
+              :checked="tools.includes(tool)"
+              @change="toggleTool(tool)"
+              class="gsd-check"
+            />
+            <span class="gsd-repo-name">{{ tool }}</span>
+          </label>
+        </div>
+
+        <label class="gsd-sublabel">Agents</label>
+        <input
+          v-model.number="agentCount"
+          class="gsd-input gsd-input--narrow"
+          type="number"
+          min="1"
+          max="16"
+          placeholder="worker default"
+        />
+
+        <div class="gsd-actions">
+          <button class="pixel-btn gsd-save-btn" :disabled="saving" @click="save">
+            {{ saving ? 'Saving…' : 'Save' }}
+          </button>
+          <span v-if="status" class="save-status" :class="'save-status-' + status">
+            {{ status === 'saved' ? 'Saved' : 'Error' }}
+          </span>
+        </div>
+        <div v-if="errorMsg" class="gsd-error">{{ errorMsg }}</div>
+      </template>
+
+      <div v-else class="gsd-readonly">
+        <div class="gsd-ro-field">
+          <span class="gsd-ro-label">Repos</span>
+          <span class="gsd-ro-value">{{ repos.length ? repos.join(', ') : '—' }}</span>
+        </div>
+        <div class="gsd-ro-field">
+          <span class="gsd-ro-label">Tools</span>
+          <span class="gsd-ro-value">{{ tools.length ? tools.join(', ') : '—' }}</span>
+        </div>
+        <div class="gsd-ro-field">
+          <span class="gsd-ro-label">Agents</span>
+          <span class="gsd-ro-value">{{ agentCount ?? '—' }}</span>
+        </div>
+        <p class="gsd-hint">Only owners can change the guild spawn defaults.</p>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { api, ApiError } from '../utils/api'
+import { useAuthStore } from '../stores/auth'
+import { useGitHubStore } from '../stores/github'
+import { groupAndSortRepos } from '../utils/repoGroups'
+
+const AVAILABLE_TOOLS = ['claude', 'codex', 'pi'] as const
+
+interface SpawnDefaults {
+  repos: string[]
+  tools: string[]
+  agent_count: number | null
+}
+
+interface GuildMemberRow {
+  user_id: string
+  role: string
+}
+
+const props = defineProps<{ guildId: string }>()
+
+const authStore = useAuthStore()
+const ghStore = useGitHubStore()
+
+const loading = ref(true)
+const saving = ref(false)
+const status = ref<'' | 'saved' | 'error'>('')
+const errorMsg = ref('')
+
+const repos = ref<string[]>([])
+const tools = ref<string[]>([])
+const agentCount = ref<number | null>(null)
+const myRole = ref<string | null>(null)
+
+const canManage = computed(() => myRole.value === 'owner')
+const groupedRepos = computed(() => groupAndSortRepos(ghStore.repos))
+
+let statusTimer: ReturnType<typeof setTimeout> | null = null
+
+onMounted(async () => {
+  if (ghStore.repos.length === 0 && ghStore.token) {
+    try {
+      await ghStore.fetchRepos()
+    } catch {
+      /* non-fatal: repo checkboxes just won't render */
+    }
+  }
+  await Promise.all([loadRole(), loadDefaults()])
+  loading.value = false
+})
+
+async function loadRole() {
+  try {
+    const members = await api<GuildMemberRow[]>(
+      `/api/guilds/${encodeURIComponent(props.guildId)}/members`,
+    )
+    myRole.value = members.find((m) => m.user_id === authStore.user?.id)?.role ?? null
+  } catch {
+    myRole.value = null
+  }
+}
+
+async function loadDefaults() {
+  try {
+    const d = await api<SpawnDefaults>(`/guilds/${encodeURIComponent(props.guildId)}/spawn-defaults`)
+    repos.value = d.repos ?? []
+    tools.value = d.tools ?? []
+    agentCount.value = d.agent_count ?? null
+  } catch {
+    repos.value = []
+    tools.value = []
+    agentCount.value = null
+  }
+}
+
+function toggleRepo(fullName: string) {
+  const idx = repos.value.indexOf(fullName)
+  if (idx >= 0) repos.value.splice(idx, 1)
+  else repos.value.push(fullName)
+}
+
+function orgAllSelected(owner: string): boolean {
+  const rs = groupedRepos.value.find((g) => g.owner === owner)?.repos ?? []
+  return rs.length > 0 && rs.every((r) => repos.value.includes(r.full_name))
+}
+
+function orgSomeSelected(owner: string): boolean {
+  const rs = groupedRepos.value.find((g) => g.owner === owner)?.repos ?? []
+  return rs.some((r) => repos.value.includes(r.full_name))
+}
+
+function toggleOrg(owner: string) {
+  const rs = groupedRepos.value.find((g) => g.owner === owner)?.repos ?? []
+  if (orgAllSelected(owner)) {
+    const names = new Set(rs.map((r) => r.full_name))
+    repos.value = repos.value.filter((n) => !names.has(n))
+  } else {
+    for (const repo of rs) {
+      if (!repos.value.includes(repo.full_name)) repos.value.push(repo.full_name)
+    }
+  }
+}
+
+function setOrgCheckboxRef(el: HTMLInputElement | null, owner: string) {
+  if (el) el.indeterminate = orgSomeSelected(owner) && !orgAllSelected(owner)
+}
+
+function toggleTool(tool: string) {
+  const idx = tools.value.indexOf(tool)
+  if (idx >= 0) tools.value.splice(idx, 1)
+  else tools.value.push(tool)
+}
+
+async function save() {
+  saving.value = true
+  status.value = ''
+  errorMsg.value = ''
+  try {
+    const saved = await api<SpawnDefaults>(
+      `/guilds/${encodeURIComponent(props.guildId)}/spawn-defaults`,
+      {
+        method: 'PUT',
+        json: {
+          repos: repos.value,
+          tools: tools.value,
+          agent_count: agentCount.value ?? null,
+        },
+      },
+    )
+    repos.value = saved.repos ?? []
+    tools.value = saved.tools ?? []
+    agentCount.value = saved.agent_count ?? null
+    status.value = 'saved'
+  } catch (e) {
+    status.value = 'error'
+    errorMsg.value = e instanceof ApiError ? e.message : 'Failed to save'
+  } finally {
+    saving.value = false
+    if (statusTimer) clearTimeout(statusTimer)
+    statusTimer = setTimeout(() => {
+      status.value = ''
+    }, 2000)
+  }
+}
+</script>
+
+<style scoped>
+.gsd {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+}
+
+.gsd-intro {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  font-style: italic;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.gsd-sublabel {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-teal);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+.gsd-hint {
+  font-size: 10px;
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+
+.gsd-repo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 140px;
+  overflow-y: auto;
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+  background: var(--color-bg-secondary);
+}
+
+.gsd-tool-list {
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+  background: var(--color-bg-secondary);
+}
+
+.gsd-repo-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 7px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.1s;
+}
+
+.gsd-repo-row:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.gsd-repo-row.selected {
+  background: rgba(232, 170, 0, 0.08);
+  border-color: var(--color-brass-dark);
+}
+
+.gsd-org-row {
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-brass-dark);
+}
+
+.gsd-org-row.selected {
+  background: rgba(232, 170, 0, 0.12);
+}
+
+.gsd-org-name {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--color-teal);
+  letter-spacing: 0.5px;
+}
+
+.gsd-repo-indent {
+  padding-left: 22px;
+}
+
+.gsd-check {
+  accent-color: var(--color-brass);
+  width: 12px;
+  height: 12px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.gsd-repo-name {
+  font-size: 10px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gsd-input {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  padding: 5px 7px;
+  outline: none;
+  border-radius: 2px;
+  box-sizing: border-box;
+}
+
+.gsd-input:focus {
+  border-color: var(--color-brass);
+}
+
+.gsd-input--narrow {
+  width: 90px;
+}
+
+.gsd-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.gsd-save-btn {
+  font-size: 7px;
+  padding: 5px 9px;
+}
+
+.gsd-save-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.gsd-error {
+  font-size: 10px;
+  color: var(--color-red);
+  word-break: break-word;
+}
+
+.gsd-readonly {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.gsd-ro-field {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.gsd-ro-label {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass-dark);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  flex: 0 0 44px;
+}
+
+.gsd-ro-value {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--color-text);
+  word-break: break-word;
+}
+</style>

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -278,6 +278,14 @@
       </div>
 
       <div class="settings-field">
+        <label class="settings-label">Worker Spawn Defaults</label>
+        <button class="pixel-btn foreman-toggle-btn" @click="showSpawnDefaults = !showSpawnDefaults">
+          {{ showSpawnDefaults ? 'Hide' : 'Manage' }}
+        </button>
+        <GuildSpawnDefaults v-if="showSpawnDefaults" :guild-id="currentGuild.id" />
+      </div>
+
+      <div class="settings-field">
         <label class="settings-label">Members</label>
         <button class="pixel-btn foreman-toggle-btn" @click="showMembers = !showMembers">
           {{ showMembers ? 'Hide' : 'Manage' }}
@@ -304,6 +312,7 @@ import { useAuthStore } from '../stores/auth'
 import { useModels } from '../composables/useModels'
 import GitHubConfigModal from './GitHubConfigModal.vue'
 import GuildMembers from './GuildMembers.vue'
+import GuildSpawnDefaults from './GuildSpawnDefaults.vue'
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string) ?? ''
 
@@ -369,6 +378,7 @@ const claudeCredsConfirmDelete = ref(false)
 
 const showForemanConfig = ref(false)
 const showMembers = ref(false)
+const showSpawnDefaults = ref(false)
 const foremanModel = ref('')
 const foremanProvider = ref('')
 // Remember the model entered for each provider. Models are provider-specific
@@ -580,6 +590,7 @@ watch(
     claudeCredsConfirmDelete.value = false
     showForemanConfig.value = false
     showMembers.value = false
+    showSpawnDefaults.value = false
     foremanModel.value = ''
     foremanProvider.value = ''
     modelByProvider.value = {}

--- a/frontend/src/components/__tests__/GuildSpawnDefaults.spec.ts
+++ b/frontend/src/components/__tests__/GuildSpawnDefaults.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { flushPromises, mount } from '@vue/test-utils'
+import GuildSpawnDefaults from '../GuildSpawnDefaults.vue'
+import { useAuthStore } from '../../stores/auth'
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+interface Routes {
+  members?: unknown
+  defaults?: unknown
+}
+
+/** Dispatch fetch by URL so concurrent onMounted calls resolve deterministically. */
+function mockFetch(routes: Routes, onPut?: (body: unknown) => unknown) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = String(input)
+    if (url.includes('/members')) return Promise.resolve(jsonResponse(routes.members ?? []))
+    if (url.includes('/spawn-defaults')) {
+      if (init?.method === 'PUT') {
+        const body = init.body ? JSON.parse(init.body as string) : {}
+        return Promise.resolve(jsonResponse(onPut ? onPut(body) : body))
+      }
+      return Promise.resolve(jsonResponse(routes.defaults ?? {}))
+    }
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+function mountAs(userId: string) {
+  const auth = useAuthStore()
+  auth.user = { id: userId, login: 'me' }
+  auth.loginToken = 'tok'
+  return mount(GuildSpawnDefaults, { props: { guildId: 'g1' } })
+}
+
+describe('GuildSpawnDefaults', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows an editable form with a Save button to owners', async () => {
+    mockFetch({
+      members: [{ user_id: 'u-owner', role: 'owner' }],
+      defaults: { repos: [], tools: [], agent_count: null },
+    })
+    const wrapper = mountAs('u-owner')
+    await flushPromises()
+    expect(wrapper.find('.gsd-save-btn').exists()).toBe(true)
+    expect(wrapper.find('.gsd-readonly').exists()).toBe(false)
+  })
+
+  it('shows a read-only view to non-owners', async () => {
+    mockFetch({
+      members: [{ user_id: 'u-member', role: 'member' }],
+      defaults: { repos: ['a/b'], tools: ['claude'], agent_count: 3 },
+    })
+    const wrapper = mountAs('u-member')
+    await flushPromises()
+    expect(wrapper.find('.gsd-save-btn').exists()).toBe(false)
+    expect(wrapper.find('.gsd-readonly').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Only owners can change')
+    expect(wrapper.text()).toContain('a/b')
+  })
+
+  it('saves the edited defaults via PUT', async () => {
+    const put = vi.fn((body: unknown) => body)
+    mockFetch(
+      {
+        members: [{ user_id: 'u-owner', role: 'owner' }],
+        defaults: { repos: [], tools: ['claude'], agent_count: 2 },
+      },
+      put,
+    )
+    const wrapper = mountAs('u-owner')
+    await flushPromises()
+    await wrapper.find('.gsd-save-btn').trigger('click')
+    await flushPromises()
+    expect(put).toHaveBeenCalledOnce()
+    expect(put).toHaveBeenCalledWith({ repos: [], tools: ['claude'], agent_count: 2 })
+    expect(wrapper.find('.save-status-saved').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -44,6 +44,19 @@
           </label>
         </template>
       </div>
+      <div v-if="hasGuildDefaults" class="spawn-defaults-row">
+        <span class="spawn-defaults-note">
+          {{ usingGuildDefaults ? 'Prefilled from guild defaults' : 'Overriding guild defaults' }}
+        </span>
+        <button
+          v-if="!usingGuildDefaults"
+          class="spawn-defaults-reset"
+          type="button"
+          @click="resetToGuildDefaults"
+        >
+          Reset to guild defaults
+        </button>
+      </div>
       <label class="spawn-label">Name <span class="spawn-hint">(optional)</span></label>
       <input v-model="name" class="spawn-input" type="text" placeholder="auto-generated" />
       <label class="spawn-label">Tools <span class="spawn-hint">(optional)</span></label>
@@ -136,6 +149,14 @@ interface SpawnSettings {
   envVars?: EnvPair[]
 }
 
+interface GuildSpawnDefaults {
+  repos: string[]
+  tools: string[]
+  agent_count: number | null
+}
+
+const guildDefaults = ref<GuildSpawnDefaults | null>(null)
+const usingGuildDefaults = ref(false)
 const selectedRepos = ref<string[]>([])
 const name = ref('')
 const selectedTools = ref<string[]>([])
@@ -157,6 +178,41 @@ async function loadSavedSettings(guildId: string): Promise<SpawnSettings | null>
     return null
   }
 }
+
+async function loadGuildDefaults(guildId: string): Promise<GuildSpawnDefaults | null> {
+  try {
+    return await api<GuildSpawnDefaults>(`/guilds/${guildId}/spawn-defaults`)
+  } catch {
+    return null
+  }
+}
+
+/** Apply the guild defaults as the current form values, validating repos against
+ *  what GitHub actually returned. Used both for the initial pre-fill (when the
+ *  user has no saved overrides) and the explicit "reset to guild defaults" button. */
+function applyGuildDefaults(defaults: GuildSpawnDefaults) {
+  if (repoFetchFailed.value) {
+    selectedRepos.value = []
+  } else {
+    const availableRepoNames = new Set(ghStore.repos.map((r) => r.full_name))
+    selectedRepos.value = (defaults.repos ?? []).filter((r) => availableRepoNames.has(r))
+  }
+  selectedTools.value = [...(defaults.tools ?? [])]
+  agentCount.value = defaults.agent_count ?? null
+  usingGuildDefaults.value = true
+}
+
+function resetToGuildDefaults() {
+  if (guildDefaults.value) applyGuildDefaults(guildDefaults.value)
+}
+
+const hasGuildDefaults = computed(
+  () =>
+    !!guildDefaults.value &&
+    ((guildDefaults.value.repos?.length ?? 0) > 0 ||
+      (guildDefaults.value.tools?.length ?? 0) > 0 ||
+      guildDefaults.value.agent_count != null),
+)
 
 async function saveSettings(guildId: string) {
   try {
@@ -187,9 +243,13 @@ onMounted(async () => {
     }
   }
 
-  const saved = guild ? await loadSavedSettings(guild.id) : null
+  const [saved, defaults] = guild
+    ? await Promise.all([loadSavedSettings(guild.id), loadGuildDefaults(guild.id)])
+    : [null, null]
+  guildDefaults.value = defaults
 
   if (saved && (saved.repos?.length || saved.tools?.length || saved.envVars?.length)) {
+    // The user has their own saved overrides — those win over the guild baseline.
     if (saved.repos?.length) {
       if (repoFetchFailed.value) {
         // Fetch failed — cannot validate saved repos against available ones.
@@ -202,12 +262,16 @@ onMounted(async () => {
     }
     if (saved.tools?.length) selectedTools.value = saved.tools
     if (saved.envVars?.length) envVars.value = saved.envVars
+  } else if (defaults && hasGuildDefaults.value) {
+    // No personal overrides yet — start from the guild's spawn defaults.
+    applyGuildDefaults(defaults)
   } else {
     selectedRepos.value = repoFetchFailed.value ? [] : [...ghStore.selectedRepos]
   }
 })
 
 function toggleRepo(fullName: string) {
+  usingGuildDefaults.value = false
   const idx = selectedRepos.value.indexOf(fullName)
   if (idx >= 0) {
     selectedRepos.value.splice(idx, 1)
@@ -227,6 +291,7 @@ function orgSomeSelected(owner: string): boolean {
 }
 
 function toggleOrg(owner: string) {
+  usingGuildDefaults.value = false
   const repos = groupedRepos.value.find((g) => g.owner === owner)?.repos ?? []
   if (orgAllSelected(owner)) {
     const names = new Set(repos.map((r) => r.full_name))
@@ -247,6 +312,7 @@ function setOrgCheckboxRef(el: HTMLInputElement | null, owner: string) {
 }
 
 function toggleTool(tool: string) {
+  usingGuildDefaults.value = false
   const idx = selectedTools.value.indexOf(tool)
   if (idx >= 0) {
     selectedTools.value.splice(idx, 1)
@@ -466,6 +532,36 @@ async function launch() {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.spawn-defaults-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 2px 0;
+}
+
+.spawn-defaults-note {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  font-style: italic;
+}
+
+.spawn-defaults-reset {
+  background: none;
+  border: none;
+  color: var(--color-teal);
+  cursor: pointer;
+  font-family: var(--font-mono, monospace);
+  font-size: 9px;
+  padding: 0;
+  text-decoration: underline;
+  flex-shrink: 0;
+}
+
+.spawn-defaults-reset:hover {
+  color: var(--color-brass-light);
 }
 
 .spawn-env-hint {


### PR DESCRIPTION
Add an owner-facing surface for the guild-level worker spawn baseline
(guild_spawn_defaults) and wire the per-user spawn form to inherit and
override it.

Backend:
- New GET/PUT /guilds/{id}/spawn-defaults endpoints. GET is readable by any
  member (the spawn form pre-fills from it); PUT is owner-only and full-replace,
  with agent_count validated to 1..16.
- set_guild_spawn_defaults() upserts the row directly, letting an owner curate
  the baseline instead of waiting for the next successful spawn to record it.

Frontend:
- GuildSpawnDefaults.vue: repos/tools/agents editor in the Guild Settings
  popover; editable for owners, read-only summary for everyone else.
- SpawnWorkerForm.vue: fetches the guild defaults and uses them as the baseline
  when the user has no personal saved settings, with a "Reset to guild defaults"
  affordance and a prefilled/overriding indicator. Personal saved settings still
  take precedence.

Tests: backend endpoint coverage (roundtrip, full-replace clear, agent_count
validation, owner-only) and a GuildSpawnDefaults component spec.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ALZcv9ygR1ZbyRmjbcdkrA