### PR TITLE
foreman: cut periodic-check token spend (four levers on the ~84% parent loop)

### DIFF
--- a/backend/foreman/constants.py
+++ b/backend/foreman/constants.py
@@ -6,6 +6,9 @@
 MAX_TOOL_RESULT_CHARS = 32_000
 MAX_HISTORY_MESSAGES = 20  # sliding window cap on messages sent to Anthropic
 MAX_FOREMAN_ROUNDS = 10  # safety cap on tool-call rounds per invocation
-_HUMAN_TURN_WINDOW = 5  # how many non-tool-response user turns to load from DB
+_HUMAN_TURN_WINDOW = 3  # how many non-tool-response user turns to load from DB
+# ponytail: lowered 5→3 to cut per-run parent-context tokens (~40% less history
+# on every round). Periodic checks are near-stateless so recall loss is minor;
+# raise back toward 5 if the foreman starts losing conversational thread.
 _TERMINAL_STATES = frozenset({"done", "failed", "cancelled", "error"})
 _24H_SECS = 86_400

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -71,7 +71,13 @@ from ws_types import ChatMsg, ForemanPollStatusMsg
 
 logger = logging.getLogger(__name__)
 
-POLL_MIN_SECS = 60  # initial poll interval: 1 minute
+POLL_MIN_SECS = 300  # initial poll interval: 5 minutes
+# ponytail: raised 60→300s. Periodic checks were ~84% of foreman token spend;
+# reset_foreman_poll slams the interval back to this floor on every event, so a
+# busy day fired a full-context [periodic-check] every minute. 5min cuts that ~5×.
+# Trade-off: stalled-task / devReady pickup latency goes 1min → 5min (fine).
+# Also widens the _guild_active_recently window (below), which keys off this — a
+# deliberate, benign coupling: "recently active" now means the last 5min.
 POLL_MAX_SECS = 86400  # maximum poll interval: 24 hours
 
 # Minimum age of a github_issues/github_pull_requests cache row before the

--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -1040,6 +1040,22 @@ async def _poll_loop(guild_id: str) -> None:
             logger.exception("guild=%s _poll_loop iteration failed", guild_id)
 
 
+def ensure_poll_loop(guild_id: str) -> None:
+    """Guarantee a poll loop exists for this guild WITHOUT touching its backoff.
+
+    For automated events (github webhooks post-debounce, worker connect/disconnect,
+    agent/task state updates) that already fired their own foreman run. They must
+    not reset the interval to the floor — during active development that pins the
+    poll at POLL_MIN_SECS and dominates token spend — but the safety-net loop still
+    has to be running. Never interrupts an existing loop's sleep, so the backoff
+    keeps growing naturally.
+    """
+    existing = _poll_tasks.get(guild_id)
+    if existing is None or existing.done():
+        task = spawn(_poll_loop(guild_id), name=f"foreman.poll-loop:{guild_id}")
+        _poll_tasks[guild_id] = task
+
+
 def reset_foreman_poll(guild_id: str) -> None:
     """Ensure a poll loop is running for this guild, resetting the backoff only when appropriate.
 
@@ -1072,10 +1088,7 @@ def reset_foreman_poll(guild_id: str) -> None:
     else:
         # Foreman is idle — only start a loop if none exists; do not interrupt
         # the current loop's sleep so the backoff continues to grow naturally.
-        existing = _poll_tasks.get(guild_id)
-        if existing is None or existing.done():
-            task = spawn(_poll_loop(guild_id), name=f"foreman.poll-loop:{guild_id}")
-            _poll_tasks[guild_id] = task
+        ensure_poll_loop(guild_id)
 
 
 async def _fetch_online_workers(db, guild_id: str) -> list[dict]:

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -28,7 +28,7 @@ from db import github_cache
 from events import broadcast_msg
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from foreman.constants import _TERMINAL_STATES
-from foreman.runner import reset_foreman_poll, run_foreman_ai
+from foreman.runner import ensure_poll_loop, run_foreman_ai
 from lock_service import LockService
 from models import (
     GithubEvent,
@@ -196,7 +196,10 @@ class DebounceQueue:
         await run_foreman_ai(
             guild_id, combined, user_id=user_id, task_id=task_id, child=bool(task_id)
         )
-        reset_foreman_poll(guild_id)
+        # Automated github churn (CI check/status especially) fired its run above;
+        # only guarantee the safety-net loop exists — do NOT reset the backoff, or
+        # a PR under active CI would pin the periodic poll at the floor.
+        ensure_poll_loop(guild_id)
         logger.info(
             "github webhook debounce fired key=%s events=%d guild=%s",
             key,

--- a/backend/tests/test_foreman_poll_backoff.py
+++ b/backend/tests/test_foreman_poll_backoff.py
@@ -296,3 +296,58 @@ def test_run_foreman_ai_records_action_on_tool_calls():
         assert runner._guild_active_recently(guild) is True
 
     _run(_test())
+
+
+# ---------------------------------------------------------------------------
+# ensure_poll_loop — starts a loop but never resets the backoff
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_poll_loop_starts_when_none_exists():
+    """ensure_poll_loop spawns a loop when the guild has none."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        guild = "g-ensure-new"
+        runner._poll_tasks.pop(guild, None)
+
+        fake_task = MagicMock()
+        spawned = []
+
+        def _fake_spawn(coro, **kw):
+            spawned.append(coro)
+            coro.close()  # avoid "coroutine never awaited" warning
+            return fake_task
+
+        with patch.object(runner, "spawn", side_effect=_fake_spawn):
+            runner.ensure_poll_loop(guild)
+
+        assert len(spawned) == 1
+        assert runner._poll_tasks[guild] is fake_task
+
+    _run(_test())
+
+
+def test_ensure_poll_loop_leaves_existing_loop_even_when_recently_active():
+    """The whole point of the decoupling: automated events must NOT reset the
+    backoff. Even with a fresh action timestamp, an existing running loop is left
+    untouched — no cancel, no respawn."""
+
+    async def _test():
+        import foreman.runner as runner
+
+        guild = "g-ensure-existing"
+        runner._guild_last_action_at[guild] = time.monotonic()  # recently active
+
+        old_task = MagicMock()
+        old_task.done.return_value = False
+        runner._poll_tasks[guild] = old_task
+
+        with patch.object(runner, "spawn", side_effect=AssertionError("must not spawn")):
+            runner.ensure_poll_loop(guild)
+
+        old_task.cancel.assert_not_called()
+        assert runner._poll_tasks[guild] is old_task
+
+    _run(_test())

