### PR TITLE
Fix Vitest happy-dom localStorage on Node 22+

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,6 +7,7 @@ export default mergeConfig(
     test: {
       environment: 'happy-dom',
       globals: true,
+      setupFiles: ['./vitest.setup.ts'],
       include: ['src/**/*.{test,spec}.{ts,js}', 'tests/**/*.{test,spec}.{ts,js}'],
       coverage: {
         provider: 'v8',

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,37 @@
+// Node 22+ exposes a native global `localStorage` that is `undefined` unless
+// `--localstorage-file` is passed. Because the binding merely *exists*, Vitest's
+// happy-dom setup skips copying happy-dom's real localStorage onto the global
+// (it only overrides keys absent from the global). The result: `localStorage`
+// resolves to Node's empty native one and every storage access throws.
+//
+// Install a simple Map-backed Storage so tests get working web storage
+// regardless of the Node/happy-dom interaction.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+  get length() {
+    return this.store.size
+  }
+  clear() {
+    this.store.clear()
+  }
+  getItem(key: string) {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+  key(index: number) {
+    return [...this.store.keys()][index] ?? null
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, String(value))
+  }
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  Object.defineProperty(globalThis, name, {
+    value: new MemoryStorage(),
+    configurable: true,
+    writable: true,
+  })
+}


### PR DESCRIPTION
## Problem

The frontend Vitest suite fails **locally on Node 22+** with `Cannot read properties of undefined (reading 'getItem')` — 47 tests red before any application logic runs. CI is unaffected (it pins Node 20, see `.github/workflows/ci.yml`), so this is purely a local-dev papercut on newer Node.

## Root cause

Node 22+ exposes a **native global `localStorage`** that is `undefined` unless the process is started with `--localstorage-file`. Vitest's happy-dom setup (`populateGlobal`) only copies a property from happy-dom's window onto the global if that key is *absent* from the global (or in its hardcoded key allow-list). Because `'localStorage' in globalThis` is now `true`, Vitest **skips** copying happy-dom's real `localStorage`, leaving Node's empty native binding in place. Every `localStorage.*` call then throws.

`window`/`document` are present (happy-dom is applied); only storage is shadowed. `sessionStorage` has the same exposure.

## Fix

A tiny Map-backed `Storage` polyfill installed via `setupFiles`, independent of the Node/happy-dom interaction. No new dependency.

## Result

`npm test` on Node 22+: **123 passed / 4 skipped** (was 47 failing). No change on Node 20 / CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)