### PR TITLE
feat: expose guild spawn credentials in UI

### DIFF
--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -21,7 +21,7 @@ from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg, emit_terminal_line, pending_claude_auth
 from fastapi import APIRouter, Depends, HTTPException
-from models import Guild, Task, UserSpawnSettings, Worker, live_tasks_filter
+from models import ClaudeCredentials, Guild, Task, UserSpawnSettings, Worker, live_tasks_filter
 from pydantic import BaseModel, field_validator
 from sqlalchemy import update
 from sqlmodel import col, select
@@ -29,6 +29,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from util.tasks import spawn
 from utils import (
     build_spawn_worker_env,
+    mask_secret,
     row_to_dict,
     worker_display_name,
 )
@@ -69,6 +70,10 @@ class SpawnWorkerRequest(BaseModel):
     tools: list[str] | None = None
     agent_count: int | None = None
     env_vars: dict[str, str] | None = None
+    # Guild-level foreman_config.env_vars keys to drop from this spawn only (the
+    # guild's stored credentials are unchanged). Lets an operator see what a
+    # worker would inherit and opt individual ones out for a single launch.
+    exclude_env_keys: list[str] | None = None
 
     @field_validator("env_vars")
     @classmethod
@@ -85,6 +90,20 @@ class SpawnWorkerRequest(BaseModel):
             if len(value) > _MAX_ENV_VALUE_LEN:
                 raise ValueError(
                     f"Env var value for {key!r} exceeds max length ({_MAX_ENV_VALUE_LEN} chars)"
+                )
+        return v
+
+    @field_validator("exclude_env_keys")
+    @classmethod
+    def validate_exclude_env_keys(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return v
+        if len(v) > _MAX_ENV_VARS:
+            raise ValueError(f"Too many excluded env keys (max {_MAX_ENV_VARS})")
+        for key in v:
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+                raise ValueError(
+                    f"Invalid env var key: {key!r}. Keys must match ^[A-Za-z_][A-Za-z0-9_]*$"
                 )
         return v
 
@@ -202,6 +221,9 @@ async def spawn_worker_container(
         for e in (guild_cfg.get("env_vars") or [])
         if e.get("key") and e.get("value") is not None
     }
+    if data.exclude_env_keys:
+        excluded_keys = set(data.exclude_env_keys)
+        foreman_env_vars = {k: v for k, v in foreman_env_vars.items() if k not in excluded_keys}
     # User-supplied vars at spawn time override guild defaults.
     extra_env: dict[str, str] = {**foreman_env_vars, **(data.env_vars or {})}
 
@@ -272,6 +294,44 @@ async def spawn_worker_container(
         "worker_id": worker_id,
         "container_id": spawned.short_id,
         "runtime": spawned.runtime,
+    }
+
+
+@router.get("/guilds/{guild_id}/spawn-credentials")
+async def get_spawn_credentials(
+    guild_id: str,
+    github_user_id: str = Depends(require_member()),
+    db: AsyncSession = Depends(get_db_dep),
+):
+    """Return masked credential status for the spawn form — never raw values.
+
+    Covers the two credential sources a spawned worker inherits: the guild's
+    ``foreman_config.env_vars`` (merged into every spawn unless excluded via
+    ``exclude_env_keys`` on POST /spawn-worker) and the guild's stored Claude
+    OAuth credentials. Lets an operator see, before launching, what a worker
+    will have access to without exposing the underlying secret values.
+    """
+    guild_pk = await get_guild_pk(db, guild_id)
+    if guild_pk is None:
+        raise HTTPException(status_code=404, detail="Guild not found")
+    guild_res = await db.exec(select(Guild).where(col(Guild.id) == guild_pk))
+    guild = guild_res.one()
+    config = guild.foreman_config or {}
+    guild_env_vars = [
+        {"key": e["key"], "masked_value": mask_secret(e.get("value") or "")}
+        for e in (config.get("env_vars") or [])
+        if e.get("key")
+    ]
+    creds_result = await db.exec(
+        select(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)
+    )
+    creds_row = creds_result.one_or_none()
+    return {
+        "guild_env_vars": guild_env_vars,
+        "claude_credentials": {
+            "saved": creds_row is not None,
+            "updated_at": creds_row.updated_at.isoformat() if creds_row else None,
+        },
     }
 
 

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -10,8 +10,9 @@ sys.path.insert(0, os.path.dirname(__file__))
 from datetime import UTC, datetime, timedelta
 
 from helpers import _sync_session, insert_guild, insert_member, make_auth_token
-from models import Agent, Guild, GuildSpawnDefaults, User, Worker
+from models import Agent, ClaudeCredentials, Guild, GuildSpawnDefaults, User, Worker
 from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col  # noqa: E402
 
 
@@ -354,6 +355,122 @@ def test_put_spawn_defaults_requires_owner(client):
         json={"repos": ["a/b"], "tools": [], "agent_count": 2},
     )
     assert resp.status_code == 403
