### PR TITLE
Scope worker-tool env vars per tool (claude/pi/codex)

### DIFF
--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -125,14 +125,21 @@ async def get_foreman_env_vars(
     (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) into their process environment.
     Requires a valid worker auth_token or member login_token.
 
-    Response: ``{ "env_vars": [{"key": str, "value": str}, ...] }``
+    ``env_vars`` are shared across every tool; ``tool_env_vars`` are scoped to a
+    single worker tool (claude/pi/codex) and must not leak into the others.
+
+    Response: ``{ "env_vars": [{"key", "value"}, ...],
+                  "tool_env_vars": {"claude": [...], "pi": [...], "codex": [...]} }``
     """
     res = await db.exec(select(Guild).where(col(Guild.slug) == guild_id))
     guild = res.one_or_none()
     if not guild:
         raise HTTPException(status_code=404, detail="Guild not found")
     config = guild.foreman_config or {}
-    return {"env_vars": config.get("env_vars", [])}
+    return {
+        "env_vars": config.get("env_vars", []),
+        "tool_env_vars": config.get("tool_env_vars", {}),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -67,6 +67,9 @@ class GuildUpdate(BaseModel):
 
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _MAX_FOREMAN_ENV_VARS = 20
+# Worker tools whose env vars can be scoped per-tool (passed only to that tool's
+# runner, never leaked into the others' environment).
+_SCOPED_TOOLS = {"claude", "pi", "codex"}
 _MAX_ENV_VALUE_LEN = 4096
 
 
@@ -75,6 +78,45 @@ class EnvVarItem(BaseModel):
     # None → keep the currently stored value. Kept for API compatibility; the UI
     # now sends actual values since env vars are returned in clear text.
     value: str | None = None
+
+
+def _validate_env_var_list(v: list[EnvVarItem] | None) -> list[EnvVarItem] | None:
+    if v is None:
+        return v
+    if len(v) > _MAX_FOREMAN_ENV_VARS:
+        raise ValueError(f"Too many env vars (max {_MAX_FOREMAN_ENV_VARS})")
+    for item in v:
+        if not _ENV_KEY_RE.match(item.key):
+            raise ValueError(
+                f"Invalid env var key {item.key!r}; must match ^[A-Za-z_][A-Za-z0-9_]*$"
+            )
+        if item.value is not None and len(item.value) > _MAX_ENV_VALUE_LEN:
+            raise ValueError(
+                f"Value for {item.key!r} exceeds max length ({_MAX_ENV_VALUE_LEN} chars)"
+            )
+    return v
+
+
+def _merge_env_var_list(submitted: list[EnvVarItem], existing: list[dict] | None) -> list[dict]:
+    """Merge a submitted env-var list over the stored one.
+
+    - value None → keep the existing stored value (dropped if none stored).
+    - Duplicate keys collapse, preferring a non-empty value over a blank one so a
+      stray blank row can't shadow a real credential at spawn time.
+    """
+    existing_map: dict[str, str] = {e["key"]: e["value"] for e in (existing or [])}
+    merged: dict[str, str] = {}
+    for item in submitted:
+        if item.value is None:
+            if item.key not in existing_map:
+                continue
+            resolved = existing_map[item.key]
+        else:
+            resolved = item.value
+        if item.key in merged and resolved == "" and merged[item.key] != "":
+            continue
+        merged[item.key] = resolved
+    return [{"key": k, "value": v} for k, v in merged.items()]
 
 
 class ForemanConfigUpdate(BaseModel):
@@ -93,24 +135,29 @@ class ForemanConfigUpdate(BaseModel):
     codex_default_model: str | None = Field(default=None, max_length=200)
     # None (field absent) → leave existing env_vars unchanged.
     # Empty list → clear all env_vars.
+    # Shared env vars: applied to every worker tool AND the foreman's own LLM.
     env_vars: list[EnvVarItem] | None = None
+    # Per-tool env vars: each tool's runner receives only its own set (plus the
+    # shared env_vars), so e.g. Pi's Bedrock token never reaches the Claude CLI.
+    # None → leave unchanged; a tool mapped to [] clears that tool's vars.
+    tool_env_vars: dict[str, list[EnvVarItem]] | None = None
 
     @field_validator("env_vars")
     @classmethod
     def validate_env_vars(cls, v: list[EnvVarItem] | None) -> list[EnvVarItem] | None:
+        return _validate_env_var_list(v)
+
+    @field_validator("tool_env_vars")
+    @classmethod
+    def validate_tool_env_vars(
+        cls, v: dict[str, list[EnvVarItem]] | None
+    ) -> dict[str, list[EnvVarItem]] | None:
         if v is None:
             return v
-        if len(v) > _MAX_FOREMAN_ENV_VARS:
-            raise ValueError(f"Too many env vars (max {_MAX_FOREMAN_ENV_VARS})")
-        for item in v:
-            if not _ENV_KEY_RE.match(item.key):
-                raise ValueError(
-                    f"Invalid env var key {item.key!r}; must match ^[A-Za-z_][A-Za-z0-9_]*$"
-                )
-            if item.value is not None and len(item.value) > _MAX_ENV_VALUE_LEN:
-                raise ValueError(
-                    f"Value for {item.key!r} exceeds max length ({_MAX_ENV_VALUE_LEN} chars)"
-                )
+        for tool, items in v.items():
+            if tool not in _SCOPED_TOOLS:
+                raise ValueError(f"Unknown tool {tool!r}; must be one of {sorted(_SCOPED_TOOLS)}")
+            _validate_env_var_list(items)
         return v
 
 
@@ -502,26 +549,21 @@ async def update_foreman_config(
                 # Explicit null → clear all env vars
                 config.pop("env_vars", None)
             else:
-                existing_map: dict[str, str] = {
-                    e["key"]: e["value"] for e in config.get("env_vars", [])
-                }
                 # Collapse duplicate keys (the guild edit screen can submit the
                 # same key twice — e.g. a well-known field plus a free-form row),
                 # keeping a non-empty value over a blank one so a stray blank
                 # can't shadow the real value at spawn time.
-                merged: dict[str, str] = {}
-                for item in value:
-                    if item.value is None:
-                        # Unchanged: keep the existing stored value if present
-                        if item.key not in existing_map:
-                            continue
-                        resolved = existing_map[item.key]
-                    else:
-                        resolved = item.value
-                    if item.key in merged and resolved == "" and merged[item.key] != "":
-                        continue
-                    merged[item.key] = resolved
-                config["env_vars"] = [{"key": k, "value": v} for k, v in merged.items()]
+                config["env_vars"] = _merge_env_var_list(value, config.get("env_vars"))
+        elif field == "tool_env_vars":
+            if value is None:
+                config.pop("tool_env_vars", None)
+            else:
+                # Merge each submitted tool independently; tools absent from the
+                # payload keep their stored vars. A tool mapped to [] clears it.
+                existing_tools: dict = dict(config.get("tool_env_vars") or {})
+                for tool, items in value.items():
+                    existing_tools[tool] = _merge_env_var_list(items, existing_tools.get(tool))
+                config["tool_env_vars"] = existing_tools
         elif value is None:
             config.pop(field, None)
         else:

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -395,6 +395,63 @@ def test_foreman_config_env_vars_round_trip_in_clear(client):
     }
 
 
+def test_foreman_config_tool_env_vars_round_trip_and_scope(client):
+    """Per-tool env vars round-trip under tool_env_vars, isolated per tool, and
+    merge independently of the shared env_vars list."""
+    test_client, db_url = client
+    token = make_auth_token(db_url)  # owner of g-ftool
+    insert_guild(db_url, "g-ftool")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    patch = test_client.patch(
+        "/api/guilds/g-ftool/foreman-config",
+        headers=headers,
+        json={
+            "env_vars": [{"key": "GITHUB_TOKEN", "value": "shared"}],
+            "tool_env_vars": {
+                "claude": [{"key": "CLAUDE_CODE_OAUTH_TOKEN", "value": "claude-tok"}],
+                "pi": [{"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "pi-bedrock"}],
+                "codex": [],
+            },
+        },
+    )
+    assert patch.status_code == 200
+    cfg = patch.json()
+    assert cfg["tool_env_vars"]["claude"] == [
+        {"key": "CLAUDE_CODE_OAUTH_TOKEN", "value": "claude-tok"}
+    ]
+    assert cfg["tool_env_vars"]["pi"] == [
+        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "pi-bedrock"}
+    ]
+    assert cfg["tool_env_vars"]["codex"] == []
+
+    # A later PATCH touching only claude leaves pi's scoped vars intact.
+    patch2 = test_client.patch(
+        "/api/guilds/g-ftool/foreman-config",
+        headers=headers,
+        json={"tool_env_vars": {"claude": [{"key": "ANTHROPIC_API_KEY", "value": "sk-x"}]}},
+    )
+    assert patch2.status_code == 200
+    cfg2 = patch2.json()
+    assert cfg2["tool_env_vars"]["pi"] == [
+        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "pi-bedrock"}
+    ]
+    assert {e["key"] for e in cfg2["tool_env_vars"]["claude"]} == {"ANTHROPIC_API_KEY"}
+
+
+def test_foreman_config_tool_env_vars_rejects_unknown_tool(client):
+    test_client, db_url = client
+    token = make_auth_token(db_url)
+    insert_guild(db_url, "g-fbad")
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = test_client.patch(
+        "/api/guilds/g-fbad/foreman-config",
+        headers=headers,
+        json={"tool_env_vars": {"gemini": [{"key": "GEMINI_API_KEY", "value": "x"}]}},
+    )
+    assert resp.status_code == 422
+
+
 def test_foreman_config_dedups_duplicate_keys_preferring_nonempty(client):
     """The guild edit screen can submit the same key twice (a well-known field
     plus a free-form row). The stored config keeps one entry, and a blank value

--- a/frontend/src/components/GuildSettingsPanel.vue
+++ b/frontend/src/components/GuildSettingsPanel.vue
@@ -98,6 +98,10 @@
 
             <!-- Claude: the foreman's own LLM (the AI orchestrator itself) -->
             <template v-if="foremanToolTab === 'claude'">
+              <p class="foreman-hint">
+                These configure the foreman's own orchestrator LLM (the AI itself). The Claude
+                worker CLI's environment is in the section below.
+              </p>
               <div class="foreman-field">
                 <label class="foreman-field-label">Provider</label>
                 <select v-model="foremanProvider" class="settings-input" @change="onProviderChange">
@@ -173,8 +177,9 @@
               </div>
               <p class="foreman-hint">
                 Used when the foreman assigns a task to the Pi tool without an explicit
-                model/provider override. Select "Amazon Bedrock" to run Pi against Bedrock;
-                its credentials are shared with the Claude tab's AWS Credentials fields.
+                model/provider override. Select "Amazon Bedrock" to run Pi against Bedrock; set its
+                AWS credentials in the Pi Environment section below (or the shared variables, which
+                apply to every tool).
               </p>
             </template>
 
@@ -241,6 +246,8 @@
                 </button>
               </div>
             </div>
+
+            <div class="foreman-divider">General — applies to all tools &amp; the foreman</div>
 
             <div class="foreman-field">
               <label class="foreman-field-label">System Prompt Suffix</label>
@@ -1023,6 +1030,17 @@ onBeforeUnmount(() => {
   color: var(--color-brass-light);
   background: rgba(232, 170, 0, 0.1);
   border-color: var(--color-brass);
+}
+
+.foreman-divider {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  border-top: 1px solid var(--color-brass-dark);
+  padding-top: 12px;
+  margin-top: 6px;
 }
 
 .foreman-field {

--- a/frontend/src/components/GuildSettingsPanel.vue
+++ b/frontend/src/components/GuildSettingsPanel.vue
@@ -195,6 +195,53 @@
               </p>
             </template>
 
+            <!-- Per-tool environment: passed ONLY to the selected tool's runner,
+                 never leaked to the other tools. -->
+            <div class="foreman-field">
+              <label class="foreman-field-label">{{ activeToolLabel }} Environment</label>
+              <p class="foreman-hint">
+                Passed only to the {{ activeToolLabel }} CLI — never to the other tools. Overrides
+                the shared variables below for this tool. Pick a known variable or type your own.
+              </p>
+              <div class="env-var-list">
+                <div
+                  v-for="row in toolEnvRows[foremanToolTab]"
+                  :key="row.id"
+                  class="env-var-row"
+                >
+                  <input
+                    v-model="row.key"
+                    class="settings-input env-var-key"
+                    :list="`tool-env-keys-${foremanToolTab}`"
+                    placeholder="KEY_NAME"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                  <input
+                    v-model="row.value"
+                    type="text"
+                    class="settings-input env-var-value"
+                    placeholder="value"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                  <button
+                    class="env-var-delete-btn"
+                    @click="removeToolEnvVar(row)"
+                    title="Remove variable"
+                  >
+                    ✕
+                  </button>
+                </div>
+                <datalist :id="`tool-env-keys-${foremanToolTab}`">
+                  <option v-for="k in TOOL_ENV_KEYS[foremanToolTab]" :key="k" :value="k" />
+                </datalist>
+                <button class="pixel-btn env-var-add-btn" @click="addToolEnvVar">
+                  + Add Variable
+                </button>
+              </div>
+            </div>
+
             <div class="foreman-field">
               <label class="foreman-field-label">System Prompt Suffix</label>
               <textarea
@@ -240,8 +287,11 @@
             </div>
 
             <div class="foreman-field">
-              <label class="foreman-field-label">Environment Variables</label>
-              <p class="foreman-hint">Inherited by every worker spawned in this guild.</p>
+              <label class="foreman-field-label">Shared Environment Variables</label>
+              <p class="foreman-hint">
+                Inherited by every worker tool in this guild and the foreman's own LLM. Use the
+                per-tool sections above to scope a variable to a single tool.
+              </p>
               <div class="env-var-list">
                 <div v-for="row in additionalEnvVarRows" :key="row.id" class="env-var-row">
                   <input
@@ -337,6 +387,67 @@ const FOREMAN_TOOL_TABS = [
   { id: 'codex', label: 'Codex' },
 ] as const
 const foremanToolTab = ref<(typeof FOREMAN_TOOL_TABS)[number]['id']>('claude')
+const activeToolLabel = computed(
+  () => FOREMAN_TOOL_TABS.find((t) => t.id === foremanToolTab.value)?.label ?? '',
+)
+
+// Known env-var keys per worker tool, surfaced as datalist suggestions. Users can
+// still type any other key. Sourced from each CLI's own docs (`pi --help`, Claude
+// Code / Codex provider env vars).
+const TOOL_ENV_KEYS: Record<string, string[]> = {
+  claude: [
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_AUTH_TOKEN',
+    'ANTHROPIC_BASE_URL',
+    'ANTHROPIC_MODEL',
+    'CLAUDE_CODE_USE_BEDROCK',
+    'AWS_REGION',
+    'AWS_PROFILE',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_BEARER_TOKEN_BEDROCK',
+  ],
+  codex: ['OPENAI_API_KEY', 'OPENAI_BASE_URL'],
+  pi: [
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_OAUTH_TOKEN',
+    'OPENAI_API_KEY',
+    'AZURE_OPENAI_API_KEY',
+    'AZURE_OPENAI_BASE_URL',
+    'AZURE_OPENAI_RESOURCE_NAME',
+    'AZURE_OPENAI_API_VERSION',
+    'AZURE_OPENAI_DEPLOYMENT_NAME_MAP',
+    'DEEPSEEK_API_KEY',
+    'GEMINI_API_KEY',
+    'GROQ_API_KEY',
+    'CEREBRAS_API_KEY',
+    'XAI_API_KEY',
+    'FIREWORKS_API_KEY',
+    'TOGETHER_API_KEY',
+    'OPENROUTER_API_KEY',
+    'AI_GATEWAY_API_KEY',
+    'ZAI_API_KEY',
+    'MISTRAL_API_KEY',
+    'MINIMAX_API_KEY',
+    'MOONSHOT_API_KEY',
+    'OPENCODE_API_KEY',
+    'KIMI_API_KEY',
+    'CLOUDFLARE_API_KEY',
+    'CLOUDFLARE_ACCOUNT_ID',
+    'CLOUDFLARE_GATEWAY_ID',
+    'XIAOMI_API_KEY',
+    'XIAOMI_TOKEN_PLAN_CN_API_KEY',
+    'XIAOMI_TOKEN_PLAN_AMS_API_KEY',
+    'XIAOMI_TOKEN_PLAN_SGP_API_KEY',
+    'AWS_PROFILE',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_BEARER_TOKEN_BEDROCK',
+    'AWS_REGION',
+  ],
+}
 
 const panelRef = ref<HTMLElement | null>(null)
 
@@ -425,6 +536,20 @@ interface EnvVarRow {
 let envRowSeq = 0
 const envVarRows = ref<EnvVarRow[]>([])
 
+// Per-tool env var rows, keyed by tool id. Each tool's rows are saved under
+// foreman_config.tool_env_vars[tool] and reach only that tool's runner.
+const toolEnvRows = reactive<Record<string, EnvVarRow[]>>({ claude: [], pi: [], codex: [] })
+
+function addToolEnvVar() {
+  toolEnvRows[foremanToolTab.value].push({ id: ++envRowSeq, key: '', value: '' })
+}
+
+function removeToolEnvVar(row: EnvVarRow) {
+  const rows = toolEnvRows[foremanToolTab.value]
+  const i = rows.indexOf(row)
+  if (i >= 0) rows.splice(i, 1)
+}
+
 function wellKnownValue(key: string): string {
   return envVarRows.value.find((r) => r.key === key)?.value ?? ''
 }
@@ -468,6 +593,14 @@ async function loadForemanConfig() {
         key: e.key,
         value: e.value ?? '',
       }))
+      const toolEnv = cfg.tool_env_vars ?? {}
+      for (const tool of ['claude', 'pi', 'codex']) {
+        toolEnvRows[tool] = (toolEnv[tool] ?? []).map((e: { key: string; value?: string }) => ({
+          id: ++envRowSeq,
+          key: e.key,
+          value: e.value ?? '',
+        }))
+      }
     }
   } catch {
     // non-fatal: fields stay blank (will use server defaults)
@@ -521,6 +654,20 @@ async function saveForemanConfig() {
       envByKey.set(key, r.value)
     }
     body.env_vars = [...envByKey].map(([key, value]) => ({ key, value }))
+    // Per-tool env vars: send all three tools so an emptied tab clears its set.
+    const toolEnvVars: Record<string, { key: string; value: string }[]> = {}
+    for (const tool of ['claude', 'pi', 'codex']) {
+      const byKey = new Map<string, string>()
+      for (const r of toolEnvRows[tool]) {
+        const key = r.key.trim()
+        if (!key) continue
+        const existing = byKey.get(key)
+        if (existing && r.value === '' && existing !== '') continue
+        byKey.set(key, r.value)
+      }
+      toolEnvVars[tool] = [...byKey].map(([key, value]) => ({ key, value }))
+    }
+    body.tool_env_vars = toolEnvVars
     const res = await fetch(
       `${API_BASE}/api/guilds/${encodeURIComponent(currentGuild.value.id)}/foreman-config`,
       {
@@ -538,6 +685,16 @@ async function saveForemanConfig() {
         key: e.key,
         value: e.value ?? '',
       }))
+      const savedToolEnv = saved.tool_env_vars ?? {}
+      for (const tool of ['claude', 'pi', 'codex']) {
+        toolEnvRows[tool] = (savedToolEnv[tool] ?? []).map(
+          (e: { key: string; value?: string }) => ({
+            id: ++envRowSeq,
+            key: e.key,
+            value: e.value ?? '',
+          }),
+        )
+      }
     } else {
       foremanStatus.value = 'error'
     }

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -291,6 +291,7 @@ async def run_claude_auto(
     claude_path: str = "claude",
     resume_session_id: str | None = None,
     model: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Run claude on *description* in *cwd*. Returns (success, stop_reason, last_assistant_text, session_id).
 
@@ -333,6 +334,7 @@ async def run_claude_auto(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             limit=STDOUT_LINE_LIMIT,
+            env=env,
         )
         logger.info("claude subprocess started pid=%s", proc.pid)
         claude_proc = ClaudeProcess(proc)

--- a/worker/pioneer_worker/codex_runner.py
+++ b/worker/pioneer_worker/codex_runner.py
@@ -83,6 +83,7 @@ async def run_codex_auto(
     openai_api_key: str | None = None,
     model: str | None = None,
     resume_session_id: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Run codex on *description* in *cwd*. Returns (success, stop_reason, last_text, session_id).
 
@@ -108,6 +109,7 @@ async def run_codex_auto(
         openai_api_key=openai_api_key,
         model=model,
         resume_session_id=resume_session_id,
+        env=env,
     )
     if resume_session_id and not success:
         logger.warning(
@@ -125,6 +127,7 @@ async def run_codex_auto(
             openai_api_key=openai_api_key,
             model=model,
             resume_session_id=None,
+            env=env,
         )
     return success, stop_reason, last_text, session_id
 
@@ -139,6 +142,7 @@ async def _run_codex_once(
     openai_api_key: str | None,
     model: str | None,
     resume_session_id: str | None,
+    env: dict[str, str] | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Single codex invocation. See run_codex_auto for the retrying wrapper."""
     last_message_file = tempfile.NamedTemporaryFile(
@@ -173,16 +177,16 @@ async def _run_codex_once(
         # prompt content and tries to drain it. Give it an idle TTY so the
         # explicit prompt argument is the only task input.
         master_fd, slave_fd = pty.openpty()
-        env = dict(os.environ)
+        subprocess_env = dict(env) if env is not None else dict(os.environ)
         if openai_api_key is not None:
-            env["OPENAI_API_KEY"] = openai_api_key
+            subprocess_env["OPENAI_API_KEY"] = openai_api_key
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=cwd,
             stdin=slave_fd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env=env,
+            env=subprocess_env,
             limit=8 * 1024 * 1024,  # raise readline limit to 8 MB
         )
         os.close(slave_fd)

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -161,6 +161,7 @@ async def run_pi_auto(
     model: str | None = None,
     provider: str | None = None,
     resume_session_id: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Run pi on *description* in *cwd*.
 
@@ -194,6 +195,7 @@ async def run_pi_auto(
         model=model,
         provider=provider,
         resume_session_id=resume_session_id,
+        env=env,
     )
     if resume_session_id and not success:
         logger.warning(
@@ -212,6 +214,7 @@ async def run_pi_auto(
             model=model,
             provider=provider,
             resume_session_id=None,
+            env=env,
         )
     return success, stop_reason, last_text, session_id
 
@@ -227,6 +230,7 @@ async def _run_pi_once(
     model: str | None,
     provider: str | None,
     resume_session_id: str | None,
+    env: dict[str, str] | None = None,
 ) -> tuple[bool, str, str, str | None]:
     """Single pi invocation. See run_pi_auto for the retrying wrapper."""
     cmd = [pi_path]
@@ -257,6 +261,7 @@ async def _run_pi_once(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             limit=_STREAM_LIMIT,
+            env=env,
             # Own process group so _signal_group() can reap pi's tool children.
             start_new_session=True,
         )

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -172,6 +172,10 @@ class Worker:
         self._broadcast_repos: list[str] = list(cfg.repos)
         # Available tool runners detected at startup (e.g. ["claude", "codex", "pi"]).
         self._available_tools: list[str] = []
+        # Per-tool env vars (claude/pi/codex). Kept OUT of os.environ so one tool's
+        # credentials never leak into another's subprocess; merged over os.environ
+        # only when spawning that specific tool. See _env_for_tool.
+        self._tool_env: dict[str, dict[str, str]] = {}
 
     # ------------------------------------------------------------------ HTTP
     async def _http(self, *, authed: bool = False) -> httpx.AsyncClient:
@@ -305,7 +309,8 @@ class Worker:
                     "Foreman env vars: status %d (no vars or not auth'd)", resp.status_code
                 )
                 return
-            env_vars = resp.json().get("env_vars", [])
+            payload = resp.json()
+            env_vars = payload.get("env_vars", [])
             applied = 0
             for item in env_vars:
                 key = item.get("key", "")
@@ -320,8 +325,33 @@ class Worker:
                     logger.debug("Skipping foreman env var %s (already set in environment)", key)
             if applied:
                 logger.info("Applied %d foreman env var(s) to process environment", applied)
+
+            # Per-tool env vars stay scoped: stored here, never dumped into
+            # os.environ, and merged in only when the matching tool is spawned.
+            self._tool_env = {}
+            for tool, items in (payload.get("tool_env_vars") or {}).items():
+                scoped: dict[str, str] = {}
+                for item in items or []:
+                    key = item.get("key", "")
+                    value = item.get("value")
+                    if key and value is not None:
+                        scoped[key] = value
+                if scoped:
+                    self._tool_env[tool] = scoped
+                    logger.info("Loaded %d scoped env var(s) for tool %r", len(scoped), tool)
         except Exception as exc:
             logger.warning("Could not fetch foreman env vars: %s", exc)
+
+    def _env_for_tool(self, tool: str) -> dict[str, str]:
+        """Return the environment a *tool*'s runner subprocess should inherit.
+
+        Base process env (which already carries the shared foreman env_vars)
+        overlaid with the tool's own scoped vars. Scoped vars win so a guild can
+        override a shared default for one tool without affecting the others.
+        """
+        env = dict(os.environ)
+        env.update(self._tool_env.get(tool, {}))
+        return env
 
     async def _check_gh_auth(self) -> None:
         """Run `gh auth status` and log the result as a startup health check."""
@@ -401,13 +431,14 @@ class Worker:
         is dropped from the available-tools list with a warning rather than
         launched and failed per-task.
         """
+        env = self._env_for_tool(name)
         if name == "claude":
-            if os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
+            if env.get("ANTHROPIC_API_KEY") or env.get("CLAUDE_CODE_OAUTH_TOKEN"):
                 return True
             # Fall back to a locally logged-in CLI (dev machines / keychain).
             return await self._claude_is_authenticated()
         if name == "codex":
-            return bool(os.environ.get("OPENAI_API_KEY") or self.cfg.openai_api_key)
+            return bool(env.get("OPENAI_API_KEY") or self.cfg.openai_api_key)
         return True  # pi and any other tool need no credentials
 
     async def _detect_available_tools(self) -> None:
@@ -1885,6 +1916,9 @@ class Worker:
             success = False
             stop_reason = "no_events"
             last_msg = ""
+            # Scoped environment for this tool: shared vars + this tool's own set,
+            # with the other tools' credentials deliberately excluded.
+            tool_env = self._env_for_tool(tool)
 
             while True:
                 if tool == "codex":
@@ -1910,6 +1944,7 @@ class Worker:
                         openai_api_key=self.cfg.openai_api_key,
                         model=_codex_model,
                         resume_session_id=resume_session_id,
+                        env=tool_env,
                     )
                 elif tool == "pi":
                     _pi_model = task.get("model") or self.cfg.pi_model
@@ -1938,6 +1973,7 @@ class Worker:
                         on_usage=_collect_usage,
                         on_proc=_on_proc,
                         resume_session_id=resume_session_id,
+                        env=tool_env,
                     )
                     # pi returns its session via the return value, not the
                     # ClaudeProcess slot; just release the live handle so the
@@ -1968,6 +2004,7 @@ class Worker:
                         claude_path=self.cfg.claude_path,
                         resume_session_id=resume_session_id,
                         model=_claude_model,
+                        env=tool_env,
                     )
 
                     _capture_session_and_clear()

--- a/worker/tests/test_tools_detection.py
+++ b/worker/tests/test_tools_detection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -214,6 +215,47 @@ class TestCredentialGating:
         with patch("shutil.which", return_value="pi"):
             await worker._detect_available_tools()
         assert "pi" in worker._available_tools
+
+
+class TestPerToolEnvScoping:
+    """Per-tool env vars reach only their own tool and gate credentials without
+    leaking into os.environ or the other tools."""
+
+    async def test_env_for_tool_isolates_scoped_vars(self, monkeypatch):
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setenv("SHARED_VAR", "shared")
+        worker = Worker(_make_cfg())
+        worker._tool_env = {
+            "claude": {"CLAUDE_CODE_OAUTH_TOKEN": "claude-tok"},
+            "pi": {"AWS_BEARER_TOKEN_BEDROCK": "pi-bedrock"},
+        }
+
+        claude_env = worker._env_for_tool("claude")
+        pi_env = worker._env_for_tool("pi")
+
+        # Each tool sees its own scoped var plus the shared process env...
+        assert claude_env["CLAUDE_CODE_OAUTH_TOKEN"] == "claude-tok"
+        assert claude_env["SHARED_VAR"] == "shared"
+        assert pi_env["AWS_BEARER_TOKEN_BEDROCK"] == "pi-bedrock"
+        # ...but never the other tool's scoped var.
+        assert "AWS_BEARER_TOKEN_BEDROCK" not in claude_env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in pi_env
+        # Scoped vars must not have leaked into the real process environment.
+        assert "AWS_BEARER_TOKEN_BEDROCK" not in os.environ
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in os.environ
+
+    async def test_scoped_credential_gates_tool_availability(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        cfg = _make_cfg(tools=["claude"], claude_path="claude")
+        worker = Worker(cfg)
+        worker._claude_is_authenticated = AsyncMock(return_value=False)
+        # Credential present only in the claude-scoped env (never os.environ).
+        worker._tool_env = {"claude": {"CLAUDE_CODE_OAUTH_TOKEN": "claude-tok"}}
+        with patch("shutil.which", return_value="claude"):
+            await worker._detect_available_tools()
+        assert "claude" in worker._available_tools
 
 
 class TestToolsCLIFlag:


### PR DESCRIPTION
## Problem

Env vars were a single flat `foreman_config.env_vars` list. The worker dumped **all** of them into `os.environ`, so every runner subprocess (claude/pi/codex) inherited **everything** — no isolation. A Bedrock token meant for Pi also landed in the Claude CLI's environment.

## Solution

Split env vars **by tool** while keeping the shared bag (per the scoping decision — backward compatible, JSON, no DB migration).

- **Data model**: add `foreman_config.tool_env_vars: {claude, pi, codex}` alongside the existing shared `env_vars`.
- **Backend** (`guilds.py`, `foreman.py`): per-tool validation (rejects unknown tools), independent per-tool merge (mirrors the shared-list dedup), and the worker `env-vars` endpoint now also returns `tool_env_vars`.
- **Worker** (`worker.py`): scoped vars are stored in `self._tool_env` and **never** written to `os.environ`. New `_env_for_tool(tool)` overlays a tool's vars on the base env only when spawning that tool; `_tool_has_credentials` consults the scoped env.
- **Runners** (claude/pi/codex): each gains an `env=` param passed to the subprocess (`env=None` preserves the prior inherit-everything behavior).
- **Frontend** (`GuildSettingsPanel.vue`): each Claude/Pi/Codex tab gets a scoped-env section with a datalist dropdown of that CLI's known keys; the shared list is relabeled/explained.

The docker spawn path deliberately still injects only the shared `env_vars` into the container's flat env — scoped vars are fetched per-tool inside the worker so isolation holds for both docker and standalone workers.

## UI layout

The foreman settings screen now reads as its two real buckets:
- **Per-tool** (the Claude/Pi/Codex tabs): tool-specific model/provider fields + a scoped `<Tool> Environment` section.
- **General** (below a divider, rendered once): system prompt suffix, max rounds, poll intervals, and the **Shared Environment Variables** list (all tools + the foreman's own LLM).

Also captioned the Claude tab's provider/model/credentials as the foreman's own orchestrator LLM (distinct from the Claude worker CLI's env section below it), so the two "claudes" no longer read as one.

## Env vars surfaced per tool

- **Claude**: `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL`, `CLAUDE_CODE_USE_BEDROCK`, `AWS_*`.
- **Codex**: `OPENAI_API_KEY`, `OPENAI_BASE_URL`.
- **Pi**: the full ~30-key provider list from `pi --help`.

## Out of scope

Per-task foreman-chosen extra CLI flags — deferred to #1036. The runners' new `env=` param mirrors exactly where a per-task `extra_args=` would slot in, so this doesn't box it out.

## Testing

- `backend`: 71 pass, incl. new round-trip / per-tool isolation / unknown-tool-rejection cases.
- `worker`: 116 pass, incl. new env-isolation (`_env_for_tool`) and scoped-credential-gating tests.
- `frontend`: `vue-tsc` type-check clean. Vitest not run — the local `node_modules` has linux binaries on this darwin machine (pre-existing env issue); the panel spec asserts only fields this PR doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)