### PR TITLE
fix(worker): map pi provider "bedrock" → "amazon-bedrock"

### DIFF
--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -13,6 +13,18 @@ from .log_format import strip_worktree_prefix
 
 logger = logging.getLogger(__name__)
 
+# Pioneer names its Bedrock provider "bedrock" everywhere (foreman config,
+# guild pi_default_provider, task.provider), but pi's CLI calls it
+# "amazon-bedrock" — passing "bedrock" straight through makes pi exit 1 with
+# `Unknown provider "bedrock"`. Translate at the pi boundary only.
+_PI_PROVIDER_ALIASES = {"bedrock": "amazon-bedrock"}
+
+
+def pi_provider_arg(provider: str | None) -> str | None:
+    """Map a pioneer provider id to pi's CLI provider name (pass-through if unmapped)."""
+    return _PI_PROVIDER_ALIASES.get(provider, provider) if provider else provider
+
+
 EmitFn = Callable[..., Awaitable[None]]  # emit(line: str, detail: dict | None = None)
 UsageFn = Callable[[dict], Awaitable[None]]  # on_usage(record: dict)
 OnProcFn = Callable[["PiProcess"], None]  # on_proc(proc) — worker's live-handle callback
@@ -238,7 +250,7 @@ async def _run_pi_once(
         cmd += ["--session", resume_session_id]
     cmd += ["--mode", "rpc"]
     if provider:
-        cmd += ["--provider", provider]
+        cmd += ["--provider", pi_provider_arg(provider)]
     if model:
         cmd += ["--model", model]
     logger.info("Spawning pi in %s; description=%r", cwd, description)

--- a/worker/tests/test_pi_runner.py
+++ b/worker/tests/test_pi_runner.py
@@ -8,7 +8,26 @@ import os
 import sys
 
 import pytest
-from pioneer_worker.pi_runner import parse_pi_event, run_pi_auto
+from pioneer_worker.pi_runner import parse_pi_event, pi_provider_arg, run_pi_auto
+
+# ---------------------------------------------------------------------------
+# pi_provider_arg — pioneer provider id -> pi CLI provider name
+# ---------------------------------------------------------------------------
+
+
+def test_pi_provider_arg_maps_bedrock():
+    # pi rejects "bedrock"; it must become "amazon-bedrock".
+    assert pi_provider_arg("bedrock") == "amazon-bedrock"
+
+
+def test_pi_provider_arg_passes_through_unmapped():
+    assert pi_provider_arg("anthropic") == "anthropic"
+    assert pi_provider_arg("openai") == "openai"
+
+
+def test_pi_provider_arg_none():
+    assert pi_provider_arg(None) is None
+
 
 # ---------------------------------------------------------------------------
 # parse_pi_event


### PR DESCRIPTION
## Problem
Every Bedrock-backed **pi** task failed immediately. The worker builds `pi --provider <provider>` from `task.provider` / the guild's `pi_default_provider`, which is pioneer's canonical name `bedrock`. But pi's CLI calls that provider `amazon-bedrock`, so it exits 1 with:

```
Error: Unknown provider "bedrock". Use --list-models to see available providers/models.
```

Verified live: with `--provider amazon-bedrock --model us.anthropic.claude-opus-4-6-v1` + `AWS_BEARER_TOKEN_BEDROCK`, pi starts and streams RPC events normally.

## Fix
Translate the provider id to pi's name at the pi boundary only (`pi_provider_arg`, `bedrock → amazon-bedrock`); pioneer keeps `bedrock` as its canonical name everywhere else (foreman, guild config).

## Note on debuggability
This was hard to see: pi's stderr (`Unknown provider …`) is forwarded to the **agent event stream** via `emit()` (`pi_runner.py` `_drain_stderr`), not the worker's Python logger — so `docker logs` only showed the misleading `produced no stdout events — check PATH/auth`. Worth a follow-up to also log tool stderr at warning level.

## Tests
`pi_provider_arg` mapping (bedrock→amazon-bedrock, pass-through, None). `pytest tests/test_pi_runner.py -k provider` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)