### PR TITLE
fix(worker): validate codex/pi credentials via CLI; pi provider via --models glob

### DIFF
--- a/frontend/src/components/GuildSettingsPanel.vue
+++ b/frontend/src/components/GuildSettingsPanel.vue
@@ -325,10 +325,10 @@
               </div>
             </template>
 
-            <!-- Pi: provider-agnostic tool, so it needs both a default model and provider -->
+            <!-- Pi: provider-agnostic tool, so it needs a provider + model override -->
             <template v-else-if="workerSubTab === 'pi'">
               <div class="foreman-field">
-                <label class="foreman-field-label">Default Provider</label>
+                <label class="foreman-field-label">Provider Override</label>
                 <select v-model="piDefaultProvider" class="settings-input">
                   <option value="">default (anthropic)</option>
                   <option v-for="p in modelsStore.providers" :key="p.id" :value="p.id">
@@ -337,7 +337,7 @@
                 </select>
               </div>
               <div class="foreman-field">
-                <label class="foreman-field-label">Default Model</label>
+                <label class="foreman-field-label">Model Override</label>
                 <input
                   v-model="piDefaultModel"
                   class="settings-input"
@@ -354,10 +354,11 @@
                 </datalist>
               </div>
               <p class="foreman-hint">
-                Used when the foreman assigns a task to the Pi tool without an explicit
-                model/provider override. Select "Amazon Bedrock" to run Pi against Bedrock; set its
-                AWS credentials in the Pi Environment section below (or the General forwarded
-                variables, which apply to every tool).
+                Overrides the model Pi runs when the foreman assigns it a task without an explicit
+                model/provider. Setting a provider forces Pi onto that provider's models (Pi ignores
+                a bare provider unless the model is pinned too). Select "Amazon Bedrock" to run Pi
+                against Bedrock; set its AWS credentials in the Pi Environment section below (or the
+                General forwarded variables, which apply to every tool).
               </p>
             </template>
 

