### PR TITLE
fix: dispatch analyze_epic tool (was unreachable)

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -468,7 +468,11 @@ async def _guild_github_token(guild_id: str, user_id: str | None = None) -> tupl
             if row:
                 return (row.access_token, row.github_username)
         else:
-            app_token = get_app_installation_token()
+            inst_res = await db.exec(
+                select(col(Guild.github_app_installation_id)).where(col(Guild.slug) == guild_id)
+            )
+            installation_id = inst_res.first()
+            app_token = get_app_installation_token(installation_id)
             if app_token:
                 return (app_token, get_app_slug())
 
@@ -2355,6 +2359,7 @@ async def _exec_one_tool(
             "search_github_issues",
             "get_pr_status",
             "review_pr_internal",
+            "analyze_epic",
         ):
             logger.info("Executing GitHub tool %s with input %s", tu.name, inp)
             creds = await _guild_github_token(guild_id, user_id)

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -468,11 +468,7 @@ async def _guild_github_token(guild_id: str, user_id: str | None = None) -> tupl
             if row:
                 return (row.access_token, row.github_username)
         else:
-            inst_res = await db.exec(
-                select(col(Guild.github_app_installation_id)).where(col(Guild.slug) == guild_id)
-            )
-            installation_id = inst_res.first()
-            app_token = get_app_installation_token(installation_id)
+            app_token = get_app_installation_token()
             if app_token:
                 return (app_token, get_app_slug())
 

--- a/backend/tests/test_analyze_epic.py
+++ b/backend/tests/test_analyze_epic.py
@@ -53,3 +53,39 @@ def test_analyze_epic_file_gap_issues_default_false():
     tool = next(t for t in FOREMAN_TOOLS if t["name"] == "analyze_epic")
     desc = tool["input_schema"]["properties"]["file_gap_issues"]["description"]
     assert "Default: false" in desc
+
+
+async def test_analyze_epic_dispatches(monkeypatch):
+    """Regression: analyze_epic must be in the GitHub-tool gate so its handler is
+    reachable. A dead branch would leave result_text="" (empty content); a reachable
+    branch with no token returns the 'No GitHub token' error."""
+    import auth_deps
+    import foreman.tools as tools
+
+    class _FakeDB:
+        async def close(self):
+            pass
+
+    async def _fake_get_db():
+        return _FakeDB()
+
+    async def _fake_guild_pk(db, guild_id):
+        return 0
+
+    async def _fake_token(guild_id, user_id=None):
+        return None  # no creds -> handler returns the token error, proving dispatch
+
+    monkeypatch.setattr(tools, "get_db", _fake_get_db)
+    monkeypatch.setattr(auth_deps, "get_guild_pk", _fake_guild_pk)
+    monkeypatch.setattr(tools, "_guild_github_token", _fake_token)
+
+    class _ToolUse:
+        id = "tool-1"
+        name = "analyze_epic"
+        input = {"repo": "o/r", "issue_number": 1}
+
+    block = await tools._exec_one_tool("g1", _ToolUse())
+
+    assert block["content"], "analyze_epic returned empty content — handler unreachable"
+    assert block.get("is_error") is True
+    assert "No GitHub token" in block["content"]


### PR DESCRIPTION
## Problem
`analyze_epic` returned empty results on every call. Its handler (`backend/foreman/tools.py:2737`) lives inside the GitHub-tool `else` block gated by a tool-name tuple (`tools.py:2349`), but `"analyze_epic"` was never added to that tuple. The branch was unreachable, so `result_text` stayed `""` and the tool returned empty content.

## Fix
- Add `"analyze_epic"` to the gating tuple so its handler dispatches.
- Add `test_analyze_epic_dispatches`: with no GitHub token, a reachable handler returns the "No GitHub token" error; a dead branch would return empty content. Guards against the branch regressing to unreachable.

## Test
```
6 passed in 0.01s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)