### PR TITLE
docs: add async timing note to spawn_worker documentation

### DIFF
--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -28,7 +28,9 @@ the branch from GitHub. Pass preferred_worker_id to force a specific worker.
 - Shut down a misbehaving or no-longer-needed worker process via shutdown_worker \
 (graceful: idle agents exit immediately, busy agents finish their current task)
 - Spawn a new worker via spawn_worker when no online worker covers the repos a task \
-needs, or when all capable workers are busy and work is queueing. Never spawn a \
+needs, or when all capable workers are busy and work is queueing. spawn_worker is \
+asynchronous — it returns immediately but the worker takes about 2 minutes to come \
+online, so don't expect it to be assignable right away. Never spawn a \
 duplicate for repos an online (or currently starting) worker already covers. Spawned \
 workers shut down automatically after a period of inactivity, so don't spawn \
 speculatively and don't worry about cleaning up idle ones

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1129,6 +1129,11 @@ async def spawn_worker(
 ) -> tuple[str, bool]:
     """Spawn a new worker container.
 
+    Asynchronous: this coroutine returns as soon as the container/ECS task has
+    been started, not once the worker is online. The worker process itself
+    takes about 2 minutes to come up and register before it can pick up
+    assigned tasks.
+
     *user_id* identifies the human on whose behalf the worker is being spawned
     (e.g. a Discord user's linked Pioneer Square account) and is stamped onto
     the new ``Worker`` row for ownership attribution. ``None`` for

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -703,8 +703,9 @@ FOREMAN_TOOLS = [
         "description": (
             "Start a new worker process to run tasks. Use when no worker is online for the "
             "repos a task needs, or when every capable worker is busy and work is queueing up. "
-            "The worker is pre-registered and its container/ECS task is started immediately; it "
-            "comes online within a minute or so and then picks up assigned tasks. Do not spawn "
+            "This call is asynchronous: it returns as soon as the worker is pre-registered and "
+            "its container/ECS task has been started, but the worker itself takes about 2 "
+            "minutes to come online and start picking up assigned tasks. Do not spawn "
             "a duplicate if a worker for the same repos is already online or currently starting. "
             "Spawned workers are automatically shut down after a period of inactivity, so there "
             "is no need to clean up idle workers yourself (shutdown_worker still works for an "


### PR DESCRIPTION
## Summary
- `spawn_worker` returns as soon as the container/ECS task is started, not once the worker is online — the worker itself takes about 2 minutes to come up and start picking up tasks.
- Added this clarifying note to the three places that describe `spawn_worker`'s behavior: the tool's JSON schema description (`backend/foreman/tools_schema.py`), the foreman system prompt (`backend/foreman/prompt.py`), and the function docstring (`backend/foreman/tools.py`).

## Test plan
- [x] Reviewed the diff for accuracy against `spawn_worker`'s actual async control flow (returns after container start, worker registers separately)
- Docs-only change, no functional code touched