--- a/worker/pioneer_worker/pi_runner.py
+++ b/worker/pioneer_worker/pi_runner.py
@@ -250,7 +250,11 @@ async def _run_pi_once(
         cmd += ["--session", resume_session_id]
     cmd += ["--mode", "rpc"]
     if provider:
-        cmd += ["--provider", pi_provider_arg(provider)]
+        # `--provider` only takes effect alongside `--model`; on its own pi
+        # stays on its default provider. `--models {provider}/*` actually
+        # switches the active provider (and picks its first matching model),
+        # which is what we want when a provider is set without a specific model.
+        cmd += ["--models", f"{pi_provider_arg(provider)}/*"]
     if model:
         cmd += ["--model", model]
     logger.info("Spawning pi in %s; description=%r", cwd, description)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -471,19 +471,19 @@ class Worker:
             # Fall back to a locally logged-in CLI (dev machines / keychain).
             return await self._claude_is_authenticated()
         if name == "codex":
-            return bool(env.get("OPENAI_API_KEY") or self.cfg.openai_api_key)
+            if env.get("OPENAI_API_KEY") or self.cfg.openai_api_key:
+                return True
+            # Fall back to a locally logged-in CLI (chatgpt tokens in auth.json).
+            return await self._codex_is_authenticated()
         if name == "pi":
-            # Pi speaks to ~20 providers via ~35 different env vars — API keys,
-            # OAuth tokens, and AWS/Bedrock forms like AWS_BEARER_TOKEN_BEDROCK
-            # (see TOOL_ENV_KEYS in GuildSettingsPanel.vue). Rather than mirror
-            # that list and drift from it, treat pi as configured when the guild
-            # set any scoped env var for it. An empty pi tab means pi would launch,
-            # fail auth per-task, and — as the only tool left when claude/codex are
-            # unconfigured — silently swallow every task; drop it instead.
-            # ponytail: presence check, not per-key validation; a scoped non-cred
-            # var (e.g. AWS_REGION alone) still counts. Tighten to the key list if
-            # that false-positive ever bites.
-            return bool(self._tool_env.get("pi"))
+            # Pi speaks to ~20 providers via ~35 different env vars, so mirroring
+            # that key list here would drift from it. Instead ask pi: `pi
+            # --list-models` only lists providers whose creds/config are present
+            # in the environment, so a non-empty catalog means pi has something
+            # usable. It doesn't truly auth, but an unconfigured pi lists nothing
+            # and would otherwise launch, fail per-task, and — as the only tool
+            # left when claude/codex are unconfigured — silently swallow tasks.
+            return await self._pi_has_models()
         return True  # any other tool needs no credentials
 
     async def _ensure_tools_installed(self) -> None:
@@ -631,6 +631,101 @@ class Worker:
         else:
             logger.info("claude auth status reports loggedIn=false")
         return logged_in
+
+    async def _codex_is_authenticated(self) -> bool:
+        """Return True if `codex doctor --json --summary` reports auth configured.
+
+        Mirrors _claude_is_authenticated: the exit code alone doesn't isolate
+        auth (doctor returns 0 with unrelated warnings), so we parse the JSON
+        and read the auth.credentials check's status. A timeout guards against a
+        hung subprocess.
+        """
+        import json as _json
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self.cfg.codex_path,
+                "doctor",
+                "--json",
+                "--summary",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=self._env_for_tool("codex"),
+            )
+        except FileNotFoundError as exc:
+            logger.warning("codex binary not found at %r: %s", self.cfg.codex_path, exc)
+            return False
+        except Exception as exc:
+            logger.warning("codex doctor spawn failed: %s", exc)
+            return False
+
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=20.0)
+        except TimeoutError:
+            logger.warning("codex doctor timed out after 20s; killing pid=%s", proc.pid)
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            return False
+
+        raw = stdout.decode(errors="replace").strip()
+        try:
+            parsed = _json.loads(raw)
+        except _json.JSONDecodeError:
+            logger.warning("codex doctor output is not JSON: %s", raw[:200])
+            return False
+        status = parsed.get("checks", {}).get("auth.credentials", {}).get("status")
+        logger.info("codex doctor auth.credentials status=%s", status)
+        return status == "ok"
+
+    async def _pi_has_models(self) -> bool:
+        """Return True if `pi --list-models` prints at least one model row.
+
+        pi --list-models doesn't authenticate, but it only lists providers whose
+        credentials/config are present in the environment, so a non-empty
+        catalog means pi has something usable. A timeout guards a hung
+        subprocess (it may do startup network fetches).
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self.cfg.pi_path,
+                "--list-models",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=self._env_for_tool("pi"),
+            )
+        except FileNotFoundError as exc:
+            logger.warning("pi binary not found at %r: %s", self.cfg.pi_path, exc)
+            return False
+        except Exception as exc:
+            logger.warning("pi --list-models spawn failed: %s", exc)
+            return False
+
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=20.0)
+        except TimeoutError:
+            logger.warning("pi --list-models timed out after 20s; killing pid=%s", proc.pid)
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            return False
+
+        if proc.returncode != 0:
+            logger.warning("pi --list-models rc=%d", proc.returncode)
+            return False
+        # First line is the "provider model ..." header; any data row means a
+        # provider is configured. "Warning:" lines don't count as models.
+        rows = [
+            ln
+            for ln in stdout.decode(errors="replace").splitlines()
+            if ln.strip() and not ln.startswith(("provider", "Warning"))
+        ]
+        logger.info("pi --list-models returned %d model rows", len(rows))
+        return bool(rows)
 
     # ------------------------------------------------------------------ Control API
     def _status_snapshot(self) -> dict:

--- a/worker/tests/test_tools_detection.py
+++ b/worker/tests/test_tools_detection.py
@@ -194,33 +194,47 @@ class TestCredentialGating:
             await worker._detect_available_tools()
         assert "claude" in worker._available_tools
 
-    async def test_codex_requires_openai_key(self, monkeypatch):
+    async def test_codex_env_key_skips_cli_check(self, monkeypatch):
+        # An env OPENAI_API_KEY is a fast-path: codex is included without
+        # running `codex doctor`.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        worker = Worker(_make_cfg(tools=["codex"], codex_path="codex"))
+        worker._codex_is_authenticated = AsyncMock(return_value=False)
+        with patch("shutil.which", return_value="codex"):
+            await worker._detect_available_tools()
+        assert "codex" in worker._available_tools
+        worker._codex_is_authenticated.assert_not_awaited()
+
+    async def test_codex_without_key_falls_back_to_cli(self, monkeypatch):
+        # No env key → gated on `codex doctor` auth status.
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         cfg = _make_cfg(tools=["codex"], codex_path="codex")
         worker = Worker(cfg)
+        worker._codex_is_authenticated = AsyncMock(return_value=False)
         with patch("shutil.which", return_value="codex"):
             await worker._detect_available_tools()
         assert "codex" not in worker._available_tools
 
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
-        worker2 = Worker(_make_cfg(tools=["codex"], codex_path="codex"))
+        worker2 = Worker(cfg)
+        worker2._codex_is_authenticated = AsyncMock(return_value=True)
         with patch("shutil.which", return_value="codex"):
             await worker2._detect_available_tools()
         assert "codex" in worker2._available_tools
 
-    async def test_pi_without_scoped_env_is_excluded(self):
-        # Empty pi tab → no scoped env → dropped.
+    async def test_pi_without_models_is_excluded(self):
+        # `pi --list-models` returns nothing → dropped.
         cfg = _make_cfg(tools=["pi"], pi_path="pi")
         worker = Worker(cfg)
+        worker._pi_has_models = AsyncMock(return_value=False)
         with patch("shutil.which", return_value="pi"):
             await worker._detect_available_tools()
         assert "pi" not in worker._available_tools
 
-    async def test_pi_with_scoped_env_is_included(self):
-        # Any scoped var (a Bedrock bearer token here) counts as configured.
+    async def test_pi_with_models_is_included(self):
+        # `pi --list-models` returns at least one model → configured.
         cfg = _make_cfg(tools=["pi"], pi_path="pi")
         worker = Worker(cfg)
-        worker._tool_env = {"pi": {"AWS_BEARER_TOKEN_BEDROCK": "tok"}}
+        worker._pi_has_models = AsyncMock(return_value=True)
         with patch("shutil.which", return_value="pi"):
             await worker._detect_available_tools()
         assert "pi" in worker._available_tools


### PR DESCRIPTION
## What

Two related fixes to how the worker handles the Pi/Codex runners.

### Credential detection (`_tool_has_credentials`)
All three tools now confirm they can actually run by asking the CLI, matching how `claude` already worked, instead of inferring from env-var presence:

- **codex** — env `OPENAI_API_KEY`/`cfg.openai_api_key` fast-path, else `codex doctor --json --summary` and check `checks["auth.credentials"].status == "ok"`.
- **pi** — `pi --list-models`. It doesn't truly authenticate, but it only lists providers whose creds/config are present in the environment, so a non-empty catalog means Pi has something usable. (An unconfigured Pi lists nothing and would otherwise launch, fail per-task, and — as the only tool left when claude/codex are unconfigured — silently swallow tasks.)

Both new helpers mirror `_claude_is_authenticated`: per-tool env, 20s timeout, kill-on-hang.

### Pi provider selection (`pi_runner.py`)
A bare `--provider` leaves Pi on its default provider — it only takes effect alongside `--model`. Switched to `--models {provider}/*`, which actually forces Pi onto that provider's models (verified: it ran against Bedrock's `amazon.nova-2-lite`). `--model` still pins a specific model on top when set.

### UI (`GuildSettingsPanel.vue`)
Relabeled the Pi guild fields from "Default Provider"/"Default Model" to "Provider Override"/"Model Override" and reworded the hint, since the provider selector now works by overriding the active model.

## Caveat
On a host/container with stored codex ChatGPT tokens or Pi config, these checks pass even with no guild env vars set — same "presence, not real auth" ceiling the previous code had.

## Tests
`test_tools_detection.py` (28) and `test_pi_runner.py` (42) pass. Updated the two credential-gating tests that asserted the old env-presence behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)