### PR TITLE
feat(worker): attribute push + PR to the triggering user, App for reads/comments

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -25,6 +25,7 @@ from models import (
     GithubToken,
     Guild,
     GuildMember,
+    Task,
     User,
     UserSession,
 )
@@ -77,21 +78,43 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
 @router.get("/auth/github/token")
 async def get_github_token(
     guild_id: str = Query(...),
+    task_id: str | None = Query(None),
     _principal: str = Depends(require_worker_or_member),
     db: AsyncSession = Depends(get_db_dep),
 ):
     """Return a GitHub token for the guild, for workers to use.
 
-    Prefers the GitHub App installation token when configured (so worker
-    actions like ``gh pr comment`` are attributed to the App identity);
-    otherwise falls back to the stored OAuth token for the guild's linked
-    GitHub user.
+    When ``task_id`` is given (push / PR creation), prefers the OAuth token of
+    the human who triggered that task so the branch and PR are attributed to
+    them, falling back to the App installation token if that user has no stored
+    token. Without ``task_id`` (guild-level reads: clone / fetch / webhook),
+    prefers the GitHub App installation token so automation is attributed to the
+    App identity; otherwise falls back to the guild owner's OAuth token.
 
     Requires a worker auth_token (from registration) or a member login_token.
     Without auth, anyone knowing a guild_id could exfiltrate the GitHub token."""
     guild_res = await db.exec(select(Guild).where(col(Guild.slug) == guild_id))
     guild = guild_res.one_or_none()
     installation_id = guild.github_app_installation_id if guild else None
+
+    # Task-scoped request → attribute to the triggering user's OAuth token.
+    if task_id:
+        task_q = select(col(Task.user_id)).where(col(Task.id) == task_id)
+        if guild is not None:
+            task_q = task_q.where(col(Task.guild_id) == guild.id)
+        task_user_id = (await db.exec(task_q)).one_or_none()
+        if task_user_id:
+            row = (
+                await db.exec(
+                    select(col(GithubToken.access_token), col(GithubToken.github_username)).where(
+                        col(GithubToken.github_user_id) == task_user_id
+                    )
+                )
+            ).first()
+            if row:
+                return {"access_token": row.access_token, "username": row.github_username}
+        # No user token for this task — fall through to the App/owner token.
+
     app_token = get_app_installation_token(installation_id)
     if app_token:
         resp = {"access_token": app_token, "username": get_app_slug()}

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -395,6 +395,7 @@ async def assign_task(
             phase=data.phase or "execute",
             parent_task_id=data.parent_task_id,
             created_at=created_at,
+            user_id=github_user_id,
         )
     )
     await db.commit()

--- a/backend/tests/test_credentials_auth.py
+++ b/backend/tests/test_credentials_auth.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 
 sys.path.insert(0, os.path.dirname(__file__))
 from helpers import _sync_session, insert_guild
-from models import GithubToken, Guild
+from models import GithubToken, Guild, Task
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col  # noqa: E402
@@ -102,6 +102,78 @@ def test_get_github_token_uses_guild_members_owner(client):
     data = resp.json()
     assert "access_token" in data
     assert "username" in data
