### PR TITLE
style: ruff format spawn-settings files

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -853,9 +853,13 @@ class SpawnSettings(SQLModel, table=True):
     # Concurrent agent slots; NULL = worker default.
     agent_count: int | None = None
     # Worker-facing env vars, {KEY: VALUE}. All are forwarded to the container.
-    env_vars: dict = Field(default_factory=dict, sa_column=Column(JSON, nullable=False, server_default=text("'{}'")))
+    env_vars: dict = Field(
+        default_factory=dict, sa_column=Column(JSON, nullable=False, server_default=text("'{}'"))
+    )
     # Per-tool scoped env, {tool: {KEY: VALUE}} — merged only when that tool spawns.
-    tool_env_vars: dict = Field(default_factory=dict, sa_column=Column(JSON, nullable=False, server_default=text("'{}'")))
+    tool_env_vars: dict = Field(
+        default_factory=dict, sa_column=Column(JSON, nullable=False, server_default=text("'{}'"))
+    )
     # Default provider/model for tool runs (was foreman_config.pi_default_*).
     provider: str | None = None
     model: str | None = None

--- a/backend/routes/guilds.py
+++ b/backend/routes/guilds.py
@@ -647,7 +647,11 @@ async def update_foreman_config(
         if e.get("forward") and e.get("key") and e.get("value") is not None
     }
     worker_tool_env = {
-        tool: {i["key"]: i["value"] for i in (items or []) if i.get("key") and i.get("value") is not None}
+        tool: {
+            i["key"]: i["value"]
+            for i in (items or [])
+            if i.get("key") and i.get("value") is not None
+        }
         for tool, items in (config.get("tool_env_vars") or {}).items()
     }
     await upsert_spawn_row(

--- a/backend/spawn_config.py
+++ b/backend/spawn_config.py
@@ -14,6 +14,7 @@ call args. Merge rules per field type:
 
 See models.SpawnSettings for the storage shape.
 """
+
 from __future__ import annotations
 
 import json
@@ -136,7 +137,9 @@ async def upsert_spawn_row(db, guild_pk: int, user_id: str | None = None, **fiel
     return row
 
 
-async def resolve_spawn(db, guild_pk: int, user_id: str | None, call: SpawnLayer | None = None) -> ResolvedSpawn:
+async def resolve_spawn(
+    db, guild_pk: int, user_id: str | None, call: SpawnLayer | None = None
+) -> ResolvedSpawn:
     """Load the guild baseline + user override rows and merge with optional call args."""
     from models import SpawnSettings  # noqa: PLC0415 — avoid circular import at module load
     from sqlmodel import col, select  # noqa: PLC0415


### PR DESCRIPTION
`#1060` merged before its ruff-format fix landed, so `main` currently fails `ruff format --check` on `backend/models.py`, `backend/routes/guilds.py`, and `backend/spawn_config.py`.

This applies `ruff format` to those three files — line wraps + a blank line after `spawn_config.py`'s module docstring. No logic change; `ruff check` + `ruff format --check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)