### PR TITLE
Pre-fetch devReady issues and fire periodic-check on empty boards

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -286,16 +286,19 @@ This is the polling safety net for the immediate webhook-triggered pickup descri
 "Reacting to devReady issue webhooks" above — it catches issues that became devReady while
 no webhook fired (e.g. label applied before the webhook was configured, or a missed delivery).
 
-On every [periodic-check] event:
-1. Call search_github_issues on the primary repo with query "label:devReady" (also try "label:dev-ready" and "label:ready-for-dev" as fallbacks).
-2. For each returned issue that has no assignee:
-   a. Skip it if any existing non-terminal task already references this issue number (check the current <state> task list).
-   b. Call claim_github_issue to assign it.
-   c. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number and
-      issue_repo on both calls so the worker's PR references the issue automatically and the
-      task groups under its issue in the sidebar.
-3. The label check must cover (case-insensitive): devReady, dev-ready, ready-for-dev, ready.
-4. Never pick up an issue that is already assigned to someone else.
+Every [periodic-check] event that finds unassigned devReady issues includes an "Unassigned
+devReady issues ready for pickup" section — the primary repo is searched for you this cycle
+(labels devReady, dev-ready, ready-for-dev, ready) and results already deduped against active
+tasks. You do not need to call search_github_issues yourself. For each listed issue:
+1. Call claim_github_issue to assign it.
+2. Call create_task + assign_task (as an atomic pair) to start work, passing issue_number and
+   issue_repo on both calls so the worker's PR references the issue automatically and the
+   task groups under its issue in the sidebar.
+3. Never pick up an issue that is already assigned to someone else.
+
+If a [periodic-check] has no such section, no unassigned devReady issues were found this
+cycle — no action needed. Only fall back to search_github_issues if you need a broader or
+ad-hoc query (a non-primary repo, a different label, etc.).
 
 ## Periodic PR status refresh
 Every [periodic-check] message that mentions open-PR tasks includes a "Fresh GitHub PR

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import time
+import urllib.parse
 from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -69,7 +70,7 @@ from ws_types import ChatMsg, ForemanPollStatusMsg
 logger = logging.getLogger(__name__)
 
 POLL_MIN_SECS = 60  # initial poll interval: 1 minute
-POLL_MAX_SECS = 14400  # maximum poll interval: 4 hours
+POLL_MAX_SECS = 86400  # maximum poll interval: 24 hours
 
 # Upper bound on rows fetched by _load_history before Python-side windowing,
 # so query cost stays flat regardless of the table's total lifetime turn count.
