### PR TITLE
Validate guild settings passthrough to worker spawn (foreman context)

### DIFF
--- a/backend/foreman/runner.py
+++ b/backend/foreman/runner.py
@@ -1422,6 +1422,12 @@ async def _run_foreman_ai(
         )
         return
 
+    # Automated triggers (periodic-check, worker-online/offline, task-complete,
+    # ...) call _trigger_foreman without a user_id. Falling back to the guild
+    # owner (rather than leaving it None) means this resolved user_id, threaded
+    # through to exec_tools -> _exec_one_tool -> spawn_worker below, lets an
+    # owner's personal spawn_settings override apply and stamps Worker.user_id
+    # on foreman-initiated spawns instead of leaving them unattributed.
     if not user_id:
         user_id = await _get_guild_user_id(guild_id) or guild_id
 

--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -2313,7 +2313,17 @@ async def _exec_one_tool(
                     )
 
             elif tu.name == "spawn_worker":
-                result_text, is_error = await spawn_worker(inp, guild_id, guild_pk, db)
+                # user_id here is whoever's foreman session is running this tool
+                # call — for periodic-check/other automated triggers, runner.py's
+                # _run_foreman_ai resolves it to the guild owner (see
+                # _get_guild_user_id) rather than leaving it unset. Passing it
+                # through lets resolve_spawn() apply that user's spawn_settings
+                # override layer (on top of the guild baseline, which resolves
+                # off guild_pk regardless) and stamps Worker.user_id so the
+                # spawned worker is attributed instead of orphaned.
+                result_text, is_error = await spawn_worker(
+                    inp, guild_id, guild_pk, db, user_id=user_id
+                )
 
             elif tu.name == "get_task_status":
                 task_id = inp["task_id"]


### PR DESCRIPTION
**Task:** Validate guild settings passthrough to worker spawn (foreman context)
**Task ID:** `t-2e1wyx`

Automated by Pioneer Square worker agent.