### PR TITLE
fix(worker): clone/fetch with the triggering user's token, not the App token

### DIFF
--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -1666,7 +1666,11 @@ class Worker:
     async def _execute_task(self, task: dict, agent: Agent) -> None:
         task_id = task["id"]
         desc = task.get("description") or ""
-        token = self.cfg.github_token
+        # Clone/fetch as the triggering user's OAuth token, same as push does
+        # below. The App installation token (self.cfg.github_token) is scoped to
+        # one org, so a remote worker can't clone a repo the App isn't installed
+        # on; the user's token can. Falls back to the App token per _task_github_token.
+        token = await self._task_github_token(task_id)
         issue_repo = task.get("issue_repo") or ""
         explicit_repos = task.get("repos") or []
         if explicit_repos:


### PR DESCRIPTION
## Problem

Remote workers fail to clone repos the GitHub App isn't installed on.

Two token paths converge on `/auth/github/token`:

- **Push/PR** (`worker.py`) calls `_task_github_token(task_id)` → backend returns the **triggering user's OAuth token**, falling back to the App installation token.
- **Clone/fetch** used `self.cfg.github_token`, fetched once with **no** `task_id` → backend prefers the **App installation token** (`routes/auth.py`).

The App installation token is scoped to a single org/account. A remote worker cloning a repo the App isn't installed on gets a token with no access — even though the user who triggered the task can read it.

## Fix

Route clone/fetch through the same `_task_github_token(task_id)` path push already uses, so it prefers the user's OAuth token and falls back to the App token.

## Notes

- `ensure_repo` embeds the token in the persisted `origin` URL, so a follow-up on an existing checkout still fetches with the original clone-time token. Pre-existing; the token is short-lived either way.
- Token-selection logic is now identical to push, which `test_credentials_auth.py` already covers at the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)