### PR TITLE
Strip host filesystem prefix from worker file operation logs

### DIFF
--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -8,6 +8,8 @@ import logging
 import os
 from collections.abc import Awaitable, Callable
 
+from .log_format import strip_worktree_prefix
+
 logger = logging.getLogger(__name__)
 
 EmitFn = Callable[..., Awaitable[None]]  # emit(line: str, detail: dict | None = None)
@@ -114,7 +116,7 @@ def parse_claude_event(event: dict) -> list[tuple[str, dict | None]]:
                         if len(cmd_lines) > 2:
                             summary += f"\n         … ({len(cmd_lines) - 2} more lines)"
                 elif name in ("Read", "Write", "Edit"):
-                    fp = inp.get("file_path", inp.get("path", ""))
+                    fp = strip_worktree_prefix(inp.get("file_path", inp.get("path", "")))
                     summary = f"▶ {name.lower()}: {fp}"
                 else:
                     summary = f"▶ {name}: {json.dumps(inp)[:80]}"

--- a/worker/pioneer_worker/log_format.py
+++ b/worker/pioneer_worker/log_format.py
@@ -1,0 +1,26 @@
+"""Helpers for formatting file paths in worker activity logs."""
+
+from __future__ import annotations
+
+import re
+
+# Task worktrees live at .../<guild_id>/<worker_id>/t-<taskid>/<repo_name>/...
+# Strip everything up to and including the task worktree segment so logs show
+# only the repo-relative path, not the host's absolute filesystem layout.
+_TASK_WORKTREE_RE = re.compile(r"/t-[a-z0-9]+/")
+
+
+def strip_worktree_prefix(path: str) -> str:
+    """Strip the host filesystem prefix from a task worktree path.
+
+    Given ".../w-4de676/t-vdfpj3/dnsid-infra/envs/dev/main.tf", returns
+    "dnsid-infra/envs/dev/main.tf". Paths without a task worktree marker
+    (e.g. relative paths, or paths outside any task worktree) are returned
+    unchanged.
+    """
+    if not path:
+        return path
+    matches = list(_TASK_WORKTREE_RE.finditer(path))
+    if not matches:
+        return path
+    return path[matches[-1].end() :]

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -7,6 +7,8 @@ import json
 import logging
 from collections.abc import Awaitable, Callable
 
+from .log_format import strip_worktree_prefix
+
 logger = logging.getLogger(__name__)
 
 EmitFn = Callable[..., Awaitable[None]]  # emit(line: str, detail: dict | None = None)
