### PR TITLE
Add guild_id and user_id to api_request_log

### DIFF
--- a/backend/alembic/versions/20260728_000001_add_guild_user_to_api_request_log.py
+++ b/backend/alembic/versions/20260728_000001_add_guild_user_to_api_request_log.py
@@ -1,0 +1,46 @@
+"""Add guild_id and user_id to api_request_log.
+
+Revision ID: 20260728_000001_add_guild_user_to_api_request_log
+Revises: 20260728_000000_add_last_refreshed_at_to_github_cache
+Create Date: 2026-07-28
+
+Adds the guild (int FK to guilds.id) and github user id an API call was made
+on behalf of, so usage/cost can be attributed per-guild and per-user. Both
+nullable: pre-existing rows stay NULL, as do system/worker-driven calls.
+
+Note: request_id (the Anthropic x-request-id HTTP header, e.g. req_...) and
+response->>'id' (the Message object id, e.g. msg_...) are DIFFERENT ids, so
+there is no backfill of request_id from the response body.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260728_000001_add_guild_user_to_api_request_log"
+down_revision: str | Sequence[str] | None = "20260728_000000_add_last_refreshed_at_to_github_cache"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("api_request_log", sa.Column("guild_id", sa.Integer(), nullable=True))
+    op.add_column("api_request_log", sa.Column("user_id", sa.Text(), nullable=True))
+    op.create_foreign_key(
+        "fk_api_request_log_guild_id",
+        "api_request_log",
+        "guilds",
+        ["guild_id"],
+        ["id"],
+    )
+    op.create_index("ix_api_request_log_guild_id", "api_request_log", ["guild_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_api_request_log_guild_id", table_name="api_request_log")
+    op.drop_constraint("fk_api_request_log_guild_id", "api_request_log", type_="foreignkey")
+    op.drop_column("api_request_log", "user_id")
+    op.drop_column("api_request_log", "guild_id")

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -520,6 +520,8 @@ async def _create_api_request_log(
     messages: list,
     extra: dict,
     task_id: str | None = None,
+    guild_id: str | None = None,
+    user_id: str | None = None,
 ) -> int:
     """Insert an api_request_log row before making the Anthropic API call.
 
@@ -534,6 +536,8 @@ async def _create_api_request_log(
             messages=messages,
             extra=extra or None,
             task_id=task_id,
+            guild_id=await get_guild_pk(db, guild_id) if guild_id else None,
+            user_id=user_id,
         )
         db.add(log)
         await db.commit()
