### PR TITLE
fix(worker): skip empty pushes and stop masking failures as awaiting-review

### DIFF
--- a/worker/pioneer_worker/github_pr.py
+++ b/worker/pioneer_worker/github_pr.py
@@ -75,13 +75,16 @@ async def push_branch(
     worktree_path: str,
     token: str | None,
     emit: EmitFn,
-) -> bool:
-    """Push *branch* using *token*. Returns True on success.
+) -> str:
+    """Push *branch* to origin using *token*.
+
+    Returns one of: ``"pushed"`` (commits published), ``"nothing"`` (no commits
+    beyond the base — nothing to push, not a failure), or ``"failed"`` (a real
+    error, e.g. git permission denied).
 
     The token is passed in an explicit push URL rather than baked into the
     shared ``origin`` remote, so concurrent agents can push as different users
-    and a stale clone-time token can never be reused. ``-u`` is omitted so the
-    token-bearing URL is never persisted as the branch upstream."""
+    and a stale clone-time token can never be reused."""
     # Stage and commit any uncommitted work so it isn't silently lost on push
     # (can happen on max-turns, plan-phase completion, or normal task end).
     rc_status, status_out, _ = await git_ops.run_git(["status", "--porcelain"], cwd=worktree_path)
@@ -94,7 +97,23 @@ async def push_branch(
         )
         if rc_commit != 0:
             await emit(f"✗ Auto-commit failed: {commit_err.strip()[:120]}", level=_LEVEL)
-            return False
+            return "failed"
+
+    # Skip the push when the branch has no commits beyond what's already
+    # published — avoids creating empty remote branches / PRs when the agent
+    # did nothing (e.g. bailed on a permission prompt). Compare against the
+    # upstream if one exists (continued task), else the base (origin/HEAD).
+    rc_up, upstream, _ = await git_ops.run_git(
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        cwd=worktree_path,
+    )
+    base_ref = upstream.strip() if rc_up == 0 and upstream.strip() else "origin/HEAD"
+    rc_cnt, ahead, _ = await git_ops.run_git(
+        ["rev-list", "--count", f"{base_ref}..HEAD"], cwd=worktree_path
+    )
+    if rc_cnt == 0 and ahead.strip() == "0":
+        await emit(f"No new commits on {branch} — skipping push", level=_LEVEL)
+        return "nothing"
 
     await emit(f"Pushing {branch}...", level=_LEVEL)
     # ponytail: token in argv is visible via `ps`/DEBUG logs; acceptable for a
