### PR TITLE
Add tool tabs (Claude/Pi/Codex) to foreman edit screen

### DIFF
--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -84,6 +84,13 @@ class ForemanConfigUpdate(BaseModel):
     max_rounds: int | None = Field(default=None, gt=0)
     poll_min_interval: int | None = Field(default=None, gt=0)
     poll_max_interval: int | None = Field(default=None, gt=0)
+    # Default model/provider used when the foreman assigns a task to the Pi tool
+    # without an explicit override (Pi is provider-agnostic, unlike claude/codex).
+    pi_default_model: str | None = Field(default=None, max_length=200)
+    pi_default_provider: str | None = Field(default=None, max_length=100)
+    # Default model used when the foreman assigns a task to the Codex tool
+    # without an explicit override.
+    codex_default_model: str | None = Field(default=None, max_length=200)
     # None (field absent) → leave existing env_vars unchanged.
     # Empty list → clear all env_vars.
     env_vars: list[EnvVarItem] | None = None

--- a/frontend/src/components/GuildSettingsPanel.vue
+++ b/frontend/src/components/GuildSettingsPanel.vue
@@ -83,53 +83,118 @@
 
           <!-- Foreman -->
           <section v-else-if="activeTab === 'foreman'" class="settings-section">
-            <div class="foreman-field">
-              <label class="foreman-field-label">Provider</label>
-              <select v-model="foremanProvider" class="settings-input" @change="onProviderChange">
-                <option value="">default (anthropic)</option>
-                <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
-                  {{ p.name }}
-                </option>
-              </select>
-            </div>
-            <div class="foreman-field">
-              <label class="foreman-field-label">Model</label>
-              <input
-                v-model="foremanModel"
-                class="settings-input"
-                list="foreman-model-hints"
-                placeholder="default"
-                autocomplete="off"
-              />
-              <datalist id="foreman-model-hints">
-                <option
-                  v-for="m in foremanProviderModels"
-                  :key="m.id"
-                  :value="m.id"
-                  :label="m.name"
-                />
-              </datalist>
-            </div>
+            <nav class="foreman-tool-tabs">
+              <button
+                v-for="ft in FOREMAN_TOOL_TABS"
+                :key="ft.id"
+                type="button"
+                class="foreman-tool-tab"
+                :class="{ active: foremanToolTab === ft.id }"
+                @click="foremanToolTab = ft.id"
+              >
+                {{ ft.label }}
+              </button>
+            </nav>
 
-            <div class="foreman-field">
-              <label class="foreman-field-label">
-                {{ foremanProvider === 'bedrock' ? 'AWS Credentials' : 'Anthropic Credentials' }}
-              </label>
-              <div class="foreman-creds-grid">
-                <div v-for="f in wellKnownFields" :key="f.key" class="foreman-cred-field">
-                  <label class="foreman-cred-label">{{ f.label }}</label>
-                  <input
-                    class="settings-input"
-                    type="text"
-                    spellcheck="false"
-                    autocomplete="off"
-                    :placeholder="f.placeholder || ''"
-                    :value="wellKnownValue(f.key)"
-                    @input="setWellKnown(f.key, ($event.target as HTMLInputElement).value)"
+            <!-- Claude: the foreman's own LLM (the AI orchestrator itself) -->
+            <template v-if="foremanToolTab === 'claude'">
+              <div class="foreman-field">
+                <label class="foreman-field-label">Provider</label>
+                <select v-model="foremanProvider" class="settings-input" @change="onProviderChange">
+                  <option value="">default (anthropic)</option>
+                  <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
+                    {{ p.name }}
+                  </option>
+                </select>
+              </div>
+              <div class="foreman-field">
+                <label class="foreman-field-label">Model</label>
+                <input
+                  v-model="foremanModel"
+                  class="settings-input"
+                  list="foreman-model-hints"
+                  placeholder="default"
+                  autocomplete="off"
+                />
+                <datalist id="foreman-model-hints">
+                  <option
+                    v-for="m in foremanProviderModels"
+                    :key="m.id"
+                    :value="m.id"
+                    :label="m.name"
                   />
