### PR TITLE
feat: enforce worker spawn cooldown in foreman tool and REST endpoint

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -9,6 +9,7 @@ import asyncio
 import contextvars
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -1164,6 +1165,17 @@ async def spawn_worker(
             "spawn_worker requires at least one repo in the 'repos' list — this guild has "
             "no recorded spawn defaults to fall back on."
         ), True
+
+    if guild_pk is not None:
+        from worker_lifecycle import check_worker_spawn_cooldown  # noqa: PLC0415
+
+        remaining = await check_worker_spawn_cooldown(db, guild_pk)
+        if remaining is not None:
+            minutes = max(1, math.ceil(remaining.total_seconds() / 60))
+            return (
+                "Worker spawn cooldown active. Try again in "
+                f"{minutes} minute{'s' if minutes != 1 else ''}."
+            ), True
 
     worker_id = "w-" + secrets.token_hex(3)
     auth_token = secrets.token_urlsafe(32)

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -34,6 +35,7 @@ from utils import (
     worker_display_name,
 )
 from worker_lifecycle import (
+    check_worker_spawn_cooldown,
     force_kill_worker_if_unresponsive,
     generate_worker_id,
     get_guild_spawn_defaults,
@@ -210,6 +212,17 @@ async def spawn_worker_container(
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
+
+    remaining = await check_worker_spawn_cooldown(db, guild_pk)
+    if remaining is not None:
+        minutes = max(1, math.ceil(remaining.total_seconds() / 60))
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                "Worker spawn cooldown active. Try again in "
+                f"{minutes} minute{'s' if minutes != 1 else ''}."
+            ),
+        )
 
     # Merge guild-level foreman env vars (base) with user-supplied env vars (override).
     guild_cfg_res = await db.exec(

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -2274,7 +2274,9 @@ class TestSpawnWorker:
                     repos='["acme/widgets"]',
                     tools='["claude", "pi"]',
                     agent_count=3,
-                    updated_at=datetime.now(UTC),
+                    # Older than the spawn cooldown window so this fixture (an
+                    # existing recorded default) doesn't itself trip the cooldown.
+                    updated_at=datetime.now(UTC) - timedelta(minutes=10),
                 )
             )
             session.commit()
@@ -2319,7 +2321,9 @@ class TestSpawnWorker:
                     repos='["acme/widgets"]',
                     tools='["claude"]',
                     agent_count=3,
-                    updated_at=datetime.now(UTC),
+                    # Older than the spawn cooldown window so this fixture (an
+                    # existing recorded default) doesn't itself trip the cooldown.
+                    updated_at=datetime.now(UTC) - timedelta(minutes=10),
                 )
             )
             session.commit()
@@ -2357,6 +2361,79 @@ class TestSpawnWorker:
         assert r.get("is_error") is True
         assert "no recorded spawn defaults" in r["content"]
         fake_docker_client.containers.run.assert_not_called()
+
+    async def test_spawn_worker_rejects_when_guild_in_cooldown(self, db_session):
+        """A guild that spawned a worker within the cooldown window is refused, no container started."""
+        from models import GuildSpawnDefaults  # noqa: PLC0415
+
+        insert_guild(db_session, "g-spawn-cooldown")
+        with _sync_session(db_session) as session:
+            guild_pk = session.execute(
+                select(col(Guild.id)).where(col(Guild.slug) == "g-spawn-cooldown")
+            ).scalar_one()
+            session.add(
+                GuildSpawnDefaults(
+                    guild_id=guild_pk,
+                    repos="[]",
+                    tools="[]",
+                    agent_count=None,
+                    updated_at=datetime.now(UTC) - timedelta(minutes=1),
+                )
+            )
+            session.commit()
+
+        fake_docker_client = MagicMock()
+        with (
+            patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_docker_client)),
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        ):
+            results = await exec_tools(
+                "g-spawn-cooldown",
+                [_fake_tool_use("spawn_worker", {"repos": ["acme/widgets"]})],
+            )
+
+        r = results[0]
+        assert r.get("is_error") is True
+        assert "cooldown" in r["content"].lower()
+        assert "4 minute" in r["content"]
+        fake_docker_client.containers.run.assert_not_called()
+
+    async def test_spawn_worker_allowed_after_cooldown_expires(self, db_session):
+        """A guild whose last spawn is older than the cooldown window may spawn again."""
+        from models import GuildSpawnDefaults  # noqa: PLC0415
+
+        insert_guild(db_session, "g-spawn-cooldown-ok")
+        with _sync_session(db_session) as session:
+            guild_pk = session.execute(
+                select(col(Guild.id)).where(col(Guild.slug) == "g-spawn-cooldown-ok")
+            ).scalar_one()
+            session.add(
+                GuildSpawnDefaults(
+                    guild_id=guild_pk,
+                    repos="[]",
+                    tools="[]",
+                    agent_count=None,
+                    updated_at=datetime.now(UTC) - timedelta(minutes=10),
+                )
+            )
+            session.commit()
+
+        fake_container = SimpleNamespace(id="abcdef0123456789")
+        fake_docker_client = MagicMock()
+        fake_docker_client.containers.get.side_effect = Exception("not found")
+        fake_docker_client.containers.run.return_value = fake_container
+        with (
+            patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_docker_client)),
+            patch("foreman.tools.broadcast", new_callable=AsyncMock),
+        ):
+            results = await exec_tools(
+                "g-spawn-cooldown-ok",
+                [_fake_tool_use("spawn_worker", {"repos": ["acme/widgets"]})],
+            )
+
+        r = results[0]
+        assert r.get("is_error") is not True, f"spawn_worker failed: {r['content']}"
+        fake_docker_client.containers.run.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -565,6 +565,90 @@ def test_spawn_worker_rejects_invalid_exclude_env_key(client):
     assert resp.status_code == 422
 
 