--- a/backend/tests/test_github_webhooks_phase2.py
+++ b/backend/tests/test_github_webhooks_phase2.py
@@ -561,7 +561,7 @@ class TestDebounce:
         with (
             patch.object(wh, "_debounce_queue", queue),
             patch.object(wh, "run_foreman_ai", new=fake_run_foreman),
-            patch.object(wh, "reset_foreman_poll"),
+            patch.object(wh, "ensure_poll_loop"),
         ):
             try:
                 yield

--- a/backend/ws_handlers.py
+++ b/backend/ws_handlers.py
@@ -31,7 +31,7 @@ from fastapi import WebSocket
 from foreman.classify import is_human_event
 from foreman.github_url_parser import parse_github_urls
 from foreman.proxy import fail_pending_for_websocket, resolve_foreman_api_response
-from foreman.runner import reset_foreman_poll, run_foreman_ai
+from foreman.runner import ensure_poll_loop, reset_foreman_poll, run_foreman_ai
 from foreman.tools import maybe_post_plan_comment
 from lock_service import LockService
 from models import Agent, Message, Task, TaskEvent, TaskLog, User, Worker
@@ -435,7 +435,8 @@ async def handle_join(ctx: WSContext, data: dict) -> None:
             ForemanRegisteredMsg(guildId=ctx.guild_id, agentId=agent_id),
         )
     elif agent_type == "worker":
-        reset_foreman_poll(ctx.guild_id)
+        # Worker connect is automated churn — ensure the loop, don't reset backoff.
+        ensure_poll_loop(ctx.guild_id)
         # Replay any pending tasks already assigned to this worker so they
         # aren't lost if the backend sent task-assigned while the socket was
         # down. The worker's HTTP _fetch_pending_tasks() covers the same gap,
@@ -568,7 +569,8 @@ async def handle_agent_state(ctx: WSContext, data: dict) -> None:
             taskId=update_vals.get("current_task_id"),
         ),
     )
-    reset_foreman_poll(ctx.guild_id)
+    # Agent state update is automated churn — ensure the loop, don't reset backoff.
+    ensure_poll_loop(ctx.guild_id)
 
 
 async def handle_chat(ctx: WSContext, data: dict) -> None:
@@ -768,7 +770,8 @@ async def handle_worker_disconnect(ctx: WSContext, data: dict) -> None:
                 worker_id,
                 ctx.guild_id,
             )
-    reset_foreman_poll(ctx.guild_id)
+    # Worker disconnect is automated churn — ensure the loop, don't reset backoff.
+    ensure_poll_loop(ctx.guild_id)
 
 
 async def handle_task_update(ctx: WSContext, data: dict) -> None:
@@ -798,7 +801,8 @@ async def handle_task_update(ctx: WSContext, data: dict) -> None:
         await ctx.db.commit()
     await broadcast_msg(ctx.guild_id, TaskUpdateMsg.model_validate(data), exclude=ctx.websocket)
     if "state" in update_values:
-        reset_foreman_poll(ctx.guild_id)
+        # Worker-driven task state update is automated — ensure the loop, no reset.
+        ensure_poll_loop(ctx.guild_id)
     # Free the task's Discord stream buffer once it reaches a terminal state
     # (failed/cancelled/error), draining any tail output first.
     if update_values.get("state") in _TERMINAL_STATES:

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -99,6 +99,10 @@ resource "aws_ecs_task_definition" "backend" {
         { name = "DISCORD_GATEWAY_ENABLED", value = var.discord_gateway_enabled },
         { name = "DISCORD_DEV_GUILD_ID", value = var.discord_dev_guild_id },
         { name = "DISCORD_PR_DEBOUNCE_SECONDS", value = var.discord_pr_debounce_seconds },
+        # Coalesces bursty GitHub webhook events (CI check_run/check_suite/status
+        # especially) before each batch triggers a foreman run — a major foreman
+        # token-cost lever. Default 30s in code; raised here to cut CI-driven runs.
+        { name = "WEBHOOK_DEBOUNCE_SECONDS", value = var.webhook_debounce_seconds },
       ]
 
       secrets = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -499,3 +499,9 @@ variable "discord_pr_debounce_seconds" {
   type        = string
   default     = ""
 }
+
+variable "webhook_debounce_seconds" {
+  description = "Seconds to coalesce bursty GitHub webhook events before each batch triggers a foreman run. Code default is 30; raised to cut CI-driven foreman token spend."
+  type        = string
+  default     = "120"
+}


### PR DESCRIPTION
## Why

Token analysis of `api_request_log` (split by `task_id` regime, bucketed around the 06-21 child-context ship and 07-07 lock refactor) showed the **parent / guild-wide foreman context is ~77–84% of all foreman token spend in every window**, and it's the line item that's growing — roughly **9M → 15M tokens/day**. Child-context spend is small and flat (~1.7–3.0M/day) by comparison.

The parent loop is driven by periodic checks and event-triggered runs. `reset_foreman_poll` slams the interval back to the `POLL_MIN_SECS` floor on every event — and during active development `_guild_active_recently` is always true, so CI webhooks and worker churn kept the poll pinned at the floor. Each run also loops up to `max_rounds` API calls that re-send the whole growing message array.

## What — four coordinated levers

**1. Poll frequency** — `POLL_MIN_SECS` 60 → 300s. ~5× fewer periodic runs during active bursts. Only cost is detection latency (stalled tasks / devReady pickup) going 1min → 5min. Also widens the `_guild_active_recently` window that keys off the same constant — benign, intended.

**2. Context size** — `_HUMAN_TURN_WINDOW` 5 → 3. ~40% less guild history loaded on every round of every run. Periodic checks are near-stateless, so recall loss is minor.

**3. CI event coalescing** — `WEBHOOK_DEBOUNCE_SECONDS` wired into terraform at 120s (code default 30, never set). `check_run`/`check_suite`/`status` fire on every CI step, so at 30s a PR under active CI triggered a foreman run ~every 30s. ~4× fewer CI-driven runs; the 5-min poll backstops CI reaction.

**4. Decouple firing a run from resetting the backoff** — the root cause. `reset_foreman_poll` conflated "ensure a poll loop exists" with "reset the backoff to the floor." Split out `ensure_poll_loop(guild_id)`, which guarantees the safety-net loop without touching the backoff. Automated events (github webhooks, worker connect/disconnect, agent/task state updates) already fire their own run — they now call `ensure_poll_loop` and let the backoff keep growing. Only responsive events reset it:

| trigger | behavior |
|---|---|
| human chat, task-complete, followup-done, needs-input | `reset_foreman_poll` (reset backoff) |
| github webhooks, worker connect/disconnect, agent state, task state | `ensure_poll_loop` (fire, no reset) |

Left `MAX_FOREMAN_ROUNDS` alone on purpose — cutting it makes runs stop with work unfinished, which just re-triggers next cycle (more runs, not fewer). Still tunable per-guild via the `max_rounds` config key.

## Test

- `test_foreman_poll_backoff.py`: added coverage for `ensure_poll_loop` — starts a loop when none exists, and (the crux) leaves an existing loop untouched even when recently active.
- Updated `test_github_webhooks_phase2.py` to patch `ensure_poll_loop`.
- 234 passing across the touched suites (poll-backoff, webhooks, discord-router, foreman, runner, worker-notify); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)