@@ -637,6 +638,66 @@ async def _fetch_pr_status_lines(guild_id: str, pr_tasks: list[dict]) -> list[st
     return lines
 
 
+# devReady label variants, checked case-insensitively (mirrors prompt.py step 3).
+_DEVREADY_LABELS = ("devReady", "dev-ready", "ready-for-dev", "ready")
+
+
+async def _fetch_devready_issues(
+    guild_id: str, linked_issues: set[tuple[str, int]]
+) -> list[str]:
+    """Pre-fetch unassigned devReady issues on the primary repo for pickup.
+
+    Runs every periodic-check so the foreman acts on injected data instead of
+    calling search_github_issues itself. Best effort: a search failure (rate
+    limit, missing token, no primary repo) is logged and skipped. Already-linked
+    issues (an existing non-terminal task references them) are filtered out here
+    so the foreman only sees genuinely new work.
+    """
+    from foreman.tools import _gh_api, _guild_github_token, _to_thread
+
+    creds = await _guild_github_token(guild_id)
+    if not creds:
+        return []
+    token, _username = creds
+
+    db = await get_db()
+    try:
+        row = await db.exec(
+            select(col(Guild.primary_repo)).where(col(Guild.slug) == guild_id)
+        )
+        primary_repo = row.one_or_none()
+    finally:
+        await db.close()
+    if not primary_repo:
+        return []
+
+    # Merge results across label variants, deduping by issue number.
+    seen: dict[int, dict] = {}
+    for label in _DEVREADY_LABELS:
+        query = urllib.parse.quote(f'label:"{label}" no:assignee')
+        url = (
+            f"/search/issues?q={query}+repo:{primary_repo}+state:open"
+            "&per_page=10&sort=created&order=desc"
+        )
+        try:
+            data = await _to_thread(_gh_api, url, token)
+        except Exception:
+            logger.warning(
+                "guild=%s devReady search failed for label=%s", guild_id, label, exc_info=True
+            )
+            continue
+        for i in data.get("items", []) if isinstance(data, dict) else data:
+            seen.setdefault(i["number"], i)
+
+    lines: list[str] = []
+    for num, i in sorted(seen.items()):
+        if (primary_repo, num) in linked_issues:
+            continue  # an existing non-terminal task already owns this issue
+        labels = ", ".join(l["name"] for l in i.get("labels", []))
+        lines.append(f"- {primary_repo}#{num}: {i['title']} [labels: {labels}] ({i['html_url']})")
+    return lines
+
+
 async def _sweep_closed_issues(guild_id: str, linked_issues: set[tuple[str, int]]) -> None:
     """Sweep tasks whose linked GitHub issue has closed.
 
@@ -764,16 +825,19 @@ async def _poll_loop(guild_id: str) -> None:
                 next_interval / 60,
             )
 
+            # Always fire a [periodic-check] — even with zero active tasks. An empty
+            # board is exactly when the devReady sweep (which runs on every
+            # periodic-check) needs to pull in new work; gating on active_tasks
+            # silently stalled devReady pickup once a guild drained.
+            linked_issues = {
+                (t["issue_repo"], t["issue_number"])
+                for t in active_tasks
+                if t.get("issue_repo") and t.get("issue_number")
+            }
             if active_tasks:
                 task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active_tasks)
                 pr_tasks = [t for t in active_tasks if t.get("pr_url")]
                 pr_status_lines = await _fetch_pr_status_lines(guild_id, pr_tasks)
-
-                linked_issues = {
-                    (t["issue_repo"], t["issue_number"])
-                    for t in active_tasks
-                    if t.get("issue_repo") and t.get("issue_number")
-                }
                 await _sweep_closed_issues(guild_id, linked_issues)
 
                 msg = (
@@ -793,15 +857,31 @@ async def _poll_loop(guild_id: str) -> None:
                     )
                 else:
                     msg += " If everything looks healthy, no action is needed."
+            else:
+                msg = "[periodic-check] Automated status poll — no non-terminal tasks."
 
-                # Deferred import: ws_handlers imports from the foreman package at
-                # module load time, so importing it back at module scope here would
-                # create a circular import.
-                from ws_handlers import _trigger_foreman
-
-                await _trigger_foreman(
-                    guild_id, "periodic-check", msg, task_name=f"foreman.poll:{guild_id}"
+            # Pre-fetched devReady issues ready for pickup (see prompt "Periodic
+            # devReady issue pickup"). Injecting them here saves the foreman a
+            # search_github_issues round-trip and guarantees the sweep runs.
+            devready_lines = await _fetch_devready_issues(guild_id, linked_issues)
+            if devready_lines:
+                msg += (
+                    "\n\nUnassigned devReady issues ready for pickup (fetched this "
+                    "cycle, already deduped against active tasks):\n"
+                    + "\n".join(devready_lines)
+                    + "\nFor each, call claim_github_issue then create_task + assign_task "
+                    "(passing issue_number and issue_repo on both). Skip any already "
+                    "assigned to someone else."
                 )
+
+            # Deferred import: ws_handlers imports from the foreman package at
+            # module load time, so importing it back at module scope here would
+            # create a circular import.
+            from ws_handlers import _trigger_foreman
+
+            await _trigger_foreman(
+                guild_id, "periodic-check", msg, task_name=f"foreman.poll:{guild_id}"
+            )
 
             # Announce next check interval so the UI can display a countdown.
             interval = next_interval

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -642,9 +642,7 @@ async def _fetch_pr_status_lines(guild_id: str, pr_tasks: list[dict]) -> list[st
 _DEVREADY_LABELS = ("devReady", "dev-ready", "ready-for-dev", "ready")
 
 
-async def _fetch_devready_issues(
-    guild_id: str, linked_issues: set[tuple[str, int]]
-) -> list[str]:
+async def _fetch_devready_issues(guild_id: str, linked_issues: set[tuple[str, int]]) -> list[str]:
     """Pre-fetch unassigned devReady issues on the primary repo for pickup.
 
     Runs every periodic-check so the foreman acts on injected data instead of
@@ -662,9 +660,7 @@ async def _fetch_devready_issues(
 
     db = await get_db()
     try:
-        row = await db.exec(
-            select(col(Guild.primary_repo)).where(col(Guild.slug) == guild_id)
-        )
+        row = await db.exec(select(col(Guild.primary_repo)).where(col(Guild.slug) == guild_id))
         primary_repo = row.one_or_none()
     finally:
         await db.close()

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -2566,6 +2566,48 @@ class TestExecToolsResultHandling:
         parsed = json.loads(results[0]["content"])
         assert parsed[0]["number"] == 3
 
+    async def test_fetch_devready_dedups_labels_and_filters_linked(self, db_session):
+        """Pre-fetch merges label variants (dedup by number) and drops already-linked issues."""
+        from foreman.runner import _fetch_devready_issues
+
+        insert_guild(db_session, "g-devready")
+        with _sync_session(db_session) as session:
+            guild_pk = session.scalar(
+                select(col(Guild.id)).where(col(Guild.slug) == "g-devready")
+            )
+            session.execute(
+                update(Guild).where(col(Guild.id) == guild_pk).values(primary_repo="org/repo")
+            )
+            session.commit()
+
+        def fake_gh_api(url, token):
+            # Issue 3 carries both devReady and dev-ready; 4 is only under dev-ready;
+            # 5 is already linked to an active task and must be filtered out.
+            def issue(n, labels):
+                return {
+                    "number": n,
+                    "title": f"Issue {n}",
+                    "html_url": f"https://github.com/org/repo/issues/{n}",
+                    "labels": [{"name": lbl} for lbl in labels],
+                }
+
+            if "devReady" in url:
+                return {"items": [issue(3, ["devReady"]), issue(5, ["devReady"])]}
+            if "dev-ready" in url:
+                return {"items": [issue(3, ["dev-ready"]), issue(4, ["dev-ready"])]}
+            return {"items": []}
+
+        with (
+            patch("foreman.tools._guild_github_token", return_value=("tok", "user")),
+            patch("foreman.tools._gh_api", side_effect=fake_gh_api),
+        ):
+            lines = await _fetch_devready_issues("g-devready", {("org/repo", 5)})
+
+        joined = "\n".join(lines)
+        assert len(lines) == 2  # 3 (deduped across labels) and 4; 5 filtered as linked
+        assert "org/repo#3" in joined and "org/repo#4" in joined
+        assert "#5" not in joined
+
     async def test_empty_result_does_not_crash(self, db_session):
         """A tool that produces an empty string result is valid."""
         insert_guild(db_session, "g-empty-res")

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -2572,9 +2572,7 @@ class TestExecToolsResultHandling:
 
         insert_guild(db_session, "g-devready")
         with _sync_session(db_session) as session:
-            guild_pk = session.scalar(
-                select(col(Guild.id)).where(col(Guild.slug) == "g-devready")
-            )
+            guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "g-devready"))
             session.execute(
                 update(Guild).where(col(Guild.id) == guild_pk).values(primary_repo="org/repo")
             )


