### PR TITLE
Wire DEBUG_TOKEN secret to enable backend /debug/query routes

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -25,6 +25,27 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.3.0"
   constraints = "~> 4.0"

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -111,6 +111,7 @@ resource "aws_ecs_task_definition" "backend" {
           ANTHROPIC_API_KEY      = aws_ssm_parameter.secret["anthropic_api_key"]
           PIONEER_FOREMAN_KEY    = aws_ssm_parameter.secret["pioneer_foreman_key"]
           DISCORD_BOT_TOKEN      = aws_ssm_parameter.secret["discord_bot_token"]
+          DEBUG_TOKEN            = aws_ssm_parameter.secret["debug_token"]
         } : { name = key, valueFrom = param.arn }
       ]
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,6 +17,10 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 
   # Remote state in S3. Bootstrap the bucket (and, on Terraform < 1.10, a

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -26,7 +26,15 @@ locals {
     pioneer_ci_key           = var.pioneer_ci_key
     discord_bot_token        = var.discord_bot_token
     aws_bearer_token_bedrock = var.aws_bearer_token_bedrock
+    # Falls back to an unguessable value, not the shared placeholder — see the
+    # variable "debug_token" comment for why this secret must fail closed.
+    debug_token = coalesce(var.debug_token, random_password.debug_token.result)
   }
+}
+
+resource "random_password" "debug_token" {
+  length  = 48
+  special = false
 }
 
 resource "aws_ssm_parameter" "secret" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -384,6 +384,18 @@ variable "pioneer_foreman_key" {
   default     = "CHANGE_ME_IN_SSM"
 }
 
+variable "debug_token" {
+  # The backend mounts /debug/query whenever DEBUG_TOKEN is non-empty (main.py),
+  # with no placeholder-stripping — so unlike the other secrets we can't seed the
+  # shared "CHANGE_ME_IN_SSM" placeholder here or the routes would go live behind
+  # a publicly-known token. Left empty, ssm.tf seeds an unguessable random value
+  # (routes mounted but unreachable); set a real token to actually use them.
+  description = "Bearer token gating the backend /debug/query routes. Leave empty to keep them unreachable; set a real value to enable."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "pioneer_ci_key" {
   description = "Shared secret for GitHub Actions CI-completion notifications to /guilds/{guild_id}/foreman/ci-notify."
   type        = string


### PR DESCRIPTION
## What

The backend mounts the `/debug/query` routes only when `DEBUG_TOKEN` is set (`backend/main.py:493`), but terraform never provided that env var — so those routes are unavailable in the deployed environments.

This wires `DEBUG_TOKEN` as an SSM `SecureString` secret alongside the other credentials:
- `variables.tf` — new `debug_token` variable (default `""`)
- `ssm.tf` — SSM parameter, plus a `random_password` fallback
- `ecs.tf` — `DEBUG_TOKEN` added to the backend `secrets` block
- `main.tf` — adds the `hashicorp/random` provider

## The one twist

`main.py` mounts the routes on **any non-empty** `DEBUG_TOKEN` and does no placeholder-stripping. Seeding the shared `"CHANGE_ME_IN_SSM"` placeholder (like the other secrets) would expose the debug routes behind a publicly-known token — fail-open.

So `debug_token` defaults to `""`, and `ssm.tf` falls back to an unguessable `random_password`. The routes stay mounted-but-unreachable until an operator rotates the SSM parameter (`aws ssm put-parameter --name /<project>/<env>/debug_token ...`) to a token they choose. `ignore_changes = [value]` means that rotation survives future applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)