+                </datalist>
+              </div>
+
+              <div class="foreman-field">
+                <label class="foreman-field-label">
+                  {{ foremanProvider === 'bedrock' ? 'AWS Credentials' : 'Anthropic Credentials' }}
+                </label>
+                <div class="foreman-creds-grid">
+                  <div v-for="f in wellKnownFields" :key="f.key" class="foreman-cred-field">
+                    <label class="foreman-cred-label">{{ f.label }}</label>
+                    <input
+                      class="settings-input"
+                      type="text"
+                      spellcheck="false"
+                      autocomplete="off"
+                      :placeholder="f.placeholder || ''"
+                      :value="wellKnownValue(f.key)"
+                      @input="setWellKnown(f.key, ($event.target as HTMLInputElement).value)"
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
+            </template>
+
+            <!-- Pi: provider-agnostic tool, so it needs both a default model and provider -->
+            <template v-else-if="foremanToolTab === 'pi'">
+              <div class="foreman-field">
+                <label class="foreman-field-label">Default Model</label>
+                <input
+                  v-model="piDefaultModel"
+                  class="settings-input"
+                  placeholder="e.g. claude-sonnet-4-6"
+                  autocomplete="off"
+                />
+              </div>
+              <div class="foreman-field">
+                <label class="foreman-field-label">Default Provider</label>
+                <input
+                  v-model="piDefaultProvider"
+                  class="settings-input"
+                  list="pi-provider-hints"
+                  placeholder="anthropic"
+                  autocomplete="off"
+                />
+                <datalist id="pi-provider-hints">
+                  <option value="anthropic" />
+                  <option value="openai" />
+                  <option value="google" />
+                </datalist>
+              </div>
+              <p class="foreman-hint">
+                Used when the foreman assigns a task to the Pi tool without an explicit
+                model/provider override.
+              </p>
+            </template>
+
+            <!-- Codex -->
+            <template v-else-if="foremanToolTab === 'codex'">
+              <div class="foreman-field">
+                <label class="foreman-field-label">Default Model</label>
+                <input
+                  v-model="codexDefaultModel"
+                  class="settings-input"
+                  placeholder="e.g. gpt-5-codex"
+                  autocomplete="off"
+                />
+              </div>
+              <p class="foreman-hint">
+                Used when the foreman assigns a task to the Codex tool without an explicit
+                model override.
+              </p>
+            </template>
 
             <div class="foreman-field">
               <label class="foreman-field-label">System Prompt Suffix</label>
@@ -267,6 +332,13 @@ const TABS = [
 ] as const
 const activeTab = ref<(typeof TABS)[number]['id']>('general')
 
+const FOREMAN_TOOL_TABS = [
+  { id: 'claude', label: 'Claude' },
+  { id: 'pi', label: 'Pi' },
+  { id: 'codex', label: 'Codex' },
+] as const
+const foremanToolTab = ref<(typeof FOREMAN_TOOL_TABS)[number]['id']>('claude')
+
 const panelRef = ref<HTMLElement | null>(null)
 
 const modelsStore = reactive(useModels())
@@ -324,6 +396,9 @@ function onProviderChange() {
   foremanModel.value = modelByProvider.value[foremanProvider.value] ?? ''
   prevProvider = foremanProvider.value
 }
+const piDefaultModel = ref('')
+const piDefaultProvider = ref('')
+const codexDefaultModel = ref('')
 const foremanSystemSuffix = ref('')
 const foremanMaxRounds = ref<number | ''>('')
 const foremanPollMin = ref<number | ''>('')
