### PR TITLE
Unify spawn settings into one table + one override path

### DIFF
--- a/backend/alembic/versions/20260728_000002_add_spawn_settings.py
+++ b/backend/alembic/versions/20260728_000002_add_spawn_settings.py
@@ -1,0 +1,165 @@
+"""Add unified spawn_settings table and backfill from the three legacy sources.
+
+Revision ID: 20260728_000002_add_spawn_settings
+Revises: 20260728_000000_add_last_refreshed_at_to_github_cache
+Create Date: 2026-07-28
+
+Additive step of the spawn-settings unification. Creates spawn_settings (guild
+baseline row = user_id NULL; user override = user_id set) and backfills it from:
+  - guild_spawn_defaults      -> baseline repos/tools/agent_count
+  - guilds.foreman_config     -> baseline env_vars (forward=true only),
+                                 tool_env_vars, provider/model (pi_default_*)
+  - user_spawn_settings       -> per-user override repos/tools/env_vars
+
+The legacy tables and the foreman_config worker-slice are left in place; a later
+migration drops them once all readers are cut over (issue: unify-spawn-settings).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260728_000002_add_spawn_settings"
+down_revision: str | Sequence[str] | None = "20260728_000000_add_last_refreshed_at_to_github_cache"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _spawn_table() -> sa.Table:
+    md = sa.MetaData()
+    return sa.Table(
+        "spawn_settings",
+        md,
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("guild_id", sa.Integer, nullable=False),
+        sa.Column("user_id", sa.Text, nullable=True),
+        sa.Column("repos", sa.Text, nullable=False),
+        sa.Column("tools", sa.Text, nullable=False),
+        sa.Column("agent_count", sa.Integer, nullable=True),
+        sa.Column("env_vars", sa.JSON, nullable=False),
+        sa.Column("tool_env_vars", sa.JSON, nullable=False),
+        sa.Column("provider", sa.Text, nullable=True),
+        sa.Column("model", sa.Text, nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "spawn_settings",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("user_id", sa.Text(), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("repos", sa.Text(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("tools", sa.Text(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("agent_count", sa.Integer(), nullable=True),
+        sa.Column("env_vars", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("tool_env_vars", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("provider", sa.Text(), nullable=True),
+        sa.Column("model", sa.Text(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "uq_spawn_settings_guild_baseline",
+        "spawn_settings",
+        ["guild_id"],
+        unique=True,
+        postgresql_where=sa.text("user_id IS NULL"),
+    )
+    op.create_index(
+        "uq_spawn_settings_guild_user",
+        "spawn_settings",
+        ["guild_id", "user_id"],
+        unique=True,
+        postgresql_where=sa.text("user_id IS NOT NULL"),
+    )
+
+    conn = op.get_bind()
+    now = datetime.now(UTC)
+    spawn = _spawn_table()
+    rows: list[dict] = []
+
+    # --- guild baseline rows: guild_spawn_defaults + foreman_config worker-slice ---
+    gsd = {
+        r.guild_id: r
+        for r in conn.execute(
+            sa.text("SELECT guild_id, repos, tools, agent_count FROM guild_spawn_defaults")
+        )
+    }
+    guilds = conn.execute(sa.text("SELECT id, foreman_config FROM guilds")).fetchall()
+    for g in guilds:
+        cfg = g.foreman_config or {}
+        if isinstance(cfg, str):
+            cfg = json.loads(cfg or "{}")
+        env_vars = {
+            e["key"]: e["value"]
+            for e in (cfg.get("env_vars") or [])
+            if e.get("forward") and e.get("key") and e.get("value") is not None
+        }
+        tool_env_vars = {
+            tool: {i["key"]: i["value"] for i in (items or []) if i.get("key") and i.get("value") is not None}
+            for tool, items in (cfg.get("tool_env_vars") or {}).items()
+        }
+        tool_env_vars = {t: kv for t, kv in tool_env_vars.items() if kv}
+        d = gsd.get(g.id)
+        # Skip guilds with nothing to migrate — resolve() treats a missing
+        # baseline the same as an empty one.
+        if d is None and not env_vars and not tool_env_vars and not cfg.get("pi_default_provider"):
+            continue
+        rows.append(
+            {
+                "guild_id": g.id,
+                "user_id": None,
+                "repos": d.repos if d else "[]",
+                "tools": d.tools if d else "[]",
+                "agent_count": d.agent_count if d else None,
+                "env_vars": env_vars,
+                "tool_env_vars": tool_env_vars,
+                "provider": cfg.get("pi_default_provider"),
+                "model": cfg.get("pi_default_model"),
+                "updated_at": now,
+            }
+        )
+
+    # --- user override rows: user_spawn_settings ---
+    uss = conn.execute(
+        sa.text("SELECT guild_id, user_id, settings_json FROM user_spawn_settings")
+    ).fetchall()
+    for u in uss:
+        try:
+            s = json.loads(u.settings_json or "{}")
+        except (ValueError, TypeError):
+            s = {}
+        env_vars = {
+            e["key"]: e["value"]
+            for e in (s.get("envVars") or [])
+            if e.get("key") and e.get("value") is not None
+        }
+        rows.append(
+            {
+                "guild_id": u.guild_id,
+                "user_id": u.user_id,
+                "repos": json.dumps(s.get("repos") or []),
+                "tools": json.dumps(s.get("tools") or []),
+                "agent_count": s.get("agent_count"),
+                "env_vars": env_vars,
+                "tool_env_vars": {},
+                "provider": None,
+                "model": None,
+                "updated_at": now,
+            }
+        )
+
+    if rows:
+        op.bulk_insert(spawn, rows)
+
+
+def downgrade() -> None:
+    op.drop_index("uq_spawn_settings_guild_user", table_name="spawn_settings")
+    op.drop_index("uq_spawn_settings_guild_baseline", table_name="spawn_settings")
+    op.drop_table("spawn_settings")

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1143,29 +1143,28 @@ async def spawn_worker(
 
     Returns (result_text, is_error).
     """
-    from worker_lifecycle import get_guild_spawn_defaults  # noqa: PLC0415
+    from spawn_config import SpawnLayer, merge_layers, resolve_spawn  # noqa: PLC0415
 
-    repos: list = inp.get("repos") or []
-    tools_list: list[str] = inp.get("tools") or []
-    agent_count: int | None = inp.get("agent_count")
     custom_name: str | None = inp.get("name")
 
-    # Fall back to the guild's last-successful-spawn defaults for anything the
-    # call didn't specify, so "spawn a worker" works without restating the
-    # guild's usual configuration.
-    if guild_pk is not None and (not repos or not tools_list or agent_count is None):
-        defaults = await get_guild_spawn_defaults(db, guild_pk)
-        if defaults is not None:
-            if not repos:
-                repos = json.loads(defaults.repos or "[]")
-            if not tools_list:
-                tools_list = json.loads(defaults.tools or "[]")
-            if agent_count is None:
-                agent_count = defaults.agent_count
+    # One resolution path: call args override the user's spawn_settings override
+    # over the guild baseline (see spawn_config). Anything the call omits falls
+    # back down the layers, so "spawn a worker" works without restating config.
+    call = SpawnLayer(
+        repos=inp.get("repos") or None,
+        tools=inp.get("tools") or None,
+        agent_count=inp.get("agent_count"),
+    )
+    resolved = (
+        await resolve_spawn(db, guild_pk, user_id, call)
+        if guild_pk is not None
+        else merge_layers([call])
+    )
+    repos = resolved.repos
+    tools_list = resolved.tools
     # "Spawn a worker" means one agent unless asked for more; without this the
     # worker falls through to config's max_agents default (4). ponytail: 1 slot.
