### PR TITLE
feat(discord): keep spawn worker popup live until worker comes online

### DIFF
--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -33,6 +33,7 @@ Registered slash commands (see scripts/register_discord_commands.py):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import math
@@ -62,6 +63,7 @@ from models import (
 from oauth import FRONTEND_URL
 from sqlalchemy import func, update
 from sqlmodel import col, select
+from util.tasks import spawn
 from ws_types import TaskCancelMsg, TaskCreatedMsg, TaskUpdateMsg
 
 logger = logging.getLogger(__name__)
@@ -90,6 +92,14 @@ _CONNECT_TOKEN_TTL = timedelta(minutes=15)
 _MANAGE_CHANNELS_BIT = 0x10
 
 _DEFAULT_OPERATOR_ROLE_NAME = "Pioneer Square Operator"
+
+# How long to keep polling a freshly-spawned worker's state before giving up
+# on updating the Discord popup in place. 5 minutes comfortably covers a cold
+# ECS container start (image pull + boot + gateway handshake) — see issue #991.
+_WORKER_ONLINE_TIMEOUT = timedelta(minutes=5)
+
+# Interval between worker-state polls while awaiting the online transition.
+_WORKER_ONLINE_POLL_INTERVAL = 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -748,7 +758,27 @@ async def _cmd_worker_spawn(interaction: dict) -> None:
         return
 
     status = state if state == "online" else "queued"
-    embeds = [
+    await _send_followup(token, embeds=_worker_spawn_embed(worker_id, status, repos, tools_list))
+
+    # The popup above reflects a point-in-time check; the worker is typically
+    # still mid-ECS-startup at this point. Keep polling in the background and
+    # edit the same message in place once the outcome is known, instead of
+    # leaving the popup stuck on "queued" — see issue #991.
+    if status != "online":
+        spawn(
+            _await_worker_online(token, worker_id, repos, tools_list),
+            name=f"discord-await-worker-online-{worker_id}",
+        )
+
+
+def _worker_spawn_embed(
+    worker_id: str, status: str, repos: list[str], tools_list: list[str]
+) -> list[dict]:
+    color = {
+        "online": 0x1ABC9C,  # teal, matches discord_notifier's "worker-online"
+        "offline": 0xE74C3C,  # red — spawn failed, or the worker dropped before joining
+    }.get(status, 0xF39C12)  # gold — still queued/starting
+    return [
         {
             "title": f"Worker Spawned: {worker_id}",
             "description": (
@@ -756,11 +786,55 @@ async def _cmd_worker_spawn(interaction: dict) -> None:
                 f"Repos: {', '.join(repos) if repos else '—'}\n"
                 f"Tools: {', '.join(tools_list) if tools_list else 'default'}"
             ),
-            "color": 0xF39C12,
+            "color": color,
             "timestamp": datetime.now(UTC).isoformat(),
         }
     ]
-    await _send_followup(token, embeds=embeds)
+
+
+async def _await_worker_online(
+    token: str, worker_id: str, repos: list[str], tools_list: list[str]
+) -> None:
+    """Poll a freshly-spawned worker's state and update the Discord popup in place.
+
+    Runs as a background task (see ``util.tasks.spawn``) so the interaction
+    handler itself doesn't block on ECS container startup. Discord follow-up
+    messages have no server-side expiry, so editing ``@original`` once the
+    worker actually reports online (or goes offline before joining) replaces
+    the transient "queued" status with the real outcome, rather than leaving
+    the popup looking stale for the ~minute a cold container takes to start.
+    Gives up after ``_WORKER_ONLINE_TIMEOUT`` and reports a timeout message.
+    """
+    deadline = asyncio.get_event_loop().time() + _WORKER_ONLINE_TIMEOUT.total_seconds()
+    try:
+        while asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(_WORKER_ONLINE_POLL_INTERVAL)
+            async with AsyncSessionLocal() as db:
+                state_result = await db.exec(
+                    select(col(Worker.state)).where(col(Worker.id) == worker_id)
+                )
+                state = state_result.one_or_none()
+            if state == "online":
+                await _send_followup(
+                    token, embeds=_worker_spawn_embed(worker_id, "online", repos, tools_list)
+                )
+                return
+            if state == "offline":
+                await _send_followup(
+                    token, embeds=_worker_spawn_embed(worker_id, "offline", repos, tools_list)
+                )
+                return
+    except Exception:
+        logger.exception("discord: _await_worker_online failed for worker_id=%s", worker_id)
+        return
+
+    await _send_followup(
+        token,
+        content=(
+            f"Worker `{worker_id}` is taking longer than expected to come online "
+            "(ECS container may still be starting). Check `/ps workers` for current status."
+        ),
+    )
 
 
 async def _permission_denied_message() -> str:

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -892,9 +892,7 @@ async def test_await_worker_online_times_out(monkeypatch):
     mock_db = AsyncMock()
     mock_db.__aenter__ = AsyncMock(return_value=mock_db)
     mock_db.__aexit__ = AsyncMock(return_value=False)
-    mock_db.exec = AsyncMock(
-        return_value=MagicMock(one_or_none=MagicMock(return_value="spawning"))
-    )
+    mock_db.exec = AsyncMock(return_value=MagicMock(one_or_none=MagicMock(return_value="spawning")))
 
     sent = []
 

--- a/backend/tests/test_discord_interactions.py
+++ b/backend/tests/test_discord_interactions.py
@@ -835,6 +835,85 @@ async def test_cmd_worker_spawn_cooldown_active(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# _await_worker_online — background poller that keeps the spawn popup updated
+# until the worker actually joins (see issue #991)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_await_worker_online_updates_message_once_joined(monkeypatch):
+    """_await_worker_online edits the popup to 'online' once the worker joins."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    import routes.discord as discord_routes
+
+    monkeypatch.setattr(discord_routes, "_WORKER_ONLINE_POLL_INTERVAL", 0)
+    monkeypatch.setattr(discord_routes, "_WORKER_ONLINE_TIMEOUT", timedelta(seconds=5))
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        side_effect=[
+            MagicMock(one_or_none=MagicMock(return_value="spawning")),  # still starting up
+            MagicMock(one_or_none=MagicMock(return_value="online")),  # joined
+        ]
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("discord_notifier.patch", new=fake_patch),
+    ):
+        await discord_routes._await_worker_online("tok-spawn", "w-abc123", ["org/repo"], ["claude"])
+
+    assert sent
+    embed = sent[-1]["embeds"][0]
+    assert "w-abc123" in embed["title"]
+    assert "online" in embed["description"]
+
+
+@pytest.mark.asyncio
+async def test_await_worker_online_times_out(monkeypatch):
+    """_await_worker_online reports a timeout instead of polling forever."""
+    monkeypatch.setenv("DISCORD_APPLICATION_ID", "app-id")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+    import routes.discord as discord_routes
+
+    monkeypatch.setattr(discord_routes, "_WORKER_ONLINE_POLL_INTERVAL", 0)
+    monkeypatch.setattr(discord_routes, "_WORKER_ONLINE_TIMEOUT", timedelta(seconds=0))
+
+    mock_db = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+    mock_db.exec = AsyncMock(
+        return_value=MagicMock(one_or_none=MagicMock(return_value="spawning"))
+    )
+
+    sent = []
+
+    async def fake_patch(path, payload):
+        sent.append(payload)
+
+    with (
+        patch("routes.discord.AsyncSessionLocal", return_value=mock_db),
+        patch("discord_notifier.patch", new=fake_patch),
+    ):
+        await discord_routes._await_worker_online("tok-spawn", "w-abc123", ["org/repo"], ["claude"])
+
+    mock_db.exec.assert_not_called()
+    assert sent
+    assert "w-abc123" in sent[0]["content"]
+    assert "taking longer" in sent[0]["content"]
+
+
+# ---------------------------------------------------------------------------
 # Permission helpers for /join-channel and /leave-channel (pure unit)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Closes #991 — the Discord "spawn worker w-xxx" popup previously showed a single point-in-time status and never updated, so it looked stale/timed-out during ECS container startup.
- After the initial follow-up message, spawns a background task (`_await_worker_online`) that polls the worker's state every 5s for up to 5 minutes and edits the same Discord message in place once the worker transitions to `online` (success) or `offline` (spawn failed), matching the acceptance criteria in #991.
- If the worker still hasn't come online after the 5-minute timeout, the popup is updated with a message telling the user to check `/ps workers`, rather than leaving it silently stuck.
- Extracted the embed construction into `_worker_spawn_embed` so both the initial message and the background updates render consistent status colors (gold = queued/starting, teal = online, red = offline).

## Test plan
- [x] `backend/tests/test_discord_interactions.py` covers the new polling/update behavior
- [ ] Manual: spawn a worker via `/ps spawn` in Discord and confirm the popup updates to "online" once the worker joins

🤖 Generated with [Claude Code](https://claude.com/claude-code)