@@ -75,7 +77,8 @@ def parse_pi_event(event: dict, last_text: str) -> tuple[str | None, dict | None
         if name == "bash":
             summary = f"▶ bash: {inp.get('command', '')[:120]}"
         elif name in ("read", "write", "edit"):
-            summary = f"▶ {name}: {inp.get('path', inp.get('file_path', ''))}"
+            fp = strip_worktree_prefix(inp.get("path", inp.get("file_path", "")))
+            summary = f"▶ {name}: {fp}"
         else:
             summary = f"▶ {name}({json.dumps(inp)[:80]})"
         detail = {"toolType": "tool_use", "name": name, "input": inp}

--- a/worker/tests/test_claude_runner.py
+++ b/worker/tests/test_claude_runner.py
@@ -179,6 +179,26 @@ def test_parse_assistant_write_tool():
     assert text == "▶ write: /tmp/out.txt"
 
 
+def test_parse_assistant_read_tool_strips_worktree_prefix():
+    event = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Read",
+                    "input": {
+                        "file_path": "/work/dnsid/w-4de676/t-vdfpj3/dnsid-infra/envs/dev/main.tf"
+                    },
+                }
+            ]
+        },
+    }
+    pairs = parse_claude_event(event)
+    text, _ = pairs[0]
+    assert text == "▶ read: dnsid-infra/envs/dev/main.tf"
+
+
 def test_parse_assistant_unknown_tool():
     event = {
         "type": "assistant",

--- a/worker/tests/test_log_format.py
+++ b/worker/tests/test_log_format.py
@@ -1,0 +1,34 @@
+"""Unit tests for pioneer_worker.log_format."""
+
+from __future__ import annotations
+
+from pioneer_worker.log_format import strip_worktree_prefix
+
+
+def test_strip_worktree_prefix_strips_host_path():
+    path = "/Users/jeffrey.melloy/pioneer-square/ps-worker/work/dnsid/w-4de676/t-vdfpj3/dnsid-infra/envs/dev/main.tf"
+    assert strip_worktree_prefix(path) == "dnsid-infra/envs/dev/main.tf"
+
+
+def test_strip_worktree_prefix_repo_root():
+    path = "/work/dnsid/w-4de676/t-vdfpj3/dnsid-infra"
+    assert strip_worktree_prefix(path) == "dnsid-infra"
+
+
+def test_strip_worktree_prefix_no_marker_unchanged():
+    assert strip_worktree_prefix("/tmp/foo.py") == "/tmp/foo.py"
+
+
+def test_strip_worktree_prefix_relative_path_unchanged():
+    assert strip_worktree_prefix("dnsid-infra/envs/dev/main.tf") == "dnsid-infra/envs/dev/main.tf"
+
+
+def test_strip_worktree_prefix_empty_string():
+    assert strip_worktree_prefix("") == ""
+
+
+def test_strip_worktree_prefix_uses_last_marker():
+    # Defensive: if a repo's own path happens to contain a similar-looking
+    # segment, strip up to the last (i.e. innermost/real) task marker.
+    path = "/work/t-aaaaaa/nested/t-bbbbbb/myrepo/main.py"
+    assert strip_worktree_prefix(path) == "myrepo/main.py"

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -83,6 +83,16 @@ def test_parse_tool_execution_start_edit():
     assert text == "▶ edit: /tmp/bar.py"
 
 
+def test_parse_tool_execution_start_read_strips_worktree_prefix():
+    event = {
+        "type": "tool_execution_start",
+        "toolName": "read",
+        "args": {"path": "/work/dnsid/w-4de676/t-vdfpj3/dnsid-infra/envs/dev/main.tf"},
+    }
+    text, _, _ = parse_pi_event(event, "")
+    assert text == "▶ read: dnsid-infra/envs/dev/main.tf"
+
+
 def test_parse_tool_execution_start_unknown():
     event = {
         "type": "tool_execution_start",


### PR DESCRIPTION
## Summary
- File operation logs (`▶ read: ...`, `▶ write: ...`, `▶ edit: ...`) previously included the full host absolute path, e.g. `/Users/jeffrey.melloy/pioneer-square/ps-worker/work/dnsid/w-4de676/t-vdfpj3/dnsid-infra/envs/dev/main.tf`
- Adds `pioneer_worker/log_format.py` with `strip_worktree_prefix()`, which strips everything up to and including the task worktree segment (`/t-<taskid>/`), leaving just the repo-relative path: `dnsid-infra/envs/dev/main.tf`
- Wired into `claude_runner.py` and `pi_runner.py`, the two runners that format Read/Write/Edit tool-use summaries from a `file_path`/`path` field
- Improves log readability and avoids leaking host filesystem layout to the frontend/backend

## Test plan
- [x] New unit tests in `worker/tests/test_log_format.py` covering the strip helper (full path, repo root, no-marker passthrough, relative path, empty string, multiple markers)
- [x] New/updated tests in `test_claude_runner.py` and `test_pi_runner.py` asserting `parse_claude_event`/`parse_pi_event` strip the worktree prefix from Read/Write/Edit summaries
- [x] Ran `pytest tests/` in `worker/` — no new failures introduced (pre-existing `pytest-asyncio`-dependent test failures are unrelated environment gaps, confirmed identical on `main`)