### PR TITLE
Fix Discord task stream threads for standalone tasks

### DIFF
--- a/backend/discord_notifier.py
+++ b/backend/discord_notifier.py
@@ -47,6 +47,12 @@ Phase 4 — live task-stream mirroring
     inbound (``discord/gateway.py``, ``discord/router.py``) through the same
     table.
 
+    ``notify_task_stream_event`` posts a single embed into that same
+    ``"task_stream"`` thread (creating it if needed) and, unlike
+    ``notify_task_stream``, always runs — it's the fallback lifecycle
+    notification (task-assigned, etc.) for tasks with no linked GitHub issue,
+    which ``notify_event`` can't route into an ``"issue"`` thread.
+
 Phase 5 — new-member welcome DM
     ``send_welcome_dm`` is called by the Gateway client (``discord.gateway``)
     when a ``GUILD_MEMBER_ADD`` event arrives, and DMs the new member
@@ -1035,6 +1041,39 @@ async def _ensure_task_thread(task_id: str, channel: str) -> str | None:
         return f"⚙ {task_id}: {description}" if description else f"⚙ {task_id}"
 
     return await _get_or_create_thread(_SUBJECT_TASK_STREAM, task_id, channel, _thread_name)
+
+
+async def notify_task_stream_event(
+    guild_id: str,
+    task_id: str,
+    event_type: str,
+    title: str,
+    description: str,
+    color: int | None = None,
+) -> None:
+    """Post a Discord embed into *task_id*'s task-stream thread, creating it first.
+
+    Fallback destination for tasks with no linked GitHub issue (e.g. created
+    directly from Discord chat) — ``notify_event``'s ``"issue"`` thread has
+    nothing to key off in that case and would otherwise degrade to a flat
+    channel post (see its docstring). This reuses the same ``"task_stream"``
+    binding/thread as ``notify_task_stream``'s live terminal-output mirroring
+    (``_ensure_task_thread``), so a task never ends up with two separate
+    threads — but unlike that mirroring, this always runs; it is not gated
+    behind ``DISCORD_STREAM_TASKS``.
+
+    Silent no-op when the bot token isn't configured or no channel can be
+    resolved for *guild_id*. Never raises.
+    """
+    if not bot_token():
+        return
+    channel = await _resolve_channel_for_guild(guild_id)
+    if not channel:
+        return
+    thread_id = await _ensure_task_thread(task_id, channel)
+    if not thread_id:
+        return
+    await _post_to_thread(thread_id, event_type, title, description, color=color)
 
 
 def _chunk_content(text: str, size: int) -> list[str]:

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -768,9 +768,7 @@ def _spawn_discord_task_assigned(
             task_id,
             fallback_title,
             issue_repo=inp.get("issue_repo"),
-            issue_number=int(inp["issue_number"])
-            if inp.get("issue_number") is not None
-            else None,
+            issue_number=int(inp["issue_number"]) if inp.get("issue_number") is not None else None,
         ),
         name=f"discord.task-assigned:{task_id}",
     )

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -711,35 +711,39 @@ async def notify_discord_task_assigned(
     caller's context — so a slow GitHub API call delays this background task,
     not the tool call that triggered it.
 
-    When they're omitted, the GitHub title lookup is skipped and
-    ``notify_event`` resolves the destination from the task's own linkage
-    (see ``discord_notifier._canonical_coords``).
+    When they're omitted, the GitHub title lookup is skipped and this falls
+    back to the task's own ``"task_stream"`` thread (see
+    ``discord_notifier.notify_task_stream_event``) — every task gets a
+    Discord thread of some kind, whether or not it has a linked GitHub issue.
 
     Skips entirely when Discord notifications aren't configured.
     """
     if not discord_notifier.is_configured():
         return
-    title = fallback_title
-    thread_name = None
     description = f"Foreman assigned task `{task_id}`."
     if issue_repo and issue_number is not None:
         title = await _resolve_issue_title(guild_id, issue_repo, issue_number, fallback_title)
         prefix = f"#{issue_number}: "
         thread_name = prefix + title[: 100 - len(prefix)]
         description = f"Foreman assigned task `{task_id}` on {issue_repo}#{issue_number}: {title}"
-    await discord_notifier.notify_event(
+        await discord_notifier.notify_event(
+            "task-assigned",
+            title=f"Task assigned: #{issue_number}",
+            description=description,
+            issue_repo=issue_repo,
+            issue_number=issue_number,
+            thread_name=thread_name,
+            ps_guild_slug=guild_id,
+            task_id=task_id,
+        )
+        return
+
+    await discord_notifier.notify_task_stream_event(
+        guild_id,
+        task_id,
         "task-assigned",
-        title=(
-            f"Task assigned: #{issue_number}"
-            if issue_number is not None
-            else f"Task assigned: {task_id}"
-        ),
+        title=f"Task assigned: {task_id}",
         description=description,
-        issue_repo=issue_repo,
-        issue_number=issue_number,
-        thread_name=thread_name,
-        ps_guild_slug=guild_id,
-        task_id=task_id,
     )
 
 
@@ -748,30 +752,28 @@ def _spawn_discord_task_assigned(
     inp: dict,
     task_id: str,
     fallback_title: str,
-    parent_task_id: str | None = None,
 ) -> None:
-    """Fire off ``notify_discord_task_assigned`` when there's a thread to route to.
+    """Fire off ``notify_discord_task_assigned`` for a just-assigned task.
 
     Shared by both branches of ``assign_task`` (re-assign vs. newly created
-    task). Fires when the tool call carries issue context (legacy per-issue
-    thread routing) or a *parent_task_id* (root-thread routing via the
-    issue-rooted task tree) — either gives ``notify_event`` something to
-    resolve a destination thread from.
+    task). Always spawns: every assigned task gets a Discord notification,
+    routed to its linked issue's thread when the tool call carries
+    ``issue_repo``/``issue_number``, or to its own task-stream thread
+    otherwise (standalone tasks created without a GitHub issue, e.g. from
+    Discord chat — see ``notify_discord_task_assigned``).
     """