+def test_spawn_worker_rejects_when_guild_in_cooldown(client, monkeypatch):
+    """A guild that spawned a worker within the cooldown window gets 429, no container started."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-cooldown")
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-cooldown"))
+        session.add(
+            GuildSpawnDefaults(
+                guild_id=guild_pk,
+                repos="[]",
+                tools="[]",
+                agent_count=None,
+                updated_at=datetime.now(UTC) - timedelta(minutes=1),
+            )
+        )
+        session.commit()
+
+    import worker_runtime
+
+    started = {"called": False}
+
+    async def fake_check_runtime_available():
+        return None
+
+    async def fake_start_worker_container(*, env, guild_id):
+        started["called"] = True
+        return worker_runtime.SpawnedWorker(
+            handle="fake-handle", short_id="fakehandle12", runtime="docker"
+        )
+
+    monkeypatch.setattr(worker_runtime, "check_runtime_available", fake_check_runtime_available)
+    monkeypatch.setattr(worker_runtime, "start_worker_container", fake_start_worker_container)
+
+    resp = test_client.post(
+        "/guilds/guild-cooldown/spawn-worker",
+        headers=_auth(db_url),
+        json={"repos": ["a/b"]},
+    )
+
+    assert resp.status_code == 429
+    assert "cooldown" in resp.json()["detail"].lower()
+    assert started["called"] is False
+
+
+def test_spawn_worker_allowed_after_cooldown_expires(client, monkeypatch):
+    """A guild whose last spawn is older than the cooldown window may spawn again."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-cooldown-ok")
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(
+            select(col(Guild.id)).where(col(Guild.slug) == "guild-cooldown-ok")
+        )
+        session.add(
+            GuildSpawnDefaults(
+                guild_id=guild_pk,
+                repos="[]",
+                tools="[]",
+                agent_count=None,
+                updated_at=datetime.now(UTC) - timedelta(minutes=10),
+            )
+        )
+        session.commit()
+
+    import worker_runtime
+
+    async def fake_check_runtime_available():
+        return None
+
+    async def fake_start_worker_container(*, env, guild_id):
+        return worker_runtime.SpawnedWorker(
+            handle="fake-handle", short_id="fakehandle12", runtime="docker"
+        )
+
+    monkeypatch.setattr(worker_runtime, "check_runtime_available", fake_check_runtime_available)
+    monkeypatch.setattr(worker_runtime, "start_worker_container", fake_start_worker_container)
+
+    resp = test_client.post(
+        "/guilds/guild-cooldown-ok/spawn-worker",
+        headers=_auth(db_url),
+        json={"repos": ["a/b"]},
+    )
+    assert resp.status_code == 200
+
+
 def test_spawn_worker_env_does_not_inject_claude_oauth_token():
     """Claude credentials are per-guild: they come from the guild's foreman
     env_vars, so a backend-wide CLAUDE_CODE_OAUTH_TOKEN is NOT injected at spawn.


### PR DESCRIPTION
Discord's /worker-spawn was the only caller checking check_worker_spawn_cooldown() before spawning. Wire the same 5-minute, per-guild cooldown into foreman/tools.py:spawn_worker() (used by the foreman AI) and routes/workers.py:spawn_worker_container() (the REST endpoint) so a guild can't bypass it via those paths, returning a descriptive error/429 with the remaining wait time.

Closes #1027