### PR TITLE
Make container_image_tag required to remove the "latest" footgun

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -78,9 +78,13 @@ variable "route53_zone_id" {
 # -----------------------------------------------------------------------------
 
 variable "container_image_tag" {
-  description = "Image tag (commit SHA) deployed for all services. deploy.yml passes -var container_image_tag=<sha> on every push; a bare `terraform apply` without it falls back to the default below, which must be a tag that exists in ECR."
+  # No default on purpose: deploy.yml always passes -var container_image_tag=<sha>.
+  # A "latest" default was a footgun — nothing ever pushes that tag, so a bare
+  # `terraform apply` (without the var) would point every task def at a
+  # nonexistent image and break the running services. Required means a bare
+  # apply fails loudly instead.
+  description = "Image tag (commit SHA) deployed for all services. deploy.yml passes -var container_image_tag=<sha> on every push. Required — a bare `terraform apply` must specify a tag that exists in ECR."
   type        = string
-  default     = "latest"
 }
 
 variable "log_retention_days" {


### PR DESCRIPTION
## Problem

`container_image_tag` defaulted to `"latest"` (`terraform/variables.tf`), but **nothing ever pushes a `latest` tag** to ECR — CI tags images by commit SHA and `deploy.yml` always passes `-var container_image_tag=<sha>`.

So any bare `terraform apply` (without the var) silently fell back to `latest`, pointed every task definition at a nonexistent image, and broke the running services with `CannotPullContainerError: ...:latest: not found`. This actually happened — a manual apply reset the backend service to the `latest` task def and it couldn't pull.

## Fix

Drop the default. The variable is now required, so an apply without it fails loudly at plan time (`No value for required variable`) instead of deploying an image that doesn't exist. `deploy.yml` is unaffected — it already passes the SHA on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)