@@ -1574,6 +1578,8 @@ async def _run_foreman_ai(
                 messages=messages,
                 extra={"max_tokens": 1024, "tools": tools},
                 task_id=_task_id,
+                guild_id=guild_id,
+                user_id=user_id,
             )
             llm_result = await _call_llm(
                 guild_id,
@@ -1807,6 +1813,8 @@ async def _run_foreman_ai(
                     "tool_choice": {"type": "none"},
                 },
                 task_id=_task_id,
+                guild_id=guild_id,
+                user_id=user_id,
             )
             wrap_llm_result = await _call_llm(
                 guild_id,

--- a/backend/models.py
+++ b/backend/models.py
@@ -529,6 +529,12 @@ class ApiRequestLog(SQLModel, table=True):
     stop_reason: str | None = None
     # Task this API call was made on behalf of (nullable; foreman may handle multiple tasks).
     task_id: str | None = Field(default=None, foreign_key="tasks.id")
+    # Guild this call was made for (int FK to guilds.id; nullable — pre-existing
+    # rows and any call where the guild can't be resolved leave it NULL).
+    guild_id: int | None = Field(default=None, foreign_key="guilds.id")
+    # github_user_id of the human this call was made on behalf of; NULL for
+    # system/worker-driven calls. No FK, matching tasks.user_id / messages.user_id.
+    user_id: str | None = None
     # Extra API parameters: max_tokens, tools list, tool_choice, etc.
     extra: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -186,6 +186,28 @@ resource "aws_iam_role_policy" "ecs_task_worker_dispatch" {
   policy = data.aws_iam_policy_document.ecs_task_worker_dispatch.json
 }
 
+# --- ECS Exec: SSM channels so `aws ecs execute-command` can open a shell in
+# a running task (used for one-off DB access / debugging via `run-task
+# --enable-execute-command`). No resource-level scoping is supported on these
+# ssmmessages actions. ---
+resource "aws_iam_role_policy" "ecs_task_exec" {
+  name = "${local.name_prefix}-ecs-task-exec"
+  role = aws_iam_role.ecs_task.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
 # -----------------------------------------------------------------------------
 # GitHub Actions OIDC — used by .github/workflows/deploy.yml (build/push +
 # terraform apply) via aws-actions/configure-aws-credentials with

--- a/terraform/metabase.tf
+++ b/terraform/metabase.tf
@@ -1,0 +1,210 @@
+# Metabase — on-demand BI tool, fronted by the existing ALB on a subdomain.
+#
+# "Scaled to nothing" by default: metabase_desired_count = 0, so there is no
+# running task (and no Fargate cost) at rest. Start it on demand by setting the
+# count to 1 (see the `metabase-up`/`metabase-down` note in README / the CLI
+# one-liners), stop it by setting it back to 0. The ALB rule, target group,
+# cert, and log group are all free while idle.
+#
+# It reuses the existing RDS instance (a separate `metabase` database created
+# out-of-band) for its own metadata, so there is no second database to run.
+#
+# ponytail: no request-driven wake-from-zero — ECS/Fargate can't natively
+# scale UP from 0 tasks (nothing exists to trip a metric), so start/stop is a
+# manual count toggle. Add a scheduled scale-down (nightly -> 0) or an
+# EventBridge "wake" lambda only if the manual toggle proves annoying.
+
+variable "metabase_desired_count" {
+  description = "Metabase ECS desired count. 0 = off (scaled to nothing), 1 = running. This is the on/off knob."
+  type        = number
+  default     = 0
+}
+
+variable "metabase_image" {
+  # ponytail: floating tag. A restart could pull a newer Metabase — fine for an
+  # on-demand tool. Pin to a specific vX.Y.Z if a surprise upgrade ever bites.
+  description = "Metabase container image."
+  type        = string
+  default     = "metabase/metabase:latest"
+}
+
+locals {
+  metabase_fqdn = "metabase.${var.domain_name}"
+}
+
+# --- TLS: its own cert (a SAN on the prod cert would force that single cert to
+# re-validate and risk the main site). DNS-validated manually on Linode. ---
+resource "aws_acm_certificate" "metabase" {
+  domain_name       = local.metabase_fqdn
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = { Name = "${local.name_prefix}-metabase-cert" }
+}
+
+# Attach to the existing HTTPS listener as an extra cert (SNI picks it by host).
+# https listener always exists in this deployment (domain_name is set).
+resource "aws_lb_listener_certificate" "metabase" {
+  listener_arn    = aws_lb_listener.https[0].arn
+  certificate_arn = aws_acm_certificate.metabase.arn
+}
+
+# --- SG: ALB -> Metabase on 3000. The task ALSO joins the ecs_tasks SG (below)
+# so RDS, which already trusts ecs_tasks, needs no edit. ---
+resource "aws_security_group" "metabase" {
+  name        = "${local.name_prefix}-metabase-sg"
+  description = "Allow inbound from the ALB to the Metabase task on 3000"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "Metabase Jetty port from ALB"
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${local.name_prefix}-metabase-sg" }
+}
+
+resource "aws_lb_target_group" "metabase" {
+  name        = "${local.name_prefix}-metabase"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    path                = "/api/health"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+  }
+
+  deregistration_delay = 30
+
+  tags = { Name = "${local.name_prefix}-metabase-tg" }
+}
+
+resource "aws_lb_listener_rule" "metabase" {
+  listener_arn = aws_lb_listener.https[0].arn
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.metabase.arn
+  }
+
+  condition {
+    host_header {
+      values = [local.metabase_fqdn]
+    }
+  }
+
+  tags = { Name = "${local.name_prefix}-metabase-rule" }
+}
+
+resource "aws_cloudwatch_log_group" "metabase" {
+  name              = "/ecs/${local.name_prefix}/metabase"
+  retention_in_days = var.log_retention_days
+
+  tags = { Name = "${local.name_prefix}-metabase-logs" }
+}
+
+resource "aws_ecs_task_definition" "metabase" {
+  family                   = "${local.name_prefix}-metabase"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 1024 # ponytail: 1 vCPU / 2GB is Metabase's comfortable floor; bump if it OOMs.
+  memory                   = 2048
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "metabase"
+      image     = var.metabase_image
+      essential = true
+
+      portMappings = [{ containerPort = 3000, protocol = "tcp" }]
+
+      environment = [
+        { name = "MB_DB_TYPE", value = "postgres" },
+        { name = "MB_DB_DBNAME", value = "metabase" },
+        { name = "MB_DB_HOST", value = aws_db_instance.postgres.address },
+        { name = "MB_DB_PORT", value = "5432" },
+        { name = "MB_DB_USER", value = var.db_username },
+        { name = "MB_SITE_URL", value = "https://${local.metabase_fqdn}" },
+      ]
+
+      secrets = [
+        { name = "MB_DB_PASS", valueFrom = aws_ssm_parameter.secret["db_password"].arn },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.metabase.name
+          "awslogs-region"        = local.region
+          "awslogs-stream-prefix" = "metabase"
+        }
+      }
+    }
+  ])
+
+  tags = { Name = "${local.name_prefix}-metabase" }
+}
+
+resource "aws_ecs_service" "metabase" {
+  name            = "${local.name_prefix}-metabase"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.metabase.arn
+  desired_count   = var.metabase_desired_count
+  launch_type     = "FARGATE"
+
+  # Metabase takes ~1-2 min to boot before /api/health passes.
+  health_check_grace_period_seconds = 180
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.metabase.id, aws_security_group.ecs_tasks.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.metabase.arn
+    container_name   = "metabase"
+    container_port   = 3000
+  }
+
+  # desired_count is the on/off toggle, flipped 0<->1 via `aws ecs
+  # update-service` on demand. Ignore it here so a later `terraform apply`
+  # doesn't yank a running Metabase back to 0 (or vice versa).
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  tags = { Name = "${local.name_prefix}-metabase" }
+}
+
+output "metabase_url" {
+  description = "Metabase URL once DNS + cert are in place and the service is scaled to 1."
+  value       = "https://${local.metabase_fqdn}"
+}
+
+output "metabase_cert_validation" {
+  description = "DNS record to add on Linode to validate the Metabase cert."
+  value       = [for o in aws_acm_certificate.metabase.domain_validation_options : { name = o.resource_record_name, type = o.resource_record_type, value = o.resource_record_value }]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,6 +15,9 @@ variable "project_name" {
 }
 
 variable "environment" {
+  # NOTE: label is "staging" but this is the ONLY live deployment and it serves
+  # the single real org — treat it as production. Not renamed to "prod" because
+  # that reshuffles every resource name/ARN (a destroy+recreate).
   description = "Deployment environment name (e.g. staging, prod). Used in resource names and tags."
   type        = string
   default     = "staging"


### PR DESCRIPTION
**Stacked on #1052 (`metabase-ondemand`).**

Adds `guild_id` (int FK → `guilds.id`) and `user_id` (github user id, no FK, matching `tasks.user_id`) to `api_request_log`, so foreman Anthropic usage/cost can be attributed per-guild and per-user.

- Both columns nullable — pre-existing rows and system/worker-driven calls stay NULL.
- `_create_api_request_log` resolves the guild slug via `get_guild_pk`; both foreman call sites pass `guild_id`/`user_id`.
- Migration `20260728_000001` adds the columns + FK + index on `guild_id`.

**No `request_id` backfill:** `request_id` is the Anthropic `x-request-id` HTTP header (`req_...`); `response->>'id'` is the Message object id (`msg_...`). Different identifiers, so setting one from the other would be wrong (and `request_id` is UNIQUE + FK'd from `foreman_turns`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)