+
+
+def _insert_task(db_url: str, guild_slug: str, task_id: str, user_id: str | None) -> None:
+    now = datetime.now(UTC)
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == guild_slug))
+        assert guild_pk is not None, f"Guild {guild_slug!r} not found"
+        session.execute(
+            pg_insert(Task)
+            .values(
+                id=task_id,
+                guild_id=guild_pk,
+                description="do a thing",
+                state="pending",
+                created_at=now,
+                user_id=user_id,
+            )
+            .on_conflict_do_nothing(index_elements=["id"])
+        )
+        session.commit()
+
+
+def test_get_github_token_task_id_returns_triggering_user_token(client):
+    """With task_id, the endpoint returns the triggering user's own OAuth token
+    (push/PR attributed to them), not the guild owner's."""
+    test_client, db_url = client
+    insert_guild(db_url, "g-task-tok")  # owner gh-user-test, token gh_tok
+    # A different human triggered the task; seed their distinct token.
+    _seed_github_token(db_url, user_id="gh-triggerer")
+    with _sync_session(db_url) as session:
+        session.execute(
+            pg_insert(GithubToken)
+            .values(
+                github_user_id="gh-triggerer",
+                github_username="triggerer",
+                access_token="trigger_tok",
+                token_type="bearer",
+                scope="repo",
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+            .on_conflict_do_update(
+                index_elements=["github_user_id"], set_={"access_token": "trigger_tok"}
+            )
+        )
+        session.commit()
+    _insert_task(db_url, "g-task-tok", "t-trig1", user_id="gh-triggerer")
+    worker = _register_worker(test_client, "g-task-tok")
+    resp = test_client.get(
+        "/auth/github/token",
+        params={"guild_id": "g-task-tok", "task_id": "t-trig1"},
+        headers={"Authorization": f"Bearer {worker['auth_token']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["access_token"] == "trigger_tok"
+
+
+def test_get_github_token_task_id_falls_back_when_no_user_token(client):
+    """A task whose user has no stored token falls back to the guild owner's
+    token (which, in prod with an App configured, would be the App token)."""
+    test_client, db_url = client
+    insert_guild(db_url, "g-task-fb")
+    _seed_github_token(db_url)
+    _insert_task(db_url, "g-task-fb", "t-nouser", user_id=None)
+    worker = _register_worker(test_client, "g-task-fb")
+    resp = test_client.get(
+        "/auth/github/token",
+        params={"guild_id": "g-task-fb", "task_id": "t-nouser"},
+        headers={"Authorization": f"Bearer {worker['auth_token']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["access_token"] == "gh_tok"
 
 
 def test_get_github_token_no_owner_in_guild_members(client):

--- a/backend/tests/test_credentials_auth.py
+++ b/backend/tests/test_credentials_auth.py
@@ -173,7 +173,8 @@ def test_get_github_token_task_id_falls_back_when_no_user_token(client):
         headers={"Authorization": f"Bearer {worker['auth_token']}"},
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["access_token"] == "gh_tok"
+    # Owner gh-user-test's token from the auth fixture (make_auth_token).
+    assert resp.json()["access_token"] == "gh_tok_fake"
 
 
 def test_get_github_token_no_owner_in_guild_members(client):

--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -73,9 +73,15 @@ async def push_branch(
     *,
     branch: str,
     worktree_path: str,
+    token: str | None,
     emit: EmitFn,
 ) -> bool:
-    """Push *branch* to origin. Returns True on success."""
+    """Push *branch* using *token*. Returns True on success.
+
+    The token is passed in an explicit push URL rather than baked into the
+    shared ``origin`` remote, so concurrent agents can push as different users
+    and a stale clone-time token can never be reused. ``-u`` is omitted so the
+    token-bearing URL is never persisted as the branch upstream."""
     # Stage and commit any uncommitted work so it isn't silently lost on push
     # (can happen on max-turns, plan-phase completion, or normal task end).
     rc_status, status_out, _ = await git_ops.run_git(["status", "--porcelain"], cwd=worktree_path)
@@ -91,7 +97,22 @@ async def push_branch(
             return False
 
     await emit(f"Pushing {branch}...", level=_LEVEL)
-    rc, _, err = await git_ops.run_git(["push", "-u", "origin", branch], cwd=worktree_path)
+    # ponytail: token in argv is visible via `ps`/DEBUG logs; acceptable for a
+    # single-tenant worker. Upgrade to a stdin credential helper if that changes.
+    push_args = ["push", "-u", "origin", branch]
+    if token:
+        rc_u, origin_url, _ = await git_ops.run_git(
+            ["remote", "get-url", "origin"], cwd=worktree_path
+        )
+        m = (
+            re.search(r"github\.com[:/](.+?/[^/\s]+?)(?:\.git)?$", origin_url.strip())
+            if rc_u == 0
+            else None
+        )
+        if m:
+            authed = f"https://x-access-token:{token}@github.com/{m.group(1)}.git"
+            push_args = ["push", authed, f"{branch}:{branch}"]
+    rc, _, err = await git_ops.run_git(push_args, cwd=worktree_path)
     if rc != 0:
         await emit(f"✗ Push failed: {err.strip()[:120]}", level=_LEVEL)
         return False

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -291,6 +291,29 @@ class Worker:
             os.environ["GITHUB_TOKEN"] = self.cfg.github_token
             logger.info("GITHUB_TOKEN set in environment for gh CLI and subprocesses")
 
+    async def _task_github_token(self, task_id: str) -> str | None:
+        """Fetch a fresh token to push/PR *task_id* as its triggering user.
+
+        The backend returns that user's OAuth token (so the branch and PR are
+        attributed to the human who triggered the task), falling back to the
+        App installation token. Fetched per task and used in an explicit push
+        URL — never persisted in the shared ``origin`` remote — so concurrent
+        agents pushing as different users don't collide, and the token is never
+        stale the way a clone-time embedded token was.
+        """
+        try:
+            async with await self._http(authed=True) as client:
+                resp = await client.get(
+                    "/auth/github/token",
+                    params={"guild_id": self.cfg.guild_id, "task_id": task_id},
+                )
+            if resp.status_code == 200:
+                return resp.json().get("access_token")
+            logger.warning("No task GitHub token from backend (status %d)", resp.status_code)
+        except Exception as exc:
+            logger.warning("Could not fetch task GitHub token: %s", exc)
+        return self.cfg.github_token
+
     async def _fetch_guild_env_vars(self) -> None:
         """Fetch guild-level env vars from foreman config and apply to the process environment.
 
@@ -2027,28 +2050,41 @@ class Worker:
                     records=usage_records,
                 )
 
+            # Push/PR are attributed to the human who triggered the task (their
+            # OAuth token), falling back to the App token — see _task_github_token.
+            push_token = await self._task_github_token(task_id)
             if is_review:
                 # Review tasks only read the PR and post a `gh pr review` —
                 # never push commits or auto-commit stray local changes.
                 await emit("Review phase — skipping push (read-only task).", level=LEVEL_WORKER)
+                pr_url = await github_pr.find_existing_pr(
+                    branch=branch, worktree_path=primary_wt, token=push_token
+                )
             else:
                 # Push the branch regardless of outcome so partial work is visible
                 # and a follow-up run can build on it.
                 push_ok = await github_pr.push_branch(
                     branch=branch,
                     worktree_path=primary_wt,
+                    token=push_token,
                     emit=emit,
                 )
                 if push_ok:
                     await emit(f"Branch pushed: {branch}", level=LEVEL_WORKER)
+                pr_url = await github_pr.find_existing_pr(
+                    branch=branch, worktree_path=primary_wt, token=push_token
+                )
+                if not pr_url and push_ok:
+                    pr_url = await github_pr.open_pr(
+                        task=task,
+                        branch=branch,
+                        worktree_path=primary_wt,
+                        token=push_token,
+                        emit=emit,
+                    )
 
-            pr_url = await github_pr.find_existing_pr(
-                branch=branch,
-                worktree_path=primary_wt,
-                token=token,
-            )
             if pr_url:
-                label = "Reviewed PR" if is_review else "✓ Claude-authored PR"
+                label = "Reviewed PR" if is_review else "✓ PR"
                 await emit(f"{label}: {pr_url}", level=LEVEL_WORKER)
                 await self._ensure_pr_webhook(pr_url, emit)
 

--- a/worker/tests/test_followup_branch_reuse.py
+++ b/worker/tests/test_followup_branch_reuse.py
@@ -209,7 +209,7 @@ async def test_new_task_still_generates_fresh_branch():
         patch("pioneer_worker.worker.github_pr.push_branch", return_value=True),
         patch(
             "pioneer_worker.worker.github_pr.open_pr",
-            return_value=("https://github.com/o/r/pull/1", 1),
+            return_value="https://github.com/o/r/pull/1",
         ),
         patch("pioneer_worker.worker.github_pr.find_existing_pr", return_value=None),
         patch("pioneer_worker.worker.claude_runner.run_claude_auto", side_effect=fake_run_claude),
@@ -265,7 +265,7 @@ async def test_new_task_branch_contains_full_task_id_not_truncated():
         patch("pioneer_worker.worker.github_pr.push_branch", return_value=True),
         patch(
             "pioneer_worker.worker.github_pr.open_pr",
-            return_value=("https://github.com/o/r/pull/1", 1),
+            return_value="https://github.com/o/r/pull/1",
         ),
         patch("pioneer_worker.worker.github_pr.find_existing_pr", return_value=None),
         patch("pioneer_worker.worker.claude_runner.run_claude_auto", side_effect=fake_run_claude),


### PR DESCRIPTION
## Problem
The worker pushed and opened PRs with a single guild-scoped token fetched once at startup and **baked into the `origin` remote at clone time**. GitHub App installation tokens expire hourly, so a long-lived clone pushed with a stale `ghs_` and failed (`could not read Password` / `Bad credentials`). It also meant no automated work was attributed to the human who triggered the task.

## Change — split the identities
- **Push + PR** → the triggering user's OAuth token, **falling back to the App token**. Fetched per task via `/auth/github/token?task_id=`; the backend resolves the user from `Task.user_id`.
- **Reads** (clone / fetch / webhook) → App token, unchanged.
- **Comments** (PR reviews, epic analysis) → already App-side via the foreman; unchanged.

`push_branch` now pushes to an explicit `x-access-token:<token>@github.com/...` URL built at push time (no `-u`, nothing persisted). This fixes the stale-token bug at the root and is concurrency-safe — worktrees share one `origin`, so a per-user token can't live in the remote when several agents run at once. `open_pr` is re-wired into `_execute_task` (it had rotted into dead code), and REST `assign_task` now stamps `user_id`.

Refresh tokens are **not** needed: classic OAuth user tokens don't expire; App tokens re-mint from the private key.

## Deliberately deferred (`ponytail:` comments)
- Read-token freshness on long-lived workers (reads still use the startup App token in `origin`).
- Commit identity stays the bot (author≠pusher is fine); revisit with signed commits.
- Token appears in `push` argv (visible via `ps`/DEBUG only, single-tenant worker).

## Tests
- Backend: `test_credentials_auth.py` — 6 passed, incl. 2 new (user-token vs. App fallback on `task_id`).
- Worker: full suite 283 passed; fixed two `open_pr` mocks that returned a `(url, num)` tuple where the real function returns a URL string (never exercised until `open_pr` was wired back in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)