### PR DESCRIPTION
## Problem
The devReady sweep runs *on every* `[periodic-check]`, but the poll loop only emitted that event when the guild had non-terminal tasks (`if active_tasks:`). Once a guild's board drained to zero, no periodic-check fired — so the devReady sweep stopped exactly when new work should be pulled in. Since the periodic sweep is the safety net for missed `issues/labeled` webhooks, an empty guild could sit idle indefinitely.

## Changes
- **Always fire `[periodic-check]`**, even with zero active tasks.
- **New `_fetch_devready_issues()`** in `runner.py` (mirrors `_fetch_pr_status_lines` / `_sweep_closed_issues`): searches the primary repo across label variants (`devReady`, `dev-ready`, `ready-for-dev`, `ready`, `no:assignee`), dedups by issue number, and filters out issues already owned by a non-terminal task. Results are injected into the periodic-check message so the foreman acts on them directly instead of spending a `search_github_issues` round-trip.
- **Prompt** updated to consume the injected list (`claim_github_issue` → `create_task` + `assign_task`); `search_github_issues` kept as an explicit fallback for ad-hoc / non-primary-repo queries.
- **`POLL_MAX_SECS` → 24h** (was 4h).

## Testing
- New `test_fetch_devready_dedups_labels_and_filters_linked` — verifies label-variant dedup and linked-issue filtering.
- `pytest tests/test_foreman.py -k "fetch_devready or search_github_issues"` → 2 passed.

## Notes
- Idle/empty guilds now trigger a foreman run every cycle (up to the 24h backoff cap) — intended, to make pickup reliable, but it does mean extra foreman API calls on idle guilds.
- Kept the 4-label search loop (up to 4 GitHub search calls per poll) to match prior behavior. If the fallback labels are dead in practice, this can drop to a single `devReady` query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)