### PR TITLE
feat(foreman): scope child send_followup/redirect_task to own task

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1317,20 +1317,29 @@ def _full_log_content(data_json: str | None) -> str | None:
 
 
 def _task_mutation_blocked(guild_id: str, task_id: str, own_task_id: str | None) -> str | None:
-    """Return a user-facing message if *task_id* is owned by a different in-flight
-    Foreman context right now, else None.
+    """Return a user-facing message if *task_id* cannot be mutated right now, else None.
 
     ``own_task_id`` is the task_id of the per-task child context this tool
     call is itself running in (None for a parent/whole-guild run). A run
-    never conflicts with its own per-task lock — this only fires when a
-    *different* context holds it, which in practice means a parent run
-    (periodic-check or human chat) reaching into a task whose own child run
-    is currently mutating it. See issue #927: parent and child runs key on
-    different (guild_id, key) pairs and would otherwise never serialise
-    against each other for the same task.
+    never conflicts with its own per-task lock or scope — this only fires
+    for a *different* task_id, in two cases:
+
+    1. A per-task child context (``own_task_id`` set) is scoped to its own
+       task only (see docs/foreman-per-task-context.md, issue #997) — it
+       must not reach into another task's lifecycle, which stays the parent
+       Foreman's job.
+    2. A parent run (periodic-check or human chat) reaching into a task
+       whose own child run is currently mutating it. See issue #927: parent
+       and child runs key on different (guild_id, key) pairs and would
+       otherwise never serialise against each other for the same task.
     """
     if own_task_id == task_id:
         return None
+    if own_task_id is not None:
+        return (
+            f"This is a task-scoped child Foreman context for {own_task_id} — it cannot "
+            f"act on task {task_id}. Only the parent Foreman can manage other tasks."
+        )
     from foreman.runner import is_child_task_run_active  # noqa: PLC0415 — avoids circular import
 
     if is_child_task_run_active(guild_id, task_id):

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -1997,6 +1997,136 @@ class TestExecToolsDispatching:
         assert ev is None, "No pending-followup event should be queued — follow-up was dispatched"
 
 
+class TestChildForemanFollowupAndRedirect:
+    """Per-task child Foreman contexts must be able to call send_followup and
+    redirect_task on their own task (issue #997), and must not be able to
+    reach into a different task's lifecycle from within that scoped context.
+
+    ``own_task_id`` mirrors what ``run_foreman_ai(child=True, task_id=...)``
+    passes through to ``exec_tools`` for a real child turn.
+    """
+
+    async def test_child_context_send_followup_succeeds_on_own_task(self, db_session):
+        insert_guild(db_session, "g-child-fu-ok")
+        _insert_worker(db_session, "g-child-fu-ok", "w-child1")
+        _insert_agent(db_session, "g-child-fu-ok", "w-child1", "a-child1")
+        _insert_task(db_session, "t-child-fu", "g-child-fu-ok", "w-child1")
+        broadcast_calls = []
+
+        async def capture(gid, msg):
+            broadcast_calls.append(msg)
+
+        with patch("foreman.tools.broadcast", side_effect=capture):
+            results = await exec_tools(
+                "g-child-fu-ok",
+                [
+                    _fake_tool_use(
+                        "send_followup",
+                        {"task_id": "t-child-fu", "instructions": "Add more tests"},
+                    )
+                ],
+                own_task_id="t-child-fu",
+            )
+
+        assert results[0].get("is_error") is not True
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        assert len(followup_msgs) == 1
+        assert followup_msgs[0]["instructions"] == "Add more tests"
+
+    async def test_child_context_redirect_task_succeeds_on_own_task(self, db_session):
+        insert_guild(db_session, "g-child-redir-ok")
+        _insert_worker(db_session, "g-child-redir-ok", "w-child2")
+        _insert_task(db_session, "t-child-redir", "g-child-redir-ok", "w-child2", state="working")
+
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-child-redir-ok",
+                [
+                    _fake_tool_use(
+                        "redirect_task",
+                        {"task_id": "t-child-redir", "instructions": "New direction"},
+                    )
+                ],
+                own_task_id="t-child-redir",
+            )
+
+        assert results[0].get("is_error") is not True
+        assert "redirect" in results[0]["content"].lower()
+
+    async def test_child_context_send_followup_rejected_on_other_task(self, db_session):
+        """A child scoped to t-child-own must not be able to send_followup on
+        some other task t-other, even if that other task exists and is free."""
+        insert_guild(db_session, "g-child-fu-scope")
+        _insert_worker(db_session, "g-child-fu-scope", "w-child3")
+        _insert_agent(db_session, "g-child-fu-scope", "w-child3", "a-child3")
+        _insert_task(db_session, "t-child-own", "g-child-fu-scope", "w-child3")
+        _insert_task(db_session, "t-other", "g-child-fu-scope", "w-child3")
+        broadcast_calls = []
+
+        async def capture(gid, msg):
+            broadcast_calls.append(msg)
+
+        with patch("foreman.tools.broadcast", side_effect=capture):
+            results = await exec_tools(
+                "g-child-fu-scope",
+                [
+                    _fake_tool_use(
+                        "send_followup",
+                        {"task_id": "t-other", "instructions": "Do this instead"},
+                    )
+                ],
+                own_task_id="t-child-own",
+            )
+
+        assert results[0].get("is_error") is True
+        assert "task-scoped" in results[0]["content"].lower()
+        followup_msgs = [m for m in broadcast_calls if m.get("type") == "task-followup"]
+        assert len(followup_msgs) == 0
+
+    async def test_child_context_redirect_task_rejected_on_other_task(self, db_session):
+        insert_guild(db_session, "g-child-redir-scope")
+        _insert_worker(db_session, "g-child-redir-scope", "w-child4")
+        _insert_task(db_session, "t-child-own2", "g-child-redir-scope", "w-child4", state="working")
+        _insert_task(db_session, "t-other2", "g-child-redir-scope", "w-child4", state="working")
+
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock) as mock_broadcast:
+            results = await exec_tools(
+                "g-child-redir-scope",
+                [
+                    _fake_tool_use(
+                        "redirect_task",
+                        {"task_id": "t-other2", "instructions": "New direction"},
+                    )
+                ],
+                own_task_id="t-child-own2",
+            )
+
+        assert results[0].get("is_error") is True
+        assert "task-scoped" in results[0]["content"].lower()
+        mock_broadcast.assert_not_called()
+
+    async def test_parent_context_still_allowed_to_redirect_any_task(self, db_session):
+        """Baseline: a parent/whole-guild run (own_task_id=None) is unaffected by
+        the child-scope restriction and can still redirect any task in the guild."""
+        insert_guild(db_session, "g-parent-redirect")
+        _insert_worker(db_session, "g-parent-redirect", "w-parent1")
+        _insert_task(db_session, "t-parent-any", "g-parent-redirect", "w-parent1", state="working")
+
+        with patch("foreman.tools.broadcast", new_callable=AsyncMock):
+            results = await exec_tools(
+                "g-parent-redirect",
+                [
+                    _fake_tool_use(
+                        "redirect_task",
+                        {"task_id": "t-parent-any", "instructions": "New direction"},
+                    )
+                ],
+            )
+
+        assert results[0].get("is_error") is not True
+        assert "redirect" in results[0]["content"].lower()
+
+
 class TestFinalizeClosedIssueAtomicity:
     """finalize_closed_issue (backend/foreman/tools.py) guards against a lost-update
     race (jmelloy/pioneer-square#851, PR #848 review) by making the terminal-state

--- a/docs/foreman-per-task-context.md
+++ b/docs/foreman-per-task-context.md
@@ -65,6 +65,13 @@ create or assign new work. The child state preamble includes only the relevant
 task and assigned worker, keeping review context small and free of unrelated
 task history.
 
+`send_followup` and `redirect_task` are scoped to the child's own task
+(issue [#997](https://github.com/jmelloy/pioneer-square/issues/997)):
+`_task_mutation_blocked()` in `backend/foreman/tools.py` rejects a call whose
+`task_id` differs from the child's own, so a per-task child context can course
+correct or continue its own task but cannot reach into another task's
+lifecycle — that stays the parent Foreman's job.
+
 ---
 
 ## Operational Notes


### PR DESCRIPTION
## Summary
- Closes #997. `CHILD_FOREMAN_TOOLS` already exposed `send_followup` and `redirect_task` to per-task child Foreman contexts, but `_task_mutation_blocked()` in `backend/foreman/tools.py` only guarded against a *parent* run racing a child's own task — it did not stop a child context from calling these tools against a *different* task_id in the same guild.
- Added an explicit scope check: a per-task child context (`own_task_id` set) can now only mutate its own task; any other `task_id` is rejected with a task-scoped error message. Parent/whole-guild runs (`own_task_id=None`) are unaffected.
- Documented the new authorization boundary in `docs/foreman-per-task-context.md`.

## Test plan
- [x] `python -m pytest tests/test_foreman.py -k ChildForemanFollowupAndRedirect -v` — 5 new tests covering: child `send_followup` on own task (succeeds), child `redirect_task` on own task (succeeds), child `send_followup` on another task (rejected), child `redirect_task` on another task (rejected), parent `redirect_task` on any task (baseline, unaffected)
- [x] `python -m pytest tests/test_foreman.py` — full suite, 155 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)