-    if agent_count is None:
-        agent_count = 1
+    agent_count = resolved.agent_count if resolved.agent_count is not None else 1
     if not repos:
         return (
             "spawn_worker requires at least one repo in the 'repos' list — this guild has "
@@ -1201,21 +1200,9 @@ async def spawn_worker(
     )
     await db.commit()
 
-    # Fetch guild-level env vars from foreman config and pass them to the worker.
-    foreman_env_vars: dict[str, str] = {}
-    if guild_pk is not None:
-        guild_res = await db.exec(
-            select(col(Guild.foreman_config)).where(col(Guild.id) == guild_pk)
-        )
-        guild_cfg = guild_res.one_or_none() or {}
-        # Only forward=True vars reach the worker; unshared foreman credentials
-        # stay with the foreman's own LLM (parity with the user spawn path).
-        foreman_env_vars = {
-            e["key"]: e["value"]
-            for e in (guild_cfg.get("env_vars") or [])
-            if e.get("forward") and e.get("key") and e.get("value") is not None
-        }
-
+    # Worker-facing env vars come from the resolved spawn_settings (guild
+    # baseline + user override), already merged in spawn_config. tool_env_vars
+    # still reach the worker via /guilds/{id}/foreman/env-vars at startup.
     env = build_spawn_worker_env(
         guild_id=guild_id,
         repos=repos,
@@ -1225,7 +1212,7 @@ async def spawn_worker(
         auth_token=auth_token,
         agent_count=agent_count,
         tools=tools_list or None,
-        extra_env=foreman_env_vars or None,
+        extra_env=resolved.env_vars or None,
     )
 
     try:

--- a/backend/models.py
+++ b/backend/models.py
@@ -801,6 +801,61 @@ class GuildSpawnDefaults(SQLModel, table=True):
     updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
 
 
+class SpawnSettings(SQLModel, table=True):
+    """Unified spawn configuration, at two scopes in one table.
+
+    A row with ``user_id IS NULL`` is the guild's baseline; a row with a
+    ``user_id`` is that user's override for the same guild. One resolver
+    (``spawn_config.resolve_spawn``) layers call-args > user row > guild row >
+    process env into the settings a worker container is launched with.
+
+    Supersedes guild_spawn_defaults (repos/tools/agent_count), user_spawn_settings
+    (per-user repos/tools/env), and the *worker-facing* slice of
+    guilds.foreman_config (forwarded env_vars, tool_env_vars, pi provider/model).
+    foreman_config keeps only the foreman's own LLM credentials. There is no
+    ``forward`` flag: everything here is by definition worker-bound.
+    """
+
+    __tablename__ = "spawn_settings"  # type: ignore[assignment]
+    __table_args__ = (
+        # One baseline row per guild (user_id NULL) and one override per
+        # (guild, user). Two partial unique indexes because NULLs don't collide
+        # in a normal unique index.
+        Index(
+            "uq_spawn_settings_guild_baseline",
+            "guild_id",
+            unique=True,
+            postgresql_where=text("user_id IS NULL"),
+        ),
+        Index(
+            "uq_spawn_settings_guild_user",
+            "guild_id",
+            "user_id",
+            unique=True,
+            postgresql_where=text("user_id IS NOT NULL"),
+        ),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    guild_id: int = Field(foreign_key="guilds.id")
+    # NULL = guild baseline; set = this user's override for the guild.
+    user_id: str | None = Field(default=None, foreign_key="users.id")
+    # JSON-serialised list of "owner/repo" strings (same encoding as workers.repos).
+    repos: str = Field(default="[]", sa_column=Column(Text, nullable=False, server_default="'[]'"))
+    # JSON-serialised list of tool runner names.
+    tools: str = Field(default="[]", sa_column=Column(Text, nullable=False, server_default="'[]'"))
+    # Concurrent agent slots; NULL = worker default.
+    agent_count: int | None = None
+    # Worker-facing env vars, {KEY: VALUE}. All are forwarded to the container.
+    env_vars: dict = Field(default_factory=dict, sa_column=Column(JSON, nullable=False, server_default=text("'{}'")))
+    # Per-tool scoped env, {tool: {KEY: VALUE}} — merged only when that tool spawns.
+    tool_env_vars: dict = Field(default_factory=dict, sa_column=Column(JSON, nullable=False, server_default=text("'{}'")))
+    # Default provider/model for tool runs (was foreman_config.pi_default_*).
+    provider: str | None = None
+    model: str | None = None
+    updated_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
+
+
 class PushToken(SQLModel, table=True):
     """APNs (or, in the future, FCM) device token registered by the iOS app.
 

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -133,15 +133,23 @@ async def get_foreman_env_vars(
     Response: ``{ "env_vars": [{"key", "value"}, ...],
                   "tool_env_vars": {"claude": [...], "pi": [...], "codex": [...]} }``
     """
+    from spawn_config import get_spawn_row  # noqa: PLC0415
+
     res = await db.exec(select(Guild).where(col(Guild.slug) == guild_id))
     guild = res.one_or_none()
     if not guild:
         raise HTTPException(status_code=404, detail="Guild not found")
-    config = guild.foreman_config or {}
-    forwarded = [e for e in config.get("env_vars", []) if e.get("forward")]
+    # Worker-facing env now lives in the spawn_settings guild baseline (env_vars
+    # are all worker-bound — no forward flag — and tool_env_vars stay scoped).
+    row = await get_spawn_row(db, guild.id, None)
+    env_vars = dict(row.env_vars) if row else {}
+    tool_env_vars = dict(row.tool_env_vars) if row else {}
     return {
-        "env_vars": forwarded,
-        "tool_env_vars": config.get("tool_env_vars", {}),
+        "env_vars": [{"key": k, "value": v} for k, v in env_vars.items()],
+        "tool_env_vars": {
+            tool: [{"key": k, "value": v} for k, v in (kv or {}).items()]
+            for tool, kv in tool_env_vars.items()
+        },
     }
 
 

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -633,6 +633,32 @@ async def update_foreman_config(
 
     guild.foreman_config = config
     await db.commit()
+
+    # Keep the spawn_settings guild baseline in sync with foreman_config's
+    # worker-facing slice: resolve_spawn reads spawn_settings, but the guild
+    # settings UI still edits foreman_config (until its own cutover). Forwarded
+    # env vars, per-tool scoped vars, and the pi provider/model defaults are the
+    # bits that reach a worker; the foreman's own credentials stay behind.
+    from spawn_config import upsert_spawn_row  # noqa: PLC0415
+
+    worker_env = {
+        e["key"]: e["value"]
+        for e in (config.get("env_vars") or [])
+        if e.get("forward") and e.get("key") and e.get("value") is not None
+    }
+    worker_tool_env = {
+        tool: {i["key"]: i["value"] for i in (items or []) if i.get("key") and i.get("value") is not None}
+        for tool, items in (config.get("tool_env_vars") or {}).items()
+    }
+    await upsert_spawn_row(
+        db,
+        guild.id,
+        None,
+        env_vars=worker_env,
+        tool_env_vars={t: kv for t, kv in worker_tool_env.items() if kv},
+        provider=config.get("pi_default_provider"),
+        model=config.get("pi_default_model"),
+    )
     return config
 
 

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -22,8 +22,9 @@ from auth_deps import get_guild_pk, require_member
 from database import get_db_dep
 from events import broadcast_msg, emit_terminal_line
 from fastapi import APIRouter, Depends, HTTPException
-from models import ClaudeCredentials, Guild, Task, UserSpawnSettings, Worker, live_tasks_filter
+from models import ClaudeCredentials, Task, Worker, live_tasks_filter
 from pydantic import BaseModel, field_validator
+from spawn_config import SpawnLayer, get_spawn_row, resolve_spawn, upsert_spawn_row
 from sqlalchemy import update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -38,9 +39,7 @@ from worker_lifecycle import (
     check_worker_spawn_cooldown,
     force_kill_worker_if_unresponsive,
     generate_worker_id,
-    get_guild_spawn_defaults,
     record_worker_spawn,
-    set_guild_spawn_defaults,
 )
 from ws_handlers import _resolve_user_identifier
 from ws_types import TaskAssignedMsg, WorkerMessageMsg, WorkerShutdownMsg
@@ -224,39 +223,25 @@ async def spawn_worker_container(
             ),
         )
 
-    # Merge guild-level foreman env vars (base) with user-supplied env vars (override).
-    guild_cfg_res = await db.exec(
-        select(col(Guild.foreman_config)).where(col(Guild.id) == guild_pk)
+    # One resolution path (see spawn_config): request args override this user's
+    # spawn_settings override over the guild baseline. The empty-value guard and
+    # the guild/user env merge all live in resolve_spawn now.
+    resolved = await resolve_spawn(
+        db,
+        guild_pk,
+        github_user_id,
+        SpawnLayer(
+            repos=data.repos or None,
+            tools=data.tools or None,
+            agent_count=data.agent_count,
+            env_vars=data.env_vars or None,
+        ),
     )
-    guild_cfg = guild_cfg_res.one_or_none() or {}
-    # The guild edit screen can store the same key twice (one real value, one
-    # blank — see #dup). Collapse duplicates so the real value wins instead of
-    # whichever entry happens to come last.
-    # Only vars explicitly marked forward=True reach workers; the rest stay with
-    # the foreman's own LLM (see EnvVarItem.forward). This keeps foreman
-    # credentials from leaking into every worker tool automatically.
-    foreman_env_vars: dict[str, str] = {}
-    for e in guild_cfg.get("env_vars") or []:
-        if not e.get("forward"):
-            continue
-        k, v = e.get("key"), e.get("value")
-        if not k or v is None:
-            continue
-        if k in foreman_env_vars and v == "" and foreman_env_vars[k] != "":
-            continue
-        foreman_env_vars[k] = v
+    # exclude_env_keys drops specific keys from the resolved worker env for this
+    # spawn only (the UI's per-spawn opt-out).
     if data.exclude_env_keys:
-        excluded_keys = set(data.exclude_env_keys)
-        foreman_env_vars = {k: v for k, v in foreman_env_vars.items() if k not in excluded_keys}
-    # User-supplied vars at spawn time override guild defaults — but an empty
-    # user value must not blank out a guild credential that has a real value
-    # (the value wins). Without this, a stale empty spawn-setting for a key that
-    # also exists as a guild credential boots the container with no value.
-    extra_env: dict[str, str] = dict(foreman_env_vars)
-    for k, v in (data.env_vars or {}).items():
-        if v == "" and foreman_env_vars.get(k):
-            continue
-        extra_env[k] = v
+        for k in set(data.exclude_env_keys):
+            resolved.env_vars.pop(k, None)
 
     # Pre-register the worker so the container inherits a known worker_id and
     # can skip self-registration on startup.
@@ -267,11 +252,12 @@ async def spawn_worker_container(
         Worker(
             id=worker_id,
             guild_id=guild_pk,
-            repos=json.dumps(data.repos),
+            repos=json.dumps(resolved.repos),
             state="offline",
             created_at=datetime.now(UTC),
             auth_token=auth_token,
             name=worker_name,
+            user_id=github_user_id,
         )
     )
     await db.commit()
@@ -282,14 +268,14 @@ async def spawn_worker_container(
 
     env = build_spawn_worker_env(
         guild_id=guild_id,
-        repos=data.repos,
+        repos=resolved.repos,
         worker_name=worker_name,
         source_env=dict(os.environ),
         worker_id=worker_id,
         auth_token=auth_token,
-        agent_count=data.agent_count,
-        tools=data.tools or None,
-        extra_env=extra_env or None,
+        agent_count=resolved.agent_count,
+        tools=resolved.tools or None,
+        extra_env=resolved.env_vars or None,
     )
 
     try:
@@ -341,13 +327,12 @@ async def get_spawn_credentials(
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
-    guild_res = await db.exec(select(Guild).where(col(Guild.id) == guild_pk))
-    guild = guild_res.one()
-    config = guild.foreman_config or {}
+    # The env a worker would actually get for this user, resolved through the
+    # single spawn path (guild baseline + this user's override), masked.
+    resolved = await resolve_spawn(db, guild_pk, github_user_id)
     guild_env_vars = [
-        {"key": e["key"], "masked_value": mask_secret(e.get("value") or "")}
-        for e in (config.get("env_vars") or [])
-        if e.get("key") and e.get("forward")
+        {"key": k, "masked_value": mask_secret(v or "")}
+        for k, v in sorted(resolved.env_vars.items())
     ]
     creds_result = await db.exec(
         select(ClaudeCredentials).where(col(ClaudeCredentials.guild_id) == guild_pk)
@@ -496,22 +481,14 @@ async def get_spawn_settings(
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
-    result = await db.exec(
-        select(UserSpawnSettings).where(
-            col(UserSpawnSettings.guild_id) == guild_pk,
-            col(UserSpawnSettings.user_id) == github_user_id,
-        )
-    )
-    row = result.one_or_none()
+    row = await get_spawn_row(db, guild_pk, github_user_id)
     if row is None:
         return {}
-    try:
-        return json.loads(row.settings_json)
-    except json.JSONDecodeError as exc:
-        logger.warning(
-            "Corrupt settings_json for user %s guild %s: %s", github_user_id, guild_pk, exc
-        )
-        return {}
+    return {
+        "repos": json.loads(row.repos or "[]"),
+        "tools": json.loads(row.tools or "[]"),
+        "envVars": [{"key": k, "value": v} for k, v in (row.env_vars or {}).items()],
+    }
 
 
 @router.put("/guilds/{guild_id}/spawn-settings")
@@ -525,39 +502,23 @@ async def save_spawn_settings(
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
-    result = await db.exec(
-        select(UserSpawnSettings).where(
-            col(UserSpawnSettings.guild_id) == guild_pk,
-            col(UserSpawnSettings.user_id) == github_user_id,
-        )
-    )
-    row = result.one_or_none()
-    # model_dump() without exclude_none gives full-replace PUT semantics: every field
-    # is always written, so callers cannot do partial updates through this endpoint.
-    incoming = data.model_dump()
-    now = datetime.now(UTC)
+    # Full-replace PUT semantics: every field is written, so this is the user's
+    # complete override row for the guild.
     # TODO: encrypt env var values at rest before production use (tracked in GH issue #537).
-    # Currently stored as plaintext JSON — an improvement over localStorage but not
-    # suitable for highly sensitive credentials until encryption is added.
-    settings_blob = json.dumps(incoming)
-    if row is None:
-        db.add(
-            UserSpawnSettings(
-                guild_id=guild_pk,
-                user_id=github_user_id,
-                settings_json=settings_blob,
-                updated_at=now,
-            )
-        )
-    else:
-        row.settings_json = settings_blob
-        row.updated_at = now
-    await db.commit()
+    env_vars = {p.key: p.value for p in data.envVars if p.key}
+    await upsert_spawn_row(
+        db,
+        guild_pk,
+        github_user_id,
+        repos=json.dumps(data.repos),
+        tools=json.dumps(data.tools),
+        env_vars=env_vars,
+    )
     return {"status": "saved"}
 
 
 def _spawn_defaults_payload(row) -> dict:
-    """Serialise a GuildSpawnDefaults row (or None) to the wire shape."""
+    """Serialise a spawn_settings baseline row (or None) to the wire shape."""
     if row is None:
         return {"repos": [], "tools": [], "agent_count": None}
     return {
@@ -582,7 +543,7 @@ async def get_spawn_defaults(
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
-    row = await get_guild_spawn_defaults(db, guild_pk)
+    row = await get_spawn_row(db, guild_pk, None)
     return _spawn_defaults_payload(row)
 
 
@@ -603,14 +564,14 @@ async def save_spawn_defaults(
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:
         raise HTTPException(status_code=404, detail="Guild not found")
-    await set_guild_spawn_defaults(
+    row = await upsert_spawn_row(
         db,
         guild_pk,
-        repos=data.repos,
-        tools=data.tools,
+        None,
+        repos=json.dumps(data.repos),
+        tools=json.dumps(data.tools),
         agent_count=data.agent_count,
     )
-    row = await get_guild_spawn_defaults(db, guild_pk)
     return _spawn_defaults_payload(row)
 
 

--- a/backend/spawn_config.py
+++ b/backend/spawn_config.py
@@ -1,0 +1,126 @@
+"""Single resolution path for worker spawn settings.
+
+Both spawn callers (the foreman spawn_worker tool and the REST/UI spawn
+endpoint) resolve through here so the override rules live in exactly one place.
+
+Precedence, low -> high: guild baseline row < user override row < explicit
+call args. Merge rules per field type:
+  - lists (repos, tools): the highest layer that provides a NON-EMPTY list wins
+    (replace, not concatenate).
+  - scalars (agent_count, provider, model): highest layer with a non-None value.
+  - maps (env_vars, tool_env_vars): key-by-key overlay, higher layer wins — but
+    an empty-string value never blanks a real value set by a lower layer (the
+    one place that guard lives).
+
+See models.SpawnSettings for the storage shape.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SpawnLayer:
+    """One layer of spawn settings. A field left None/empty means 'unset here'."""
+
+    repos: list[str] | None = None
+    tools: list[str] | None = None
+    agent_count: int | None = None
+    env_vars: dict[str, str] | None = None
+    tool_env_vars: dict[str, dict[str, str]] | None = None
+    provider: str | None = None
+    model: str | None = None
+
+
+@dataclass
+class ResolvedSpawn:
+    repos: list[str] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
+    agent_count: int | None = None
+    env_vars: dict[str, str] = field(default_factory=dict)
+    tool_env_vars: dict[str, dict[str, str]] = field(default_factory=dict)
+    provider: str | None = None
+    model: str | None = None
+
+
+def _merge_env(base: dict[str, str], over: dict[str, str]) -> dict[str, str]:
+    """Overlay *over* onto *base*; an empty value never blanks a real one."""
+    out = dict(base)
+    for k, v in over.items():
+        if v == "" and out.get(k):
+            continue
+        out[k] = v
+    return out
+
+
+def merge_layers(layers: list[SpawnLayer | None]) -> ResolvedSpawn:
+    """Fold ordered layers (lowest priority first) into a ResolvedSpawn."""
+    r = ResolvedSpawn()
+    for layer in layers:
+        if layer is None:
+            continue
+        if layer.repos:  # non-empty list wins
+            r.repos = list(layer.repos)
+        if layer.tools:
+            r.tools = list(layer.tools)
+        if layer.agent_count is not None:
+            r.agent_count = layer.agent_count
+        if layer.provider is not None:
+            r.provider = layer.provider
+        if layer.model is not None:
+            r.model = layer.model
+        if layer.env_vars:
+            r.env_vars = _merge_env(r.env_vars, layer.env_vars)
+        if layer.tool_env_vars:
+            for tool, kv in layer.tool_env_vars.items():
+                r.tool_env_vars[tool] = _merge_env(r.tool_env_vars.get(tool, {}), kv or {})
+    return r
+
+
+def row_to_layer(row) -> SpawnLayer | None:
+    """Convert a SpawnSettings row to a SpawnLayer (repos/tools are JSON strings)."""
+    if row is None:
+        return None
+
+    def _list(s: str | None) -> list[str]:
+        try:
+            return json.loads(s or "[]")
+        except (ValueError, TypeError):
+            return []
+
+    return SpawnLayer(
+        repos=_list(row.repos),
+        tools=_list(row.tools),
+        agent_count=row.agent_count,
+        env_vars=dict(row.env_vars or {}),
+        tool_env_vars={t: dict(kv or {}) for t, kv in (row.tool_env_vars or {}).items()},
+        provider=row.provider,
+        model=row.model,
+    )
+
+
+async def resolve_spawn(db, guild_pk: int, user_id: str | None, call: SpawnLayer | None = None) -> ResolvedSpawn:
+    """Load the guild baseline + user override rows and merge with optional call args."""
+    from models import SpawnSettings  # noqa: PLC0415 — avoid circular import at module load
+    from sqlmodel import col, select  # noqa: PLC0415
+
+    guild_row = (
+        await db.exec(
+            select(SpawnSettings).where(
+                col(SpawnSettings.guild_id) == guild_pk,
+                col(SpawnSettings.user_id).is_(None),
+            )
+        )
+    ).one_or_none()
+    user_row = None
+    if user_id is not None:
+        user_row = (
+            await db.exec(
+                select(SpawnSettings).where(
+                    col(SpawnSettings.guild_id) == guild_pk,
+                    col(SpawnSettings.user_id) == user_id,
+                )
+            )
+        ).one_or_none()
+    return merge_layers([row_to_layer(guild_row), row_to_layer(user_row), call])

--- a/backend/spawn_config.py
+++ b/backend/spawn_config.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
 
 @dataclass
@@ -98,6 +99,41 @@ def row_to_layer(row) -> SpawnLayer | None:
         provider=row.provider,
         model=row.model,
     )
+
+
+async def get_spawn_row(db, guild_pk: int, user_id: str | None = None):
+    """Return the guild baseline row (user_id=None) or a user override row, or None."""
+    from models import SpawnSettings  # noqa: PLC0415
+    from sqlmodel import col, select  # noqa: PLC0415
+
+    clause = (
+        col(SpawnSettings.user_id).is_(None)
+        if user_id is None
+        else col(SpawnSettings.user_id) == user_id
+    )
+    return (
+        await db.exec(select(SpawnSettings).where(col(SpawnSettings.guild_id) == guild_pk, clause))
+    ).one_or_none()
+
+
+async def upsert_spawn_row(db, guild_pk: int, user_id: str | None = None, **fields):
+    """Create or update a spawn_settings row, setting only the provided fields.
+
+    Partial by design: e.g. the spawn-defaults endpoint sets repos/tools/agent_count
+    on the guild baseline without touching its env_vars/tool_env_vars/provider.
+    """
+    from models import SpawnSettings  # noqa: PLC0415
+
+    row = await get_spawn_row(db, guild_pk, user_id)
+    if row is None:
+        row = SpawnSettings(guild_id=guild_pk, user_id=user_id, updated_at=datetime.now(UTC))
+        db.add(row)
+    for k, v in fields.items():
+        setattr(row, k, v)
+    row.updated_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(row)
+    return row
 
 
 async def resolve_spawn(db, guild_pk: int, user_id: str | None, call: SpawnLayer | None = None) -> ResolvedSpawn:

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -2259,9 +2259,10 @@ class TestSpawnWorker:
             row = session.execute(select(GuildSpawnDefaults)).scalars().one_or_none()
         assert row is None
 
-    async def test_spawn_worker_records_defaults_for_defaulted_params(self, db_session):
-        """When params come from guild defaults (not explicit), they are re-persisted."""
-        from models import GuildSpawnDefaults  # noqa: PLC0415
+    async def test_spawn_worker_resolves_defaulted_params_from_baseline(self, db_session):
+        """Params omitted from the call resolve from the guild baseline; explicit
+        ones override. Spawning does not rewrite the baseline row."""
+        from models import SpawnSettings  # noqa: PLC0415
 
         insert_guild(db_session, "g-spawn-rec2")
         with _sync_session(db_session) as session:
@@ -2269,14 +2270,13 @@ class TestSpawnWorker:
                 select(col(Guild.id)).where(col(Guild.slug) == "g-spawn-rec2")
             ).scalar_one()
             session.add(
-                GuildSpawnDefaults(
+                SpawnSettings(
                     guild_id=guild_pk,
+                    user_id=None,
                     repos='["acme/widgets"]',
                     tools='["claude", "pi"]',
                     agent_count=3,
-                    # Older than the spawn cooldown window so this fixture (an
-                    # existing recorded default) doesn't itself trip the cooldown.
-                    updated_at=datetime.now(UTC) - timedelta(minutes=10),
+                    updated_at=datetime.now(UTC),
                 )
             )
             session.commit()
@@ -2286,8 +2286,7 @@ class TestSpawnWorker:
         fake_docker_client.containers.get.side_effect = Exception("not found")
         fake_docker_client.containers.run.return_value = fake_container
 
-        # Spawn with explicit tools override only — repos and agent_count
-        # come from defaults, so those should be re-persisted unchanged.
+        # Explicit tools override; repos + agent_count come from the baseline.
         with (
             patch("worker_runtime._get_docker_client", AsyncMock(return_value=fake_docker_client)),
             patch("foreman.tools.broadcast", new_callable=AsyncMock),
@@ -2298,17 +2297,21 @@ class TestSpawnWorker:
             )
         assert results[0].get("is_error") is not True, results[0]["content"]
 
-        # tools should NOT have been overwritten (was explicit override).
-        # repos and agent_count were defaulted → re-persisted unchanged.
+        env = fake_docker_client.containers.run.call_args.kwargs["environment"]
+        assert env["PIONEER_TOOLS"] == "claude,codex"  # call override wins
+        assert env["PIONEER_REPOS"] == "acme/widgets"  # from baseline
+        assert env["PIONEER_MAX_AGENTS"] == "3"  # from baseline
+
+        # Spawning does not rewrite the baseline row.
         with _sync_session(db_session) as session:
-            row = session.execute(select(GuildSpawnDefaults)).scalars().one()
-        assert json.loads(row.tools) == ["claude", "pi"]  # original defaults preserved
+            row = session.execute(select(SpawnSettings)).scalars().one()
+        assert json.loads(row.tools) == ["claude", "pi"]
         assert json.loads(row.repos) == ["acme/widgets"]
         assert row.agent_count == 3
 
     async def test_spawn_worker_falls_back_to_guild_defaults(self, db_session):
-        """spawn_worker with no repos uses the guild's recorded spawn defaults."""
-        from models import GuildSpawnDefaults  # noqa: PLC0415
+        """spawn_worker with no repos uses the guild baseline spawn_settings row."""
+        from models import SpawnSettings  # noqa: PLC0415
 
         insert_guild(db_session, "g-spawn-def")
         with _sync_session(db_session) as session:
@@ -2316,14 +2319,13 @@ class TestSpawnWorker:
                 select(col(Guild.id)).where(col(Guild.slug) == "g-spawn-def")
             ).scalar_one()
             session.add(
-                GuildSpawnDefaults(
+                SpawnSettings(
                     guild_id=guild_pk,
+                    user_id=None,
                     repos='["acme/widgets"]',
                     tools='["claude"]',
                     agent_count=3,
-                    # Older than the spawn cooldown window so this fixture (an
-                    # existing recorded default) doesn't itself trip the cooldown.
-                    updated_at=datetime.now(UTC) - timedelta(minutes=10),
+                    updated_at=datetime.now(UTC),
                 )
             )
             session.commit()

--- a/backend/tests/test_spawn_config.py
+++ b/backend/tests/test_spawn_config.py
@@ -1,0 +1,79 @@
+"""Tests for the unified spawn-settings resolver (backend/spawn_config.py)."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from spawn_config import ResolvedSpawn, SpawnLayer, merge_layers  # noqa: E402
+
+
+def test_empty_layers():
+    r = merge_layers([None, None])
+    assert r == ResolvedSpawn()
+
+
+def test_guild_baseline_only():
+    guild = SpawnLayer(repos=["a/b"], tools=["pi"], agent_count=2, provider="bedrock")
+    r = merge_layers([guild, None, None])
+    assert r.repos == ["a/b"]
+    assert r.tools == ["pi"]
+    assert r.agent_count == 2
+    assert r.provider == "bedrock"
+
+
+def test_user_overrides_guild_scalars_and_lists():
+    guild = SpawnLayer(repos=["a/b"], tools=["pi"], agent_count=2, model="m1")
+    user = SpawnLayer(repos=["c/d"], agent_count=4)  # tools/model unset -> inherit guild
+    r = merge_layers([guild, user])
+    assert r.repos == ["c/d"]  # user non-empty list wins
+    assert r.tools == ["pi"]  # user left it unset -> guild survives
+    assert r.agent_count == 4
+    assert r.model == "m1"
+
+
+def test_call_args_win_over_user_and_guild():
+    guild = SpawnLayer(tools=["pi"], agent_count=1)
+    user = SpawnLayer(tools=["claude"], agent_count=2)
+    call = SpawnLayer(agent_count=8)
+    r = merge_layers([guild, user, call])
+    assert r.tools == ["claude"]  # highest non-empty (user); call left tools unset
+    assert r.agent_count == 8  # call wins
+
+
+def test_empty_list_does_not_clobber():
+    guild = SpawnLayer(repos=["a/b"])
+    user = SpawnLayer(repos=[])  # empty -> not a real override
+    r = merge_layers([guild, user])
+    assert r.repos == ["a/b"]
+
+
+def test_env_vars_overlay_key_by_key():
+    guild = SpawnLayer(env_vars={"AWS_REGION": "us-east-1", "TOKEN": "guild-tok"})
+    user = SpawnLayer(env_vars={"TOKEN": "user-tok", "EXTRA": "x"})
+    r = merge_layers([guild, user])
+    assert r.env_vars == {"AWS_REGION": "us-east-1", "TOKEN": "user-tok", "EXTRA": "x"}
+
+
+def test_empty_env_value_does_not_blank_real_one():
+    # The one empty-value guard: a stale "" from a higher layer must not wipe a
+    # real credential set by a lower layer.
+    guild = SpawnLayer(env_vars={"AWS_BEARER_TOKEN_BEDROCK": "real-token"})
+    user = SpawnLayer(env_vars={"AWS_BEARER_TOKEN_BEDROCK": ""})
+    r = merge_layers([guild, user])
+    assert r.env_vars["AWS_BEARER_TOKEN_BEDROCK"] == "real-token"
+
+
+def test_empty_env_value_can_set_when_no_lower_value():
+    user = SpawnLayer(env_vars={"NEWKEY": ""})
+    r = merge_layers([None, user])
+    assert r.env_vars["NEWKEY"] == ""
+
+
+def test_tool_env_vars_merge_per_tool():
+    guild = SpawnLayer(tool_env_vars={"pi": {"A": "1"}, "claude": {"C": "3"}})
+    user = SpawnLayer(tool_env_vars={"pi": {"B": "2"}})
+    r = merge_layers([guild, user])
+    assert r.tool_env_vars == {"pi": {"A": "1", "B": "2"}, "claude": {"C": "3"}}

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -21,6 +21,19 @@ def _auth(db_url: str) -> dict:
     return {"Authorization": f"Bearer {make_auth_token(db_url)}"}
 
 
+def _set_guild_env(test_client, db_url: str, slug: str, env_vars: list[dict]) -> None:
+    """Set a guild's env vars via the real PATCH endpoint.
+
+    Routes through PATCH /guilds/{slug}, which merges/dedups and syncs the
+    forwarded worker-slice into the spawn_settings baseline (the source the spawn
+    path resolves from). ``env_vars`` items are {key, value, forward} dicts.
+    """
+    resp = test_client.patch(
+        f"/api/guilds/{slug}/foreman-config", headers=_auth(db_url), json={"env_vars": env_vars}
+    )
+    assert resp.status_code == 200, resp.text
+
+
 def _workers_for_guild(db_url: str, guild_id: str) -> list[Worker]:
     """Query workers for *guild_id* directly (no list-workers REST endpoint exists)."""
     with _sync_session(db_url) as session:
@@ -296,47 +309,6 @@ def test_put_spawn_defaults_rejects_bad_agent_count(client):
     assert resp.status_code == 422
 
 
-def test_put_spawn_defaults_preserves_updated_at_for_cooldown(client):
-    """Editing defaults must not reset guild_spawn_defaults.updated_at.
-
-    check_worker_spawn_cooldown() reads updated_at as the last *spawn* time; an
-    owner curating the baseline is not a spawn, so an edit must not start a
-    spurious spawn cooldown.
-    """
-    test_client, db_url = client
-    insert_guild(db_url, "guild-sd6")
-    test_client.put(
-        "/guilds/guild-sd6/spawn-defaults",
-        headers=_auth(db_url),
-        json={"repos": ["a/b"], "tools": [], "agent_count": 1},
-    )
-    # Simulate a spawn that happened 10 minutes ago.
-    past = datetime.now(UTC) - timedelta(minutes=10)
-    with _sync_session(db_url) as session:
-        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-sd6"))
-        session.execute(
-            update(GuildSpawnDefaults)
-            .where(col(GuildSpawnDefaults.guild_id) == guild_pk)
-            .values(updated_at=past)
-        )
-        session.commit()
-    # Owner edits the defaults — content changes, but the spawn clock must not.
-    test_client.put(
-        "/guilds/guild-sd6/spawn-defaults",
-        headers=_auth(db_url),
-        json={"repos": ["a/c"], "tools": ["claude"], "agent_count": 2},
-    )
-    with _sync_session(db_url) as session:
-        row = session.execute(
-            select(GuildSpawnDefaults).where(col(GuildSpawnDefaults.guild_id) == guild_pk)
-        ).scalar_one()
-    assert json.loads(row.repos) == ["a/c"]
-    assert json.loads(row.tools) == ["claude"]
-    assert row.agent_count == 2
-    # updated_at is unchanged (still ~10 minutes ago), so no cooldown was started.
-    assert abs((row.updated_at - past).total_seconds()) < 1
-
-
 def test_put_spawn_defaults_requires_owner(client):
     """Non-owner members can read defaults but not set them."""
     test_client, db_url = client
@@ -373,24 +345,12 @@ def test_get_spawn_credentials_masks_guild_env_var_values(client):
     """Guild foreman env var values are never returned in the clear from this endpoint."""
     test_client, db_url = client
     insert_guild(db_url, "guild-cred2")
-    with _sync_session(db_url) as session:
-        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-cred2"))
-        session.execute(
-            update(Guild)
-            .where(col(Guild.id) == guild_pk)
-            .values(
-                foreman_config={
-                    "env_vars": [
-                        {
-                            "key": "ANTHROPIC_API_KEY",
-                            "value": "sk-ant-supersecretvalue",
-                            "forward": True,
-                        }
-                    ]
-                }
-            )
-        )
-        session.commit()
+    _set_guild_env(
+        test_client,
+        db_url,
+        "guild-cred2",
+        [{"key": "ANTHROPIC_API_KEY", "value": "sk-ant-supersecretvalue", "forward": True}],
+    )
     resp = test_client.get("/guilds/guild-cred2/spawn-credentials", headers=_auth(db_url))
     assert resp.status_code == 200
     body = resp.json()
@@ -424,21 +384,15 @@ def test_spawn_worker_excludes_selected_guild_env_keys(client, monkeypatch):
     """exclude_env_keys drops those guild-level credentials from this spawn only."""
     test_client, db_url = client
     insert_guild(db_url, "guild-cred4")
-    with _sync_session(db_url) as session:
-        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-cred4"))
-        session.execute(
-            update(Guild)
-            .where(col(Guild.id) == guild_pk)
-            .values(
-                foreman_config={
-                    "env_vars": [
-                        {"key": "ANTHROPIC_API_KEY", "value": "keep-me", "forward": True},
-                        {"key": "OPENAI_API_KEY", "value": "drop-me", "forward": True},
-                    ]
-                }
-            )
-        )
-        session.commit()
+    _set_guild_env(
+        test_client,
+        db_url,
+        "guild-cred4",
+        [
+            {"key": "ANTHROPIC_API_KEY", "value": "keep-me", "forward": True},
+            {"key": "OPENAI_API_KEY", "value": "drop-me", "forward": True},
+        ],
+    )
 
     import worker_runtime
 
@@ -475,21 +429,15 @@ def test_spawn_worker_only_forwards_flagged_guild_env_vars(client, monkeypatch):
     reach the spawned worker; a forwarded one does."""
     test_client, db_url = client
     insert_guild(db_url, "guild-fwd")
-    with _sync_session(db_url) as session:
-        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-fwd"))
-        session.execute(
-            update(Guild)
-            .where(col(Guild.id) == guild_pk)
-            .values(
-                foreman_config={
-                    "env_vars": [
-                        {"key": "SHARED_TOKEN", "value": "yes", "forward": True},
-                        {"key": "FOREMAN_ONLY", "value": "no"},  # no forward flag
-                    ]
-                }
-            )
-        )
-        session.commit()
+    _set_guild_env(
+        test_client,
+        db_url,
+        "guild-fwd",
+        [
+            {"key": "SHARED_TOKEN", "value": "yes", "forward": True},
+            {"key": "FOREMAN_ONLY", "value": "no", "forward": False},  # not forwarded
+        ],
+    )
 
     import worker_runtime
 
@@ -522,20 +470,12 @@ def test_spawn_worker_empty_user_value_does_not_clobber_guild_credential(client,
     must not blank out the credential's real value (the value wins)."""
     test_client, db_url = client
     insert_guild(db_url, "guild-cred-clob")
-    with _sync_session(db_url) as session:
-        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-cred-clob"))
-        session.execute(
-            update(Guild)
-            .where(col(Guild.id) == guild_pk)
-            .values(
-                foreman_config={
-                    "env_vars": [
-                        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "real-token", "forward": True}
-                    ]
-                }
-            )
-        )
-        session.commit()
+    _set_guild_env(
+        test_client,
+        db_url,
+        "guild-cred-clob",
+        [{"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "real-token", "forward": True}],
+    )
 
     import worker_runtime
 
@@ -563,26 +503,20 @@ def test_spawn_worker_empty_user_value_does_not_clobber_guild_credential(client,
 
 
 def test_spawn_worker_guild_duplicate_key_prefers_nonempty(client, monkeypatch):
-    """A guild config that already stores the same key twice (one real value,
-    one blank — the pre-existing bad data) must boot the container with the real
-    value, not whichever entry comes last."""
+    """Submitting the same key twice (one real value, one blank) must collapse to
+    the real value on write, so the container boots with the real value — not
+    whichever entry came last."""
     test_client, db_url = client
     insert_guild(db_url, "guild-cred-dup")
-    with _sync_session(db_url) as session:
-        guild_pk = session.scalar(select(col(Guild.id)).where(col(Guild.slug) == "guild-cred-dup"))
-        session.execute(
-            update(Guild)
-            .where(col(Guild.id) == guild_pk)
-            .values(
-                foreman_config={
-                    "env_vars": [
-                        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "real-token", "forward": True},
-                        {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "", "forward": True},
-                    ]
-                }
-            )
-        )
-        session.commit()
+    _set_guild_env(
+        test_client,
+        db_url,
+        "guild-cred-dup",
+        [
+            {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "real-token", "forward": True},
+            {"key": "AWS_BEARER_TOKEN_BEDROCK", "value": "", "forward": True},
+        ],
+    )
 
     import worker_runtime
 

--- a/frontend/src/components/GuildSettingsPanel.vue
+++ b/frontend/src/components/GuildSettingsPanel.vue
@@ -198,9 +198,10 @@
             <div class="foreman-field">
               <label class="foreman-field-label">Environment Variables</label>
               <p class="foreman-hint">
-                Used by the foreman's own LLM (credentials, base URLs, etc.). A variable stays with
-                the foreman unless you tick <em>forward</em> — then it is also sent to every worker
-                tool in this guild. Scope a variable to a single tool in Worker Settings.
+                Used only by the foreman's own LLM (credentials, base URLs, etc.) — these are
+                <em>not</em> sent to workers. To give a variable to every worker, add it under
+                Worker Settings → General; to scope it to one tool, use the Claude / Pi / Codex
+                tabs.
               </p>
               <p v-if="envDefaultKeys.length" class="foreman-hint">
                 From the server environment (masked, always available to the foreman):
@@ -210,10 +211,9 @@
                 <div class="env-var-row env-var-head">
                   <span class="env-var-key">Key</span>
                   <span class="env-var-value">Value</span>
-                  <span class="env-var-fwd" title="Also send to worker tools">fwd</span>
                   <span class="env-var-spacer"></span>
                 </div>
-                <div v-for="row in envVarRows" :key="row.id" class="env-var-row">
+                <div v-for="row in foremanEnvRows" :key="row.id" class="env-var-row">
                   <input
                     v-model="row.key"
                     class="settings-input env-var-key"
@@ -230,15 +230,9 @@
                     spellcheck="false"
                     autocomplete="off"
                   />
-                  <input
-                    v-model="row.forward"
-                    type="checkbox"
-                    class="env-var-fwd"
-                    title="Forward this variable to worker tools"
-                  />
                   <button
                     class="env-var-delete-btn"
-                    @click="removeEnvVar(row)"
+                    @click="removeEnvRow(foremanEnvRows, row)"
                     title="Remove variable"
                   >
                     ✕
@@ -247,7 +241,9 @@
                 <datalist id="foreman-env-keys">
                   <option v-for="k in FOREMAN_ENV_KEYS" :key="k" :value="k" />
                 </datalist>
-                <button class="pixel-btn env-var-add-btn" @click="addEnvVar">+ Add Variable</button>
+                <button class="pixel-btn env-var-add-btn" @click="addEnvRow(foremanEnvRows)">
+                  + Add Variable
+                </button>
               </div>
             </div>
 
@@ -287,27 +283,46 @@
               </button>
             </nav>
 
-            <!-- General: what every worker tool receives (the forwarded foreman vars) -->
+            <!-- General: env vars every worker tool in this guild receives -->
             <template v-if="workerSubTab === 'general'">
               <p class="foreman-hint">
-                Every worker tool in this guild inherits these variables — the ones marked
-                <em>forward</em> on the Foreman tab. Edit them there; use the Claude / Pi / Codex
-                tabs to override a value for a single tool.
+                Every worker tool in this guild inherits these variables. Use the Claude / Pi /
+                Codex tabs to override a value for a single tool.
               </p>
-              <div v-if="forwardedEnvRows.length" class="env-var-list">
+              <div class="env-var-list">
                 <div class="env-var-row env-var-head">
                   <span class="env-var-key">Key</span>
                   <span class="env-var-value">Value</span>
+                  <span class="env-var-spacer"></span>
                 </div>
-                <div v-for="row in forwardedEnvRows" :key="row.id" class="env-var-row">
-                  <span class="env-var-key env-var-ro">{{ row.key }}</span>
-                  <span class="env-var-value env-var-ro">{{ row.value || '—' }}</span>
+                <div v-for="row in workerEnvRows" :key="row.id" class="env-var-row">
+                  <input
+                    v-model="row.key"
+                    class="settings-input env-var-key"
+                    placeholder="KEY_NAME"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                  <input
+                    v-model="row.value"
+                    type="text"
+                    class="settings-input env-var-value"
+                    placeholder="value"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                  <button
+                    class="env-var-delete-btn"
+                    @click="removeEnvRow(workerEnvRows, row)"
+                    title="Remove variable"
+                  >
+                    ✕
+                  </button>
                 </div>
+                <button class="pixel-btn env-var-add-btn" @click="addEnvRow(workerEnvRows)">
+                  + Add Variable
+                </button>
               </div>
-              <p v-else class="foreman-hint">
-                No forwarded variables yet. Tick <em>forward</em> on a Foreman variable to send it to
-                workers.
-              </p>
             </template>
 
             <!-- Pi: provider-agnostic tool, so it needs both a default model and provider -->
@@ -327,7 +342,11 @@
                   v-model="piDefaultModel"
                   class="settings-input"
                   list="pi-model-hints"
-                  :placeholder="piDefaultProvider === 'bedrock' ? 'inference-profile ARN' : 'e.g. claude-sonnet-4-6'"
+                  :placeholder="
+                    piDefaultProvider === 'bedrock'
+                      ? 'inference-profile ARN'
+                      : 'e.g. claude-sonnet-4-6'
+                  "
                   autocomplete="off"
                 />
                 <datalist id="pi-model-hints">
@@ -354,8 +373,8 @@
                 />
               </div>
               <p class="foreman-hint">
-                Used when the foreman assigns a task to the Codex tool without an explicit
-                model override.
+                Used when the foreman assigns a task to the Codex tool without an explicit model
+                override.
               </p>
             </template>
 
@@ -419,7 +438,11 @@
               >
                 {{ foremanSaving ? 'Saving…' : 'Save' }}
               </button>
-              <span v-if="foremanStatus" class="save-status" :class="'save-status-' + foremanStatus">
+              <span
+                v-if="foremanStatus"
+                class="save-status"
+                :class="'save-status-' + foremanStatus"
+              >
                 {{ foremanStatus === 'saved' ? 'Saved' : 'Error' }}
               </span>
             </div>
@@ -614,19 +637,26 @@ const foremanModelPlaceholder = computed(() => {
   const key = foremanProvider.value === 'bedrock' ? 'FOREMAN_BEDROCK_MODEL' : 'FOREMAN_MODEL'
   return envDefaults.value[key] ? `${envDefaults.value[key]} · from env` : 'default'
 })
-// The forwarded subset shown read-only on the Worker Settings → General tab.
-const forwardedEnvRows = computed(() => envVarRows.value.filter((r) => r.forward))
-
 interface EnvVarRow {
   id: number
   key: string
   value: string
-  // Foreman env_vars only: forward this var to worker tools. Per-tool rows
-  // ignore it (they're always scoped to their own tool).
-  forward?: boolean
 }
 let envRowSeq = 0
-const envVarRows = ref<EnvVarRow[]>([])
+// Guild env vars split by destination instead of a per-row `forward` checkbox:
+// workerEnvRows reach every worker tool (persisted with forward=true), while
+// foremanEnvRows stay with the foreman's own LLM (forward=false). The wire
+// format still carries the flag; the UI derives it from which list a var is in.
+const workerEnvRows = ref<EnvVarRow[]>([])
+const foremanEnvRows = ref<EnvVarRow[]>([])
+
+function addEnvRow(rows: EnvVarRow[]) {
+  rows.push({ id: ++envRowSeq, key: '', value: '' })
+}
+function removeEnvRow(rows: EnvVarRow[], row: EnvVarRow) {
+  const i = rows.indexOf(row)
+  if (i >= 0) rows.splice(i, 1)
+}
 
 // Per-tool env var rows, keyed by tool id. Each tool's rows are saved under
 // foreman_config.tool_env_vars[tool] and reach only that tool's runner.
@@ -668,14 +698,17 @@ async function loadForemanConfig() {
       foremanPollMin.value = cfg.poll_min_interval ?? ''
       foremanPollMax.value = cfg.poll_max_interval ?? ''
       // Env var values are returned in clear text so they can be verified/edited.
-      envVarRows.value = (cfg.env_vars ?? []).map(
-        (e: { key: string; value?: string; forward?: boolean }) => ({
-          id: ++envRowSeq,
-          key: e.key,
-          value: e.value ?? '',
-          forward: !!e.forward,
-        }),
-      )
+      // Split by forward: forwarded → worker (General) list, rest → foreman list.
+      workerEnvRows.value = []
+      foremanEnvRows.value = []
+      for (const e of (cfg.env_vars ?? []) as {
+        key: string
+        value?: string
+        forward?: boolean
+      }[]) {
+        const target = e.forward ? workerEnvRows : foremanEnvRows
+        target.value.push({ id: ++envRowSeq, key: e.key, value: e.value ?? '' })
+      }
       const toolEnv = cfg.tool_env_vars ?? {}
       for (const tool of ['claude', 'pi', 'codex']) {
         toolEnvRows[tool] = (toolEnv[tool] ?? []).map((e: { key: string; value?: string }) => ({
@@ -688,15 +721,6 @@ async function loadForemanConfig() {
   } catch {
     // non-fatal: fields stay blank (will use server defaults)
   }
-}
-
-function addEnvVar() {
-  envVarRows.value.push({ id: ++envRowSeq, key: '', value: '', forward: false })
-}
-
-function removeEnvVar(row: EnvVarRow) {
-  const i = envVarRows.value.indexOf(row)
-  if (i >= 0) envVarRows.value.splice(i, 1)
 }
 
 async function saveForemanConfig() {
@@ -723,16 +747,23 @@ async function saveForemanConfig() {
     else body.poll_min_interval = null
     if (foremanPollMax.value !== '') body.poll_max_interval = foremanPollMax.value
     else body.poll_max_interval = null
-    // Send every keyed row. Skip empty keys; collapse duplicate keys, keeping a
-    // non-empty value (and forward=true) over a blank/unset one so a stray blank
-    // row can't shadow the real credential or drop its forward flag.
+    // Combine both destination lists into the wire format: worker rows carry
+    // forward=true, foreman-only rows forward=false. Skip empty keys; collapse
+    // duplicate keys, keeping a non-empty value over a blank one. If the same
+    // key appears in both lists, worker (forward=true) wins so it still reaches
+    // workers.
     const envByKey = new Map<string, { value: string; forward: boolean }>()
-    for (const r of envVarRows.value) {
-      const key = r.key.trim()
-      if (!key) continue
-      const existing = envByKey.get(key)
-      if (existing && r.value === '' && existing.value !== '') continue
-      envByKey.set(key, { value: r.value, forward: !!r.forward || !!existing?.forward })
+    for (const { rows, forward } of [
+      { rows: foremanEnvRows.value, forward: false },
+      { rows: workerEnvRows.value, forward: true },
+    ]) {
+      for (const r of rows) {
+        const key = r.key.trim()
+        if (!key) continue
+        const existing = envByKey.get(key)
+        if (existing && r.value === '' && existing.value !== '') continue
+        envByKey.set(key, { value: r.value, forward: forward || !!existing?.forward })
+      }
     }
     body.env_vars = [...envByKey].map(([key, { value, forward }]) => ({ key, value, forward }))
     // Per-tool env vars: send all three tools so an emptied tab clears its set.
@@ -761,14 +792,16 @@ async function saveForemanConfig() {
       foremanStatus.value = 'saved'
       // Re-sync with the server's canonical config (clear-text values).
       const saved = await res.json()
-      envVarRows.value = (saved.env_vars ?? []).map(
-        (e: { key: string; value?: string; forward?: boolean }) => ({
-          id: ++envRowSeq,
-          key: e.key,
-          value: e.value ?? '',
-          forward: !!e.forward,
-        }),
-      )
+      workerEnvRows.value = []
+      foremanEnvRows.value = []
+      for (const e of (saved.env_vars ?? []) as {
+        key: string
+        value?: string
+        forward?: boolean
+      }[]) {
+        const target = e.forward ? workerEnvRows : foremanEnvRows
+        target.value.push({ id: ++envRowSeq, key: e.key, value: e.value ?? '' })
+      }
       const savedToolEnv = saved.tool_env_vars ?? {}
       for (const tool of ['claude', 'pi', 'codex']) {
         toolEnvRows[tool] = (savedToolEnv[tool] ?? []).map(
@@ -1233,14 +1266,6 @@ onBeforeUnmount(() => {
   font-size: 10px;
 }
 
-/* Forward checkbox column + its header/read-only cells. */
-.env-var-fwd {
-  flex: 0 0 28px;
-  display: flex;
-  justify-content: center;
-  accent-color: var(--color-brass);
-}
-
 .env-var-spacer {
   flex: 0 0 22px;
 }
@@ -1251,14 +1276,6 @@ onBeforeUnmount(() => {
   color: var(--color-brass-dark);
   letter-spacing: 1px;
   text-transform: uppercase;
-}
-
-.env-var-ro {
-  font-family: var(--font-mono, monospace);
-  color: var(--color-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .env-var-delete-btn {

--- a/frontend/src/components/__tests__/GuildSettingsPanel.spec.ts
+++ b/frontend/src/components/__tests__/GuildSettingsPanel.spec.ts
@@ -111,18 +111,18 @@ describe('GuildSettingsPanel worker tool tabs', () => {
 
     await inputs[0].setValue('claude-opus-4-8')
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      {
-        ok: true,
-        status: 200,
-        json: async () => ({ pi_default_model: 'claude-opus-4-8' }),
-      } as Response,
-    )
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ pi_default_model: 'claude-opus-4-8' }),
+    } as Response)
     const saveBtn = wrapper.findAll('button').find((b) => b.text() === 'Save')
     await saveBtn!.trigger('click')
     await flushPromises()
 
-    const patchCall = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'PATCH')
+    const patchCall = fetchSpy.mock.calls.find(
+      ([, init]) => (init as RequestInit)?.method === 'PATCH',
+    )
     expect(patchCall).toBeTruthy()
     const body = JSON.parse((patchCall![1] as RequestInit).body as string)
     expect(body.pi_default_model).toBe('claude-opus-4-8')
@@ -142,25 +142,25 @@ describe('GuildSettingsPanel worker tool tabs', () => {
 
     await piProviderSelect.setValue('bedrock')
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      {
-        ok: true,
-        status: 200,
-        json: async () => ({ pi_default_provider: 'bedrock' }),
-      } as Response,
-    )
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ pi_default_provider: 'bedrock' }),
+    } as Response)
     const saveBtn = wrapper.findAll('button').find((b) => b.text() === 'Save')
     await saveBtn!.trigger('click')
     await flushPromises()
 
-    const patchCall = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'PATCH')
+    const patchCall = fetchSpy.mock.calls.find(
+      ([, init]) => (init as RequestInit)?.method === 'PATCH',
+    )
     expect(patchCall).toBeTruthy()
     const body = JSON.parse((patchCall![1] as RequestInit).body as string)
     expect(body.pi_default_provider).toBe('bedrock')
   })
 })
 
-describe('GuildSettingsPanel foreman env forwarding', () => {
+describe('GuildSettingsPanel worker vs foreman env split', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
   })
@@ -168,47 +168,52 @@ describe('GuildSettingsPanel foreman env forwarding', () => {
     vi.restoreAllMocks()
   })
 
-  it('round-trips the per-var forward flag and reflects it on the Worker General tab', async () => {
-    // A stored var with forward=true, another without.
+  const keyValues = (wrapper: ReturnType<typeof mount>) =>
+    wrapper.findAll('input.env-var-key').map((i) => (i.element as HTMLInputElement).value)
+
+  it('splits env by destination (no forward checkbox) and saves the right flags', async () => {
+    // One forwarded (worker/General) var and one foreman-only var.
     const wrapper = await openForemanTab({
       env_vars: [
         { key: 'ANTHROPIC_API_KEY', value: 'sk', forward: true },
-        { key: 'FOREMAN_ONLY', value: 'x' },
+        { key: 'FOREMAN_ONLY', value: 'x', forward: false },
       ],
     })
 
-    const boxes = wrapper.findAll('input[type="checkbox"].env-var-fwd')
-    expect(boxes.length).toBe(2)
-    expect((boxes[0].element as HTMLInputElement).checked).toBe(true)
-    expect((boxes[1].element as HTMLInputElement).checked).toBe(false)
+    // The per-row forward checkbox is gone.
+    expect(wrapper.find('input[type="checkbox"].env-var-fwd').exists()).toBe(false)
+    // Foreman tab shows only the foreman-only var, as an editable input.
+    expect(keyValues(wrapper)).toEqual(['FOREMAN_ONLY'])
 
-    // Forward the second var too, then save.
-    await boxes[1].setValue(true)
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        env_vars: [
-          { key: 'ANTHROPIC_API_KEY', value: 'sk', forward: true },
-          { key: 'FOREMAN_ONLY', value: 'x', forward: true },
-        ],
-      }),
-    } as Response)
+    // Worker Settings → General (default sub-tab) shows the forwarded var, editable.
+    const workerTab = wrapper.findAll('.settings-tab').find((t) => t.text() === 'Worker Settings')
+    await workerTab!.trigger('click')
+    await flushPromises()
+    expect(keyValues(wrapper)).toEqual(['ANTHROPIC_API_KEY'])
+
+    // Add a new worker-wide var in General.
+    const addBtn = wrapper
+      .findAll('.env-var-add-btn')
+      .find((b) => b.text().includes('Add Variable'))
+    await addBtn!.trigger('click')
+    const keyInputs = wrapper.findAll('input.env-var-key')
+    await keyInputs[keyInputs.length - 1].setValue('WORKER_NEW')
+    const valInputs = wrapper.findAll('input.env-var-value')
+    await valInputs[valInputs.length - 1].setValue('v')
+
+    // Save (Worker Settings tab) → forwarded vars carry forward=true, foreman-only false.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ env_vars: [] }))
     const saveBtn = wrapper.findAll('.foreman-actions button').find((b) => b.text() === 'Save')
     await saveBtn!.trigger('click')
     await flushPromises()
 
-    const patchCall = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'PATCH')
+    const patchCall = fetchSpy.mock.calls.find(
+      ([, init]) => (init as RequestInit)?.method === 'PATCH',
+    )
     const body = JSON.parse((patchCall![1] as RequestInit).body as string)
-    const byKey = Object.fromEntries(body.env_vars.map((e: { key: string; forward: boolean }) => [e.key, e.forward]))
-    expect(byKey).toEqual({ ANTHROPIC_API_KEY: true, FOREMAN_ONLY: true })
-
-    // The Worker Settings → General tab lists only forwarded vars.
-    const workerTab = wrapper.findAll('.settings-tab').find((t) => t.text() === 'Worker Settings')
-    await workerTab!.trigger('click')
-    await flushPromises()
-    const roKeys = wrapper.findAll('.env-var-ro.env-var-key').map((s) => s.text())
-    expect(roKeys).toContain('ANTHROPIC_API_KEY')
-    expect(roKeys).toContain('FOREMAN_ONLY')
+    const byKey = Object.fromEntries(
+      body.env_vars.map((e: { key: string; forward: boolean }) => [e.key, e.forward]),
+    )
+    expect(byKey).toEqual({ ANTHROPIC_API_KEY: true, WORKER_NEW: true, FOREMAN_ONLY: false })
   })
 })


### PR DESCRIPTION
Spawn-settings unification (additive).

## Goal
Collapse the three spawn-config surfaces — `guild_spawn_defaults`, `user_spawn_settings`, and the worker-facing slice of `guilds.foreman_config` — into one table (`spawn_settings`, one row per guild baseline + one per user override), resolved by `spawn_config.resolve_spawn` with precedence **call-args > user row > guild row**.

## Backend
- [x] `models.SpawnSettings` — one table, two scopes (user_id NULL = guild baseline; set = user override); two partial unique indexes.
- [x] `spawn_config.resolve_spawn` / `merge_layers` — the single override path. Lists replace-if-nonempty, scalars first-non-null, env maps overlay key-by-key with the empty-value guard in one place. 9 unit tests.
- [x] Migration `20260728_000002` — create + backfill from all three sources (verified against prod-shaped dev data).
- [x] Cut over both spawn paths (foreman tool + REST), the spawn-defaults / spawn-settings / spawn-credentials endpoints, and the worker `/foreman/env-vars` fetch to `spawn_settings`.
- [x] `update_foreman_config` syncs the worker slice into the baseline so `resolve_spawn` stays authoritative while the settings UI still edits `foreman_config`.

## Frontend
- [x] `GuildSettingsPanel`: dropped the per-row **forward** checkbox. Worker-wide env is now directly editable under **Worker Settings → General** (was a read-only mirror); foreman-only env lives on the **Foreman** tab. `forward` is derived from which list a var is in — wire format unchanged. Spec rewritten; full suite (123) passes.

**Backend: 1221 passed. Frontend: 123 passed.**

## Follow-up (PR2)
Now purely backend cleanup: drop `guild_spawn_defaults` + `user_spawn_settings`, and remove the `forward` flag from the wire format / `foreman_config` worker slice (the UI no longer exposes it). 

**Merge-ordering:** `check_worker_spawn_cooldown` still reads `guild_spawn_defaults` on this branch; the separate cooldown fix (repoint to `workers.started_at`) must merge before PR2 drops that table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)