-    has_issue = inp.get("issue_number") is not None and inp.get("issue_repo")
-    if has_issue or parent_task_id is not None:
-        spawn(
-            notify_discord_task_assigned(
-                guild_id,
-                task_id,
-                fallback_title,
-                issue_repo=inp.get("issue_repo"),
-                issue_number=int(inp["issue_number"])
-                if inp.get("issue_number") is not None
-                else None,
-            ),
-            name=f"discord.task-assigned:{task_id}",
-        )
+    spawn(
+        notify_discord_task_assigned(
+            guild_id,
+            task_id,
+            fallback_title,
+            issue_repo=inp.get("issue_repo"),
+            issue_number=int(inp["issue_number"])
+            if inp.get("issue_number") is not None
+            else None,
+        ),
+        name=f"discord.task-assigned:{task_id}",
+    )
 
 
 async def notify_discord_followup(
@@ -1640,19 +1642,9 @@ async def _exec_one_tool(
                                 )
                                 await db.commit()
                                 name_result = await db.exec(
-                                    select(col(Task.name), col(Task.parent_task_id)).where(
-                                        col(Task.id) == existing_task_id
-                                    )
+                                    select(col(Task.name)).where(col(Task.id) == existing_task_id)
                                 )
-                                name_row = name_result.one_or_none()
-                                task_name = (name_row[0] if name_row else None) or desc[:60]
-                                # The update above only overwrites parent_task_id when the
-                                # caller passed one this call — re-select the persisted value
-                                # so root-thread routing sees a parent set by an earlier call
-                                # (e.g. the original create_task), not just this one's input.
-                                effective_parent_task_id = (
-                                    name_row[1] if name_row else parent_task_id
-                                )
+                                task_name = name_result.one_or_none() or desc[:60]
                                 task_id = existing_task_id
                                 await broadcast(
                                     guild_id,
@@ -1685,7 +1677,6 @@ async def _exec_one_tool(
                                     },
                                     task_id,
                                     task_name,
-                                    parent_task_id=effective_parent_task_id,
                                 )
                                 result_text = f"Task {task_id} assigned to {wid}."
                             else:

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -26,6 +26,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
 import database as database_module
+import discord_notifier
 from _test_config import TEST_DATABASE_URL  # noqa: E402
 from auth_deps import get_guild_pk
 from database import get_db
@@ -42,7 +43,7 @@ from foreman.runner import (
     _load_history,
     _save_turn,
 )
-from foreman.tools import exec_tools
+from foreman.tools import _spawn_discord_task_assigned, exec_tools, notify_discord_task_assigned
 from helpers import _sync_session, create_db, insert_agent, insert_guild, insert_task, insert_worker
 from models import ForemanTurn, Guild, Lock, Task, TaskEvent, TaskLog, Worker  # noqa: E402
 from sqlalchemy import func, select, update  # noqa: E402
@@ -1995,6 +1996,97 @@ class TestExecToolsDispatching:
                 select(TaskEvent).where(TaskEvent.task_id == "t-err1")
             ).scalar_one_or_none()
         assert ev is None, "No pending-followup event should be queued — follow-up was dispatched"
