### PR TITLE
Worker Settings restructure + gate credential forwarding to workers

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1207,10 +1207,12 @@ async def spawn_worker(
             select(col(Guild.foreman_config)).where(col(Guild.id) == guild_pk)
         )
         guild_cfg = guild_res.one_or_none() or {}
+        # Only forward=True vars reach the worker; unshared foreman credentials
+        # stay with the foreman's own LLM (parity with the user spawn path).
         foreman_env_vars = {
             e["key"]: e["value"]
             for e in (guild_cfg.get("env_vars") or [])
-            if e.get("key") and e.get("value") is not None
+            if e.get("forward") and e.get("key") and e.get("value") is not None
         }
 
     env = build_spawn_worker_env(

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -126,7 +126,9 @@ async def get_foreman_env_vars(
     Requires a valid worker auth_token or member login_token.
 
     ``env_vars`` are shared across every tool; ``tool_env_vars`` are scoped to a
-    single worker tool (claude/pi/codex) and must not leak into the others.
+    single worker tool (claude/pi/codex) and must not leak into the others. Only
+    shared vars marked ``forward=True`` are returned — unshared ones stay with
+    the foreman's own LLM and never reach a worker.
 
     Response: ``{ "env_vars": [{"key", "value"}, ...],
                   "tool_env_vars": {"claude": [...], "pi": [...], "codex": [...]} }``
@@ -136,8 +138,9 @@ async def get_foreman_env_vars(
     if not guild:
         raise HTTPException(status_code=404, detail="Guild not found")
     config = guild.foreman_config or {}
+    forwarded = [e for e in config.get("env_vars", []) if e.get("forward")]
     return {
-        "env_vars": config.get("env_vars", []),
+        "env_vars": forwarded,
         "tool_env_vars": config.get("tool_env_vars", {}),
     }
 

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -72,12 +72,48 @@ _MAX_FOREMAN_ENV_VARS = 20
 _SCOPED_TOOLS = {"claude", "pi", "codex"}
 _MAX_ENV_VALUE_LEN = 4096
 
+# Foreman LLM settings that can be supplied by the process environment. Surfaced
+# (masked) on GET so the settings UI can show "from env" instead of an empty
+# field when the guild hasn't overridden them.
+_FOREMAN_ENV_DEFAULT_KEYS = (
+    "FOREMAN_PROVIDER",
+    "FOREMAN_MODEL",
+    "FOREMAN_BEDROCK_MODEL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "AWS_DEFAULT_REGION",
+    "AWS_PROFILE",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_BEARER_TOKEN_BEDROCK",
+)
+
+
+def _mask_env_default(key: str, value: str) -> str:
+    """Show non-secret config (provider/model/region/url) as-is; mask secrets to
+    the last 4 chars so the UI can confirm one is set without leaking it."""
+    if any(tag in key for tag in ("KEY", "TOKEN", "SECRET")):
+        return f"••••{value[-4:]}" if len(value) > 4 else "••••"
+    return value
+
+
+def _foreman_env_defaults() -> dict[str, str]:
+    return {
+        k: _mask_env_default(k, v) for k in _FOREMAN_ENV_DEFAULT_KEYS if (v := os.environ.get(k))
+    }
+
 
 class EnvVarItem(BaseModel):
     key: str
     # None → keep the currently stored value. Kept for API compatibility; the UI
     # now sends actual values since env vars are returned in clear text.
     value: str | None = None
+    # Shared env_vars only: True → also forward this var to worker tools. Default
+    # (None/False) keeps it with the foreman's own LLM and does NOT leak it to
+    # workers. Ignored for tool_env_vars (those are always scoped to their tool).
+    forward: bool | None = None
 
 
 def _validate_env_var_list(v: list[EnvVarItem] | None) -> list[EnvVarItem] | None:
@@ -101,22 +137,32 @@ def _merge_env_var_list(submitted: list[EnvVarItem], existing: list[dict] | None
     """Merge a submitted env-var list over the stored one.
 
     - value None → keep the existing stored value (dropped if none stored).
+    - forward None → keep the existing stored flag (so a value-only PATCH doesn't
+      silently un-forward a var); explicit True/False overrides it.
     - Duplicate keys collapse, preferring a non-empty value over a blank one so a
       stray blank row can't shadow a real credential at spawn time.
     """
-    existing_map: dict[str, str] = {e["key"]: e["value"] for e in (existing or [])}
-    merged: dict[str, str] = {}
+    existing_map: dict[str, dict] = {e["key"]: e for e in (existing or [])}
+    merged: dict[str, dict] = {}
     for item in submitted:
         if item.value is None:
             if item.key not in existing_map:
                 continue
-            resolved = existing_map[item.key]
+            resolved = existing_map[item.key].get("value", "")
         else:
             resolved = item.value
-        if item.key in merged and resolved == "" and merged[item.key] != "":
+        forward = item.forward
+        if forward is None:
+            forward = bool(existing_map.get(item.key, {}).get("forward"))
+        if item.key in merged and resolved == "" and merged[item.key]["value"] != "":
             continue
-        merged[item.key] = resolved
-    return [{"key": k, "value": v} for k, v in merged.items()]
+        entry: dict = {"key": item.key, "value": resolved}
+        if forward:
+            # Only persist the flag when set, keeping unshared entries' shape as
+            # {key, value} (back-compat with stored configs and existing tests).
+            entry["forward"] = True
+        merged[item.key] = entry
+    return list(merged.values())
 
 
 class ForemanConfigUpdate(BaseModel):
@@ -521,7 +567,7 @@ async def get_foreman_config(
     guild = res.one_or_none()
     if not guild:
         raise HTTPException(status_code=404, detail="Guild not found")
-    return guild.foreman_config or {}
+    return {**(guild.foreman_config or {}), "env_defaults": _foreman_env_defaults()}
 
 
 @router.patch("/api/guilds/{guild_id}/foreman-config")

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -232,8 +232,13 @@ async def spawn_worker_container(
     # The guild edit screen can store the same key twice (one real value, one
     # blank — see #dup). Collapse duplicates so the real value wins instead of
     # whichever entry happens to come last.
+    # Only vars explicitly marked forward=True reach workers; the rest stay with
+    # the foreman's own LLM (see EnvVarItem.forward). This keeps foreman
+    # credentials from leaking into every worker tool automatically.
     foreman_env_vars: dict[str, str] = {}
     for e in guild_cfg.get("env_vars") or []:
+        if not e.get("forward"):
+            continue
         k, v = e.get("key"), e.get("value")
         if not k or v is None:
             continue
@@ -327,7 +332,8 @@ async def get_spawn_credentials(
     """Return masked credential status for the spawn form — never raw values.
 
     Covers the two credential sources a spawned worker inherits: the guild's
-    ``foreman_config.env_vars`` (merged into every spawn unless excluded via
+    forwarded ``foreman_config.env_vars`` (only vars marked ``forward=True``
+    reach a worker; merged into every spawn unless excluded via
     ``exclude_env_keys`` on POST /spawn-worker) and the guild's stored Claude
     OAuth credentials. Lets an operator see, before launching, what a worker
     will have access to without exposing the underlying secret values.
@@ -341,7 +347,7 @@ async def get_spawn_credentials(
     guild_env_vars = [
         {"key": e["key"], "masked_value": mask_secret(e.get("value") or "")}
         for e in (config.get("env_vars") or [])
-        if e.get("key")
+        if e.get("key") and e.get("forward")
     ]
     creds_result = await db.exec(
         select(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)

--- a/backend/tests/test_guild_api.py
+++ b/backend/tests/test_guild_api.py
@@ -494,7 +494,9 @@ def test_foreman_config_bedrock_without_model_rejected(client, monkeypatch):
     assert patch.status_code == 400
 
     got = test_client.get("/api/guilds/g-fconf2/foreman-config", headers=headers)
-    assert got.json() == {}
+    # env_defaults is a read-only view of the process environment, not stored
+    # config — the rejected save must have persisted nothing else.
+    assert {k: v for k, v in got.json().items() if k != "env_defaults"} == {}
 
 
 def test_foreman_config_bedrock_with_model_accepted(client, monkeypatch):

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -380,7 +380,13 @@ def test_get_spawn_credentials_masks_guild_env_var_values(client):
             .where(col(Guild.id) == guild_pk)
             .values(
                 foreman_config={
-                    "env_vars": [{"key": "ANTHROPIC_API_KEY", "value": "sk-ant-supersecretvalue"}]
+                    "env_vars": [
+                        {
+                            "key": "ANTHROPIC_API_KEY",
+                            "value": "sk-ant-supersecretvalue",
+                            "forward": True,
+                        }
+                    ]
                 }
             )
         )
@@ -426,8 +432,8 @@ def test_spawn_worker_excludes_selected_guild_env_keys(client, monkeypatch):
             .values(
                 foreman_config={
                     "env_vars": [
-                        {"key": "ANTHROPIC_API_KEY", "value": "keep-me"},
-                        {"key": "OPENAI_API_KEY", "value": "drop-me"},
+                        {"key": "ANTHROPIC_API_KEY", "value": "keep-me", "forward": True},
+                        {"key": "OPENAI_API_KEY", "value": "drop-me", "forward": True},
                     ]
                 }
             )
@@ -464,6 +470,53 @@ def test_spawn_worker_excludes_selected_guild_env_keys(client, monkeypatch):
     assert stored_keys == {"ANTHROPIC_API_KEY", "OPENAI_API_KEY"}
 
 
+def test_spawn_worker_only_forwards_flagged_guild_env_vars(client, monkeypatch):
+    """A guild env var without forward=True stays with the foreman and must not
+    reach the spawned worker; a forwarded one does."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-fwd")
+    with _sync_session(db_url) as session:
+        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-fwd"))
+        session.execute(
+            update(Guild)
+            .where(col(Guild.id) == guild_pk)
+            .values(
+                foreman_config={
+                    "env_vars": [
+                        {"key": "SHARED_TOKEN", "value": "yes", "forward": True},
+                        {"key": "FOREMAN_ONLY", "value": "no"},  # no forward flag
+                    ]
+                }
+            )
+        )
+        session.commit()
+
+    import worker_runtime
+
+    captured_env: dict = {}
+
+    async def fake_check_runtime_available():
+        return None
+
+    async def fake_start_worker_container(*, env, guild_id):
+        captured_env.update(env)
+        return worker_runtime.SpawnedWorker(
+            handle="fake-handle", short_id="fakehandle12", runtime="docker"
+        )
+
+    monkeypatch.setattr(worker_runtime, "check_runtime_available", fake_check_runtime_available)
+    monkeypatch.setattr(worker_runtime, "start_worker_container", fake_start_worker_container)
+
+    resp = test_client.post(
+        "/guilds/guild-fwd/spawn-worker",
+        headers=_auth(db_url),
+        json={"repos": ["a/b"]},
+    )
+    assert resp.status_code == 200
+    assert captured_env.get("SHARED_TOKEN") == "yes"
+    assert "FOREMAN_ONLY" not in captured_env
+
+
 def test_spawn_worker_empty_user_value_does_not_clobber_guild_credential(client, monkeypatch):
     """An empty spawn-time value for a key that also exists as a guild credential
     must not blank out the credential's real value (the value wins)."""
@@ -476,7 +529,9 @@ def test_spawn_worker_empty_user_value_does_not_clobber_guild_credential(client,
             .where(col(Guild.id) == guild_pk)
             .values(
                 foreman_config={
-                    "env_vars": [{"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "real-token"}]
+                    "env_vars": [
+                        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "real-token", "forward": True}
+                    ]
                 }
             )
         )
@@ -521,8 +576,8 @@ def test_spawn_worker_guild_duplicate_key_prefers_nonempty(client, monkeypatch):
             .values(
                 foreman_config={
                     "env_vars": [
-                        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "real-token"},
-                        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": ""},
+                        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "real-token", "forward": True},
+                        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "", "forward": True},
                     ]
                 }
             )

--- a/frontend/src/components/GuildSettingsPanel.vue
+++ b/frontend/src/components/GuildSettingsPanel.vue
@@ -114,173 +114,42 @@
             </div>
           </section>
 
-          <!-- Foreman -->
+          <!-- Foreman — the orchestrator AI itself (its LLM + orchestration knobs).
+               Per-worker-tool defaults/env live under Worker Settings. -->
           <section v-else-if="activeTab === 'foreman'" class="settings-section">
-            <nav class="foreman-tool-tabs">
-              <button
-                v-for="ft in FOREMAN_TOOL_TABS"
-                :key="ft.id"
-                type="button"
-                class="foreman-tool-tab"
-                :class="{ active: foremanToolTab === ft.id }"
-                @click="foremanToolTab = ft.id"
-              >
-                {{ ft.label }}
-              </button>
-            </nav>
-
-            <!-- Claude: the foreman's own LLM (the AI orchestrator itself) -->
-            <template v-if="foremanToolTab === 'claude'">
-              <p class="foreman-hint">
-                These configure the foreman's own orchestrator LLM (the AI itself). The Claude
-                worker CLI's environment is in the section below.
-              </p>
-              <div class="foreman-field">
-                <label class="foreman-field-label">Provider</label>
-                <select v-model="foremanProvider" class="settings-input" @change="onProviderChange">
-                  <option value="">default (anthropic)</option>
-                  <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
-                    {{ p.name }}
-                  </option>
-                </select>
-              </div>
-              <div class="foreman-field">
-                <label class="foreman-field-label">Model</label>
-                <input
-                  v-model="foremanModel"
-                  class="settings-input"
-                  list="foreman-model-hints"
-                  placeholder="default"
-                  autocomplete="off"
-                />
-                <datalist id="foreman-model-hints">
-                  <option
-                    v-for="m in foremanProviderModels"
-                    :key="m.id"
-                    :value="m.id"
-                    :label="m.name"
-                  />
-                </datalist>
-              </div>
-
-              <div class="foreman-field">
-                <label class="foreman-field-label">
-                  {{ foremanProvider === 'bedrock' ? 'AWS Credentials' : 'Anthropic Credentials' }}
-                </label>
-                <div class="foreman-creds-grid">
-                  <div v-for="f in wellKnownFields" :key="f.key" class="foreman-cred-field">
-                    <label class="foreman-cred-label">{{ f.label }}</label>
-                    <input
-                      class="settings-input"
-                      type="text"
-                      spellcheck="false"
-                      autocomplete="off"
-                      :placeholder="f.placeholder || ''"
-                      :value="wellKnownValue(f.key)"
-                      @input="setWellKnown(f.key, ($event.target as HTMLInputElement).value)"
-                    />
-                  </div>
-                </div>
-              </div>
-            </template>
-
-            <!-- Pi: provider-agnostic tool, so it needs both a default model and provider -->
-            <template v-else-if="foremanToolTab === 'pi'">
-              <div class="foreman-field">
-                <label class="foreman-field-label">Default Provider</label>
-                <select v-model="piDefaultProvider" class="settings-input">
-                  <option value="">default (anthropic)</option>
-                  <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
-                    {{ p.name }}
-                  </option>
-                </select>
-              </div>
-              <div class="foreman-field">
-                <label class="foreman-field-label">Default Model</label>
-                <input
-                  v-model="piDefaultModel"
-                  class="settings-input"
-                  list="pi-model-hints"
-                  :placeholder="piDefaultProvider === 'bedrock' ? 'inference-profile ARN' : 'e.g. claude-sonnet-4-6'"
-                  autocomplete="off"
-                />
-                <datalist id="pi-model-hints">
-                  <option v-for="m in piProviderModels" :key="m.id" :value="m.id" :label="m.name" />
-                </datalist>
-              </div>
-              <p class="foreman-hint">
-                Used when the foreman assigns a task to the Pi tool without an explicit
-                model/provider override. Select "Amazon Bedrock" to run Pi against Bedrock; set its
-                AWS credentials in the Pi Environment section below (or the shared variables, which
-                apply to every tool).
-              </p>
-            </template>
-
-            <!-- Codex -->
-            <template v-else-if="foremanToolTab === 'codex'">
-              <div class="foreman-field">
-                <label class="foreman-field-label">Default Model</label>
-                <input
-                  v-model="codexDefaultModel"
-                  class="settings-input"
-                  placeholder="e.g. gpt-5-codex"
-                  autocomplete="off"
-                />
-              </div>
-              <p class="foreman-hint">
-                Used when the foreman assigns a task to the Codex tool without an explicit
-                model override.
-              </p>
-            </template>
-
-            <!-- Per-tool environment: passed ONLY to the selected tool's runner,
-                 never leaked to the other tools. -->
+            <p class="foreman-hint">
+              These configure the foreman's own orchestrator LLM (the AI itself). Fields left blank
+              fall back to the server defaults shown below.
+            </p>
             <div class="foreman-field">
-              <label class="foreman-field-label">{{ activeToolLabel }} Environment</label>
-              <p class="foreman-hint">
-                Passed only to the {{ activeToolLabel }} CLI — never to the other tools. Overrides
-                the shared variables below for this tool. Pick a known variable or type your own.
-              </p>
-              <div class="env-var-list">
-                <div
-                  v-for="row in toolEnvRows[foremanToolTab]"
-                  :key="row.id"
-                  class="env-var-row"
-                >
-                  <input
-                    v-model="row.key"
-                    class="settings-input env-var-key"
-                    :list="`tool-env-keys-${foremanToolTab}`"
-                    placeholder="KEY_NAME"
-                    spellcheck="false"
-                    autocomplete="off"
-                  />
-                  <input
-                    v-model="row.value"
-                    type="text"
-                    class="settings-input env-var-value"
-                    placeholder="value"
-                    spellcheck="false"
-                    autocomplete="off"
-                  />
-                  <button
-                    class="env-var-delete-btn"
-                    @click="removeToolEnvVar(row)"
-                    title="Remove variable"
-                  >
-                    ✕
-                  </button>
-                </div>
-                <datalist :id="`tool-env-keys-${foremanToolTab}`">
-                  <option v-for="k in TOOL_ENV_KEYS[foremanToolTab]" :key="k" :value="k" />
-                </datalist>
-                <button class="pixel-btn env-var-add-btn" @click="addToolEnvVar">
-                  + Add Variable
-                </button>
-              </div>
+              <label class="foreman-field-label">Provider</label>
+              <select v-model="foremanProvider" class="settings-input" @change="onProviderChange">
+                <option value="">{{ providerDefaultLabel }}</option>
+                <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
+                  {{ p.name }}
+                </option>
+              </select>
+            </div>
+            <div class="foreman-field">
+              <label class="foreman-field-label">Model</label>
+              <input
+                v-model="foremanModel"
+                class="settings-input"
+                list="foreman-model-hints"
+                :placeholder="foremanModelPlaceholder"
+                autocomplete="off"
+              />
+              <datalist id="foreman-model-hints">
+                <option
+                  v-for="m in foremanProviderModels"
+                  :key="m.id"
+                  :value="m.id"
+                  :label="m.name"
+                />
+              </datalist>
             </div>
 
-            <div class="foreman-divider">General — applies to all tools &amp; the foreman</div>
+            <div class="foreman-divider">Orchestration</div>
 
             <div class="foreman-field">
               <label class="foreman-field-label">System Prompt Suffix</label>
@@ -327,16 +196,28 @@
             </div>
 
             <div class="foreman-field">
-              <label class="foreman-field-label">Shared Environment Variables</label>
+              <label class="foreman-field-label">Environment Variables</label>
               <p class="foreman-hint">
-                Inherited by every worker tool in this guild and the foreman's own LLM. Use the
-                per-tool sections above to scope a variable to a single tool.
+                Used by the foreman's own LLM (credentials, base URLs, etc.). A variable stays with
+                the foreman unless you tick <em>forward</em> — then it is also sent to every worker
+                tool in this guild. Scope a variable to a single tool in Worker Settings.
+              </p>
+              <p v-if="envDefaultKeys.length" class="foreman-hint">
+                From the server environment (masked, always available to the foreman):
+                {{ envDefaultsSummary }}
               </p>
               <div class="env-var-list">
-                <div v-for="row in additionalEnvVarRows" :key="row.id" class="env-var-row">
+                <div class="env-var-row env-var-head">
+                  <span class="env-var-key">Key</span>
+                  <span class="env-var-value">Value</span>
+                  <span class="env-var-fwd" title="Also send to worker tools">fwd</span>
+                  <span class="env-var-spacer"></span>
+                </div>
+                <div v-for="row in envVarRows" :key="row.id" class="env-var-row">
                   <input
                     v-model="row.key"
                     class="settings-input env-var-key"
+                    list="foreman-env-keys"
                     placeholder="KEY_NAME"
                     spellcheck="false"
                     autocomplete="off"
@@ -349,6 +230,12 @@
                     spellcheck="false"
                     autocomplete="off"
                   />
+                  <input
+                    v-model="row.forward"
+                    type="checkbox"
+                    class="env-var-fwd"
+                    title="Forward this variable to worker tools"
+                  />
                   <button
                     class="env-var-delete-btn"
                     @click="removeEnvVar(row)"
@@ -357,6 +244,9 @@
                     ✕
                   </button>
                 </div>
+                <datalist id="foreman-env-keys">
+                  <option v-for="k in FOREMAN_ENV_KEYS" :key="k" :value="k" />
+                </datalist>
                 <button class="pixel-btn env-var-add-btn" @click="addEnvVar">+ Add Variable</button>
               </div>
             </div>
@@ -379,9 +269,160 @@
             </div>
           </section>
 
-          <!-- Spawn Defaults -->
+          <!-- Worker Settings — spawn defaults + per-worker-tool model/env config -->
           <section v-else-if="activeTab === 'spawn'" class="settings-section">
             <GuildSpawnDefaults v-if="currentGuild" :guild-id="currentGuild.id" />
+
+            <div class="foreman-divider">Worker Tools</div>
+            <nav class="foreman-tool-tabs">
+              <button
+                v-for="ft in WORKER_SUBTABS"
+                :key="ft.id"
+                type="button"
+                class="foreman-tool-tab"
+                :class="{ active: workerSubTab === ft.id }"
+                @click="workerSubTab = ft.id"
+              >
+                {{ ft.label }}
+              </button>
+            </nav>
+
+            <!-- General: what every worker tool receives (the forwarded foreman vars) -->
+            <template v-if="workerSubTab === 'general'">
+              <p class="foreman-hint">
+                Every worker tool in this guild inherits these variables — the ones marked
+                <em>forward</em> on the Foreman tab. Edit them there; use the Claude / Pi / Codex
+                tabs to override a value for a single tool.
+              </p>
+              <div v-if="forwardedEnvRows.length" class="env-var-list">
+                <div class="env-var-row env-var-head">
+                  <span class="env-var-key">Key</span>
+                  <span class="env-var-value">Value</span>
+                </div>
+                <div v-for="row in forwardedEnvRows" :key="row.id" class="env-var-row">
+                  <span class="env-var-key env-var-ro">{{ row.key }}</span>
+                  <span class="env-var-value env-var-ro">{{ row.value || '—' }}</span>
+                </div>
+              </div>
+              <p v-else class="foreman-hint">
+                No forwarded variables yet. Tick <em>forward</em> on a Foreman variable to send it to
+                workers.
+              </p>
+            </template>
+
+            <!-- Pi: provider-agnostic tool, so it needs both a default model and provider -->
+            <template v-else-if="workerSubTab === 'pi'">
+              <div class="foreman-field">
+                <label class="foreman-field-label">Default Provider</label>
+                <select v-model="piDefaultProvider" class="settings-input">
+                  <option value="">default (anthropic)</option>
+                  <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
+                    {{ p.name }}
+                  </option>
+                </select>
+              </div>
+              <div class="foreman-field">
+                <label class="foreman-field-label">Default Model</label>
+                <input
+                  v-model="piDefaultModel"
+                  class="settings-input"
+                  list="pi-model-hints"
+                  :placeholder="piDefaultProvider === 'bedrock' ? 'inference-profile ARN' : 'e.g. claude-sonnet-4-6'"
+                  autocomplete="off"
+                />
+                <datalist id="pi-model-hints">
+                  <option v-for="m in piProviderModels" :key="m.id" :value="m.id" :label="m.name" />
+                </datalist>
+              </div>
+              <p class="foreman-hint">
+                Used when the foreman assigns a task to the Pi tool without an explicit
+                model/provider override. Select "Amazon Bedrock" to run Pi against Bedrock; set its
+                AWS credentials in the Pi Environment section below (or the General forwarded
+                variables, which apply to every tool).
+              </p>
+            </template>
+
+            <!-- Codex -->
+            <template v-else-if="workerSubTab === 'codex'">
+              <div class="foreman-field">
+                <label class="foreman-field-label">Default Model</label>
+                <input
+                  v-model="codexDefaultModel"
+                  class="settings-input"
+                  placeholder="e.g. gpt-5-codex"
+                  autocomplete="off"
+                />
+              </div>
+              <p class="foreman-hint">
+                Used when the foreman assigns a task to the Codex tool without an explicit
+                model override.
+              </p>
+            </template>
+
+            <!-- Claude: no per-tool default model here (the foreman's own LLM lives
+                 in the Foreman tab); only its worker-CLI environment. -->
+            <template v-else-if="workerSubTab === 'claude'">
+              <p class="foreman-hint">
+                The Claude worker CLI takes no default model here — set its override environment
+                below.
+              </p>
+            </template>
+
+            <!-- Per-tool override environment: passed ONLY to the selected tool's
+                 runner, never to the other tools; overrides the General vars. -->
+            <div v-if="workerSubTab !== 'general'" class="foreman-field">
+              <label class="foreman-field-label">{{ activeToolLabel }} Overrides</label>
+              <p class="foreman-hint">
+                Passed only to the {{ activeToolLabel }} CLI — never to the other tools. Overrides a
+                General forwarded variable for this tool. Pick a known variable or type your own.
+              </p>
+              <div class="env-var-list">
+                <div v-for="row in toolEnvRows[workerSubTab]" :key="row.id" class="env-var-row">
+                  <input
+                    v-model="row.key"
+                    class="settings-input env-var-key"
+                    :list="`tool-env-keys-${workerSubTab}`"
+                    placeholder="KEY_NAME"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                  <input
+                    v-model="row.value"
+                    type="text"
+                    class="settings-input env-var-value"
+                    placeholder="value"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                  <button
+                    class="env-var-delete-btn"
+                    @click="removeToolEnvVar(row)"
+                    title="Remove variable"
+                  >
+                    ✕
+                  </button>
+                </div>
+                <datalist :id="`tool-env-keys-${workerSubTab}`">
+                  <option v-for="k in TOOL_ENV_KEYS[workerSubTab]" :key="k" :value="k" />
+                </datalist>
+                <button class="pixel-btn env-var-add-btn" @click="addToolEnvVar">
+                  + Add Variable
+                </button>
+              </div>
+            </div>
+
+            <div class="foreman-actions">
+              <button
+                class="pixel-btn settings-save-btn"
+                :disabled="foremanSaving"
+                @click="saveForemanConfig"
+              >
+                {{ foremanSaving ? 'Saving…' : 'Save' }}
+              </button>
+              <span v-if="foremanStatus" class="save-status" :class="'save-status-' + foremanStatus">
+                {{ foremanStatus === 'saved' ? 'Saved' : 'Error' }}
+              </span>
+            </div>
           </section>
 
           <!-- Members -->
@@ -416,20 +457,37 @@ const currentGuild = computed(() => guildStore.currentGuild)
 const TABS = [
   { id: 'general', label: 'General' },
   { id: 'foreman', label: 'Foreman' },
-  { id: 'spawn', label: 'Spawn Defaults' },
+  { id: 'spawn', label: 'Worker Settings' },
   { id: 'members', label: 'Members' },
 ] as const
 const activeTab = ref<(typeof TABS)[number]['id']>('general')
 
-const FOREMAN_TOOL_TABS = [
+// Worker Settings sub-tabs: General (vars every tool receives) + one override
+// tab per worker tool.
+const WORKER_SUBTABS = [
+  { id: 'general', label: 'General' },
   { id: 'claude', label: 'Claude' },
   { id: 'pi', label: 'Pi' },
   { id: 'codex', label: 'Codex' },
 ] as const
-const foremanToolTab = ref<(typeof FOREMAN_TOOL_TABS)[number]['id']>('claude')
+const workerSubTab = ref<(typeof WORKER_SUBTABS)[number]['id']>('general')
 const activeToolLabel = computed(
-  () => FOREMAN_TOOL_TABS.find((t) => t.id === foremanToolTab.value)?.label ?? '',
+  () => WORKER_SUBTABS.find((t) => t.id === workerSubTab.value)?.label ?? '',
 )
+
+// Common foreman env-var keys, surfaced as datalist suggestions on the Foreman
+// tab. Users can still type any other key.
+const FOREMAN_ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_BASE_URL',
+  'AWS_DEFAULT_REGION',
+  'AWS_PROFILE',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_BEARER_TOKEN_BEDROCK',
+]
 
 // Known env-var keys per worker tool, surfaced as datalist suggestions. Users can
 // still type any other key. Sourced from each CLI's own docs (`pi --help`, Claude
@@ -498,34 +556,6 @@ const foremanProviderModels = computed(() =>
 const piProviderModels = computed(() =>
   piDefaultProvider.value ? modelsStore.modelsForProvider(piDefaultProvider.value) : [],
 )
-// Dedicated, provider-specific credential fields. These are stored as ordinary
-// env_vars under the hood (the foreman client reads them via extra_env) but get
-// first-class inputs so users don't have to remember exact var names.
-interface WellKnownField {
-  key: string
-  label: string
-  placeholder?: string
-}
-const FOREMAN_WELL_KNOWN: Record<string, WellKnownField[]> = {
-  anthropic: [
-    { key: 'ANTHROPIC_API_KEY', label: 'API Key', placeholder: 'sk-ant-…' },
-    { key: 'ANTHROPIC_AUTH_TOKEN', label: 'Auth Token (optional)' },
-    {
-      key: 'ANTHROPIC_BASE_URL',
-      label: 'Base URL (optional)',
-      placeholder: 'https://api.anthropic.com',
-    },
-  ],
-  bedrock: [
-    { key: 'AWS_DEFAULT_REGION', label: 'Region', placeholder: 'us-east-1' },
-    { key: 'AWS_PROFILE', label: 'Profile (optional)' },
-    { key: 'AWS_ACCESS_KEY_ID', label: 'Access Key ID' },
-    { key: 'AWS_SECRET_ACCESS_KEY', label: 'Secret Access Key' },
-    { key: 'AWS_SESSION_TOKEN', label: 'Session Token (optional)' },
-    { key: 'AWS_BEARER_TOKEN_BEDROCK', label: 'Bedrock Bearer Token (optional)' },
-  ],
-}
-
 const renameValue = ref('')
 const primaryRepoValue = ref('')
 const renameStatus = ref<'' | 'saved' | 'error'>('')
@@ -565,19 +595,35 @@ const foremanPollMax = ref<number | ''>('')
 const foremanSaving = ref(false)
 const foremanStatus = ref<'' | 'saved' | 'error'>('')
 let foremanStatusTimer: ReturnType<typeof setTimeout> | null = null
-const wellKnownFields = computed(
-  () => FOREMAN_WELL_KNOWN[foremanProvider.value || 'anthropic'] ?? [],
+
+// Masked foreman defaults supplied by the server's process environment (see
+// GET foreman-config). Shown so an unset field reads as "inherited from env"
+// rather than blank/unconfigured. Non-secret values (provider/model/region)
+// come through in the clear; secrets are already masked server-side.
+const envDefaults = ref<Record<string, string>>({})
+const envDefaultKeys = computed(() => Object.keys(envDefaults.value))
+const envDefaultsSummary = computed(() =>
+  envDefaultKeys.value.map((k) => `${k}=${envDefaults.value[k]}`).join(', '),
 )
-const wellKnownKeys = computed(() => new Set(wellKnownFields.value.map((f) => f.key)))
-// Free-form list excludes keys that have a dedicated field for the current provider.
-const additionalEnvVarRows = computed(() =>
-  envVarRows.value.filter((r) => !wellKnownKeys.value.has(r.key)),
+const providerDefaultLabel = computed(() =>
+  envDefaults.value.FOREMAN_PROVIDER
+    ? `default (${envDefaults.value.FOREMAN_PROVIDER} · from env)`
+    : 'default (anthropic)',
 )
+const foremanModelPlaceholder = computed(() => {
+  const key = foremanProvider.value === 'bedrock' ? 'FOREMAN_BEDROCK_MODEL' : 'FOREMAN_MODEL'
+  return envDefaults.value[key] ? `${envDefaults.value[key]} · from env` : 'default'
+})
+// The forwarded subset shown read-only on the Worker Settings → General tab.
+const forwardedEnvRows = computed(() => envVarRows.value.filter((r) => r.forward))
 
 interface EnvVarRow {
   id: number
   key: string
   value: string
+  // Foreman env_vars only: forward this var to worker tools. Per-tool rows
+  // ignore it (they're always scoped to their own tool).
+  forward?: boolean
 }
 let envRowSeq = 0
 const envVarRows = ref<EnvVarRow[]>([])
@@ -587,28 +633,15 @@ const envVarRows = ref<EnvVarRow[]>([])
 const toolEnvRows = reactive<Record<string, EnvVarRow[]>>({ claude: [], pi: [], codex: [] })
 
 function addToolEnvVar() {
-  toolEnvRows[foremanToolTab.value].push({ id: ++envRowSeq, key: '', value: '' })
+  if (workerSubTab.value === 'general') return
+  toolEnvRows[workerSubTab.value].push({ id: ++envRowSeq, key: '', value: '' })
 }
 
 function removeToolEnvVar(row: EnvVarRow) {
-  const rows = toolEnvRows[foremanToolTab.value]
+  if (workerSubTab.value === 'general') return
+  const rows = toolEnvRows[workerSubTab.value]
   const i = rows.indexOf(row)
   if (i >= 0) rows.splice(i, 1)
-}
-
-function wellKnownValue(key: string): string {
-  return envVarRows.value.find((r) => r.key === key)?.value ?? ''
-}
-
-function setWellKnown(key: string, value: string) {
-  const row = envVarRows.value.find((r) => r.key === key)
-  if (value) {
-    if (row) row.value = value
-    else envVarRows.value.push({ id: ++envRowSeq, key, value })
-  } else if (row) {
-    // Empty value → drop the row so we don't persist blank vars.
-    envVarRows.value.splice(envVarRows.value.indexOf(row), 1)
-  }
 }
 
 async function loadForemanConfig() {
@@ -620,6 +653,7 @@ async function loadForemanConfig() {
     )
     if (res.ok) {
       const cfg = await res.json()
+      envDefaults.value = cfg.env_defaults ?? {}
       foremanModel.value = cfg.model ?? ''
       foremanProvider.value = cfg.provider ?? ''
       // Seed the per-provider model memory with the persisted pairing so a later
@@ -634,11 +668,14 @@ async function loadForemanConfig() {
       foremanPollMin.value = cfg.poll_min_interval ?? ''
       foremanPollMax.value = cfg.poll_max_interval ?? ''
       // Env var values are returned in clear text so they can be verified/edited.
-      envVarRows.value = (cfg.env_vars ?? []).map((e: { key: string; value?: string }) => ({
-        id: ++envRowSeq,
-        key: e.key,
-        value: e.value ?? '',
-      }))
+      envVarRows.value = (cfg.env_vars ?? []).map(
+        (e: { key: string; value?: string; forward?: boolean }) => ({
+          id: ++envRowSeq,
+          key: e.key,
+          value: e.value ?? '',
+          forward: !!e.forward,
+        }),
+      )
       const toolEnv = cfg.tool_env_vars ?? {}
       for (const tool of ['claude', 'pi', 'codex']) {
         toolEnvRows[tool] = (toolEnv[tool] ?? []).map((e: { key: string; value?: string }) => ({
@@ -654,7 +691,7 @@ async function loadForemanConfig() {
 }
 
 function addEnvVar() {
-  envVarRows.value.push({ id: ++envRowSeq, key: '', value: '' })
+  envVarRows.value.push({ id: ++envRowSeq, key: '', value: '', forward: false })
 }
 
 function removeEnvVar(row: EnvVarRow) {
@@ -686,20 +723,18 @@ async function saveForemanConfig() {
     else body.poll_min_interval = null
     if (foremanPollMax.value !== '') body.poll_max_interval = foremanPollMax.value
     else body.poll_max_interval = null
-    // Send actual values for every keyed row (dedicated credential fields and
-    // free-form rows alike both live in envVarRows). Skip rows with empty keys.
-    // A well-known key can be entered twice (dedicated field + a free-form row
-    // that then hides itself); collapse duplicates, keeping the non-empty value
-    // so a stray blank row can't shadow the real credential at spawn time.
-    const envByKey = new Map<string, string>()
+    // Send every keyed row. Skip empty keys; collapse duplicate keys, keeping a
+    // non-empty value (and forward=true) over a blank/unset one so a stray blank
+    // row can't shadow the real credential or drop its forward flag.
+    const envByKey = new Map<string, { value: string; forward: boolean }>()
     for (const r of envVarRows.value) {
       const key = r.key.trim()
       if (!key) continue
       const existing = envByKey.get(key)
-      if (existing && r.value === '' && existing !== '') continue
-      envByKey.set(key, r.value)
+      if (existing && r.value === '' && existing.value !== '') continue
+      envByKey.set(key, { value: r.value, forward: !!r.forward || !!existing?.forward })
     }
-    body.env_vars = [...envByKey].map(([key, value]) => ({ key, value }))
+    body.env_vars = [...envByKey].map(([key, { value, forward }]) => ({ key, value, forward }))
     // Per-tool env vars: send all three tools so an emptied tab clears its set.
     const toolEnvVars: Record<string, { key: string; value: string }[]> = {}
     for (const tool of ['claude', 'pi', 'codex']) {
@@ -726,11 +761,14 @@ async function saveForemanConfig() {
       foremanStatus.value = 'saved'
       // Re-sync with the server's canonical config (clear-text values).
       const saved = await res.json()
-      envVarRows.value = (saved.env_vars ?? []).map((e: { key: string; value?: string }) => ({
-        id: ++envRowSeq,
-        key: e.key,
-        value: e.value ?? '',
-      }))
+      envVarRows.value = (saved.env_vars ?? []).map(
+        (e: { key: string; value?: string; forward?: boolean }) => ({
+          id: ++envRowSeq,
+          key: e.key,
+          value: e.value ?? '',
+          forward: !!e.forward,
+        }),
+      )
       const savedToolEnv = saved.tool_env_vars ?? {}
       for (const tool of ['claude', 'pi', 'codex']) {
         toolEnvRows[tool] = (savedToolEnv[tool] ?? []).map(
@@ -1195,23 +1233,32 @@ onBeforeUnmount(() => {
   font-size: 10px;
 }
 
-.foreman-creds-grid {
+/* Forward checkbox column + its header/read-only cells. */
+.env-var-fwd {
+  flex: 0 0 28px;
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  justify-content: center;
+  accent-color: var(--color-brass);
 }
 
-.foreman-cred-field {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.env-var-spacer {
+  flex: 0 0 22px;
 }
 
-.foreman-cred-label {
+.env-var-head span {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--color-brass-dark);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.env-var-ro {
   font-family: var(--font-mono, monospace);
-  font-size: 9px;
-  color: var(--color-text-dim);
-  letter-spacing: 0.5px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .env-var-delete-btn {

--- a/frontend/src/components/__tests__/GuildSettingsPanel.spec.ts
+++ b/frontend/src/components/__tests__/GuildSettingsPanel.spec.ts
@@ -35,7 +35,7 @@ function mockFetch(foremanConfig: Record<string, unknown>) {
   })
 }
 
-async function openForemanTab(foremanConfig: Record<string, unknown>) {
+async function openTab(label: string, foremanConfig: Record<string, unknown>) {
   mockFetch(foremanConfig)
   const guild = useGuildStore()
   guild.currentGuild = { id: 'g1', name: 'Test Guild' }
@@ -43,11 +43,14 @@ async function openForemanTab(foremanConfig: Record<string, unknown>) {
   auth.loginToken = 'tok'
   const wrapper = mount(GuildSettingsPanel)
   await flushPromises()
-  const foremanTab = wrapper.findAll('.settings-tab').find((t) => t.text() === 'Foreman')
-  await foremanTab!.trigger('click')
+  const tab = wrapper.findAll('.settings-tab').find((t) => t.text() === label)
+  await tab!.trigger('click')
   await flushPromises()
   return wrapper
 }
+
+const openForemanTab = (cfg: Record<string, unknown>) => openTab('Foreman', cfg)
+const openWorkerTab = (cfg: Record<string, unknown>) => openTab('Worker Settings', cfg)
 
 describe('GuildSettingsPanel foreman provider/model', () => {
   beforeEach(() => {
@@ -79,7 +82,7 @@ describe('GuildSettingsPanel foreman provider/model', () => {
   })
 })
 
-describe('GuildSettingsPanel foreman tool tabs', () => {
+describe('GuildSettingsPanel worker tool tabs', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
   })
@@ -87,17 +90,17 @@ describe('GuildSettingsPanel foreman tool tabs', () => {
     vi.restoreAllMocks()
   })
 
-  it('defaults to the Claude sub-tab and shows the existing provider/model fields', async () => {
-    const wrapper = await openForemanTab({})
+  it('defaults to the General sub-tab; the foreman LLM fields stay in the Foreman tab', async () => {
+    const wrapper = await openWorkerTab({})
     const toolTabs = wrapper.findAll('.foreman-tool-tab')
-    expect(toolTabs.map((t) => t.text())).toEqual(['Claude', 'Pi', 'Codex'])
-    expect(toolTabs.find((t) => t.text() === 'Claude')!.classes()).toContain('active')
-    expect(wrapper.find('select').exists()).toBe(true)
-    expect(wrapper.find('input[list="foreman-model-hints"]').exists()).toBe(true)
+    expect(toolTabs.map((t) => t.text())).toEqual(['General', 'Claude', 'Pi', 'Codex'])
+    expect(toolTabs.find((t) => t.text() === 'General')!.classes()).toContain('active')
+    // The foreman's own model input never renders under Worker Settings.
+    expect(wrapper.find('input[list="foreman-model-hints"]').exists()).toBe(false)
   })
 
   it('lets the Pi default model be set and saved', async () => {
-    const wrapper = await openForemanTab({ pi_default_model: 'claude-sonnet-4-6' })
+    const wrapper = await openWorkerTab({ pi_default_model: 'claude-sonnet-4-6' })
 
     const piTab = wrapper.findAll('.foreman-tool-tab').find((t) => t.text() === 'Pi')
     await piTab!.trigger('click')
@@ -126,7 +129,7 @@ describe('GuildSettingsPanel foreman tool tabs', () => {
   })
 
   it('lets the Pi default provider be set to Bedrock and saved', async () => {
-    const wrapper = await openForemanTab({ pi_default_provider: 'anthropic' })
+    const wrapper = await openWorkerTab({ pi_default_provider: 'anthropic' })
 
     const piTab = wrapper.findAll('.foreman-tool-tab').find((t) => t.text() === 'Pi')
     await piTab!.trigger('click')
@@ -154,5 +157,58 @@ describe('GuildSettingsPanel foreman tool tabs', () => {
     expect(patchCall).toBeTruthy()
     const body = JSON.parse((patchCall![1] as RequestInit).body as string)
     expect(body.pi_default_provider).toBe('bedrock')
+  })
+})
+
+describe('GuildSettingsPanel foreman env forwarding', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('round-trips the per-var forward flag and reflects it on the Worker General tab', async () => {
+    // A stored var with forward=true, another without.
+    const wrapper = await openForemanTab({
+      env_vars: [
+        { key: 'ANTHROPIC_API_KEY', value: 'sk', forward: true },
+        { key: 'FOREMAN_ONLY', value: 'x' },
+      ],
+    })
+
+    const boxes = wrapper.findAll('input[type="checkbox"].env-var-fwd')
+    expect(boxes.length).toBe(2)
+    expect((boxes[0].element as HTMLInputElement).checked).toBe(true)
+    expect((boxes[1].element as HTMLInputElement).checked).toBe(false)
+
+    // Forward the second var too, then save.
+    await boxes[1].setValue(true)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        env_vars: [
+          { key: 'ANTHROPIC_API_KEY', value: 'sk', forward: true },
+          { key: 'FOREMAN_ONLY', value: 'x', forward: true },
+        ],
+      }),
+    } as Response)
+    const saveBtn = wrapper.findAll('.foreman-actions button').find((b) => b.text() === 'Save')
+    await saveBtn!.trigger('click')
+    await flushPromises()
+
+    const patchCall = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'PATCH')
+    const body = JSON.parse((patchCall![1] as RequestInit).body as string)
+    const byKey = Object.fromEntries(body.env_vars.map((e: { key: string; forward: boolean }) => [e.key, e.forward]))
+    expect(byKey).toEqual({ ANTHROPIC_API_KEY: true, FOREMAN_ONLY: true })
+
+    // The Worker Settings → General tab lists only forwarded vars.
+    const workerTab = wrapper.findAll('.settings-tab').find((t) => t.text() === 'Worker Settings')
+    await workerTab!.trigger('click')
+    await flushPromises()
+    const roKeys = wrapper.findAll('.env-var-ro.env-var-key').map((s) => s.text())
+    expect(roKeys).toContain('ANTHROPIC_API_KEY')
+    expect(roKeys).toContain('FOREMAN_ONLY')
   })
 })

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -452,7 +452,9 @@ class Worker:
         Credentials belong in the guild env vars now (applied by
         _fetch_guild_env_vars before detection). A tool missing its credentials
         is dropped from the available-tools list with a warning rather than
-        launched and failed per-task.
+        launched and failed per-task. This holds for pi too: it needs a provider
+        credential like the others, so an unconfigured pi is dropped instead of
+        becoming a task-swallowing default.
         """
         env = self._env_for_tool(name)
         if name == "claude":
@@ -462,7 +464,19 @@ class Worker:
             return await self._claude_is_authenticated()
         if name == "codex":
             return bool(env.get("OPENAI_API_KEY") or self.cfg.openai_api_key)
-        return True  # pi and any other tool need no credentials
+        if name == "pi":
+            # Pi speaks to ~20 providers via ~35 different env vars — API keys,
+            # OAuth tokens, and AWS/Bedrock forms like AWS_BEARER_TOKEN_BEDROCK
+            # (see TOOL_ENV_KEYS in GuildSettingsPanel.vue). Rather than mirror
+            # that list and drift from it, treat pi as configured when the guild
+            # set any scoped env var for it. An empty pi tab means pi would launch,
+            # fail auth per-task, and — as the only tool left when claude/codex are
+            # unconfigured — silently swallow every task; drop it instead.
+            # ponytail: presence check, not per-key validation; a scoped non-cred
+            # var (e.g. AWS_REGION alone) still counts. Tighten to the key list if
+            # that false-positive ever bites.
+            return bool(self._tool_env.get("pi"))
+        return True  # any other tool needs no credentials
 
     async def _detect_available_tools(self) -> None:
         """Populate self._available_tools from runner binaries on PATH + credentials.
@@ -970,6 +984,20 @@ class Worker:
 
         await self._fetch_github_token_if_needed()
         await self._fetch_guild_env_vars()
+        # Log what this worker received, once every source has landed (container
+        # env, config, fetched shared vars, per-tool overrides). Keys only —
+        # never values — so credentials don't reach the logs.
+        logger.info(
+            "Worker received: tool=%s provider=%s pi_model=%s tools=%s max_agents=%d"
+            " env_keys=%s tool_env_keys=%s",
+            self.cfg.tool,
+            self.cfg.provider,
+            self.cfg.pi_model,
+            self.cfg.tools,
+            self.cfg.max_agents,
+            sorted(os.environ.keys()),
+            {tool: sorted(v.keys()) for tool, v in self._tool_env.items()},
+        )
         await self._refresh_github_repos()
         await self._check_gh_auth()
         await self._check_codex_doctor()

--- a/worker/tests/test_tools_detection.py
+++ b/worker/tests/test_tools_detection.py
@@ -208,10 +208,19 @@ class TestCredentialGating:
             await worker2._detect_available_tools()
         assert "codex" in worker2._available_tools
 
-    async def test_pi_needs_no_credentials(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    async def test_pi_without_scoped_env_is_excluded(self):
+        # Empty pi tab → no scoped env → dropped.
         cfg = _make_cfg(tools=["pi"], pi_path="pi")
         worker = Worker(cfg)
+        with patch("shutil.which", return_value="pi"):
+            await worker._detect_available_tools()
+        assert "pi" not in worker._available_tools
+
+    async def test_pi_with_scoped_env_is_included(self):
+        # Any scoped var (a Bedrock bearer token here) counts as configured.
+        cfg = _make_cfg(tools=["pi"], pi_path="pi")
+        worker = Worker(cfg)
+        worker._tool_env = {"pi": {"AWS_BEARER_TOKEN_BEDROCK": "tok"}}
         with patch("shutil.which", return_value="pi"):
             await worker._detect_available_tools()
         assert "pi" in worker._available_tools


### PR DESCRIPTION
Restructures guild settings so the **Foreman** tab is foreman-only and worker config lives under a renamed **Worker Settings** tab, and stops foreman credentials from silently reaching every worker.

## Settings UI (`GuildSettingsPanel.vue`)
- **Spawn Defaults → Worker Settings.** The `claude/pi/codex` sub-tabs moved out of Foreman into Worker Settings as **General + per-tool override** tabs, with spawn defaults (repos/tools/agents) on top.
- **Foreman tab is foreman-only:** its LLM provider/model, a flat env-var list, and orchestration knobs (system suffix, rounds, poll).
- **Removed the "disappearing" dedicated credential fields** that pulled known keys out of the env list and hid them — now one flat `KEY | value | ☐ forward` list.
- **Masked ENV defaults surfaced:** `GET foreman-config` returns `env_defaults` (secrets masked server-side); shown on provider/model placeholders and a summary line.

## Credentials no longer auto-forward
- Each shared `env_var` gains a per-var **`forward`** flag (default **off**).
- Foreman's own LLM still receives all env_vars; **workers receive only `forward=true`** ones — enforced at every worker path: user spawn (`routes/workers.py`), foreman `spawn_worker` (`foreman/tools.py`), and the worker startup fetch (`routes/foreman.py`). `spawn-credentials` shows only forwarded vars.

## Worker startup logging
- `worker.py` logs what the worker received once all env sources land — tool/provider/model/max_agents + env var **keys only** (never values). *(carried in `cc0b780`, which also gates pi on credentials like claude/codex)*

## Foreman `spawn_worker`
- Confirmed it still falls back to the guild's configured spawn defaults (repos/tools/agents, same table the UI writes) and now forwards the same forwarded env set as the user path.

## ⚠️ Behavior change
Existing guild `env_vars` have no `forward` flag → they **stop reaching workers until re-ticked**. This is the intended "don't auto-forward" default; any guild relying on a forwarded credential needs it re-checked once.

## Tests
- Backend: 231 pass (added `test_spawn_worker_only_forwards_flagged_guild_env_vars`; updated existing spawn/credential tests to the forward model).
- Frontend: 123 pass (added a forward-flag round-trip + General-tab reflection test).

## Not included
- **Spawn-form → tabbed popup** rewrite — deferred to #1042.
- **#1040** (`pi_default_provider/model` never applied at dispatch) is **not** subsumed by this PR — it's a separate dispatch-side fix. This PR only reorganizes those fields' UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)