### PR TITLE
fix(backend): Pi RPC prompt field bug in one-off Run button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,37 @@ Runners: `claude_runner.py` (primary), `codex_runner.py`, `pi_runner.py`. All re
 `(success: bool, stop_reason: str, last_text: str)`. The claude runner uses a 16 MiB stdout line
 limit to handle large `tool_result` payloads.
 
+#### Model visibility: claude vs codex vs pi
+
+`GET /api/models` (`backend/routes/models.py` + `backend/util/models_dev.py`) is the only
+programmatic model catalog in this app, and it backs the model dropdown in the frontend's
+`AgentActions.vue`. It recognizes exactly two provider ids — `anthropic` and `bedrock`
+(`_PROVIDER_ALIASES` in `models_dev.py`), sourced from the models.dev catalog. The frontend's
+`TOOL_PROVIDER` map (`claude: 'anthropic'`, `codex: 'openai'`) means **only Claude gets a live
+model dropdown today**; Codex's `'openai'` id isn't in `_PROVIDER_ALIASES`, so `modelsForProvider`
+returns `[]` for it and it silently falls back to the same free-text model input as Pi (which has
+no `TOOL_PROVIDER` entry at all).
+
+Pi itself supports far more providers than either catalog entry: `pi --help` lists ~25 provider
+API-key env vars (Anthropic, OpenAI, Azure OpenAI, Google Gemini, AWS Bedrock, OpenRouter, Groq,
+Mistral, xAI, DeepSeek, Cloudflare, Qwen, and more), and picks whichever is present in the
+environment — `worker.py`'s `_tool_has_credentials()` deliberately returns `True` unconditionally
+for `pi` ("pi and any other tool need no credentials") since the required key varies per
+provider/model the caller requests, unlike Claude/Codex which are dropped from
+`_available_tools` when their one required key is missing. Pi's own model list is queryable with
+`pi --list-models [search]` (the optional arg fuzzy-filters model names, not providers), but that
+list is filtered to whatever provider(s) currently have usable credentials in the environment —
+it is not a static catalog. Confirmed live in this sandbox: with only `AWS_BEARER_TOKEN_BEDROCK`
+set, `pi --list-models` returns 109 Bedrock-hosted models (including Bedrock's Anthropic/OpenAI/
+Google-branded models) and nothing from any other provider.
+
+Critically, this listing is CLI-only — Pi's `--mode rpc` protocol has no equivalent. Sending
+`{"type": "list_models"}` over RPC returns `{"success": false, "error": "Unknown command:
+list_models"}` (verified against the installed `pi` binary). So neither the backend nor the
+worker can fetch Pi's live model list programmatically the way `/api/models` does for
+Claude/Bedrock; surfacing it in the UI would require shelling out to `pi --list-models` and
+parsing its tabular text output.
+
 ### Auth
 
 GitHub OAuth flow: frontend calls `/auth/github/login` (gets an authorize URL) → GitHub redirects

--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -120,8 +120,11 @@ async def stream_agent(guild_id: str, agent_id: str, req: RunAgentRequest) -> No
         return
 
     if needs_stdin:
-        # Pi RPC: send the initial prompt as a JSON command, then leave stdin open
-        rpc_msg = json.dumps({"type": "prompt", "content": req.prompt}) + "\n"
+        # Pi RPC: send the initial prompt as a JSON command, then leave stdin open.
+        # The field must be "message" — pi's RPC handler reads event.message and
+        # crashes ("Cannot read properties of undefined (reading 'startsWith')")
+        # when it's missing, which pi reports as a success=false response event.
+        rpc_msg = json.dumps({"type": "prompt", "message": req.prompt}) + "\n"
         assert proc.stdin is not None  # PIPE was set above
         proc.stdin.write(rpc_msg.encode())
         await proc.stdin.drain()
@@ -166,6 +169,25 @@ async def stream_agent(guild_id: str, agent_id: str, req: RunAgentRequest) -> No
 
             if text_out:
                 await emit_terminal_line(guild_id, agent_id, text_out)
+
+            if tool == "pi":
+                # Pi's prompt can be rejected (e.g. malformed RPC message) before
+                # the agent ever starts; surface that explicitly since it has no
+                # other representation in the event stream.
+                if (
+                    event.get("type") == "response"
+                    and event.get("command") == "prompt"
+                    and not event.get("success", True)
+                ):
+                    err = event.get("error", "prompt rejected")
+                    await emit_terminal_line(guild_id, agent_id, f"✗ {err}")
+                    break
+                # Pi's RPC process stays alive after agent_end waiting for more
+                # stdin, so stdout never reaches EOF on its own — stop reading
+                # once the run is done or this loop (and the process) hangs
+                # forever instead of returning to idle.
+                if event.get("type") == "agent_end":
+                    break
 
     finally:
         if needs_stdin and proc.stdin and not proc.stdin.is_closing():

