### PR TITLE
fix(worker): track pi subprocess; default spawn to 1 agent

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1151,6 +1151,10 @@ async def spawn_worker(
                 tools_list = json.loads(defaults.tools or "[]")
             if agent_count is None:
                 agent_count = defaults.agent_count
+    # "Spawn a worker" means one agent unless asked for more; without this the
+    # worker falls through to config's max_agents default (4). ponytail: 1 slot.
+    if agent_count is None:
+        agent_count = 1
     if not repos:
         return (
             "spawn_worker requires at least one repo in the 'repos' list — this guild has "

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import signal
 from collections.abc import Awaitable, Callable
 
 from .log_format import strip_worktree_prefix
@@ -13,6 +15,54 @@ logger = logging.getLogger(__name__)
 
 EmitFn = Callable[..., Awaitable[None]]  # emit(line: str, detail: dict | None = None)
 UsageFn = Callable[[dict], Awaitable[None]]  # on_usage(record: dict)
+OnProcFn = Callable[["PiProcess"], None]  # on_proc(proc) — worker's live-handle callback
+
+
+def _signal_group(proc: asyncio.subprocess.Process, sig: signal.Signals) -> None:
+    """Signal pi's whole process group, not just pi's own pid.
+
+    pi is spawned with ``start_new_session=True`` so it leads its own process
+    group; signalling the group also reaps the tool subprocesses pi spawns
+    (bash, the model client). A bare ``proc.kill()`` orphans those onto the
+    container's PID 1, which doesn't reap them.
+    """
+    if proc.returncode is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), sig)
+    except ProcessLookupError:
+        pass
+    except Exception:
+        logger.debug("pi killpg failed", exc_info=True)
+
+
+class PiProcess:
+    """Live handle the worker holds so it can cancel/redirect a running pi.
+
+    Duck-compatible with claude_runner.ClaudeProcess (``terminate`` /
+    ``send_message`` / ``session_id``) so worker.py's cancel, redirect, and
+    message-injection paths work for pi too. Unlike ClaudeProcess, send_message
+    frames the text as a pi RPC ``prompt`` event and terminate signals the
+    whole process group.
+    """
+
+    def __init__(self, proc: asyncio.subprocess.Process) -> None:
+        self.proc = proc
+        self.session_id: str | None = None
+
+    async def send_message(self, text: str) -> bool:
+        if self.proc.stdin is None or self.proc.stdin.is_closing():
+            return False
+        try:
+            msg = json.dumps({"type": "prompt", "message": text}) + "\n"
+            self.proc.stdin.write(msg.encode())
+            await self.proc.stdin.drain()
+            return True
+        except Exception:
+            return False
+
+    async def terminate(self) -> None:
+        _signal_group(self.proc, signal.SIGTERM)
 
 # Seconds to wait for pi to exit after stdin is closed before killing it.
 _WAIT_TIMEOUT = 30