+
+
+def test_get_spawn_credentials_empty(client):
+    """A guild with no foreman env vars and no Claude credentials reports both as unset."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-cred1")
+    resp = test_client.get("/guilds/guild-cred1/spawn-credentials", headers=_auth(db_url))
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "guild_env_vars": [],
+        "claude_credentials": {"saved": False, "updated_at": None},
+    }
+
+
+def test_get_spawn_credentials_masks_guild_env_var_values(client):
+    """Guild foreman env var values are never returned in the clear from this endpoint."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-cred2")
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-cred2"))
+        session.execute(
+            update(Guild)
+            .where(col(Guild.id) == guild_pk)
+            .values(
+                foreman_config={
+                    "env_vars": [{"key": "ANTHROPIC_API_KEY", "value": "sk-ant-supersecretvalue"}]
+                }
+            )
+        )
+        session.commit()
+    resp = test_client.get("/guilds/guild-cred2/spawn-credentials", headers=_auth(db_url))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["guild_env_vars"] == [{"key": "ANTHROPIC_API_KEY", "masked_value": "sk…alue"}]
+    assert "sk-ant-supersecretvalue" not in resp.text
+
+
+def test_get_spawn_credentials_reports_claude_creds_saved(client):
+    test_client, db_url = client
+    insert_guild(db_url, "guild-cred3")
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-cred3"))
+        session.execute(
+            pg_insert(ClaudeCredentials).values(
+                guild_id=guild_pk,
+                credentials_blob="ignored-for-this-test",
+                updated_at=datetime.now(UTC),
+            )
+        )
+        session.commit()
+    resp = test_client.get("/guilds/guild-cred3/spawn-credentials", headers=_auth(db_url))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["claude_credentials"]["saved"] is True
+    assert body["claude_credentials"]["updated_at"] is not None
+    # The raw blob is never part of the response.
+    assert "ignored-for-this-test" not in resp.text
+
+
+def test_spawn_worker_excludes_selected_guild_env_keys(client, monkeypatch):
+    """exclude_env_keys drops those guild-level credentials from this spawn only."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-cred4")
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-cred4"))
+        session.execute(
+            update(Guild)
+            .where(col(Guild.id) == guild_pk)
+            .values(
+                foreman_config={
+                    "env_vars": [
+                        {"key": "ANTHROPIC_API_KEY", "value": "keep-me"},
+                        {"key": "OPENAI_API_KEY", "value": "drop-me"},
+                    ]
+                }
+            )
+        )
+        session.commit()
+
+    import worker_runtime
+
+    captured_env: dict = {}
+
+    async def fake_check_runtime_available():
+        return None
+
+    async def fake_start_worker_container(*, env, guild_id):
+        captured_env.update(env)
+        return worker_runtime.SpawnedWorker(handle="fake-handle", short_id="fakehandle12", runtime="docker")
+
+    monkeypatch.setattr(worker_runtime, "check_runtime_available", fake_check_runtime_available)
+    monkeypatch.setattr(worker_runtime, "start_worker_container", fake_start_worker_container)
+
+    resp = test_client.post(
+        "/guilds/guild-cred4/spawn-worker",
+        headers=_auth(db_url),
+        json={"repos": ["a/b"], "exclude_env_keys": ["OPENAI_API_KEY"]},
+    )
+    assert resp.status_code == 200
+    assert captured_env.get("ANTHROPIC_API_KEY") == "keep-me"
+    assert "OPENAI_API_KEY" not in captured_env
+    # The guild's stored credential is untouched — only this spawn skipped it.
+    stored = test_client.get("/guilds/guild-cred4/spawn-credentials", headers=_auth(db_url))
+    stored_keys = {e["key"] for e in stored.json()["guild_env_vars"]}
+    assert stored_keys == {"ANTHROPIC_API_KEY", "OPENAI_API_KEY"}
+
+
+def test_spawn_worker_rejects_invalid_exclude_env_key(client):
+    test_client, db_url = client
+    insert_guild(db_url, "guild-cred5")
+    resp = test_client.post(
+        "/guilds/guild-cred5/spawn-worker",
+        headers=_auth(db_url),
+        json={"repos": ["a/b"], "exclude_env_keys": ["not a valid key"]},
+    )
+    assert resp.status_code == 422
 
 
 def test_spawn_worker_env_does_not_inject_claude_oauth_token():

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -443,7 +443,9 @@ def test_spawn_worker_excludes_selected_guild_env_keys(client, monkeypatch):
 
     async def fake_start_worker_container(*, env, guild_id):
         captured_env.update(env)
-        return worker_runtime.SpawnedWorker(handle="fake-handle", short_id="fakehandle12", runtime="docker")
+        return worker_runtime.SpawnedWorker(
+            handle="fake-handle", short_id="fakehandle12", runtime="docker"
+        )
 
     monkeypatch.setattr(worker_runtime, "check_runtime_available", fake_check_runtime_available)
     monkeypatch.setattr(worker_runtime, "start_worker_container", fake_start_worker_container)

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -30,6 +30,20 @@ def row_to_dict(obj) -> dict:
     return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
 
 
+def mask_secret(value: str) -> str:
+    """Mask a credential value for display, revealing only a short prefix/suffix.
+
+    Never returns enough of the original value to reconstruct it — callers that
+    need the real value (e.g. injecting it into a worker's env) must fetch it
+    through its own unmasked source, not this helper's output.
+    """
+    if not value:
+        return ""
+    if len(value) <= 8:
+        return "•" * len(value)
+    return f"{value[:2]}…{value[-4:]}"
+
+
 def _slugify(name: str) -> str:
     """Lowercase, normalize unicode, replace non-alphanumeric runs with '-'."""
     normalized = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -85,6 +85,42 @@
         max="16"
         placeholder="4"
       />
+      <label class="spawn-label">Guild Credentials <span class="spawn-hint">(optional)</span></label>
+      <div v-if="credentialsLoading" class="spawn-hint-text">Loading credentials…</div>
+      <div v-else-if="credentialsError" class="spawn-error">{{ credentialsError }}</div>
+      <div v-else-if="!hasCredentials" class="spawn-hint-text">No guild credentials configured.</div>
+      <template v-else>
+        <div class="spawn-cred-list">
+          <label
+            v-for="cred in credentials!.guild_env_vars"
+            :key="cred.key"
+            class="spawn-repo-row spawn-cred-row"
+            :class="{ selected: includedKeys[cred.key] !== false }"
+          >
+            <input
+              type="checkbox"
+              :checked="includedKeys[cred.key] !== false"
+              @change="toggleCredential(cred.key)"
+              class="spawn-repo-check"
+            />
+            <span class="spawn-repo-name spawn-cred-key">{{ cred.key }}</span>
+            <span class="spawn-cred-value">{{ cred.masked_value }}</span>
+          </label>
+          <div class="spawn-repo-row spawn-cred-row spawn-cred-claude">
+            <span
+              class="spawn-cred-status"
+              :class="{ 'spawn-cred-status--ok': credentials!.claude_credentials.saved }"
+            >
+              {{ credentials!.claude_credentials.saved ? '●' : '○' }}
+            </span>
+            <span class="spawn-repo-name">Claude OAuth credentials</span>
+            <span class="spawn-cred-value">
+              {{ credentials!.claude_credentials.saved ? 'configured' : 'not configured' }}
+            </span>
+          </div>
+        </div>
+        <p class="spawn-env-hint">Uncheck a credential to exclude it from this launch only.</p>
+      </template>
       <label class="spawn-label">Env Vars <span class="spawn-hint">(optional)</span></label>
       <p class="spawn-env-hint">
         Key-value pairs are saved to the server and restored each session.
@@ -155,6 +191,18 @@ interface GuildSpawnDefaults {
   agent_count: number | null
 }
 
+interface GuildEnvVarStatus {
+  key: string
+  masked_value: string
+}
+
+interface SpawnCredentials {
+  guild_env_vars: GuildEnvVarStatus[]
+  claude_credentials: { saved: boolean; updated_at: string | null }
+}
+
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+
 const guildDefaults = ref<GuildSpawnDefaults | null>(null)
 const usingGuildDefaults = ref(false)
 const selectedRepos = ref<string[]>([])
@@ -168,6 +216,23 @@ const loadingRepos = ref(false)
 const repoFetchFailed = ref(false)
 const launched = ref(false)
 const launchedWorkerId = ref('')
+const credentials = ref<SpawnCredentials | null>(null)
+const credentialsLoading = ref(false)
+const credentialsError = ref('')
+// Per-key opt-out for this launch only; a key defaults to included until unchecked.
+const includedKeys = ref<Record<string, boolean>>({})
+
+const hasCredentials = computed(
+  () =>
+    !!credentials.value &&
+    (credentials.value.guild_env_vars.length > 0 || credentials.value.claude_credentials.saved),
+)
+
+const excludeEnvKeys = computed(() =>
+  (credentials.value?.guild_env_vars ?? [])
+    .map((c) => c.key)
+    .filter((key) => includedKeys.value[key] === false),
+)
 
 const groupedRepos = computed(() => groupAndSortRepos(ghStore.repos))
 
@@ -185,6 +250,45 @@ async function loadGuildDefaults(guildId: string): Promise<GuildSpawnDefaults | 
   } catch {
     return null
   }
+}
+
+async function loadCredentials(guildId: string) {
+  credentialsLoading.value = true
+  credentialsError.value = ''
+  try {
+    const result = await api<SpawnCredentials>(`/guilds/${guildId}/spawn-credentials`)
+    credentials.value = result
+    for (const cred of result.guild_env_vars) {
+      if (!(cred.key in includedKeys.value)) includedKeys.value[cred.key] = true
+    }
+  } catch (e: unknown) {
+    credentialsError.value = e instanceof Error ? e.message : 'Failed to load credentials'
+  } finally {
+    credentialsLoading.value = false
+  }
+}
+
+function toggleCredential(key: string) {
+  includedKeys.value[key] = includedKeys.value[key] === false ? true : false
+}
+
+/** Mirrors the backend's env-key regex (`SpawnWorkerRequest`) so bad keys are
+ *  caught before the request round-trip, and flags client-only duplicate keys
+ *  the backend wouldn't otherwise reject (a later dict entry silently wins). */
+function validateEnvVars(): string | null {
+  const seen = new Set<string>()
+  for (const pair of envVars.value) {
+    const key = pair.key.trim()
+    if (key === '') continue
+    if (!ENV_KEY_PATTERN.test(key)) {
+      return `Invalid env var key "${key}" — use letters, numbers, and underscores, starting with a letter or underscore.`
+    }
+    if (seen.has(key)) {
+      return `Duplicate env var key "${key}".`
+    }
+    seen.add(key)
+  }
+  return null
 }
 
 /** Apply the guild defaults as the current form values, validating repos against
@@ -247,6 +351,11 @@ onMounted(async () => {
     ? await Promise.all([loadSavedSettings(guild.id), loadGuildDefaults(guild.id)])
     : [null, null]
   guildDefaults.value = defaults
+
+  if (guild) {
+    // Fire-and-forget: credential status isn't needed to render the rest of the form.
+    loadCredentials(guild.id)
+  }
 
   if (saved && (saved.repos?.length || saved.tools?.length || saved.envVars?.length)) {
     // The user has their own saved overrides — those win over the guild baseline.
@@ -332,6 +441,11 @@ function removeEnvVar(idx: number) {
 async function launch() {
   const guild = guildStore.currentGuild
   if (!guild || selectedRepos.value.length === 0) return
+  const validationError = validateEnvVars()
+  if (validationError) {
+    error.value = validationError
+    return
+  }
   spawning.value = true
   error.value = ''
   try {
@@ -346,6 +460,7 @@ async function launch() {
         tools: selectedTools.value.length ? selectedTools.value : undefined,
         agent_count: agentCount.value ?? undefined,
         env_vars: Object.keys(envVarsPayload).length ? envVarsPayload : undefined,
+        exclude_env_keys: excludeEnvKeys.value.length ? excludeEnvKeys.value : undefined,
       },
     })
     await saveSettings(guild.id)
@@ -630,5 +745,47 @@ async function launch() {
   padding: 3px 7px;
   align-self: flex-start;
   margin-top: 1px;
+}
+
+.spawn-cred-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  border: 1px solid var(--color-brass-dark);
+  border-radius: 2px;
+  background: var(--color-bg);
+}
+
+.spawn-cred-row {
+  cursor: default;
+}
+
+.spawn-cred-key {
+  flex-shrink: 0;
+  font-family: var(--font-mono, monospace);
+}
+
+.spawn-cred-value {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  font-family: var(--font-mono, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.spawn-cred-claude {
+  cursor: default;
+  border-top: 1px solid var(--color-brass-dark);
+}
+
+.spawn-cred-status {
+  color: var(--color-text-dim);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+.spawn-cred-status--ok {
+  color: var(--color-green, #4caf50);
 }
 </style>

--- a/frontend/src/components/sidebar/__tests__/SpawnWorkerForm.spec.ts
+++ b/frontend/src/components/sidebar/__tests__/SpawnWorkerForm.spec.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { flushPromises, mount } from '@vue/test-utils'
+import SpawnWorkerForm from '../SpawnWorkerForm.vue'
+import { useAuthStore } from '../../../stores/auth'
+import { useGuildStore } from '../../../stores/guild'
+import { useGitHubStore } from '../../../stores/github'
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+interface Routes {
+  credentials?: unknown
+}
+
+function mockFetch(routes: Routes, onSpawn?: (body: unknown) => unknown) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = String(input)
+    if (url.includes('/spawn-credentials')) {
+      return Promise.resolve(jsonResponse(routes.credentials ?? { guild_env_vars: [], claude_credentials: { saved: false, updated_at: null } }))
+    }
+    if (url.includes('/spawn-worker')) {
+      const body = init?.body ? JSON.parse(init.body as string) : {}
+      return Promise.resolve(jsonResponse(onSpawn ? onSpawn(body) : { worker_id: 'w1' }))
+    }
+    if (url.includes('/spawn-settings')) return Promise.resolve(jsonResponse({}))
+    if (url.includes('/spawn-defaults')) return Promise.resolve(jsonResponse({}))
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+function mountForm() {
+  const auth = useAuthStore()
+  auth.user = { id: 'u1', login: 'me' }
+  auth.loginToken = 'tok'
+  const guild = useGuildStore()
+  guild.currentGuild = { id: 'g1', name: 'Guild', primary_repo: null }
+  const gh = useGitHubStore()
+  gh.repos = [{ full_name: 'org/repo' }]
+  return mount(SpawnWorkerForm)
+}
+
+async function selectFirstRepo(wrapper: ReturnType<typeof mountForm>) {
+  const repoCheckboxes = wrapper.findAll('.spawn-repo-list input[type="checkbox"]')
+  // Index 0 is the "select all" org checkbox; index 1 is the repo itself.
+  await repoCheckboxes[1].setValue(true)
+}
+
+describe('SpawnWorkerForm credentials', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows masked guild env vars and claude credential status', async () => {
+    mockFetch({
+      credentials: {
+        guild_env_vars: [{ key: 'ANTHROPIC_API_KEY', masked_value: 'sk…alue' }],
+        claude_credentials: { saved: true, updated_at: '2026-07-24T00:00:00Z' },
+      },
+    })
+    const wrapper = mountForm()
+    await flushPromises()
+    expect(wrapper.text()).toContain('ANTHROPIC_API_KEY')
+    expect(wrapper.text()).toContain('sk…alue')
+    expect(wrapper.text()).toContain('configured')
+    expect(wrapper.text()).not.toContain('No guild credentials configured')
+  })
+
+  it('shows an empty-state message when the guild has no credentials', async () => {
+    mockFetch({})
+    const wrapper = mountForm()
+    await flushPromises()
+    expect(wrapper.text()).toContain('No guild credentials configured')
+  })
+
+  it('excludes an unchecked credential from the spawn request', async () => {
+    const spawnSpy = vi.fn((body: unknown) => ({ worker_id: 'w1', body }))
+    mockFetch(
+      {
+        credentials: {
+          guild_env_vars: [{ key: 'ANTHROPIC_API_KEY', masked_value: 'sk…alue' }],
+          claude_credentials: { saved: false, updated_at: null },
+        },
+      },
+      spawnSpy,
+    )
+    const wrapper = mountForm()
+    await flushPromises()
+    await selectFirstRepo(wrapper)
+
+    const credCheckbox = wrapper.find('.spawn-cred-row input[type="checkbox"]')
+    expect(credCheckbox.exists()).toBe(true)
+    await credCheckbox.setValue(false)
+
+    await wrapper.find('.spawn-launch-btn').trigger('click')
+    await flushPromises()
+
+    expect(spawnSpy).toHaveBeenCalledOnce()
+    const sentBody = spawnSpy.mock.calls[0][0] as { exclude_env_keys?: string[] }
+    expect(sentBody.exclude_env_keys).toEqual(['ANTHROPIC_API_KEY'])
+  })
+
+  it('rejects an invalid env var key before spawning', async () => {
+    const spawnSpy = vi.fn((body: unknown) => ({ worker_id: 'w1', body }))
+    mockFetch({}, spawnSpy)
+    const wrapper = mountForm()
+    await flushPromises()
+    await selectFirstRepo(wrapper)
+
+    await wrapper.find('.spawn-env-add').trigger('click')
+    const keyInput = wrapper.find('.spawn-env-key')
+    await keyInput.setValue('not a valid key')
+
+    await wrapper.find('.spawn-launch-btn').trigger('click')
+    await flushPromises()
+
+    expect(spawnSpy).not.toHaveBeenCalled()
+    expect(wrapper.find('.spawn-error').text()).toContain('Invalid env var key')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a masked credential status section to the guild spawn form, showing guild `foreman_config.env_vars` keys and whether Claude OAuth credentials are configured — never exposing raw secret values.
- New `GET /guilds/{guild_id}/spawn-credentials` endpoint returns masked env var values and Claude credential presence/`updated_at`.
- Operators can uncheck individual guild credentials to exclude them from a single launch (`exclude_env_keys` on `POST /spawn-worker`) without touching the guild's stored config.
- Client-side env var key validation (mirrors backend regex, catches duplicate keys) runs before the spawn request is sent.

## Closes
Closes #999

## Test plan
- [x] `pytest backend/tests/test_worker_api.py` — 41 passed
- [x] `npx vitest run src/components/sidebar/__tests__/SpawnWorkerForm.spec.ts` — 4 passed