--- a/backend/tests/test_agent_runner.py
+++ b/backend/tests/test_agent_runner.py
@@ -1,0 +1,140 @@
+"""Unit tests for agent_runner's Pi RPC handling.
+
+Regression coverage for a bug where the one-off "Run" button's Pi invocation
+sent {"type": "prompt", "content": ...} instead of the {"message": ...} field
+pi's RPC handler actually reads. Confirmed against the real `pi` binary:
+"content" makes pi crash internally and reply with
+{"type": "response", "command": "prompt", "success": false,
+ "error": "Cannot read properties of undefined (reading 'startsWith')"},
+which stream_agent silently dropped (no case in parse_event) and then hung
+forever, since pi's RPC session never closes stdout on its own.
+
+All external calls (subprocess, DB, broadcast) are mocked — no real
+network/process usage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import agent_runner  # noqa: E402
+from agent_runner import RunAgentRequest, build_command, stream_agent  # noqa: E402
+
+
+def test_build_command_pi_uses_rpc_mode():
+    cmd, needs_stdin = build_command(RunAgentRequest(tool="pi", prompt="do a thing"))
+    assert cmd[:3] == ["pi", "--mode", "rpc"]
+    assert needs_stdin is True
+
+
+class _FakeStdout:
+    """Async-iterable feeding pre-baked JSONL events, then EOF forever."""
+
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = [line.encode() + b"\n" for line in lines]
+        self._i = 0
+
+    async def readline(self) -> bytes:
+        if self._i >= len(self._lines):
+            return b""
+        line = self._lines[self._i]
+        self._i += 1
+        return line
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        line = await self.readline()
+        if not line:
+            raise StopAsyncIteration
+        return line
+
+
+class _FakeStderr:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _FakeProc:
+    def __init__(self, stdout_lines: list[str]) -> None:
+        self.stdin = MagicMock()
+        self.stdin.write = MagicMock()
+        self.stdin.drain = AsyncMock()
+        self.stdin.close = MagicMock()
+        self.stdin.is_closing = MagicMock(return_value=False)
+        self.stdout = _FakeStdout(stdout_lines)
+        self.stderr = _FakeStderr()
+        self.returncode = 0
+
+    async def wait(self) -> int:
+        return 0
+
+
+async def _run_stream_agent(stdout_lines: list[str]) -> tuple[_FakeProc, list[str]]:
+    proc = _FakeProc(stdout_lines)
+    emitted: list[str] = []
+
+    async def fake_emit_terminal_line(guild_id, agent_id, line):
+        emitted.append(line)
+
+    with (
+        patch.object(agent_runner, "set_agent_state", AsyncMock()),
+        patch.object(agent_runner, "emit_terminal_line", fake_emit_terminal_line),
+        patch(
+            "asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ),
+    ):
+        req = RunAgentRequest(tool="pi", prompt="say hello")
+        await asyncio.wait_for(stream_agent("g1", "a1", req), timeout=5)
+    return proc, emitted
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_sends_message_field_not_content():
+    """The RPC prompt frame must use the "message" key pi's handler reads."""
+    proc, _ = await _run_stream_agent(['{"type": "agent_end"}'])
+    sent = proc.stdin.write.call_args[0][0].decode()
+    payload = json.loads(sent)
+    assert payload == {"type": "prompt", "message": "say hello"}
+    assert "content" not in payload
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_surfaces_rejected_prompt_and_does_not_hang():
+    """A pi RPC rejection (success=false) must be surfaced and end the stream.
+
+    Before the fix, parse_event() had no case for "response" events, so a
+    rejected prompt was silently dropped and the read loop waited forever for
+    another stdout line pi's still-alive RPC session was never going to send.
+    """
+    rejection = json.dumps(
+        {
+            "type": "response",
+            "command": "prompt",
+            "success": False,
+            "error": "Cannot read properties of undefined (reading 'startsWith')",
+        }
+    )
+    proc, emitted = await _run_stream_agent([rejection])
+    assert any("startsWith" in line for line in emitted)
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_stops_reading_after_agent_end():
+    """agent_end must end the read loop instead of hanging on pi's open RPC session."""
+    proc, emitted = await _run_stream_agent(['{"type": "agent_start"}', '{"type": "agent_end"}'])
+    assert proc.stdin.close.called


### PR DESCRIPTION
## Summary
- Investigated the reported Pi tool stdin/`--print` errors by invoking the real `pi` binary directly with the exact RPC payloads the codebase sends.
- Found that the worker's task path (`worker/pioneer_worker/pi_runner.py`) is correct — it already sends `{"type": "prompt", "message": ...}`.
- Found that the *other* Pi call site, `backend/agent_runner.py` (used by the frontend's one-off "▶ RUN" button on an agent), sends `{"type": "prompt", "content": ...}` instead. Confirmed against the real `pi` CLI that this wrong field name makes pi crash internally (`Cannot read properties of undefined (reading 'startsWith')`) and reply with a `success: false` response event.
- `stream_agent`'s `parse_event()` had no case for that rejection event type, so the error was silently dropped — and since pi's RPC session stays open waiting for more stdin (even after a normal `agent_end`), the read loop then hung forever instead of returning the agent to `idle`. That matches the reported "Pi tool calls appear to hang" symptom.

## Fix
- `backend/agent_runner.py`: use the `"message"` field pi's RPC handler actually reads.
- Break the stdout read loop (and proceed to close stdin / reap the process) on both a rejected-prompt response and a normal `agent_end`, instead of only relying on stdout EOF, which pi's RPC mode never produces on its own.

## Test plan
- [x] Reproduced the bug live: invoked `pi --mode rpc` with `"content"` vs `"message"` fields and confirmed the exact failure mode.
- [x] Added `backend/tests/test_agent_runner.py` (4 tests) — verified 2 of them fail against the pre-fix code and all 4 pass after the fix.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `python -m pytest -k agent_runner` passes.