### PR TITLE
Simplify task soft-delete to a single deleted_at stamp

### DIFF
--- a/backend/foreman/constants.py
+++ b/backend/foreman/constants.py
@@ -9,6 +9,3 @@ MAX_FOREMAN_ROUNDS = 10  # safety cap on tool-call rounds per invocation
 _HUMAN_TURN_WINDOW = 5  # how many non-tool-response user turns to load from DB
 _TERMINAL_STATES = frozenset({"done", "failed", "cancelled", "error"})
 _24H_SECS = 86_400
-# Default soft-delete window used when estimating completion time from deleted_at.
-# Must match routes/tasks.py DEFAULT_FINALIZE_TTL (3 days).
-_DEFAULT_TASK_TTL_SECS = 3 * 24 * 60 * 60

--- a/backend/foreman/message_utils.py
+++ b/backend/foreman/message_utils.py
@@ -8,7 +8,6 @@ from datetime import date, datetime
 from typing import Any
 
 from .constants import (
-    _DEFAULT_TASK_TTL_SECS,
     _TERMINAL_STATES,
     MAX_HISTORY_MESSAGES,
     MAX_TOOL_RESULT_CHARS,
@@ -183,8 +182,7 @@ def _summarize_task(task: dict, cutoff_ts: float) -> dict | None:
     their ``description`` field to keep context lean.  Non-terminal tasks are
     returned unchanged.
 
-    Completion time is approximated as ``deleted_at - DEFAULT_TTL`` since
-    ``finished_at`` was removed in favour of the single ``deleted_at`` column.
+    ``deleted_at`` is stamped at finalize time, so it *is* the completion instant.
     """
     state = task.get("state", "")
     if state not in _TERMINAL_STATES:
@@ -192,10 +190,9 @@ def _summarize_task(task: dict, cutoff_ts: float) -> dict | None:
     deleted_at = task.get("deleted_at")
     if deleted_at:
         try:
-            deleted_ts = datetime.fromisoformat(
+            finished_ts = datetime.fromisoformat(
                 deleted_at.replace("Z", "+00:00") if isinstance(deleted_at, str) else deleted_at
             ).timestamp()
-            finished_ts = deleted_ts - _DEFAULT_TASK_TTL_SECS
             if finished_ts < cutoff_ts:
                 return None  # older than 24 h — drop entirely
         except (ValueError, AttributeError, TypeError):

--- a/backend/foreman/prompt.py
+++ b/backend/foreman/prompt.py
@@ -81,8 +81,7 @@ Always create_task first and finalize_task after — whether you use a worker or
 2. review_pr_internal (or review_pr) — pass the PR details. Omit `action` to let the tool pick
    the verdict itself from its own diff analysis (see "Review action policy" below); only pass
    `action` explicitly to override that judgement.
-3. finalize_task(task_id=<task_id from step 1>) — call after the review returns. \
-   Use expires_in_seconds=86400 for error/failed reviews; omit (default 3 days) otherwise.
+3. finalize_task(task_id=<task_id from step 1>) — call after the review returns.
 
 CRITICAL — review output must go to GitHub PR review comments, never to a new PR.
 Workers in review phase receive explicit instructions to post via `gh pr review` and are
@@ -104,15 +103,11 @@ pedantic, and never block a merge over style.
 When dispatching a worker for a review-phase task, include this policy in the task description
 so the worker's `gh pr review` verdict follows it too.
 
-## Finalize expiry windows
-Every finalize_task call sets a soft-delete window via expires_in_seconds so the
-task table doesn't accumulate cruft. Pick the window by task type:
-- **Ephemeral tasks** (periodic-check, status-poll, automated health checks):
-  expires_in_seconds = 1200 (20 minutes)
-- **Code tasks** (execute / review / followup phases): omit the field to use
-  the default 3 days, or pass expires_in_seconds = 259200
-- **Error / failed tasks**: expires_in_seconds = 86400 (1 day)
-Pass deleted_at instead if you need an exact ISO-8601 timestamp.
+## Finalize soft-delete
+Soft-delete is automatic — you don't pick a window. A successful task tied to a
+still-open issue stays visible until the issue closes; every other finalized task
+(failures, cancellations, done tasks with no open issue) disappears from the board
+a few hours later. Just call finalize_task with the right outcome.
 
 ## GitHub access
 You have direct GitHub access via list_github_issues, get_github_issue, list_github_prs,
@@ -145,7 +140,7 @@ Use the body to decide:
   this event, but do not rely on it firing reliably — always call get_pr_status to
   confirm the merged state before calling finalize_task.
 - **PR closed unmerged**: call get_pr_status to read the rejection reason, then either
-  send_followup with the fix or finalize_task with expires_in_seconds=86400 if abandoning.
+  send_followup with the fix or finalize_task(outcome="failed") if abandoning.
 - **Review submitted, `changes_requested`**: send_followup — see "Reviewer feedback vs.
   issue intent" above; only pass along requests that don't contradict the linked issue.
 - **Review submitted, `approved`**: usually no action — wait for merge, or finalize if
@@ -332,7 +327,7 @@ the gap when a webhook was missed or never fired. Act on it immediately, per tas
   instructions to fix it.
 - **A review with state=changes_requested**: call send_followup with the requested changes.
 - **state=closed and merged=False**: read the reviews/checks for context, then either
-  send_followup with a fix or finalize_task with expires_in_seconds=86400 if abandoning.
+  send_followup with a fix or finalize_task(outcome="failed") if abandoning.
 - **Approved (state=approved review, no failing checks) with nothing else pending**: no
   action needed beyond noting it — a human or auto-merge will land it.
 This section is a snapshot fetched moments ago — you do not need to call get_pr_status
@@ -372,11 +367,10 @@ task and you own its lifecycle from here until it is finalized.
   or no worker is available to continue). You cannot create or assign new tasks — that is
   the parent's job; surface anything that needs a new task to the human.
 
-## Finalize expiry windows
-Every finalize_task call sets a soft-delete window via expires_in_seconds:
-- Ephemeral/automation tasks: expires_in_seconds = 1200 (20 minutes)
-- Code tasks (execute / review / followup): omit to use the default 3 days
-- Error / failed tasks: expires_in_seconds = 86400 (1 day)
+## Finalize soft-delete
+Soft-delete is automatic — you don't pick a window. A successful task tied to a
+still-open issue stays visible until the issue closes; every other finalized task
+disappears from the board a few hours later.
 
 ## Checking task progress
 Use get_task_status to verify this task is making progress — it returns the current

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -802,6 +802,26 @@ async def _poll_loop(guild_id: str) -> None:
                 )
                 active_tasks = [dict(r._mapping) for r in result.all()]
 
+                # Kept-alive done tasks (issue still open ⇒ deleted_at left NULL)
+                # rely on the issue-close sweep to ever be stamped; a dropped
+                # issues webhook would otherwise strand them live forever. Gather
+                # their issues too so the sweep below covers them.
+                # ponytail: re-polls each such open issue every cycle; add a
+                # per-issue cooldown if the GitHub API budget bites.
+                kept_alive_result = await db.exec(
+                    select(col(Task.issue_repo), col(Task.issue_number))
+                    .where(
+                        col(Task.guild_id) == guild_pk_val,
+                        col(Task.state).in_(list(_TERMINAL_STATES)),
+                        col(Task.deleted_at).is_(None),
+                        col(Task.issue_number).is_not(None),
+                    )
+                    .distinct()
+                )
+                kept_alive_issues = {
+                    (r[0], r[1]) for r in kept_alive_result.all() if r[0] and r[1]
+                }
+
                 # Opportunistically refresh the model catalog while we have a DB
                 # session open. The function is a no-op when the catalog is fresh.
                 from util.models_dev import refresh_model_catalog_if_stale as _refresh_catalog
@@ -829,12 +849,15 @@ async def _poll_loop(guild_id: str) -> None:
                 (t["issue_repo"], t["issue_number"])
                 for t in active_tasks
                 if t.get("issue_repo") and t.get("issue_number")
-            }
+            } | kept_alive_issues
+            # Sweep whenever any linked issue exists — kept-alive done tasks need
+            # it even when there are no non-terminal tasks left on the board.
+            if linked_issues:
+                await _sweep_closed_issues(guild_id, linked_issues)
             if active_tasks:
                 task_summary = "; ".join(f"{t['id']} ({t['state']})" for t in active_tasks)
                 pr_tasks = [t for t in active_tasks if t.get("pr_url")]
                 pr_status_lines = await _fetch_pr_status_lines(guild_id, pr_tasks)
-                await _sweep_closed_issues(guild_id, linked_issues)
 
                 msg = (
                     f"[periodic-check] Automated status poll — {n} non-terminal "

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -44,6 +44,7 @@ from models import (
     TaskLog,
     User,
     Worker,
+    finalize_soft_delete_at,
 )
 from sqlalchemy import delete, literal, update
 from sqlmodel import col, select
@@ -62,10 +63,6 @@ from ws_types import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Default soft-delete window (seconds) when finalize_task is called without
-# an explicit expiry. Mirrors backend.main.DEFAULT_FINALIZE_TTL.
-DEFAULT_FINALIZE_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days
 
 # Hard cap on any single blocking external-service call (GitHub API, Docker, A2A
 # agent).  Wrapping asyncio.to_thread with asyncio.wait_for(timeout=...) means a
@@ -112,34 +109,6 @@ async def _to_thread(fn, /, *args, **kwargs):
     )
 
 
-def _resolve_finalize_deleted_at(inp: dict) -> tuple[datetime | None, str | None]:
-    """Compute the soft-delete instant for a finalize_task tool call.
-
-    Returns ``(deleted_at, error)`` — error is non-None when the inputs
-    were malformed. Honours an explicit ``deleted_at`` first, then
-    ``expires_in_seconds``, otherwise falls back to the default 3-day window.
-    """
-    raw = inp.get("deleted_at")
-    if raw:
-        try:
-            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
-        except ValueError as exc:
-            return None, f"Invalid deleted_at: {exc}"
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=UTC)
-        return parsed.astimezone(UTC), None
-    seconds = inp.get("expires_in_seconds")
-    if seconds is not None:
-        try:
-            secs = int(seconds)
-        except (TypeError, ValueError):
-            return None, f"Invalid expires_in_seconds: {seconds!r}"
-        if secs < 0:
-            return None, "expires_in_seconds must be >= 0"
-        return datetime.now(UTC) + timedelta(seconds=secs), None
-    return datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS), None
-
-
 async def finalize_closed_issue(
     db, guild_pk: int, guild_id: str, issue_repo: str, issue_number: int
 ) -> list[str]:
@@ -155,7 +124,7 @@ async def finalize_closed_issue(
     verification comment summarising linked-PR merge status when anything was
     finalized. Returns the ids of the tasks that were finalized or swept.
     """
-    deleted_at = datetime.now(UTC) + timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS)
+    deleted_at = datetime.now(UTC)
     issue_filter = (
         col(Task.guild_id) == guild_pk,
         col(Task.issue_repo) == issue_repo,
@@ -2074,79 +2043,77 @@ async def _exec_one_tool(
                     result_text = _blocked
                     is_error = True
                 else:
-                    deleted_at, err = _resolve_finalize_deleted_at(inp)
-                    if err:
-                        result_text = err
-                        is_error = True
+                    result = await db.exec(
+                        select(Task)
+                        .where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+                        .with_for_update()
+                    )
+                    task = result.one_or_none()
+                    if not task:
+                        result_text = f"Task {task_id} not found."
                     else:
-                        result = await db.exec(
-                            select(Task)
-                            .where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
-                            .with_for_update()
+                        deleted_at = finalize_soft_delete_at(
+                            outcome, task.issue_number, task.issue_state, task.phase
                         )
-                        task = result.one_or_none()
-                        if not task:
-                            result_text = f"Task {task_id} not found."
-                        else:
-                            await db.exec(
-                                update(Task)
-                                .where(col(Task.id) == task_id)
-                                .values(
-                                    state=outcome,
-                                    deleted_at=deleted_at,
-                                )
+                        await db.exec(
+                            update(Task)
+                            .where(col(Task.id) == task_id)
+                            .values(
+                                state=outcome,
+                                deleted_at=deleted_at,
                             )
-                            # Discard any queued follow-up events — the task is closed.
-                            await db.exec(
-                                delete(TaskEvent).where(col(TaskEvent.task_id) == task_id)
-                            )
-                            await LockService(db).release(f"task:{task_id}")
+                        )
+                        # Discard any queued follow-up events — the task is closed.
+                        await db.exec(delete(TaskEvent).where(col(TaskEvent.task_id) == task_id))
+                        await LockService(db).release(f"task:{task_id}")
 
-                            # phase='issue' root tasks own an entire GitHub issue's worth of
-                            # work — cascade the soft-delete to descendants that already
-                            # finished, but never force-close in-progress/pending ones (a
-                            # human decides whether to cancel in-flight work).
-                            descendants: list[Task] = []
-                            if task.phase == "issue":
-                                descendants = await find_descendant_tasks(db, task_id)
-                                await cascade_soft_delete_terminal_descendants(
-                                    db, descendants, deleted_at
-                                )
-
-                            await db.commit()
-                            await broadcast_msg(
-                                guild_id,
-                                TaskFinalizeMsg(workerId=task.worker_id, taskId=task_id),
+                        # phase='issue' root tasks own an entire GitHub issue's worth of
+                        # work — cascade the soft-delete to descendants that already
+                        # finished, but never force-close in-progress/pending ones (a
+                        # human decides whether to cancel in-flight work).
+                        descendants: list[Task] = []
+                        if task.phase == "issue":
+                            descendants = await find_descendant_tasks(db, task_id)
+                            await cascade_soft_delete_terminal_descendants(
+                                db, descendants, deleted_at
                             )
-                            await broadcast_msg(
-                                guild_id,
-                                TaskUpdateMsg(
-                                    taskId=task_id,
-                                    state=outcome,
-                                    deletedAt=deleted_at.isoformat()
-                                    if deleted_at is not None
-                                    else None,
+
+                        await db.commit()
+                        await broadcast_msg(
+                            guild_id,
+                            TaskFinalizeMsg(workerId=task.worker_id, taskId=task_id),
+                        )
+                        await broadcast_msg(
+                            guild_id,
+                            TaskUpdateMsg(
+                                taskId=task_id,
+                                state=outcome,
+                                deletedAt=deleted_at.isoformat() if deleted_at is not None else None,
+                            ),
+                        )
+                        if (
+                            task.phase == "issue"
+                            and task.issue_repo
+                            and task.issue_number is not None
+                        ):
+                            await post_issue_close_summary_comment(
+                                guild_id, task.issue_repo, task.issue_number, descendants
+                            )
+                        if outcome == "failed":
+                            spawn(
+                                notify_discord_task_finalized(
+                                    task.issue_repo, task.issue_number, task_id, "failed"
                                 ),
+                                name=f"discord.finalize:{task_id}",
                             )
-                            if (
-                                task.phase == "issue"
-                                and task.issue_repo
-                                and task.issue_number is not None
-                            ):
-                                await post_issue_close_summary_comment(
-                                    guild_id, task.issue_repo, task.issue_number, descendants
-                                )
-                            if outcome == "failed":
-                                spawn(
-                                    notify_discord_task_finalized(
-                                        task.issue_repo, task.issue_number, task_id, "failed"
-                                    ),
-                                    name=f"discord.finalize:{task_id}",
-                                )
-                            result_text = (
-                                f"Task {task_id} finalized as {outcome}; soft-delete at "
-                                f"{deleted_at.isoformat() if deleted_at is not None else 'unknown'}."
+                        result_text = (
+                            f"Task {task_id} finalized as {outcome}; "
+                            + (
+                                f"soft-deleted at {deleted_at.isoformat()}."
+                                if deleted_at is not None
+                                else "kept live until its issue closes."
                             )
+                        )
 
             elif tu.name == "message_worker":
                 wid = inp["worker_id"]
@@ -2230,9 +2197,7 @@ async def _exec_one_tool(
                         if state in ("done", "failed", "cancelled"):
                             result_text = f"Task {task_id} is already {state}."
                         else:
-                            deleted_at = datetime.now(UTC) + timedelta(
-                                seconds=DEFAULT_FINALIZE_TTL_SECONDS
-                            )
+                            deleted_at = datetime.now(UTC)
                             await db.exec(
                                 update(Task)
                                 .where(col(Task.id) == task_id)

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -247,14 +247,9 @@ FOREMAN_TOOLS = [
             "Close a task with no further follow-up needed. "
             "Call after reviewing a completed or errored task when no additional work is required. "
             "Use outcome='failed' when the task did not succeed (push errors, agent errors, "
-            "abandoned work). Tasks are soft-deleted after their expiry window so the table "
-            "doesn't accumulate cruft. Pick the window by task type:\n"
-            "  - Ephemeral tasks (periodic-check, status-poll, automated health "
-            "checks): expires_in_seconds = 1200 (20 minutes)\n"
-            "  - Code tasks (execute / review / followup phases): omit the field "
-            "to use the default 3 days, or pass expires_in_seconds = 259200\n"
-            "  - Error / failed tasks: expires_in_seconds = 86400 (1 day)\n"
-            "Pass deleted_at instead if you need an exact ISO-8601 timestamp.\n"
+            "abandoned work). Soft-delete is automatic: successful tasks tied to a still-open "
+            "issue stay visible until the issue closes; everything else disappears from the "
+            "board a few hours after finalizing. You do not choose the window.\n"
             "NOTE: For tasks that have an open PR, the GitHub webhook *may* deliver a "
             "'PR merged' event — but do not rely on it firing reliably. Always call "
             "get_pr_status to confirm the merged state before calling finalize_task."
@@ -270,20 +265,6 @@ FOREMAN_TOOLS = [
                         "Final state to set on the task. "
                         "'done' (default) for successful completion; "
                         "'failed' for tasks that errored, hit push failures, or were abandoned."
-                    ),
-                },
-                "expires_in_seconds": {
-                    "type": "integer",
-                    "description": (
-                        "Seconds from now until the task is soft-deleted. "
-                        "Defaults to 259200 (3 days) when omitted."
-                    ),
-                },
-                "deleted_at": {
-                    "type": "string",
-                    "description": (
-                        "ISO-8601 UTC timestamp at which the task is soft-deleted. "
-                        "Takes precedence over expires_in_seconds when both are set."
                     ),
                 },
             },

--- a/backend/main.py
+++ b/backend/main.py
@@ -501,11 +501,6 @@ if os.environ.get("DEBUG_TOKEN"):
 # helpers directly. Don't use these in new code — import from the source module.
 # ---------------------------------------------------------------------------
 
-from routes.tasks import (  # noqa: E402,F401
-    DEFAULT_FINALIZE_TTL,
-    FinalizeBody,
-    _resolve_finalize_deleted_at,
-)
 from utils import build_spawn_worker_env as _build_spawn_worker_env  # noqa: E402,F401
 from utils import decode_claude_oauth_token as _decode_claude_oauth_token  # noqa: E402,F401
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 import json as _json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import JSON, Boolean, Column, DateTime, Index, Text, UniqueConstraint, or_, text
 from sqlalchemy.dialects.postgresql import JSONB
@@ -11,16 +11,48 @@ from sqlmodel import Field, SQLModel, col
 VALID_TOOLS = ("claude", "codex", "pi")
 
 
+# Grace window: a soft-deleted task stays visible this long after ``deleted_at``
+# (stamped at delete time) so operators can see just-finished work before it
+# disappears. Single knob — tune here, nowhere else.
+SOFT_DELETE_GRACE = timedelta(hours=4)
+
+
 def live_tasks_filter(now: datetime | None = None):
     """SQL clause matching tasks that have not been soft-deleted.
 
-    A task is "live" when ``deleted_at`` is NULL or set to a future timestamp.
-    *now* defaults to the current UTC time; pass an explicit value to make a
-    query reproducible in tests.
+    ``deleted_at`` records *when* a task was deleted (NULL = never). A task is
+    "live" while ``deleted_at`` is NULL or was stamped within the last
+    ``SOFT_DELETE_GRACE``. *now* defaults to the current UTC time; pass an
+    explicit value to make a query reproducible in tests.
     """
     if now is None:
         now = datetime.now(UTC)
-    return or_(col(Task.deleted_at).is_(None), col(Task.deleted_at) > now)
+    return or_(col(Task.deleted_at).is_(None), col(Task.deleted_at) > now - SOFT_DELETE_GRACE)
+
+
+def finalize_soft_delete_at(
+    outcome: str,
+    issue_number: int | None,
+    issue_state: str | None,
+    phase: str | None = None,
+    now: datetime | None = None,
+) -> datetime | None:
+    """When to stamp ``deleted_at`` for a task entering a terminal state.
+
+    Successful *sub-tasks* tied to a still-open issue stay live (return None)
+    until the issue closes — the issue-close webhook/sweep stamps them then. A
+    ``phase='issue'`` root task IS the issue proxy, not a sub-task, so finalizing
+    it means the issue tracking is done: stamp it now. Everything else (failures,
+    cancellations, done tasks with no open issue) is stamped immediately at *now*.
+    """
+    if (
+        outcome == "done"
+        and phase != "issue"
+        and issue_number is not None
+        and issue_state != "closed"
+    ):
+        return None
+    return now if now is not None else datetime.now(UTC)
 
 
 class Guild(SQLModel, table=True):
@@ -312,8 +344,8 @@ class Task(SQLModel, table=True):
     name: str | None = None
     parent_task_id: str | None = None
     phase: str | None = Field(default="execute", sa_column_kwargs={"server_default": "'execute'"})
-    # UTC instant at which this task is considered soft-deleted.
-    # NULL = live; once `now() > deleted_at`, list/get queries hide the row.
+    # UTC instant at which this task was soft-deleted. NULL = live; once it is
+    # stamped, list/get queries hide the row after `SOFT_DELETE_GRACE` elapses.
     deleted_at: datetime | None = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )

--- a/backend/routes/discord.py
+++ b/backend/routes/discord.py
@@ -82,9 +82,6 @@ _DEFERRED_CHANNEL_MESSAGE = 5
 # Ephemeral message flag
 _EPHEMERAL = 64
 
-# Default soft-delete window for cancelled tasks
-_CANCEL_TTL = timedelta(days=3)
-
 # Lifetime of a /connect-account one-time token
 _CONNECT_TOKEN_TTL = timedelta(minutes=15)
 
@@ -571,7 +568,7 @@ async def _cmd_cancel(interaction_token: str, guild_slug: str, task_id: str) -> 
                 )
                 return
 
-            deleted_at = datetime.now(UTC) + _CANCEL_TTL
+            deleted_at = datetime.now(UTC)  # cancellations are stamped immediately
             await db.exec(
                 update(Task)
                 .where(col(Task.id) == task_id)

--- a/backend/routes/tasks.py
+++ b/backend/routes/tasks.py
@@ -1,8 +1,7 @@
 """Task lifecycle routes: list, logs, follow-up, finalize, cancel, redirect.
 
-Soft-delete TTL handling lives here too — ``DEFAULT_FINALIZE_TTL``,
-``FinalizeBody``, and ``_resolve_finalize_deleted_at`` are exported for
-direct unit testing in ``tests/test_soft_delete_tasks.py``.
+Soft-delete is a single ``deleted_at`` stamp (see ``models.finalize_soft_delete_at``
+/ ``live_tasks_filter``) — no per-task TTL windows.
 """
 
 from __future__ import annotations
@@ -10,7 +9,7 @@ from __future__ import annotations
 import json
 import re
 from collections import defaultdict
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
@@ -19,7 +18,15 @@ from fastapi import APIRouter, Depends, HTTPException
 from foreman.classify import is_human_event
 from foreman.runner import run_foreman_ai
 from lock_service import LockService
-from models import GithubIssue, GithubPullRequest, Guild, Task, TaskLog, live_tasks_filter
+from models import (
+    GithubIssue,
+    GithubPullRequest,
+    Guild,
+    Task,
+    TaskLog,
+    finalize_soft_delete_at,
+    live_tasks_filter,
+)
 from pydantic import BaseModel
 from sqlalchemy import tuple_, update
 from sqlmodel import col, select
@@ -30,43 +37,12 @@ from ws_types import TaskCancelMsg, TaskFinalizeMsg, TaskRedirectMsg, TaskUpdate
 router = APIRouter()
 
 
-# Default soft-delete window for finalized tasks when the caller does not
-# specify one. 3 days lets the operator review recent work in the UI before
-# it disappears.
-DEFAULT_FINALIZE_TTL = timedelta(days=3)
-
-
 class FollowupCreate(BaseModel):
     instructions: str
 
 
-class FinalizeBody(BaseModel):
-    # Optional ISO-8601 timestamp at which to soft-delete this task.
-    deleted_at: str | None = None
-    # Optional convenience: seconds from now until soft-delete. If both fields
-    # are set, deleted_at wins.
-    expires_in_seconds: int | None = None
-
-
 class RedirectCreate(BaseModel):
     instructions: str
-
-
-def _resolve_finalize_deleted_at(body: FinalizeBody | None) -> datetime:
-    """Return a UTC datetime for the task's soft-delete instant."""
-    if body and body.deleted_at:
-        try:
-            parsed = datetime.fromisoformat(body.deleted_at.replace("Z", "+00:00"))
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=f"Invalid deleted_at: {exc}") from exc
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=UTC)
-        return parsed.astimezone(UTC)
-    if body and body.expires_in_seconds is not None:
-        if body.expires_in_seconds < 0:
-            raise HTTPException(status_code=400, detail="expires_in_seconds must be >= 0")
-        return datetime.now(UTC) + timedelta(seconds=body.expires_in_seconds)
-    return datetime.now(UTC) + DEFAULT_FINALIZE_TTL
 
 
 @router.get("/guilds/{guild_id}/tasks")
@@ -259,26 +235,31 @@ async def create_task_followup(
 async def finalize_task_endpoint(
     guild_id: str,
     task_id: str,
-    body: FinalizeBody | None = None,
     github_user_id: str = Depends(require_member()),
     db: AsyncSession = Depends(get_db_dep),
 ):
     """Signal a worker to finalize a task — no more follow-ups.
 
-    The optional body may carry ``deleted_at`` (ISO-8601) or
-    ``expires_in_seconds`` to set the task's soft-delete window. If neither is
-    set, the task is soft-deleted ``DEFAULT_FINALIZE_TTL`` from now.
+    Soft-deletes the task now, unless it is tied to a still-open issue: then
+    ``deleted_at`` stays NULL until the issue closes (see
+    ``models.finalize_soft_delete_at``).
     """
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
     result = await db.exec(
-        select(col(Task.worker_id)).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
+        select(
+            col(Task.worker_id),
+            col(Task.issue_number),
+            col(Task.issue_state),
+            col(Task.phase),
+        ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
     )
-    worker_id = result.one_or_none()
-    if not worker_id:
+    row = result.one_or_none()
+    if not row:
         raise HTTPException(status_code=404, detail="Task not found")
-    deleted_at = _resolve_finalize_deleted_at(body)
+    worker_id, issue_number, issue_state, phase = row
+    deleted_at = finalize_soft_delete_at("done", issue_number, issue_state, phase)
     await db.exec(
         update(Task).where(col(Task.id) == task_id).values(state="done", deleted_at=deleted_at)
     )
@@ -289,7 +270,7 @@ async def finalize_task_endpoint(
         TaskUpdateMsg(
             taskId=task_id,
             state="done",
-            deletedAt=deleted_at.isoformat(),
+            deletedAt=deleted_at.isoformat() if deleted_at else None,
         ),
     )
     # Return raw datetime — FastAPI's jsonable_encoder handles ISO-8601 serialisation.
@@ -318,7 +299,7 @@ async def cancel_task_endpoint(
     worker_id, state = row
     if state in ("done", "failed", "cancelled"):
         raise HTTPException(status_code=409, detail=f"Task is already {state}")
-    deleted_at = datetime.now(UTC) + DEFAULT_FINALIZE_TTL
+    deleted_at = datetime.now(UTC)
     await db.exec(
         update(Task).where(col(Task.id) == task_id).values(state="cancelled", deleted_at=deleted_at)
     )

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -20,16 +20,26 @@ import hmac
 import json
 import logging
 import os
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 import discord_notifier
 from database import get_db_dep
 from db import github_cache
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from foreman.constants import _TERMINAL_STATES
 from foreman.runner import reset_foreman_poll, run_foreman_ai
 from lock_service import LockService
-from models import GithubEvent, GithubToken, Guild, GuildMember, Message, Task, TaskEvent
+from models import (
+    GithubEvent,
+    GithubToken,
+    Guild,
+    GuildMember,
+    Message,
+    Task,
+    TaskEvent,
+    finalize_soft_delete_at,
+)
 from pydantic import BaseModel
 from sqlalchemy import delete, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -277,9 +287,6 @@ class DebounceQueue:
 
 _debounce_queue = DebounceQueue()
 
-_DEFAULT_FINALIZE_TTL_SECS = 3 * 24 * 60 * 60  # 3 days
-_DEFAULT_FAIL_TTL_SECS = 24 * 60 * 60  # 1 day
-_WEBHOOK_TERMINAL_STATES = frozenset({"done", "failed", "cancelled"})
 
 
 async def _auto_finalize_task_on_pr_merge(
@@ -295,20 +302,21 @@ async def _auto_finalize_task_on_pr_merge(
     Releases any in-progress lock, discards queued follow-up events, and broadcasts
     TaskFinalizeMsg + TaskUpdateMsg so the frontend reflects the change immediately.
     """
-    # Fetch worker_id for the broadcast; existence check only — state filtering
-    # is delegated entirely to the conditional UPDATE to eliminate SELECT→UPDATE TOCTOU.
+    # Fetch worker_id + issue link for the broadcast and the keep-alive decision;
+    # state filtering is delegated entirely to the conditional UPDATE to eliminate
+    # the SELECT→UPDATE TOCTOU.
     row_result = await db.exec(
-        select(col(Task.id), col(Task.worker_id)).where(
-            col(Task.id) == task_id, col(Task.guild_id) == guild_pk
-        )
+        select(
+            col(Task.worker_id), col(Task.issue_number), col(Task.issue_state)
+        ).where(col(Task.id) == task_id, col(Task.guild_id) == guild_pk)
     )
     task_row = row_result.one_or_none()
     if task_row is None:
         return False
-    worker_id = task_row[1]
+    worker_id, issue_number, issue_state = task_row
 
-    now = datetime.now(UTC)
-    deleted_at = now + timedelta(seconds=_DEFAULT_FINALIZE_TTL_SECS)
+    # done + still-open issue ⇒ stay live (deleted_at NULL) until the issue closes.
+    deleted_at = finalize_soft_delete_at("done", issue_number, issue_state)
 
     # Single conditional UPDATE — only fires if task is not already in a terminal
     # state, eliminating the race between two concurrent state transitions.
@@ -317,7 +325,7 @@ async def _auto_finalize_task_on_pr_merge(
         .where(
             col(Task.id) == task_id,
             col(Task.guild_id) == guild_pk,
-            col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
+            col(Task.state).notin_(list(_TERMINAL_STATES)),
         )
         .values(state="done", deleted_at=deleted_at)
     )
@@ -334,7 +342,7 @@ async def _auto_finalize_task_on_pr_merge(
         TaskUpdateMsg(
             taskId=task_id,
             state="done",
-            deletedAt=deleted_at.isoformat(),
+            deletedAt=deleted_at.isoformat() if deleted_at else None,
         ),
     )
     return True
@@ -365,8 +373,7 @@ async def _auto_fail_task_on_pr_close(
         return False
     worker_id = task_row[1]
 
-    now = datetime.now(UTC)
-    deleted_at = now + timedelta(seconds=_DEFAULT_FAIL_TTL_SECS)
+    deleted_at = datetime.now(UTC)  # failures are stamped immediately
 
     # Single conditional UPDATE — only fires if task is not already in a terminal
     # state, eliminating the race between two concurrent state transitions.
@@ -375,7 +382,7 @@ async def _auto_fail_task_on_pr_close(
         .where(
             col(Task.id) == task_id,
             col(Task.guild_id) == guild_pk,
-            col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
+            col(Task.state).notin_(list(_TERMINAL_STATES)),
         )
         .values(state="failed", deleted_at=deleted_at)
     )
@@ -892,7 +899,7 @@ async def github_webhook(
                     col(Task.guild_id) == guild_pk,
                     col(Task.branch) == head_ref,
                     col(Task.pr_url).is_(None),
-                    col(Task.state).notin_(list(_WEBHOOK_TERMINAL_STATES)),
+                    col(Task.state).notin_(list(_TERMINAL_STATES)),
                 )
             )
             branch_matched_task_ids = branch_match_result.all()

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -2946,8 +2946,9 @@ class TestSummarizeTask:
     """Terminal tasks are summarised/excluded; non-terminal tasks are kept in full."""
 
     _24H = 86_400
-    # Must match foreman/constants._DEFAULT_TASK_TTL_SECS (3 days)
-    _TTL = 3 * 24 * 60 * 60
+    # deleted_at is now stamped at finalize time (== finish instant), so there is
+    # no window to subtract: `self._iso(self._TTL - N)` resolves to `now - N`.
+    _TTL = 0
 
     def _now_ts(self):
         return datetime.now(UTC).timestamp()

--- a/backend/tests/test_soft_delete_tasks.py
+++ b/backend/tests/test_soft_delete_tasks.py
@@ -1,10 +1,15 @@
-"""Tests for soft-delete on tasks (issue #177).
+"""Tests for soft-delete on tasks.
+
+Model: ``deleted_at`` records *when* a task was deleted (stamped now() at
+finalize/cancel). A task is live while ``deleted_at`` is NULL or within
+``SOFT_DELETE_GRACE`` of now. Successful tasks tied to a still-open issue are
+left NULL until the issue closes.
 
 Covers:
 - Migration adds the deleted_at column.
-- _resolve_finalize_deleted_at honours deleted_at, expires_in_seconds, default.
-- live_tasks_filter hides soft-deleted rows from the list endpoint.
-- The finalize endpoint persists deleted_at to the row.
+- finalize_soft_delete_at: keep-alive-while-issue-open vs. stamp-now rules.
+- live_tasks_filter hides rows deleted longer ago than the grace window.
+- The finalize endpoint stamps now() (or NULL for an open-issue done task).
 """
 
 from __future__ import annotations
@@ -13,14 +18,12 @@ import os
 import sys
 from datetime import UTC, datetime, timedelta
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.dirname(__file__))
 
 from helpers import _sync_session, insert_guild, make_auth_token, raw_conn  # noqa: E402
-from models import Task
-from sqlalchemy import select, update
+from models import SOFT_DELETE_GRACE, Task, finalize_soft_delete_at  # noqa: E402
+from sqlalchemy import select, update  # noqa: E402
 from sqlmodel import col  # noqa: E402
 
 
@@ -43,14 +46,22 @@ def _create_task(test_client, guild_id: str, worker_id: str, desc: str, db_url: 
 
 
 def _set_deleted_at(db_url: str, task_id: str, deleted_at: datetime | None) -> None:
-
     with _sync_session(db_url) as session:
         session.execute(update(Task).where(col(Task.id) == task_id).values(deleted_at=deleted_at))
         session.commit()
 
 
-def _read_task(db_url: str, task_id: str) -> dict:
+def _set_issue(db_url: str, task_id: str, number: int, state: str) -> None:
+    with _sync_session(db_url) as session:
+        session.execute(
+            update(Task)
+            .where(col(Task.id) == task_id)
+            .values(issue_repo="o/r", issue_number=number, issue_state=state)
+        )
+        session.commit()
 
+
+def _read_task(db_url: str, task_id: str) -> dict:
     with _sync_session(db_url) as session:
         row = session.execute(select(Task).where(col(Task.id) == task_id)).scalar_one_or_none()
     return dict(row.model_dump()) if row else {}
@@ -74,148 +85,80 @@ def test_migration_adds_deleted_at_column(client):
 
 
 # ---------------------------------------------------------------------------
-# _resolve_finalize_deleted_at (REST helper)
+# finalize_soft_delete_at — the delete rule
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_finalize_default_window(monkeypatch):
-    from main import DEFAULT_FINALIZE_TTL, _resolve_finalize_deleted_at
-
-    fixed = datetime(2026, 1, 1, tzinfo=UTC)
-
-    class _FixedDT(datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return fixed
-
-    monkeypatch.setattr("routes.tasks.datetime", _FixedDT)
-    out = _resolve_finalize_deleted_at(None)
-    assert out == fixed + DEFAULT_FINALIZE_TTL
+def test_done_with_open_issue_stays_live():
+    """A successful task on a still-open issue is not stamped."""
+    assert finalize_soft_delete_at("done", 42, "open") is None
+    assert finalize_soft_delete_at("done", 42, None) is None  # unknown ⇒ treat as open
 
 
-def test_resolve_finalize_explicit_seconds(monkeypatch):
-    from main import FinalizeBody, _resolve_finalize_deleted_at
-
-    fixed = datetime(2026, 1, 1, tzinfo=UTC)
-
-    class _FixedDT(datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return fixed
-
-    monkeypatch.setattr("routes.tasks.datetime", _FixedDT)
-    out = _resolve_finalize_deleted_at(FinalizeBody(expires_in_seconds=1200))
-    assert out == fixed + timedelta(seconds=1200)
+def test_done_with_closed_issue_stamps_now():
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    assert finalize_soft_delete_at("done", 42, "closed", now=now) == now
 
 
-def test_resolve_finalize_explicit_deleted_at_iso():
-    from main import FinalizeBody, _resolve_finalize_deleted_at
-
-    target = "2026-06-15T12:00:00+00:00"
-    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at=target))
-    assert out == datetime.fromisoformat(target)
+def test_done_without_issue_stamps_now():
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    assert finalize_soft_delete_at("done", None, None, now=now) == now
 
 
-def test_resolve_finalize_deleted_at_naive_assumed_utc():
-    from main import FinalizeBody, _resolve_finalize_deleted_at
-
-    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at="2026-06-15T12:00:00"))
-    assert out.tzinfo is not None
-    assert out == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+def test_failed_and_cancelled_stamp_now_regardless_of_issue():
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    assert finalize_soft_delete_at("failed", 42, "open", now=now) == now
+    assert finalize_soft_delete_at("cancelled", 42, "open", now=now) == now
 
 
-def test_resolve_finalize_deleted_at_z_suffix():
-    from main import FinalizeBody, _resolve_finalize_deleted_at
-
-    out = _resolve_finalize_deleted_at(FinalizeBody(deleted_at="2026-06-15T12:00:00Z"))
-    assert out == datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
-
-
-def test_resolve_finalize_invalid_deleted_at_raises():
-    from fastapi import HTTPException
-    from main import FinalizeBody, _resolve_finalize_deleted_at
-
-    with pytest.raises(HTTPException) as excinfo:
-        _resolve_finalize_deleted_at(FinalizeBody(deleted_at="not-a-date"))
-    assert excinfo.value.status_code == 400
-
-
-def test_resolve_finalize_negative_seconds_raises():
-    from fastapi import HTTPException
-    from main import FinalizeBody, _resolve_finalize_deleted_at
-
-    with pytest.raises(HTTPException) as excinfo:
-        _resolve_finalize_deleted_at(FinalizeBody(expires_in_seconds=-1))
-    assert excinfo.value.status_code == 400
-
-
-def test_resolve_finalize_deleted_at_wins_over_seconds():
-    """If both fields are set, deleted_at takes precedence."""
-    from main import FinalizeBody, _resolve_finalize_deleted_at
-
-    out = _resolve_finalize_deleted_at(
-        FinalizeBody(deleted_at="2026-12-25T00:00:00Z", expires_in_seconds=60)
-    )
-    assert out == datetime(2026, 12, 25, tzinfo=UTC)
+def test_issue_root_task_stamps_now_even_with_open_issue():
+    """A phase='issue' root IS the issue proxy — finalizing it stamps immediately."""
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    assert finalize_soft_delete_at("done", 42, "open", phase="issue", now=now) == now
 
 
 # ---------------------------------------------------------------------------
-# live_tasks_filter — list endpoints hide soft-deleted rows
+# live_tasks_filter — grace window
 # ---------------------------------------------------------------------------
 
 
-def test_list_guild_tasks_hides_past_deleted_at(client):
+def test_list_hides_tasks_deleted_before_grace_window(client):
     test_client, db_url = client
     insert_guild(db_url, "gsd01")
     worker_id = _create_worker(test_client, "gsd01")
     t_live = _create_task(test_client, "gsd01", worker_id, "live task", db_url)
-    t_dead = _create_task(test_client, "gsd01", worker_id, "dead task", db_url)
-    t_future = _create_task(test_client, "gsd01", worker_id, "future task", db_url)
+    t_recent = _create_task(test_client, "gsd01", worker_id, "recently deleted", db_url)
+    t_dead = _create_task(test_client, "gsd01", worker_id, "long deleted", db_url)
 
-    past = datetime.now(UTC) - timedelta(seconds=5)
-    future = datetime.now(UTC) + timedelta(days=1)
-    _set_deleted_at(db_url, t_dead, past)
-    _set_deleted_at(db_url, t_future, future)
+    now = datetime.now(UTC)
+    _set_deleted_at(db_url, t_recent, now - (SOFT_DELETE_GRACE / 2))  # within grace ⇒ visible
+    _set_deleted_at(db_url, t_dead, now - SOFT_DELETE_GRACE - timedelta(minutes=1))  # past ⇒ hidden
 
     resp = test_client.get("/guilds/gsd01/tasks", headers=_auth(db_url))
     assert resp.status_code == 200
     ids = {t["id"] for t in resp.json()}
     assert t_live in ids
-    assert t_future in ids
+    assert t_recent in ids
     assert t_dead not in ids
 
 
-def test_list_worker_tasks_hides_past_deleted_at(client):
-    test_client, db_url = client
-    insert_guild(db_url, "gsd02")
-    worker_id = _create_worker(test_client, "gsd02")
-    t_live = _create_task(test_client, "gsd02", worker_id, "live", db_url)
-    t_dead = _create_task(test_client, "gsd02", worker_id, "dead", db_url)
-    _set_deleted_at(db_url, t_dead, datetime.now(UTC) - timedelta(minutes=1))
-
-    resp = test_client.get(f"/guilds/gsd02/workers/{worker_id}/tasks")
-    assert resp.status_code == 200
-    ids = {t["id"] for t in resp.json()}
-    assert ids == {t_live}
-
-
-def test_get_task_logs_404_on_soft_deleted(client):
+def test_get_task_logs_404_after_grace_window(client):
     test_client, db_url = client
     insert_guild(db_url, "gsd03")
     worker_id = _create_worker(test_client, "gsd03")
     task_id = _create_task(test_client, "gsd03", worker_id, "task", db_url)
-    _set_deleted_at(db_url, task_id, datetime.now(UTC) - timedelta(minutes=1))
+    _set_deleted_at(db_url, task_id, datetime.now(UTC) - SOFT_DELETE_GRACE - timedelta(minutes=1))
 
     resp = test_client.get(f"/guilds/gsd03/tasks/{task_id}/logs", headers=_auth(db_url))
     assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------
-# Finalize endpoint — persists deleted_at and supports overrides
+# Finalize endpoint
 # ---------------------------------------------------------------------------
 
 
-def test_finalize_endpoint_default_sets_three_day_window(client):
+def test_finalize_endpoint_stamps_now(client):
     test_client, db_url = client
     insert_guild(db_url, "gsd04")
     worker_id = _create_worker(test_client, "gsd04")
@@ -224,163 +167,47 @@ def test_finalize_endpoint_default_sets_three_day_window(client):
     before = datetime.now(UTC)
     resp = test_client.post(f"/guilds/gsd04/tasks/{task_id}/finalize", headers=_auth(db_url))
     assert resp.status_code == 200, resp.text
-    deleted_at = resp.json()["deletedAt"]
-    parsed = datetime.fromisoformat(deleted_at)
-    # Should be roughly 3 days from now (allow ±1 minute slack for slow machines).
-    assert timedelta(days=3, minutes=-1) <= parsed - before <= timedelta(days=3, minutes=1)
-    assert _read_task(db_url, task_id)["deleted_at"] == datetime.fromisoformat(deleted_at)
+    parsed = datetime.fromisoformat(resp.json()["deletedAt"])
+    assert timedelta(minutes=-1) <= parsed - before <= timedelta(minutes=1)
+    assert _read_task(db_url, task_id)["deleted_at"] == parsed
 
 
-def test_finalize_endpoint_explicit_expires_in_seconds(client):
+def test_finalize_endpoint_keeps_open_issue_task_live(client):
     test_client, db_url = client
     insert_guild(db_url, "gsd05")
     worker_id = _create_worker(test_client, "gsd05")
     task_id = _create_task(test_client, "gsd05", worker_id, "task", db_url)
+    _set_issue(db_url, task_id, 7, "open")
 
-    before = datetime.now(UTC)
-    resp = test_client.post(
-        f"/guilds/gsd05/tasks/{task_id}/finalize",
-        json={"expires_in_seconds": 1200},
-        headers=_auth(db_url),
-    )
+    resp = test_client.post(f"/guilds/gsd05/tasks/{task_id}/finalize", headers=_auth(db_url))
     assert resp.status_code == 200, resp.text
-    parsed = datetime.fromisoformat(resp.json()["deletedAt"])
-    assert timedelta(seconds=1199) <= parsed - before <= timedelta(seconds=1260)
+    assert resp.json()["deletedAt"] is None
+    row = _read_task(db_url, task_id)
+    assert row["state"] == "done"
+    assert row["deleted_at"] is None  # still live — issue is open
 
-
-def test_finalize_endpoint_explicit_deleted_at(client):
-    test_client, db_url = client
-    insert_guild(db_url, "gsd06")
-    worker_id = _create_worker(test_client, "gsd06")
-    task_id = _create_task(test_client, "gsd06", worker_id, "task", db_url)
-
-    target = "2026-12-25T00:00:00+00:00"
-    resp = test_client.post(
-        f"/guilds/gsd06/tasks/{task_id}/finalize",
-        json={"deleted_at": target},
-        headers=_auth(db_url),
-    )
-    assert resp.status_code == 200
-    assert datetime.fromisoformat(resp.json()["deletedAt"]) == datetime.fromisoformat(target)
-
-
-def test_finalize_endpoint_rejects_bad_deleted_at(client):
-    test_client, db_url = client
-    insert_guild(db_url, "gsd07")
-    worker_id = _create_worker(test_client, "gsd07")
-    task_id = _create_task(test_client, "gsd07", worker_id, "task", db_url)
-
-    resp = test_client.post(
-        f"/guilds/gsd07/tasks/{task_id}/finalize",
-        json={"deleted_at": "garbage"},
-        headers=_auth(db_url),
-    )
-    assert resp.status_code == 400
-
-
-def test_finalize_then_list_hides_after_window_passes(client):
-    """End-to-end: finalize with a tiny window, list excludes after it elapses."""
-    test_client, db_url = client
-    insert_guild(db_url, "gsd08")
-    worker_id = _create_worker(test_client, "gsd08")
-    task_id = _create_task(test_client, "gsd08", worker_id, "task", db_url)
-
-    test_client.post(
-        f"/guilds/gsd08/tasks/{task_id}/finalize",
-        json={"expires_in_seconds": 0},
-        headers=_auth(db_url),
-    )
-    # Backdate by 1 second so the strict `>` comparison hides it.
-    past = datetime.now(UTC) - timedelta(seconds=1)
-    _set_deleted_at(db_url, task_id, past)
-    resp = test_client.get("/guilds/gsd08/tasks", headers=_auth(db_url))
-    ids = {t["id"] for t in resp.json()}
-    assert task_id not in ids
+    # Still listed while the issue stays open.
+    ids = {t["id"] for t in test_client.get("/guilds/gsd05/tasks", headers=_auth(db_url)).json()}
+    assert task_id in ids
 
 
 # ---------------------------------------------------------------------------
-# Foreman tool helper — _resolve_finalize_deleted_at in foreman/tools.py
+# Foreman tool schema + prompt no longer expose an expiry knob
 # ---------------------------------------------------------------------------
 
 
-def test_foreman_tool_resolver_default():
-    from foreman.tools import DEFAULT_FINALIZE_TTL_SECONDS, _resolve_finalize_deleted_at
-
-    before = datetime.now(UTC)
-    out, err = _resolve_finalize_deleted_at({})
-    assert err is None
-    assert out is not None
-    delta = out - before
-    assert (
-        timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS - 60)
-        <= delta
-        <= timedelta(seconds=DEFAULT_FINALIZE_TTL_SECONDS + 60)
-    )
-
-
-def test_foreman_tool_resolver_explicit_seconds():
-    from foreman.tools import _resolve_finalize_deleted_at
-
-    before = datetime.now(UTC)
-    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": 1200})
-    assert err is None
-    assert out is not None
-    delta = out - before
-    assert timedelta(seconds=1199) <= delta <= timedelta(seconds=1260)
-
-
-def test_foreman_tool_resolver_invalid_seconds():
-    from foreman.tools import _resolve_finalize_deleted_at
-
-    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": "not-an-int"})
-    assert out is None
-    assert err and "Invalid expires_in_seconds" in err
-
-
-def test_foreman_tool_resolver_negative_seconds():
-    from foreman.tools import _resolve_finalize_deleted_at
-
-    out, err = _resolve_finalize_deleted_at({"expires_in_seconds": -5})
-    assert out is None
-    assert err and ">=" in err
-
-
-def test_foreman_tool_resolver_explicit_deleted_at():
-    from foreman.tools import _resolve_finalize_deleted_at
-
-    target = "2026-12-25T00:00:00Z"
-    out, err = _resolve_finalize_deleted_at({"deleted_at": target})
-    assert err is None
-    assert out == datetime(2026, 12, 25, tzinfo=UTC)
-
-
-def test_foreman_tool_resolver_invalid_deleted_at():
-    from foreman.tools import _resolve_finalize_deleted_at
-
-    out, err = _resolve_finalize_deleted_at({"deleted_at": "garbage"})
-    assert out is None
-    assert err and "Invalid deleted_at" in err
-
-
-def test_foreman_tool_definition_advertises_expiry_fields():
-    """Schema must expose expires_in_seconds and deleted_at on finalize_task."""
+def test_finalize_task_schema_has_no_expiry_fields():
     from foreman.tools import FOREMAN_TOOLS
 
     finalize = next(t for t in FOREMAN_TOOLS if t["name"] == "finalize_task")
     props = finalize["input_schema"]["properties"]
-    assert "expires_in_seconds" in props
-    assert props["expires_in_seconds"]["type"] == "integer"
-    assert "deleted_at" in props
-    assert props["deleted_at"]["type"] == "string"
-    # task_id is the only required field; expiry fields stay optional.
+    assert "expires_in_seconds" not in props
+    assert "deleted_at" not in props
+    assert set(props) == {"task_id", "outcome"}
     assert finalize["input_schema"]["required"] == ["task_id"]
 
 
-def test_foreman_prompt_documents_expiry_windows():
-    """The system prompt must mention each expiry window so the foreman picks them."""
+def test_foreman_prompt_drops_expiry_knob():
     from foreman.prompt import FOREMAN_SYSTEM
 
-    assert "1200" in FOREMAN_SYSTEM
-    assert "259200" in FOREMAN_SYSTEM
-    assert "86400" in FOREMAN_SYSTEM
-    assert "expires_in_seconds" in FOREMAN_SYSTEM
+    assert "expires_in_seconds" not in FOREMAN_SYSTEM

--- a/frontend/src/stores/__tests__/tasks.spec.ts
+++ b/frontend/src/stores/__tests__/tasks.spec.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useTasksStore } from '../tasks'
 
+// Mirrors SOFT_DELETE_GRACE_MS in ../tasks: a row stays visible this long after deleted_at.
+const GRACE_MS = 4 * 60 * 60 * 1000
+
 describe('useTasksStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -199,35 +202,38 @@ describe('useTasksStore', () => {
       expect(store.tasks[0].deleted_at).toBe(future)
       expect(store.tasks).toHaveLength(1)
 
+      // Removal fires GRACE_MS after deleted_at, not at deleted_at itself.
       vi.advanceTimersByTime(60_001)
+      expect(store.tasks).toHaveLength(1)
+      vi.advanceTimersByTime(GRACE_MS)
       expect(store.tasks).toHaveLength(0)
     })
 
-    it('drops a task immediately when deletedAt is already in the past', () => {
+    it('drops a task immediately when deletedAt + grace is already in the past', () => {
       const store = useTasksStore()
       store.tasks.push({ id: 't-1', state: 'done' })
 
       store.handleWebSocketMessage({
         type: 'task-update',
         taskId: 't-1',
-        deletedAt: new Date(Date.now() - 1000).toISOString(),
+        deletedAt: new Date(Date.now() - GRACE_MS - 1000).toISOString(),
       })
       expect(store.tasks).toHaveLength(0)
     })
 
-    it('liveTasks excludes rows whose deleted_at has passed even before the timer fires', () => {
+    it('liveTasks excludes rows whose deleted_at + grace has passed, keeps recent ones', () => {
       const store = useTasksStore()
-      const past = new Date(Date.now() - 5_000).toISOString()
-      const future = new Date(Date.now() + 5_000).toISOString()
+      const expired = new Date(Date.now() - GRACE_MS - 5_000).toISOString()
+      const recent = new Date(Date.now() - 5_000).toISOString()
       // Push directly (bypass the WS handler that would also schedule removal).
       store.tasks.push({ id: 't-live', state: 'done' })
-      store.tasks.push({ id: 't-future', state: 'done', deleted_at: future })
-      store.tasks.push({ id: 't-past', state: 'done', deleted_at: past })
+      store.tasks.push({ id: 't-recent', state: 'done', deleted_at: recent })
+      store.tasks.push({ id: 't-expired', state: 'done', deleted_at: expired })
 
       const ids = store.liveTasks.map((t) => t.id)
       expect(ids).toContain('t-live')
-      expect(ids).toContain('t-future')
-      expect(ids).not.toContain('t-past')
+      expect(ids).toContain('t-recent')
+      expect(ids).not.toContain('t-expired')
     })
 
     it('clearTasks cancels pending expiry timers', () => {
@@ -265,7 +271,7 @@ describe('useTasksStore', () => {
 
       vi.advanceTimersByTime(2_000)
       expect(store.tasks).toHaveLength(1)
-      vi.advanceTimersByTime(60_000)
+      vi.advanceTimersByTime(60_000 + GRACE_MS)
       expect(store.tasks).toHaveLength(0)
     })
 
@@ -281,7 +287,7 @@ describe('useTasksStore', () => {
       )
       await store.fetchTasks('g-1')
       expect(store.tasks).toHaveLength(1)
-      vi.advanceTimersByTime(2_000)
+      vi.advanceTimersByTime(2_000 + GRACE_MS)
       expect(store.tasks).toHaveLength(0)
     })
   })

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -11,6 +11,10 @@ export function taskTabId(id: string): string {
 // immediately on long horizons (e.g. a 3-day finalize window).
 const MAX_TIMEOUT_MS = 2_147_483_647
 
+// Grace window a soft-deleted task stays visible after `deleted_at` (stamped at
+// delete time). Must match backend models.SOFT_DELETE_GRACE (4 hours).
+const SOFT_DELETE_GRACE_MS = 4 * 60 * 60 * 1000
+
 const TERMINAL_STATES = new Set<string>(['done', 'failed', 'cancelled', 'error'])
 
 const STATE_LABELS: Record<string, string> = {
@@ -63,7 +67,7 @@ export const useTasksStore = defineStore('tasks', () => {
       _expiryTimers.delete(taskId)
     }
     if (!deletedAt) return
-    const delay = new Date(deletedAt).getTime() - Date.now()
+    const delay = new Date(deletedAt).getTime() + SOFT_DELETE_GRACE_MS - Date.now()
     if (Number.isNaN(delay)) return
     if (delay <= 0) {
       _removeTask(taskId)
@@ -121,8 +125,9 @@ export const useTasksStore = defineStore('tasks', () => {
     const prevDeletedAt = task?.deleted_at
     if (task) {
       task.state = 'cancelled'
-      // Optimistic: set deleted_at to now + 3 days (matches backend DEFAULT_FINALIZE_TTL)
-      task.deleted_at = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString()
+      // Optimistic: backend stamps deleted_at = now() on cancel; the row stays
+      // visible for SOFT_DELETE_GRACE_MS via the liveTasks filter.
+      task.deleted_at = new Date().toISOString()
     }
     try {
       await api(`/guilds/${guildId}/tasks/${taskId}/cancel`, { method: 'POST' })
@@ -240,7 +245,7 @@ export const useTasksStore = defineStore('tasks', () => {
     return tasks.value.filter((t) => {
       if (!t.deleted_at) return true
       const ts = new Date(t.deleted_at).getTime()
-      return Number.isNaN(ts) || ts > now
+      return Number.isNaN(ts) || ts + SOFT_DELETE_GRACE_MS > now
     })
   })
 


### PR DESCRIPTION
## What

Rewrites the task delete rules to the simple model: `deleted_at` records **when** a task was deleted (stamped `now()`), and one knob governs how long a deleted row stays visible.

**Core** (`models.py`):
```python
SOFT_DELETE_GRACE = timedelta(hours=4)
# live: deleted_at IS NULL OR deleted_at > now() - SOFT_DELETE_GRACE
```

**Delete rule** (`models.finalize_soft_delete_at`):
- **done + still-open issue** → left `NULL` (stays live until the issue closes; webhook/sweep stamps it)
- **done + closed/no issue**, **failed**, **cancelled**, **`phase='issue'` root** → stamped `now()`

## Why

`deleted_at` was a future hide-at instant, computed from **four** out-of-sync TTL constants (3d/3d/3d, plus a divergent 1d for PR-close failures) that a comment literally begged to stay in sync. This collapses all of that into one grace window and makes `deleted_at` mean what it says.

## Removed
- The four TTL constants, both `_resolve_finalize_deleted_at` helpers
- `FinalizeBody` + its `expires_in_seconds`/`deleted_at` request API (frontend already POSTs finalize/cancel without a body)
- The foreman `finalize_task` expiry params and the prompt guidance telling the foreman to pick windows
- The message summariser's `deleted_at - TTL` reverse-engineering (collapses to just `deleted_at` — it's the finish time now)

## Also
- Unified `_WEBHOOK_TERMINAL_STATES` into the shared `_TERMINAL_STATES` — fixes a latent split where the webhook path omitted `"error"`
- Wired the periodic sweep to gather **kept-alive done tasks'** issues, so a dropped issue-close webhook can't strand them live forever (`ponytail:` comment names a per-issue cooldown as the upgrade path)
- Frontend (`stores/tasks.ts`) mirrors the 4h grace in the expiry timer and `liveTasks` filter; optimistic cancel guess changed from `now()+3d` to `now()`

## Notes
- **Behavior change:** retention drops from 1–3 days to 4 hours — now one tunable constant.
- Backend: **206 passed**, ruff clean.
- The frontend Vitest harness is broken pre-existing on `main` (happy-dom `localStorage` — identical 47 failures with these changes stashed), so the updated frontend tests couldn't be run here; they're logically updated for the grace window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)