### PR TITLE
Apply guild pi default provider/model at dispatch (#1040)

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -112,6 +112,38 @@ async def _to_thread(fn, /, *args, **kwargs):
     )
 
 
+async def _guild_foreman_config(db, guild_pk: int | None) -> dict:
+    """Read a guild's foreman_config via the in-scope session (not a fresh one,
+    so it stays inside the caller's transaction and test fixtures apply)."""
+    if guild_pk is None:
+        return {}
+    res = await db.exec(select(col(Guild.foreman_config)).where(col(Guild.id) == guild_pk))
+    cfg = res.one_or_none()
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _apply_pi_defaults(
+    tool: str | None,
+    provider: str | None,
+    model: str | None,
+    guild_cfg: dict | None,
+) -> tuple[str | None, str | None]:
+    """Fill pi's provider/model from the guild's foreman config when a dispatch
+    left them unset. Pi is provider-agnostic and has no built-in default that
+    authenticates, so without this a pi task launches with no --provider/--model
+    and fails per-task (see #1040). Only applies to the pi tool; an explicit
+    provider/model from the foreman's tool call always wins.
+    """
+    if tool != "pi":
+        return provider, model
+    cfg = guild_cfg or {}
+    if provider is None:
+        provider = cfg.get("pi_default_provider") or None
+    if model is None:
+        model = cfg.get("pi_default_model") or None
+    return provider, model
+
+
 def _resolve_finalize_deleted_at(inp: dict) -> tuple[datetime | None, str | None]:
     """Compute the soft-delete instant for a finalize_task tool call.
 
@@ -1539,6 +1571,13 @@ async def _exec_one_tool(
                         # worker is legacy (no tools registered) — accept it as-is.
                         tool = requested_tool
 
+                    # Pi has no built-in default that authenticates — fall back to
+                    # the guild's configured pi default provider/model (#1040).
+                    if tool == "pi" and (provider is None or model is None):
+                        provider, model = _apply_pi_defaults(
+                            tool, provider, model, await _guild_foreman_config(db, guild_pk)
+                        )
+
                     from util.model_tiers import select_model_tier as _select_tier  # noqa: PLC0415
 
                     model_tier = _select_tier(phase, complexity_hint=requested_tier)
@@ -1892,6 +1931,17 @@ async def _exec_one_tool(
                                     if task_provider is not None
                                     else followup_worker_provider
                                 )
+                                # Pi has no authenticating built-in default — fall
+                                # back to the guild's configured pi default (#1040).
+                                if effective_tool == "pi" and (
+                                    effective_provider is None or effective_model is None
+                                ):
+                                    effective_provider, effective_model = _apply_pi_defaults(
+                                        effective_tool,
+                                        effective_provider,
+                                        effective_model,
+                                        await _guild_foreman_config(db, guild_pk),
+                                    )
 
                                 from util.model_tiers import (  # noqa: PLC0415
                                     select_model_tier as _select_tier,

--- a/backend/tests/test_pi_defaults.py
+++ b/backend/tests/test_pi_defaults.py
@@ -1,0 +1,26 @@
+"""Unit tests for the pi provider/model default fallback (#1040)."""
+
+from foreman.tools import _apply_pi_defaults
+
+GUILD_CFG = {"pi_default_provider": "bedrock", "pi_default_model": "arn:aws:...:profile/x"}
+
+
+def test_pi_defaults_fill_when_unset():
+    provider, model = _apply_pi_defaults("pi", None, None, GUILD_CFG)
+    assert provider == "bedrock"
+    assert model == "arn:aws:...:profile/x"
+
+
+def test_explicit_values_win_over_guild_defaults():
+    provider, model = _apply_pi_defaults("pi", "anthropic", "claude-sonnet-4-6", GUILD_CFG)
+    assert provider == "anthropic"
+    assert model == "claude-sonnet-4-6"
+
+
+def test_non_pi_tool_is_untouched():
+    assert _apply_pi_defaults("codex", None, None, GUILD_CFG) == (None, None)
+
+
+def test_missing_config_leaves_values_none():
+    assert _apply_pi_defaults("pi", None, None, {}) == (None, None)
+    assert _apply_pi_defaults("pi", None, None, None) == (None, None)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1999,7 +1999,10 @@ class Worker:
                     )
                 elif tool == "pi":
                     _pi_model = task.get("model") or self.cfg.pi_model
-                    _pi_provider = task.get("provider") or self.cfg.pi_provider
+                    # Fall back to the worker's generic provider if pi_provider is
+                    # unset, so pi still launches with a provider when the task
+                    # carried none (defensive companion to the backend #1040 fix).
+                    _pi_provider = task.get("provider") or self.cfg.pi_provider or self.cfg.provider
 
                     logger.info(
                         "Task %s: launching pi in %s (model=%s provider=%s resume=%s)",


### PR DESCRIPTION
Fixes #1040 — `pi_default_provider` / `pi_default_model` were stored and edited in guild settings but **never read at task dispatch**, so they had no effect: pi launched with no `--provider`/`--model` and failed per-task on auth (and, since claude/codex get dropped for missing credentials, pi became the only tool and swallowed every task).

## Fix
- New helper `_apply_pi_defaults(tool, provider, model, guild_cfg)` — for `tool == "pi"`, fills provider/model from `foreman_config["pi_default_*"]` when the foreman's tool call left them unset. An explicit value always wins.
- Applied at both dispatch sites: **`assign_task`** (after tool resolution) and **`send_followup`** (after `effective_provider` is computed).
- Config read through the **in-scope session** (`_guild_foreman_config(db, guild_pk)`), staying inside the handler's transaction.
- Defensive worker companion: `_pi_provider` falls back to `cfg.provider` when `pi_provider` is unset.

## Tests
- `tests/test_pi_defaults.py`: unset→filled, explicit-wins, non-pi untouched, missing-config→None.
- Backend suite green; worker tool-detection green.

## Context
Follow-up to #1043 (merged), which reorganized the pi default fields into the Worker Settings UI but deliberately left dispatch untouched. This is that dispatch-side wiring; rebased onto `main` now that #1043 has merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)