### PR TITLE
fix(worker): gate pi on credentials like claude/codex

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -452,7 +452,9 @@ class Worker:
         Credentials belong in the guild env vars now (applied by
         _fetch_guild_env_vars before detection). A tool missing its credentials
         is dropped from the available-tools list with a warning rather than
-        launched and failed per-task.
+        launched and failed per-task. This holds for pi too: it needs a provider
+        credential like the others, so an unconfigured pi is dropped instead of
+        becoming a task-swallowing default.
         """
         env = self._env_for_tool(name)
         if name == "claude":
@@ -462,7 +464,19 @@ class Worker:
             return await self._claude_is_authenticated()
         if name == "codex":
             return bool(env.get("OPENAI_API_KEY") or self.cfg.openai_api_key)
-        return True  # pi and any other tool need no credentials
+        if name == "pi":
+            # Pi speaks to ~20 providers via ~35 different env vars — API keys,
+            # OAuth tokens, and AWS/Bedrock forms like AWS_BEARER_TOKEN_BEDROCK
+            # (see TOOL_ENV_KEYS in GuildSettingsPanel.vue). Rather than mirror
+            # that list and drift from it, treat pi as configured when the guild
+            # set any scoped env var for it. An empty pi tab means pi would launch,
+            # fail auth per-task, and — as the only tool left when claude/codex are
+            # unconfigured — silently swallow every task; drop it instead.
+            # ponytail: presence check, not per-key validation; a scoped non-cred
+            # var (e.g. AWS_REGION alone) still counts. Tighten to the key list if
+            # that false-positive ever bites.
+            return bool(self._tool_env.get("pi"))
+        return True  # any other tool needs no credentials
 
     async def _detect_available_tools(self) -> None:
         """Populate self._available_tools from runner binaries on PATH + credentials.
@@ -970,6 +984,20 @@ class Worker:
 
         await self._fetch_github_token_if_needed()
         await self._fetch_guild_env_vars()
+        # Log what this worker received, once every source has landed (container
+        # env, config, fetched shared vars, per-tool overrides). Keys only —
+        # never values — so credentials don't reach the logs.
+        logger.info(
+            "Worker received: tool=%s provider=%s pi_model=%s tools=%s max_agents=%d"
+            " env_keys=%s tool_env_keys=%s",
+            self.cfg.tool,
+            self.cfg.provider,
+            self.cfg.pi_model,
+            self.cfg.tools,
+            self.cfg.max_agents,
+            sorted(os.environ.keys()),
+            {tool: sorted(v.keys()) for tool, v in self._tool_env.items()},
+        )
         await self._refresh_github_repos()
         await self._check_gh_auth()
         await self._check_codex_doctor()

--- a/worker/tests/test_tools_detection.py
+++ b/worker/tests/test_tools_detection.py
@@ -208,10 +208,19 @@ class TestCredentialGating:
             await worker2._detect_available_tools()
         assert "codex" in worker2._available_tools
 
-    async def test_pi_needs_no_credentials(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    async def test_pi_without_scoped_env_is_excluded(self):
+        # Empty pi tab → no scoped env → dropped.
         cfg = _make_cfg(tools=["pi"], pi_path="pi")
         worker = Worker(cfg)
+        with patch("shutil.which", return_value="pi"):
+            await worker._detect_available_tools()
+        assert "pi" not in worker._available_tools
+
+    async def test_pi_with_scoped_env_is_included(self):
+        # Any scoped var (a Bedrock bearer token here) counts as configured.
+        cfg = _make_cfg(tools=["pi"], pi_path="pi")
+        worker = Worker(cfg)
+        worker._tool_env = {"pi": {"AWS_BEARER_TOKEN_BEDROCK": "tok"}}
         with patch("shutil.which", return_value="pi"):
             await worker._detect_available_tools()
         assert "pi" in worker._available_tools


### PR DESCRIPTION
## Problem

Diagnosed from a staging worker that kept failing on every task. Startup logs showed:

```
WARNING  Tool 'claude' has no credentials ...; excluding
WARNING  Tool 'codex'  has no credentials ...; excluding
INFO     Available tools: ['pi']
```

`_tool_has_credentials` returned `True` for pi unconditionally (`return True  # pi and any other tool need no credentials`). So when claude/codex were dropped for missing credentials, pi became the **only** available tool — not because it was configured, but because it was never checked. The foreman then routed every task to pi, which launched as `['pi', '--mode', 'rpc']` with no provider/credentials and failed auth per-task.

## Fix

Gate pi like claude/codex: it's available only if the guild set at least one scoped env var for it (pi's Bedrock / API-key / OAuth credentials live in the per-tool scoped env). An empty pi tab now drops pi with the same warning instead of launching it to fail every task.

Presence check rather than per-key validation on purpose — pi speaks to ~20 providers via ~35 env vars (API keys, OAuth tokens, `AWS_BEARER_TOKEN_BEDROCK`, …); mirroring that list here would just drift from `TOOL_ENV_KEYS` in the frontend.

## Tests

Replaced `test_pi_needs_no_credentials` with excluded-without / included-with a scoped var (uses `AWS_BEARER_TOKEN_BEDROCK`). `tests/test_tools_detection.py`: 20 passed.

## Not included

The deeper issue — `pi_default_provider` / `pi_default_model` being write-only (stored + shown in the UI but never read on dispatch, so pi runs with no `--provider`) — is filed separately as #1040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)