### PR TITLE
feat(spawn): per-tool env overrides in the user spawn tab

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -1117,8 +1117,8 @@ def _post_agent_task(task_url: str, body: bytes) -> dict:
 # spawn_worker implementation — exposed to the parent foreman via FOREMAN_TOOLS
 # and invoked by the Discord /worker-spawn command. Spawned workers are
 # auto-reaped by worker_lifecycle.idle_worker_reaper() after a period of
-# inactivity; parameters omitted from the call fall back to the guild's
-# last-successful-spawn defaults (guild_spawn_defaults).
+# inactivity; parameters omitted from the call fall back through resolve_spawn
+# (spawn_settings: this user's override, then the guild baseline).
 # ---------------------------------------------------------------------------
 
 

--- a/backend/routes/foreman.py
+++ b/backend/routes/foreman.py
@@ -37,6 +37,7 @@ from models import (
     Guild,
     Message,
     Task,
+    Worker,
 )
 from pydantic import BaseModel
 from sqlalchemy import update
@@ -133,22 +134,30 @@ async def get_foreman_env_vars(
     Response: ``{ "env_vars": [{"key", "value"}, ...],
                   "tool_env_vars": {"claude": [...], "pi": [...], "codex": [...]} }``
     """
-    from spawn_config import get_spawn_row  # noqa: PLC0415
+    from spawn_config import resolve_spawn  # noqa: PLC0415
 
     res = await db.exec(select(Guild).where(col(Guild.slug) == guild_id))
     guild = res.one_or_none()
     if not guild:
         raise HTTPException(status_code=404, detail="Guild not found")
-    # Worker-facing env now lives in the spawn_settings guild baseline (env_vars
-    # are all worker-bound — no forward flag — and tool_env_vars stay scoped).
-    row = await get_spawn_row(db, guild.id, None)
-    env_vars = dict(row.env_vars) if row else {}
-    tool_env_vars = dict(row.tool_env_vars) if row else {}
+    # Resolve the worker's owner so this user's spawn-settings override (env_vars
+    # + per-tool tool_env_vars) layers over the guild baseline, matching what the
+    # worker's container was launched with. A worker principal maps to its
+    # Worker.user_id; a member principal is that member; otherwise baseline only.
+    user_id: str | None = None
+    if _caller.startswith("worker:"):
+        worker_id = _caller.split(":", 1)[1]
+        user_id = (
+            await db.exec(select(col(Worker.user_id)).where(col(Worker.id) == worker_id))
+        ).one_or_none()
+    elif _caller.startswith("user:"):
+        user_id = _caller.split(":", 1)[1]
+    resolved = await resolve_spawn(db, guild.id, user_id)
     return {
-        "env_vars": [{"key": k, "value": v} for k, v in env_vars.items()],
+        "env_vars": [{"key": k, "value": v} for k, v in resolved.env_vars.items()],
         "tool_env_vars": {
             tool: [{"key": k, "value": v} for k, v in (kv or {}).items()]
-            for tool, kv in tool_env_vars.items()
+            for tool, kv in resolved.tool_env_vars.items()
         },
     }
 

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -445,29 +445,49 @@ class EnvVarPair(BaseModel):
     value: str
 
 
+# The worker tools that can carry a per-tool env override, mirroring the guild
+# settings Worker Tools tabs. Unknown tool keys are rejected so the stored map
+# can't grow unbounded from a malformed payload.
+_SPAWN_TOOLS = ("claude", "pi", "codex")
+
+
+def _validate_env_pairs(pairs: list[EnvVarPair]) -> list[EnvVarPair]:
+    if len(pairs) > _MAX_SETTINGS_ENV_VARS:
+        raise ValueError(f"Too many env vars (max {_MAX_SETTINGS_ENV_VARS})")
+    for pair in pairs:
+        if len(pair.key) > _MAX_SETTINGS_ENV_KEY_LEN:
+            raise ValueError(f"Env var key exceeds max length ({_MAX_SETTINGS_ENV_KEY_LEN} chars)")
+        if len(pair.value) > _MAX_SETTINGS_ENV_VALUE_LEN:
+            raise ValueError("An env var value exceeds the maximum allowed length")
+        if pair.key and not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", pair.key):
+            raise ValueError(
+                f"Invalid env var key: {pair.key!r}. Must match ^[A-Za-z_][A-Za-z0-9_]*$"
+            )
+    return pairs
+
+
 class SaveSpawnSettingsRequest(BaseModel):
     # All fields default to empty so a PUT always replaces the full settings object
     # (no partial-update / PATCH semantics).
     repos: list[str] = []
     tools: list[str] = []
     envVars: list[EnvVarPair] = []
+    # Per-tool env overrides, {tool: [{key, value}, ...]}. Same shape as the guild
+    # settings tool_env_vars; merged in only when that tool spawns for this user.
+    toolEnvVars: dict[str, list[EnvVarPair]] = {}
 
     @field_validator("envVars")
     @classmethod
     def validate_env_var_keys(cls, v: list[EnvVarPair]) -> list[EnvVarPair]:
-        if len(v) > _MAX_SETTINGS_ENV_VARS:
-            raise ValueError(f"Too many env vars (max {_MAX_SETTINGS_ENV_VARS})")
-        for pair in v:
-            if len(pair.key) > _MAX_SETTINGS_ENV_KEY_LEN:
-                raise ValueError(
-                    f"Env var key exceeds max length ({_MAX_SETTINGS_ENV_KEY_LEN} chars)"
-                )
-            if len(pair.value) > _MAX_SETTINGS_ENV_VALUE_LEN:
-                raise ValueError("An env var value exceeds the maximum allowed length")
-            if pair.key and not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", pair.key):
-                raise ValueError(
-                    f"Invalid env var key: {pair.key!r}. Must match ^[A-Za-z_][A-Za-z0-9_]*$"
-                )
+        return _validate_env_pairs(v)
+
+    @field_validator("toolEnvVars")
+    @classmethod
+    def validate_tool_env_vars(cls, v: dict[str, list[EnvVarPair]]) -> dict[str, list[EnvVarPair]]:
+        for tool, pairs in v.items():
+            if tool not in _SPAWN_TOOLS:
+                raise ValueError(f"Unknown tool {tool!r}; expected one of {_SPAWN_TOOLS}")
+            _validate_env_pairs(pairs)
         return v
 
 
@@ -488,6 +508,10 @@ async def get_spawn_settings(
         "repos": json.loads(row.repos or "[]"),
         "tools": json.loads(row.tools or "[]"),
         "envVars": [{"key": k, "value": v} for k, v in (row.env_vars or {}).items()],
+        "toolEnvVars": {
+            tool: [{"key": k, "value": v} for k, v in (kv or {}).items()]
+            for tool, kv in (row.tool_env_vars or {}).items()
+        },
     }
 
 
@@ -506,6 +530,11 @@ async def save_spawn_settings(
     # complete override row for the guild.
     # TODO: encrypt env var values at rest before production use (tracked in GH issue #537).
     env_vars = {p.key: p.value for p in data.envVars if p.key}
+    tool_env_vars = {
+        tool: {p.key: p.value for p in pairs if p.key} for tool, pairs in data.toolEnvVars.items()
+    }
+    # Drop tools that resolved to no vars so the stored map stays clean.
+    tool_env_vars = {t: kv for t, kv in tool_env_vars.items() if kv}
     await upsert_spawn_row(
         db,
         guild_pk,
@@ -513,6 +542,7 @@ async def save_spawn_settings(
         repos=json.dumps(data.repos),
         tools=json.dumps(data.tools),
         env_vars=env_vars,
+        tool_env_vars=tool_env_vars,
     )
     return {"status": "saved"}
 
@@ -557,9 +587,9 @@ async def save_spawn_defaults(
     """Set the guild's default spawn parameters (owner only).
 
     These become the baseline the foreman's ``spawn_worker`` tool falls back to
-    and the per-user spawn form pre-fills from. A successful worker spawn still
-    refreshes them afterward (``record_worker_spawn``) — this endpoint just lets
-    an owner curate the baseline directly instead of waiting for the next spawn.
+    (via ``resolve_spawn``) and the per-user spawn form pre-fills from. Worker
+    spawns no longer write defaults back; this endpoint is the owner's curation
+    path for the guild baseline row.
     """
     guild_pk = await get_guild_pk(db, guild_id)
     if guild_pk is None:

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -883,3 +883,92 @@ def test_guild_task_list(client):
     descriptions = {t["description"] for t in resp.json()}
     assert "Alpha" in descriptions
     assert "Beta" in descriptions
+
+
+# ---------------------------------------------------------------------------
+# Per-user spawn settings: per-tool env overrides
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_settings_tool_env_vars_round_trip(client):
+    """PUT /spawn-settings persists per-tool env overrides; GET returns them,
+    dropping empty keys and tools that resolve to nothing."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-tenv")
+    headers = _auth(db_url)
+
+    resp = test_client.put(
+        "/guilds/guild-tenv/spawn-settings",
+        headers=headers,
+        json={
+            "repos": [],
+            "tools": [],
+            "envVars": [],
+            "toolEnvVars": {
+                "claude": [
+                    {"key": "ANTHROPIC_MODEL", "value": "sonnet"},
+                    {"key": "", "value": "x"},
+                ],
+                "pi": [],  # empty tool is dropped
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    got = test_client.get("/guilds/guild-tenv/spawn-settings", headers=headers).json()
+    assert got["toolEnvVars"] == {"claude": [{"key": "ANTHROPIC_MODEL", "value": "sonnet"}]}
+
+
+def test_spawn_settings_rejects_unknown_tool(client):
+    """An unknown tool key in toolEnvVars is a 422 (guards unbounded storage)."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-tbad")
+    resp = test_client.put(
+        "/guilds/guild-tbad/spawn-settings",
+        headers=_auth(db_url),
+        json={"toolEnvVars": {"bogus": [{"key": "K", "value": "v"}]}},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_foreman_env_vars_layers_user_tool_override_over_guild_baseline(client):
+    """GET /foreman/env-vars resolves the caller's per-tool override on top of the
+    guild baseline so a user's tool env reaches their worker."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-lyr")
+    headers = _auth(db_url)
+
+    # Guild baseline: claude gets BASE_ONLY + SHARED=guild (via foreman-config).
+    resp = test_client.patch(
+        "/api/guilds/guild-lyr/foreman-config",
+        headers=headers,
+        json={
+            "tool_env_vars": {
+                "claude": [
+                    {"key": "BASE_ONLY", "value": "base"},
+                    {"key": "SHARED", "value": "guild"},
+                ]
+            }
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    # This user's override: claude SHARED=user + USER_ONLY.
+    resp = test_client.put(
+        "/guilds/guild-lyr/spawn-settings",
+        headers=headers,
+        json={
+            "toolEnvVars": {
+                "claude": [
+                    {"key": "SHARED", "value": "user"},
+                    {"key": "USER_ONLY", "value": "u"},
+                ]
+            }
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    # env-vars endpoint, called as this member, merges both (user wins on SHARED).
+    got = test_client.get("/guilds/guild-lyr/foreman/env-vars", headers=headers).json()
+    claude = {p["key"]: p["value"] for p in got["tool_env_vars"].get("claude", [])}
+    assert claude == {"BASE_ONLY": "base", "SHARED": "user", "USER_ONLY": "u"}

--- a/frontend/src/components/sidebar/SpawnWorkerForm.vue
+++ b/frontend/src/components/sidebar/SpawnWorkerForm.vue
@@ -228,6 +228,63 @@
                   </button>
                 </div>
               </div>
+
+              <!-- Per-tool overrides: passed only to the selected tool's runner,
+                   never the others; overrides a shared Env Var for that tool.
+                   Mirrors Guild Settings → Worker Tools. -->
+              <div class="settings-field">
+                <label class="spawn-label"
+                  >Per-Tool Overrides <span class="spawn-hint">(optional)</span></label
+                >
+                <nav class="spawn-tool-tabs">
+                  <button
+                    v-for="tool in AVAILABLE_TOOLS"
+                    :key="tool"
+                    type="button"
+                    class="spawn-tool-tab"
+                    :class="{ active: envToolTab === tool }"
+                    @click="envToolTab = tool"
+                  >
+                    {{ tool }}
+                  </button>
+                </nav>
+                <p class="spawn-env-hint">
+                  Passed only to the {{ envToolTab }} CLI — never the other tools. Overrides an Env
+                  Var above for this tool.
+                </p>
+                <div class="spawn-env-list">
+                  <div
+                    v-for="(pair, idx) in toolEnvVars[envToolTab]"
+                    :key="idx"
+                    class="spawn-env-row"
+                  >
+                    <input
+                      v-model="pair.key"
+                      class="spawn-input spawn-env-input spawn-env-key"
+                      placeholder="KEY"
+                      type="text"
+                    />
+                    <span class="spawn-env-sep">=</span>
+                    <input
+                      v-model="pair.value"
+                      class="spawn-input spawn-env-input spawn-env-val"
+                      placeholder="value"
+                      type="text"
+                    />
+                    <button
+                      class="spawn-env-remove"
+                      @click="removeToolEnvVar(idx)"
+                      type="button"
+                      title="Remove"
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <button class="pixel-btn spawn-env-add" @click="addToolEnvVar" type="button">
+                    + Add
+                  </button>
+                </div>
+              </div>
             </section>
           </div>
         </div>
@@ -248,7 +305,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, reactive, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useGuildStore } from '../../stores/guild'
 import { useGitHubStore } from '../../stores/github'
 import { api } from '../../utils/api'
@@ -281,6 +338,7 @@ interface SpawnSettings {
   repos?: string[]
   tools?: string[]
   envVars?: EnvPair[]
+  toolEnvVars?: Record<string, EnvPair[]>
 }
 
 interface GuildSpawnDefaults {
@@ -308,6 +366,10 @@ const name = ref('')
 const selectedTools = ref<string[]>([])
 const agentCount = ref<number | null>(null)
 const envVars = ref<EnvPair[]>([])
+// Per-tool override env, keyed by tool. Reaches only that tool's runner via the
+// worker's /foreman/env-vars fetch (resolved against this user's spawn row).
+const toolEnvVars = reactive<Record<string, EnvPair[]>>({ claude: [], codex: [], pi: [] })
+const envToolTab = ref<(typeof AVAILABLE_TOOLS)[number]>('claude')
 const spawning = ref(false)
 const error = ref('')
 const loadingRepos = ref(false)
@@ -385,18 +447,28 @@ function toggleCredential(key: string) {
 /** Mirrors the backend's env-key regex (`SpawnWorkerRequest`) so bad keys are
  *  caught before the request round-trip, and flags client-only duplicate keys
  *  the backend wouldn't otherwise reject (a later dict entry silently wins). */
-function validateEnvVars(): string | null {
+function validatePairs(pairs: EnvPair[], label: string): string | null {
   const seen = new Set<string>()
-  for (const pair of envVars.value) {
+  for (const pair of pairs) {
     const key = pair.key.trim()
     if (key === '') continue
     if (!ENV_KEY_PATTERN.test(key)) {
-      return `Invalid env var key "${key}" — use letters, numbers, and underscores, starting with a letter or underscore.`
+      return `Invalid ${label} key "${key}" — use letters, numbers, and underscores, starting with a letter or underscore.`
     }
     if (seen.has(key)) {
-      return `Duplicate env var key "${key}".`
+      return `Duplicate ${label} key "${key}".`
     }
     seen.add(key)
+  }
+  return null
+}
+
+function validateEnvVars(): string | null {
+  const flat = validatePairs(envVars.value, 'env var')
+  if (flat) return flat
+  for (const tool of AVAILABLE_TOOLS) {
+    const err = validatePairs(toolEnvVars[tool], `${tool} override`)
+    if (err) return err
   }
   return null
 }
@@ -441,6 +513,12 @@ async function saveSettings(guildId: string) {
           (e) =>
             e.key.trim() !== '' && e.value.trim() !== '' && !guildCredKeys.value.has(e.key.trim()),
         ),
+        toolEnvVars: Object.fromEntries(
+          AVAILABLE_TOOLS.map((tool) => [
+            tool,
+            toolEnvVars[tool].filter((e) => e.key.trim() !== '' && e.value.trim() !== ''),
+          ]),
+        ),
       },
     })
   } catch {
@@ -482,7 +560,11 @@ onMounted(async () => {
     loadCredentials(guild.id)
   }
 
-  if (saved && (saved.repos?.length || saved.tools?.length || saved.envVars?.length)) {
+  const savedHasToolEnv = Object.values(saved?.toolEnvVars ?? {}).some((p) => p.length)
+  if (
+    saved &&
+    (saved.repos?.length || saved.tools?.length || saved.envVars?.length || savedHasToolEnv)
+  ) {
     // The user has their own saved overrides — those win over the guild baseline.
     if (saved.repos?.length) {
       if (repoFetchFailed.value) {
@@ -496,6 +578,9 @@ onMounted(async () => {
     }
     if (saved.tools?.length) selectedTools.value = saved.tools
     if (saved.envVars?.length) envVars.value = saved.envVars
+    for (const tool of AVAILABLE_TOOLS) {
+      toolEnvVars[tool] = (saved.toolEnvVars?.[tool] ?? []).map((p) => ({ ...p }))
+    }
   } else if (defaults && hasGuildDefaults.value) {
     // No personal overrides yet — start from the guild's spawn defaults.
     applyGuildDefaults(defaults)
@@ -565,6 +650,14 @@ function addEnvVar() {
 
 function removeEnvVar(idx: number) {
   envVars.value.splice(idx, 1)
+}
+
+function addToolEnvVar() {
+  toolEnvVars[envToolTab.value].push({ key: '', value: '' })
+}
+
+function removeToolEnvVar(idx: number) {
+  toolEnvVars[envToolTab.value].splice(idx, 1)
 }
 
 async function launch() {
@@ -890,6 +983,40 @@ async function launch() {
   border: 1px solid var(--color-brass-dark);
   border-radius: 2px;
   background: var(--color-bg);
+}
+
+.spawn-tool-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.spawn-tool-tab {
+  background: none;
+  border: 1px solid var(--color-brass-dark);
+  color: var(--color-brass-dark);
+  cursor: pointer;
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: 2px;
+  transition:
+    color 0.12s,
+    background 0.12s,
+    border-color 0.12s;
+}
+
+.spawn-tool-tab:hover {
+  color: var(--color-brass);
+  background: rgba(232, 170, 0, 0.06);
+}
+
+.spawn-tool-tab.active {
+  color: var(--color-brass-light);
+  background: rgba(232, 170, 0, 0.1);
+  border-color: var(--color-brass);
 }
 
 .spawn-repo-row {


### PR DESCRIPTION
## Problem

The per-user Spawn Worker tab could only set **flat** env vars, while Guild Settings → Worker Tools already supports **per-tool** overrides (Claude/Pi/Codex). And a user's per-tool env, even if it could be stored, was never resolved for the worker — `GET /foreman/env-vars` read only the guild baseline.

## Solution

Make the user spawn tab behave like guild settings, and close the read path so overrides actually reach the worker.

- **Frontend** (`SpawnWorkerForm.vue`): add a **Per-Tool Overrides** block to the Environment tab — Claude/Pi/Codex sub-tabs, each with its own key/value rows. Load/save/validate `toolEnvVars` alongside the existing flat env vars.
- **Backend** `PUT`/`GET /spawn-settings`: carry `toolEnvVars` into the user's `SpawnSettings.tool_env_vars` (unknown tool keys rejected, empty tools dropped).
- **Backend** `GET /foreman/env-vars` (the worker's startup fetch): resolve the **worker owner's** override via `resolve_spawn` (guild baseline + that user's row) instead of the baseline only — so a user's per-tool env layers over the guild's and reaches their worker.
- **Docs**: correct two stale comments. Worker spawns no longer write spawn defaults (`record_worker_spawn` only stamps the worker row); the foreman *reads* defaults through `resolve_spawn` (precedence: call-args > user row > guild baseline).

Per-tool overrides are persisted config (not one-shot launch args), matching guild-settings semantics; scoped to `claude/pi/codex` (the tools the UI shows).

## Tests

New backend tests: tool-env round-trip, unknown-tool rejection, and user-over-guild layering through the env-vars endpoint.

```
backend:  242 passed (test_worker_api, test_foreman, test_spawn_config, test_guild_api)
frontend: type-check clean, SpawnWorkerForm spec passes, eslint + prettier clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)