+
+
+class TestDiscordTaskAssignedNotification:
+    """A standalone task (no issue_number/issue_repo, no GitHub issue behind it —
+    e.g. assigned directly from Discord chat) must still get a Discord
+    notification/thread (jmelloy/pioneer-square#996). Previously
+    ``_spawn_discord_task_assigned`` silently skipped calling anything at all
+    for this case; it now always fires, and ``notify_discord_task_assigned``
+    falls back to the task's own ``task_stream`` thread instead of the
+    issue-only ``notify_event`` path.
+    """
+
+    async def test_spawn_discord_task_assigned_fires_for_standalone_task(self):
+        """No issue linkage at all must still schedule a notification."""
+        with patch("foreman.tools.spawn") as mock_spawn:
+            _spawn_discord_task_assigned("g-1", {}, "t-standalone", "Standalone task")
+
+        mock_spawn.assert_called_once()
+        # First positional arg is the notify_discord_task_assigned(...) coroutine —
+        # close it to avoid an "was never awaited" warning since we never run it.
+        mock_spawn.call_args[0][0].close()
+
+    async def test_spawn_discord_task_assigned_fires_with_issue_linkage(self):
+        """Existing issue-linked routing keeps working unchanged."""
+        with patch("foreman.tools.spawn") as mock_spawn:
+            _spawn_discord_task_assigned(
+                "g-1",
+                {"issue_number": 42, "issue_repo": "acme/widgets"},
+                "t-issue",
+                "Issue task",
+            )
+
+        mock_spawn.assert_called_once()
+        mock_spawn.call_args[0][0].close()
+
+    async def test_notify_discord_task_assigned_uses_task_stream_when_no_issue(self):
+        """No issue_repo/issue_number → falls back to the task-stream thread, not notify_event."""
+        with (
+            patch("discord_notifier.is_configured", return_value=True),
+            patch.object(discord_notifier, "notify_event", new_callable=AsyncMock) as mock_event,
+            patch.object(
+                discord_notifier, "notify_task_stream_event", new_callable=AsyncMock
+            ) as mock_stream,
+        ):
+            await notify_discord_task_assigned("g-1", "t-standalone", "Standalone task")
+
+        mock_event.assert_not_called()
+        mock_stream.assert_called_once()
+        args, kwargs = mock_stream.call_args
+        assert args[0] == "g-1"
+        assert args[1] == "t-standalone"
+        assert kwargs["title"] == "Task assigned: t-standalone"
+        assert "t-standalone" in kwargs["description"]
+
+    async def test_notify_discord_task_assigned_uses_issue_thread_when_linked(self):
+        """issue_repo/issue_number present → still routes through notify_event, unchanged."""
+        with (
+            patch("discord_notifier.is_configured", return_value=True),
+            patch.object(discord_notifier, "notify_event", new_callable=AsyncMock) as mock_event,
+            patch.object(
+                discord_notifier, "notify_task_stream_event", new_callable=AsyncMock
+            ) as mock_stream,
+            patch("foreman.tools._resolve_issue_title", new_callable=AsyncMock) as mock_title,
+        ):
+            mock_title.return_value = "Fix the bug"
+            await notify_discord_task_assigned(
+                "g-1",
+                "t-issue",
+                "Fallback title",
+                issue_repo="acme/widgets",
+                issue_number=42,
+            )
+
+        mock_stream.assert_not_called()
+        mock_event.assert_called_once()
+        assert mock_event.call_args.kwargs["issue_number"] == 42
+        assert mock_event.call_args.kwargs["issue_repo"] == "acme/widgets"
+
+    async def test_notify_discord_task_assigned_noop_when_not_configured(self):
+        """Discord not configured at all → neither path fires."""
+        with (
+            patch("discord_notifier.is_configured", return_value=False),
+            patch.object(discord_notifier, "notify_event", new_callable=AsyncMock) as mock_event,
+            patch.object(
+                discord_notifier, "notify_task_stream_event", new_callable=AsyncMock
+            ) as mock_stream,
+        ):
+            await notify_discord_task_assigned("g-1", "t-standalone", "Standalone task")
+
+        mock_event.assert_not_called()
+        mock_stream.assert_not_called()
 
 
 class TestFinalizeClosedIssueAtomicity:


### PR DESCRIPTION
## Summary
- `_spawn_discord_task_assigned` now always spawns a Discord notification for an assigned task, instead of silently no-op'ing when there's no `issue_number`/`parent_task_id`.
- `notify_discord_task_assigned` falls back to a new `discord_notifier.notify_task_stream_event` (posts into the task's own `task_stream` thread, creating it via the existing `_ensure_task_thread`) when there's no linked GitHub issue, instead of routing through the issue-only `notify_event`.
- Issue-linked tasks are unaffected — they still route through `notify_event` into the issue's thread.

Fixes #996

## Test plan
- [x] `pytest tests/test_foreman.py -k TestDiscordTaskAssignedNotification` — new unit tests covering: standalone task spawns notification, issue-linked task spawns notification, standalone task routes to `notify_task_stream_event` (not `notify_event`), issue-linked task routes to `notify_event` (not stream), and no-op when Discord isn't configured. All pass.
- [x] Full `test_discord_notifier.py` and non-DB-dependent parts of `test_foreman.py` pass (DB-dependent tests error only because this sandbox has no Postgres test instance available — unrelated to this change).