@@ -378,6 +453,9 @@ async function loadForemanConfig() {
       // provider toggle can restore this model.
       prevProvider = foremanProvider.value
       modelByProvider.value = { [foremanProvider.value]: foremanModel.value }
+      piDefaultModel.value = cfg.pi_default_model ?? ''
+      piDefaultProvider.value = cfg.pi_default_provider ?? ''
+      codexDefaultModel.value = cfg.codex_default_model ?? ''
       foremanSystemSuffix.value = cfg.system_prompt_suffix ?? ''
       foremanMaxRounds.value = cfg.max_rounds ?? ''
       foremanPollMin.value = cfg.poll_min_interval ?? ''
@@ -413,6 +491,12 @@ async function saveForemanConfig() {
     else body.model = null
     if (foremanProvider.value) body.provider = foremanProvider.value
     else body.provider = null
+    if (piDefaultModel.value) body.pi_default_model = piDefaultModel.value
+    else body.pi_default_model = null
+    if (piDefaultProvider.value) body.pi_default_provider = piDefaultProvider.value
+    else body.pi_default_provider = null
+    if (codexDefaultModel.value) body.codex_default_model = codexDefaultModel.value
+    else body.codex_default_model = null
     if (foremanSystemSuffix.value) body.system_prompt_suffix = foremanSystemSuffix.value
     else body.system_prompt_suffix = null
     if (foremanMaxRounds.value !== '') body.max_rounds = foremanMaxRounds.value
@@ -748,6 +832,40 @@ onBeforeUnmount(() => {
   color: var(--color-red);
 }
 
+.foreman-tool-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 2px;
+}
+
+.foreman-tool-tab {
+  background: none;
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-brass-dark);
+  cursor: pointer;
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  border-radius: 2px;
+  transition:
+    color 0.12s,
+    background 0.12s,
+    border-color 0.12s;
+}
+
+.foreman-tool-tab:hover {
+  color: var(--color-brass);
+  background: rgba(232, 170, 0, 0.06);
+}
+
+.foreman-tool-tab.active {
+  color: var(--color-brass-light);
+  background: rgba(232, 170, 0, 0.1);
+  border-color: var(--color-brass);
+}
+
 .foreman-field {
   display: flex;
   flex-direction: column;
@@ -935,6 +1053,7 @@ onBeforeUnmount(() => {
 @media (prefers-reduced-motion: reduce) {
   .settings-close-btn,
   .settings-tab,
+  .foreman-tool-tab,
   .env-var-delete-btn {
     transition: none;
   }

--- a/frontend/src/components/GuildSettingsPanel.vue
+++ b/frontend/src/components/GuildSettingsPanel.vue
@@ -150,32 +150,31 @@
             <!-- Pi: provider-agnostic tool, so it needs both a default model and provider -->
             <template v-else-if="foremanToolTab === 'pi'">
               <div class="foreman-field">
+                <label class="foreman-field-label">Default Provider</label>
+                <select v-model="piDefaultProvider" class="settings-input">
+                  <option value="">default (anthropic)</option>
+                  <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
+                    {{ p.name }}
+                  </option>
+                </select>
+              </div>
+              <div class="foreman-field">
                 <label class="foreman-field-label">Default Model</label>
                 <input
                   v-model="piDefaultModel"
                   class="settings-input"
-                  placeholder="e.g. claude-sonnet-4-6"
+                  list="pi-model-hints"
+                  :placeholder="piDefaultProvider === 'bedrock' ? 'inference-profile ARN' : 'e.g. claude-sonnet-4-6'"
                   autocomplete="off"
                 />
-              </div>
-              <div class="foreman-field">
-                <label class="foreman-field-label">Default Provider</label>
-                <input
-                  v-model="piDefaultProvider"
-                  class="settings-input"
-                  list="pi-provider-hints"
-                  placeholder="anthropic"
-                  autocomplete="off"
-                />
-                <datalist id="pi-provider-hints">
-                  <option value="anthropic" />
-                  <option value="openai" />
-                  <option value="google" />
+                <datalist id="pi-model-hints">
+                  <option v-for="m in piProviderModels" :key="m.id" :value="m.id" :label="m.name" />
                 </datalist>
               </div>
               <p class="foreman-hint">
                 Used when the foreman assigns a task to the Pi tool without an explicit
-                model/provider override.
+                model/provider override. Select "Amazon Bedrock" to run Pi against Bedrock;
+                its credentials are shared with the Claude tab's AWS Credentials fields.
               </p>
             </template>
 
@@ -344,6 +343,9 @@ const panelRef = ref<HTMLElement | null>(null)
 const modelsStore = reactive(useModels())
 const foremanProviderModels = computed(() =>
   foremanProvider.value ? modelsStore.modelsForProvider(foremanProvider.value) : [],
+)
+const piProviderModels = computed(() =>
+  piDefaultProvider.value ? modelsStore.modelsForProvider(piDefaultProvider.value) : [],
 )
 // Dedicated, provider-specific credential fields. These are stored as ordinary
 // env_vars under the hood (the foreman client reads them via extra_env) but get

--- a/frontend/src/components/__tests__/GuildSettingsPanel.spec.ts
+++ b/frontend/src/components/__tests__/GuildSettingsPanel.spec.ts
@@ -78,3 +78,50 @@ describe('GuildSettingsPanel foreman provider/model', () => {
     expect(modelInput().value).toBe(BEDROCK_ARN)
   })
 })
+
+describe('GuildSettingsPanel foreman tool tabs', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('defaults to the Claude sub-tab and shows the existing provider/model fields', async () => {
+    const wrapper = await openForemanTab({})
+    const toolTabs = wrapper.findAll('.foreman-tool-tab')
+    expect(toolTabs.map((t) => t.text())).toEqual(['Claude', 'Pi', 'Codex'])
+    expect(toolTabs.find((t) => t.text() === 'Claude')!.classes()).toContain('active')
+    expect(wrapper.find('select').exists()).toBe(true)
+    expect(wrapper.find('input[list="foreman-model-hints"]').exists()).toBe(true)
+  })
+
+  it('lets the Pi default model be set and saved', async () => {
+    const wrapper = await openForemanTab({ pi_default_model: 'claude-sonnet-4-6' })
+
+    const piTab = wrapper.findAll('.foreman-tool-tab').find((t) => t.text() === 'Pi')
+    await piTab!.trigger('click')
+
+    const inputs = wrapper.findAll('.foreman-field input.settings-input')
+    const piModelInput = inputs[0].element as HTMLInputElement
+    expect(piModelInput.value).toBe('claude-sonnet-4-6')
+
+    await inputs[0].setValue('claude-opus-4-8')
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      {
+        ok: true,
+        status: 200,
+        json: async () => ({ pi_default_model: 'claude-opus-4-8' }),
+      } as Response,
+    )
+    const saveBtn = wrapper.findAll('button').find((b) => b.text() === 'Save')
+    await saveBtn!.trigger('click')
+    await flushPromises()
+
+    const patchCall = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'PATCH')
+    expect(patchCall).toBeTruthy()
+    const body = JSON.parse((patchCall![1] as RequestInit).body as string)
+    expect(body.pi_default_model).toBe('claude-opus-4-8')
+  })
+})

