### PR TITLE
fix(worker): rename generated branch prefix from claude/ to ps/

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1622,7 +1622,7 @@ class Worker:
         name = task.get("name") or desc
         if is_review and not is_followup:
             # Review tasks must operate on the PR's own branch — never a
-            # freshly generated claude/... branch — or the agent won't see
+            # freshly generated ps/... branch — or the agent won't see
             # the actual PR diff. Never fall back to a generated name here:
             # doing so would silently review the wrong code.
             branch = (
@@ -1647,7 +1647,7 @@ class Worker:
         else:
             # On follow-ups we must continue on the existing branch — the original
             # worker pushed it and the foreman wants the same PR updated.
-            branch = followup_branch or f"claude/{_slug(name)}-{task_id}"
+            branch = followup_branch or f"ps/{_slug(name)}-{task_id}"
         work_dir = os.path.join(self.cfg.work_dir, self.cfg.guild_id, self.cfg.worker_id, task_id)
         logger.info(
             "Task %s branch=%s work_dir=%s followup=%s", task_id, branch, work_dir, is_followup

--- a/worker/tests/test_followup_branch_reuse.py
+++ b/worker/tests/test_followup_branch_reuse.py
@@ -220,9 +220,9 @@ async def test_new_task_still_generates_fresh_branch():
         await worker._execute_task(task, slot)
 
     assert created_branches, "create_worktree should have been called for a new task"
-    # Branch must start with "claude/" and contain the task_id prefix, not be empty
-    assert created_branches[0].startswith("claude/"), (
-        f"New task branch should start with 'claude/', got {created_branches[0]!r}"
+    # Branch must start with "ps/" and contain the task_id prefix, not be empty
+    assert created_branches[0].startswith("ps/"), (
+        f"New task branch should start with 'ps/', got {created_branches[0]!r}"
     )
     assert "t-new1"[:6] in created_branches[0], (
         f"New task branch should contain the task_id prefix, got {created_branches[0]!r}"

--- a/worker/tests/test_review_phase_guard.py
+++ b/worker/tests/test_review_phase_guard.py
@@ -206,7 +206,7 @@ async def test_review_phase_injects_no_pr_instructions(caplog: pytest.LogCapture
 async def test_review_phase_checks_out_pr_branch_via_gh(caplog: pytest.LogCaptureFixture):
     """Review-phase tasks must check out the PR's own branch (via `gh pr checkout`,
     wrapped by ``git_ops.checkout_pr_worktree``) instead of generating a new
-    ``claude/...`` branch, and must never push commits (issue #799).
+    ``ps/...`` branch, and must never push commits (issue #799).
     """
     import os
     import tempfile
@@ -264,8 +264,8 @@ async def test_review_phase_checks_out_pr_branch_via_gh(caplog: pytest.LogCaptur
     ]
     assert updates, "task record must be updated with the PR's actual branch, not a generated one"
     assert not any(
-        m.args[0].get("branch", "").startswith("claude/") for m in worker._send.await_args_list
-    ), "review tasks must never record a generated claude/... branch"
+        m.args[0].get("branch", "").startswith("ps/") for m in worker._send.await_args_list
+    ), "review tasks must never record a generated ps/... branch"
 
 
 async def test_review_prefers_pr_number_over_issue_number():


### PR DESCRIPTION
## Summary
- Worker-generated task branches were prefixed `claude/...`; change the prefix to `ps/...` in `worker/pioneer_worker/worker.py`.
- Updated the corresponding tests/comments that asserted or referenced the `claude/` prefix.

## Test plan
- [x] `python3 -m pytest worker/tests/test_followup_branch_reuse.py worker/tests/test_review_phase_guard.py -q` — 11 passed
- [x] `python3 -m pytest worker/tests -q` — 278 passed (2 pre-existing unrelated failures confirmed present on main before this change)