@@ -115,9 +134,9 @@ async def push_branch(
     rc, _, err = await git_ops.run_git(push_args, cwd=worktree_path)
     if rc != 0:
         await emit(f"✗ Push failed: {err.strip()[:120]}", level=_LEVEL)
-        return False
+        return "failed"
     await emit(f"✓ Pushed {branch}", level=_LEVEL)
-    return True
+    return "pushed"
 
 
 async def find_existing_pr(

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -2098,20 +2098,42 @@ class Worker:
                     branch=branch, worktree_path=primary_wt, token=push_token
                 )
             else:
-                # Push the branch regardless of outcome so partial work is visible
-                # and a follow-up run can build on it.
-                push_ok = await github_pr.push_branch(
+                # Push the branch so partial work is visible and a follow-up can
+                # build on it. push_branch returns "pushed" | "nothing" | "failed".
+                push_result = await github_pr.push_branch(
                     branch=branch,
                     worktree_path=primary_wt,
                     token=push_token,
                     emit=emit,
                 )
-                if push_ok:
-                    await emit(f"Branch pushed: {branch}", level=LEVEL_WORKER)
+                if push_result == "failed" and success:
+                    # A genuine push failure (e.g. git permission denied) after an
+                    # agent "success" must not surface as a reviewable result.
+                    logger.warning(
+                        "Task %s: agent reported success but push failed — marking error",
+                        task_id,
+                    )
+                    success = False
+                    stop_reason = "push_failed"
+                elif push_result == "nothing" and success:
+                    # The agent claimed success but left no commits — usually it
+                    # was blocked (e.g. every tool call denied) and never did the
+                    # work. Don't mask that as a reviewable result.
+                    logger.warning(
+                        "Task %s: agent reported success but produced no commits — marking error",
+                        task_id,
+                    )
+                    await emit(
+                        "Agent reported success but produced no commits — flagging for review.",
+                        level=LEVEL_WORKER,
+                    )
+                    success = False
+                    stop_reason = "no_changes"
+
                 pr_url = await github_pr.find_existing_pr(
                     branch=branch, worktree_path=primary_wt, token=push_token
                 )
-                if not pr_url and push_ok:
+                if not pr_url and push_result == "pushed":
                     pr_url = await github_pr.open_pr(
                         task=task,
                         branch=branch,

--- a/worker/tests/test_push_branch.py
+++ b/worker/tests/test_push_branch.py
@@ -1,0 +1,122 @@
+"""push_branch skips empty branches and reports real failures."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pioneer_worker import github_pr
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+async def _noop_emit(*_a, **_k) -> None:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_skips_push_when_no_new_commits():
+    responses = {
+        ("status", "--porcelain"): (0, "", ""),  # clean tree
+        ("rev-parse", "--abbrev-ref"): (128, "", "no upstream"),  # first push
+        ("rev-list", "--count"): (0, "0\n", ""),  # zero commits ahead
+    }
+    called = []
+
+    async def _run_git(args, cwd=None):  # noqa: ANN001
+        called.append(tuple(args[:2]))
+        return responses.get(tuple(args[:2]), (0, "", ""))
+
+    with patch.object(github_pr.git_ops, "run_git", new=_run_git):
+        result = await github_pr.push_branch(
+            branch="feat/x", worktree_path="/wt", token=None, emit=_noop_emit
+        )
+
+    assert result == "nothing"
+    assert ("push", "-u") not in called  # never attempted the push
+
+
+@pytest.mark.asyncio
+async def test_pushes_when_commits_ahead():
+    responses = {
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref"): (128, "", "no upstream"),
+        ("rev-list", "--count"): (0, "2\n", ""),  # two commits ahead
+        ("push", "-u"): (0, "", ""),
+    }
+    called = []
+
+    async def _run_git(args, cwd=None):  # noqa: ANN001
+        called.append(tuple(args[:2]))
+        return responses.get(tuple(args[:2]), (0, "", ""))
+
+    with patch.object(github_pr.git_ops, "run_git", new=_run_git):
+        result = await github_pr.push_branch(
+            branch="feat/x", worktree_path="/wt", token=None, emit=_noop_emit
+        )
+
+    assert result == "pushed"
+    assert ("push", "-u") in called
+
+
+@pytest.mark.asyncio
+async def test_returns_failed_on_push_failure():
+    responses = {
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref"): (128, "", "no upstream"),
+        ("rev-list", "--count"): (0, "1\n", ""),
+        ("push", "-u"): (1, "", "permission denied"),
+    }
+
+    async def _run_git(args, cwd=None):  # noqa: ANN001
+        return responses.get(tuple(args[:2]), (0, "", ""))
+
+    with patch.object(github_pr.git_ops, "run_git", new=_run_git):
+        result = await github_pr.push_branch(
+            branch="feat/x", worktree_path="/wt", token=None, emit=_noop_emit
+        )
+
+    assert result == "failed"
+
+
+@pytest.mark.asyncio
+async def test_success_but_no_commits_marks_error(tmp_path):
+    """A 'successful' run that produced no commits (e.g. pi blocked on every
+    tool call) must be flagged, not marked awaiting-review."""
+    cfg = Config(
+        backend_url="ws://localhost:8000",
+        guild_id="g",
+        worker_id="w",
+        max_agents=1,
+        pull_interval=3600.0,
+        work_dir=str(tmp_path),
+        repos=["org/myrepo"],
+    )
+    worker = Worker(cfg)
+    worker._available_tools = ["pi"]
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+    task = {"id": "t1", "description": "do it", "name": "do it", "tool": "pi"}
+    agent = worker.agents[0]
+
+    with (
+        patch(
+            "pioneer_worker.worker.git_ops.ensure_repo",
+            new=AsyncMock(return_value=str(tmp_path / "repo")),
+        ),
+        patch("pioneer_worker.worker.git_ops.create_worktree", new=AsyncMock(return_value=True)),
+        patch(
+            "pioneer_worker.worker.pi_runner.run_pi_auto",
+            new=AsyncMock(return_value=(True, "done", "ok", None)),  # agent "succeeded"
+        ),
+        patch(
+            "pioneer_worker.worker.github_pr.push_branch",
+            new=AsyncMock(return_value="nothing"),  # ...but produced no commits
+        ),
+        patch("pioneer_worker.worker.github_pr.find_existing_pr", new=AsyncMock(return_value=None)),
+    ):
+        await worker._execute_task(task, agent)
+
+    states = [c.kwargs.get("state") for c in worker._task_update.await_args_list]
+    assert "error" in states
+    assert "awaiting-review" not in states


### PR DESCRIPTION
## Problem

The worker was marking tasks `awaiting-review` in two situations where it shouldn't:

1. **Push failures were ignored.** `push_branch` returned a bool, but `_execute_task` never used it. If an agent reported success and the `git push` then failed (e.g. permission denied), the task still became `awaiting-review` with no branch/PR behind it. This is the "permissions issue → awaiting-review" symptom.
2. **Empty branches got pushed anyway.** There was no check for "no new commits", so an agent that did nothing (e.g. `pi` bailing when every tool call is denied) still pushed an empty branch and landed in `awaiting-review`.

## Changes

- `push_branch` now returns `"pushed" | "nothing" | "failed"`:
  - skips the push entirely when the branch has no commits beyond its base (`origin/HEAD`) or upstream — no more empty remote branches/PRs.
- `_execute_task` acts on that result for non-review tasks:
  - `failed` after an agent success → `error` / `push_failed`.
  - `nothing` after an agent success → `error` / `no_changes`, with an operator-facing emit.

Catching the `pi` permission-bail case by **outcome** (no commits) rather than by parsing `pi`'s events makes it robust to `pi`'s undocumented event variants — `pi`'s per-tool denials surface as `tool_execution_end{isError:true}` and don't (and shouldn't) fail the task on their own.

## Tests

New `worker/tests/test_push_branch.py` covers the three push outcomes and the worker-level "success but no commits → error" path. Full worker suite: 287 passed.

## Known caveat

A legitimately no-op task (e.g. a follow-up that only verifies something) will now be marked `error`/`no_changes`. Deferred per discussion — will scope the check to non-followups if it shows up in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)