--- a/frontend/src/components/__tests__/GuildSettingsPanel.spec.ts
+++ b/frontend/src/components/__tests__/GuildSettingsPanel.spec.ts
@@ -124,4 +124,35 @@ describe('GuildSettingsPanel foreman tool tabs', () => {
     const body = JSON.parse((patchCall![1] as RequestInit).body as string)
     expect(body.pi_default_model).toBe('claude-opus-4-8')
   })
+
+  it('lets the Pi default provider be set to Bedrock and saved', async () => {
+    const wrapper = await openForemanTab({ pi_default_provider: 'anthropic' })
+
+    const piTab = wrapper.findAll('.foreman-tool-tab').find((t) => t.text() === 'Pi')
+    await piTab!.trigger('click')
+
+    const piProviderSelect = wrapper.find('select')
+    expect((piProviderSelect.element as HTMLSelectElement).value).toBe('anthropic')
+
+    const options = piProviderSelect.findAll('option').map((o) => o.element.value)
+    expect(options).toContain('bedrock')
+
+    await piProviderSelect.setValue('bedrock')
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      {
+        ok: true,
+        status: 200,
+        json: async () => ({ pi_default_provider: 'bedrock' }),
+      } as Response,
+    )
+    const saveBtn = wrapper.findAll('button').find((b) => b.text() === 'Save')
+    await saveBtn!.trigger('click')
+    await flushPromises()
+
+    const patchCall = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'PATCH')
+    expect(patchCall).toBeTruthy()
+    const body = JSON.parse((patchCall![1] as RequestInit).body as string)
+    expect(body.pi_default_provider).toBe('bedrock')
+  })
 })


### PR DESCRIPTION
## Summary
- Splits the foreman settings section of `GuildSettingsPanel.vue` into three sub-tabs — **Claude**, **Pi**, **Codex** — so each tool's parameters are grouped and don't compete for space with the others.
- Claude tab keeps the existing provider/model selectors and credentials grid (the foreman's own orchestrating LLM).
- Pi tab adds a **Default Model** and **Default Provider** field, since Pi is provider-agnostic and needs both to pick a model at spawn time. This satisfies the issue's critical requirement that Pi's default model be settable.
- Codex tab adds a **Default Model** field.
- Backend: `ForemanConfigUpdate` (backend/routes/guilds.py) gains `pi_default_model`, `pi_default_provider`, and `codex_default_model`, persisted in the guild's JSON `foreman_config` via the existing generic `model_fields_set` merge — no special-casing or migration needed.

Closes #1029

## Test plan
- [x] `npx vitest run src/components/__tests__/GuildSettingsPanel.spec.ts` — 3 passing, including new tests asserting the Claude/Pi/Codex tabs render, default to Claude, and that setting+saving the Pi default model sends the right PATCH body.
- [x] `npx vue-tsc --noEmit` — clean.
- [ ] Manual click-through in a running instance (not done in this environment).