@@ -105,6 +155,7 @@ async def run_pi_auto(
     *,
     emit: EmitFn,
     on_usage: UsageFn | None = None,
+    on_proc: OnProcFn | None = None,
     pi_path: str = "pi",
     model: str | None = None,
     provider: str | None = None,
@@ -137,6 +188,7 @@ async def run_pi_auto(
         cwd,
         emit=emit,
         on_usage=on_usage,
+        on_proc=on_proc,
         pi_path=pi_path,
         model=model,
         provider=provider,
@@ -154,6 +206,7 @@ async def run_pi_auto(
             cwd,
             emit=emit,
             on_usage=on_usage,
+            on_proc=on_proc,
             pi_path=pi_path,
             model=model,
             provider=provider,
@@ -168,6 +221,7 @@ async def _run_pi_once(
     *,
     emit: EmitFn,
     on_usage: UsageFn | None,
+    on_proc: OnProcFn | None,
     pi_path: str,
     model: str | None,
     provider: str | None,
@@ -202,8 +256,14 @@ async def _run_pi_once(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             limit=_STREAM_LIMIT,
+            # Own process group so _signal_group() can reap pi's tool children.
+            start_new_session=True,
         )
         logger.info("pi subprocess started pid=%s", proc.pid)
+        # Hand the worker a live handle so its cancel/redirect/message paths
+        # (which look at Agent.current_claude) can reach this pi process.
+        if on_proc is not None:
+            on_proc(PiProcess(proc))
 
         rpc_msg = json.dumps({"type": "prompt", "message": description}) + "\n"
         proc.stdin.write(rpc_msg.encode())  # type: ignore[union-attr]
@@ -358,7 +418,7 @@ async def _run_pi_once(
                 proc.pid,
                 _WAIT_TIMEOUT,
             )
-            proc.kill()
+            _signal_group(proc, signal.SIGKILL)
             exit_code = await proc.wait()
         await stderr_task
         if event_count == 0:
@@ -398,12 +458,7 @@ async def _run_pi_once(
                     proc.stdin.close()
                 except Exception:
                     pass
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-            except Exception:
-                logger.debug("pi kill failed", exc_info=True)
+            _signal_group(proc, signal.SIGKILL)
             try:
                 await asyncio.wait_for(proc.wait(), timeout=5.0)
             except BaseException:

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -64,6 +64,7 @@ class PiProcess:
     async def terminate(self) -> None:
         _signal_group(self.proc, signal.SIGTERM)
 
+
 # Seconds to wait for pi to exit after stdin is closed before killing it.
 _WAIT_TIMEOUT = 30
 

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1928,8 +1928,13 @@ class Worker:
                         model=_pi_model,
                         provider=_pi_provider,
                         on_usage=_collect_usage,
+                        on_proc=_on_proc,
                         resume_session_id=resume_session_id,
                     )
+                    # pi returns its session via the return value, not the
+                    # ClaudeProcess slot; just release the live handle so the
+                    # worker reads as idle again (cancel/redirect used it).
+                    agent.current_claude = None
                 else:
                     _claude_model = task.get("model") or None
                     logger.info(

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -218,6 +218,40 @@ sys.exit(0)
         assert not line.endswith("\n"), f"trailing newline in emitted line: {line!r}"
 
 
+async def test_run_pi_auto_publishes_proc_handle(tmp_path) -> None:
+    """on_proc receives a live, terminate-capable handle for the pi subprocess."""
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        f"""#!{sys.executable}
+import json, sys
+print(json.dumps({{"type": "agent_end"}}), flush=True)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+
+    handles: list[object] = []
+
+    async def emit(line: str, detail: dict | None = None) -> None:
+        pass
+
+    await run_pi_auto(
+        "do the work",
+        str(tmp_path),
+        emit=emit,
+        pi_path=os.fspath(fake_pi),
+        on_proc=handles.append,
+    )
+
+    assert len(handles) == 1
+    handle = handles[0]
+    assert hasattr(handle, "terminate")
+    assert hasattr(handle, "send_message")
+    # terminate() on an already-exited proc is a no-op, not a crash.
+    await handle.terminate()
+
+
 async def test_run_pi_auto_not_found(tmp_path) -> None:
     """Missing pi binary → FileNotFoundError → returns (False, 'no_events', '', None)."""
     emitted: list[str] = []


### PR DESCRIPTION
## Why

Debugging "pi works in docker but not ECS" surfaced two related issues.

## What

**1. pi subprocess was untracked.** Only `claude_runner` populated `Agent.current_claude` (via `on_proc`), so the worker's cancel (`worker.py:1160`), redirect (`worker.py:1186`), message-injection (`worker.py:1076`), and idle-detection (`worker.py:1494`) paths couldn't see a running pi.

- `run_pi_auto` now accepts `on_proc` and publishes a `PiProcess` handle — duck-compatible with `ClaudeProcess` (`terminate` / `send_message` / `session_id`), but `send_message` uses pi's RPC `prompt` framing and `terminate` signals the whole process group.
- pi is spawned with `start_new_session=True` and killed via `killpg`, so its tool grandchildren (bash / node / model client) die with it instead of orphaning onto the container's PID 1 (Fargate doesn't reap them).
- `worker.py` passes `on_proc=_on_proc` for pi and clears the handle when the run returns.

**2. "Spawn a worker" defaulted to 4 agents.** When neither the call nor the guild's `guild_spawn_defaults` set `agent_count`, `spawn_worker` fell through to the worker's `max_agents=4` default. On ECS that means one Fargate task (fixed 1 vCPU / 2 GiB, `terraform/variables.tf`) runs 4 concurrent pi agents — each a Node process + model client + tool subprocesses — which OOM/CPU-starve and get killed (reads as "pi's subprocess died"). On a big docker dev host the 4x oversubscription is invisible. `spawn_worker` now defaults `agent_count` to 1.

Note: agent count and worker count are *not* conflated in code — one spawn = one container (`count=1` on ECS). The trap is purely that `agent_count` had no effect on the fixed Fargate task size, so the default of 4 silently oversubscribed it.

## Not included
- Same `on_proc` / process-group treatment for `codex_runner` (identical gap, untouched).
- Scaling the Fargate task cpu/memory by `agent_count` (via RunTask `overrides`) — unnecessary now that bare spawns default to 1 agent.

## Test
- `test_run_pi_auto_publishes_proc_handle` added; full `test_pi_runner.py` (39) and worker-lifecycle spawn tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)