### PR TITLE
fix(worker): stop persisting git credentials; unstick error agents; target mid-task messages

### DIFF
--- a/backend/foreman/tools.py
+++ b/backend/foreman/tools.py
@@ -2173,9 +2173,20 @@ async def _exec_one_tool(
             elif tu.name == "message_worker":
                 wid = inp["worker_id"]
                 msg = inp["message"]
+                target_task_id = inp.get("task_id")
                 await emit_terminal_line(guild_id, wid, f"[foreman] {msg}")
-                await broadcast_msg(guild_id, WorkerMessageMsg(workerId=wid, message=msg))
-                result_text = f"Message delivered to {wid}."
+                await broadcast_msg(
+                    guild_id,
+                    WorkerMessageMsg(workerId=wid, message=msg, taskId=target_task_id),
+                )
+                result_text = (
+                    f"Message sent to {wid} for task {target_task_id}."
+                    if target_task_id
+                    else (
+                        f"Message sent to {wid}. Without a task_id the worker only delivers it "
+                        "when exactly one of its agents is running."
+                    )
+                )
 
             elif tu.name == "redirect_task":
                 task_id = inp["task_id"]

--- a/backend/foreman/tools_schema.py
+++ b/backend/foreman/tools_schema.py
@@ -273,12 +273,24 @@ FOREMAN_TOOLS = [
     },
     {
         "name": "message_worker",
-        "description": "Send a message to a worker's terminal — reaches the active agent subprocess mid-task; has no effect if the worker is idle.",
+        "description": (
+            "Send a message to a worker's terminal — reaches the agent subprocess running "
+            "mid-task; has no effect if the worker is idle. Always pass task_id when you mean "
+            "a specific task: a worker runs several tasks at once, and without it the message "
+            "is only delivered when exactly one agent is running."
+        ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "worker_id": {"type": "string"},
                 "message": {"type": "string"},
+                "task_id": {
+                    "type": "string",
+                    "description": (
+                        "Task (t-xxxxxx) whose agent should receive the message. Required in "
+                        "practice whenever the worker may be running more than one task."
+                    ),
+                },
             },
             "required": ["worker_id", "message"],
         },

--- a/backend/routes/workers.py
+++ b/backend/routes/workers.py
@@ -141,6 +141,9 @@ class TaskCreate(BaseModel):
 
 class WorkerMessage(BaseModel):
     message: str
+    # Optional target task. A worker runs several agents at once, so a message
+    # without one is only delivered when exactly one of them is running.
+    task_id: str | None = None
 
 
 @router.post("/guilds/{guild_id}/workers")
@@ -633,8 +636,12 @@ async def message_worker(
         raise HTTPException(status_code=400, detail="Empty message")
 
     await emit_terminal_line(guild_id, worker_id, f"[foreman → worker] {text_msg}")
-    await broadcast_msg(guild_id, WorkerMessageMsg(workerId=worker_id, message=text_msg))
-    return {"status": "delivered"}
+    await broadcast_msg(
+        guild_id,
+        WorkerMessageMsg(workerId=worker_id, message=text_msg, taskId=data.task_id),
+    )
+    # "sent", not "delivered": the worker decides whether a running agent matches.
+    return {"status": "sent"}
 
 
 @router.post("/guilds/{guild_id}/workers/{worker_id}/shutdown")

--- a/backend/tests/test_foreman.py
+++ b/backend/tests/test_foreman.py
@@ -814,7 +814,7 @@ class TestExecToolsDispatching:
         # which would also match unrelated error text.
         assert re.search(r"\bt-[a-z0-9]{6}\b", results[0]["content"])
         assert "queued" in results[1]["content"].lower()
-        assert "delivered" in results[2]["content"].lower()
+        assert "sent" in results[2]["content"].lower()
 
     async def test_send_followup_defaults_to_first_worker_tool(self, db_session):
         insert_guild(db_session, "g-followup-tooldefault")
@@ -1426,10 +1426,45 @@ class TestExecToolsDispatching:
                     )
                 ],
             )
-        assert "delivered" in results[0]["content"].lower()
+        # "sent", not "delivered": whether it lands is the worker's call — it
+        # only injects when it can identify the agent the message is meant for.
+        assert "sent" in results[0]["content"].lower()
         worker_msgs = [m for m in broadcast_calls if m.type == "worker-message"]
         assert len(worker_msgs) == 1
         assert worker_msgs[0].message == "Hello worker"
+        assert worker_msgs[0].taskId is None
+
+    async def test_message_worker_forwards_the_target_task_id(self, db_session):
+        """A worker runs several agents at once, so the task id has to travel with
+        the message or the worker cannot tell which agent it is for."""
+        insert_guild(db_session, "g-msgwkr-task")
+        broadcast_calls: list = []
+
+        async def fake_broadcast_msg(guild_id, msg):
+            broadcast_calls.append(msg)
+
+        with (
+            patch("foreman.tools.broadcast_msg", new=fake_broadcast_msg),
+            patch("foreman.tools.emit_terminal_line", new_callable=AsyncMock),
+        ):
+            results = await exec_tools(
+                "g-msgwkr-task",
+                [
+                    _fake_tool_use(
+                        "message_worker",
+                        {
+                            "worker_id": "w-msgwkr",
+                            "message": "check the migration",
+                            "task_id": "t-abc123",
+                        },
+                    )
+                ],
+            )
+        assert not results[0].get("is_error")
+        assert "t-abc123" in results[0]["content"]
+        worker_msgs = [m for m in broadcast_calls if m.type == "worker-message"]
+        assert len(worker_msgs) == 1
+        assert worker_msgs[0].taskId == "t-abc123"
 
     async def test_redirect_task_not_found(self, db_session):
         insert_guild(db_session, "g-redirect-missing")

--- a/backend/tests/test_worker_api.py
+++ b/backend/tests/test_worker_api.py
@@ -8,6 +8,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
 
 from helpers import _sync_session, insert_guild, insert_member, make_auth_token
 from models import Agent, ClaudeCredentials, Guild, GuildSpawnDefaults, User, Worker
@@ -197,6 +198,63 @@ def test_assign_task_appears_in_list(client):
 # ---------------------------------------------------------------------------
 # Worker shutdown
 # ---------------------------------------------------------------------------
+
+
+def test_message_worker_forwards_the_task_id(client, monkeypatch):
+    """The target task travels with the message.
+
+    A worker runs several agents concurrently, so a message with no task id can
+    only be delivered when exactly one is running — the worker refuses to guess
+    rather than inject one task's instructions into another's session.
+    """
+    test_client, db_url = client
+    insert_guild(db_url, "guild-msg")
+    worker_id = _create_worker(test_client, "guild-msg")
+
+    broadcasts: list = []
+
+    async def fake_broadcast(guild_id, msg, *a, **kw):
+        broadcasts.append(msg)
+
+    monkeypatch.setattr("routes.workers.broadcast_msg", fake_broadcast)
+    monkeypatch.setattr("routes.workers.emit_terminal_line", AsyncMock())
+
+    resp = test_client.post(
+        f"/guilds/guild-msg/workers/{worker_id}/message",
+        headers=_auth(db_url),
+        json={"message": "check the migration", "task_id": "t-abc123"},
+    )
+    assert resp.status_code == 200, resp.text
+    # "sent", not "delivered" — the worker decides whether a running agent matches.
+    assert resp.json()["status"] == "sent"
+    msgs = [m for m in broadcasts if getattr(m, "type", None) == "worker-message"]
+    assert len(msgs) == 1
+    assert msgs[0].taskId == "t-abc123"
+    assert msgs[0].message == "check the migration"
+
+
+def test_message_worker_without_a_task_id_still_sends(client, monkeypatch):
+    """Back-compat: the UI's per-worker message box has no task to name."""
+    test_client, db_url = client
+    insert_guild(db_url, "guild-msg2")
+    worker_id = _create_worker(test_client, "guild-msg2")
+
+    broadcasts: list = []
+
+    async def fake_broadcast(guild_id, msg, *a, **kw):
+        broadcasts.append(msg)
+
+    monkeypatch.setattr("routes.workers.broadcast_msg", fake_broadcast)
+    monkeypatch.setattr("routes.workers.emit_terminal_line", AsyncMock())
+
+    resp = test_client.post(
+        f"/guilds/guild-msg2/workers/{worker_id}/message",
+        headers=_auth(db_url),
+        json={"message": "hello"},
+    )
+    assert resp.status_code == 200, resp.text
+    msgs = [m for m in broadcasts if getattr(m, "type", None) == "worker-message"]
+    assert msgs[0].taskId is None
 
 
 def test_shutdown_worker_signals_and_disables(client, monkeypatch):

--- a/backend/ws_types.py
+++ b/backend/ws_types.py
@@ -261,6 +261,11 @@ class WorkerMessageMsg(_WS):
     type: Literal["worker-message"] = "worker-message"
     workerId: str
     message: str
+    # Which of the worker's concurrently running agents the message is for. A
+    # worker runs max_agents tasks at once, so without this the worker has to
+    # guess and can inject the text into an unrelated task's agent. None = let
+    # the worker deliver only if exactly one agent is running.
+    taskId: str | None = None
 
 
 class WorkerShutdownMsg(_WS):

--- a/worker/pioneer_worker/claude_runner.py
+++ b/worker/pioneer_worker/claude_runner.py
@@ -326,6 +326,7 @@ async def run_claude_auto(
     stop_reason = "no_events"
     event_count = 0
     session_id = None
+    proc: asyncio.subprocess.Process | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -432,3 +433,17 @@ async def run_claude_auto(
         logger.exception("claude subprocess crashed: %s", exc)
         await emit(f"[claude] ✗ {exc}")
         return False, "error_during_execution", last_text, session_id
+    finally:
+        # Anything that escapes the streaming loop — a WS send that gave up, a
+        # stdout line past STDOUT_LINE_LIMIT — leaves claude running against the
+        # worktree with nothing holding a reference to it. Reap it here; on the
+        # normal path returncode is already set and this is a no-op.
+        if proc is not None and proc.returncode is None:
+            logger.warning("Reaping orphaned claude subprocess pid=%s", proc.pid)
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            except Exception as exc:  # pragma: no cover
+                logger.debug("Failed to reap claude pid=%s: %s", proc.pid, exc)

--- a/worker/pioneer_worker/config.py
+++ b/worker/pioneer_worker/config.py
@@ -355,7 +355,10 @@ def load(explicit_path: str | None = None, overrides: dict | None = None) -> Con
             if overrides.get("claude_max_turns") is not None
             else claude_block.get("max_turns", 50)
         ),
-        max_agents=int(_max_agents_val),
+        # Floor at 1: the agent pool is sized from this, so a 0 (or negative)
+        # produces a worker that connects, announces no agents, and silently
+        # never runs anything.
+        max_agents=max(1, int(_max_agents_val)),
         public_backend_url=overrides.get("public_backend_url")
         or raw.get("public_backend_url")
         or os.environ.get("PIONEER_FRONTEND_URL"),

--- a/worker/pioneer_worker/git_ops.py
+++ b/worker/pioneer_worker/git_ops.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import os
+import re
 import time
 from collections.abc import Awaitable, Callable
 
@@ -15,16 +17,44 @@ logger = logging.getLogger(__name__)
 EmitFn = Callable[..., Awaitable[None]]
 _LEVEL = "worker"
 
+# Matches a remote URL carrying inline credentials (https://<userinfo>@host/…).
+_CREDENTIALED_URL_RE = re.compile(r"^(https?://)[^/@]+@")
 
-async def run_git(args: list[str], cwd: str | None = None) -> tuple[int, str, str]:
+
+def _auth_env(token: str | None) -> dict[str, str] | None:
+    """Per-invocation git config carrying *token*, or None when there is none.
+
+    The token travels as an ``http.extraHeader`` supplied through git's
+    ``GIT_CONFIG_*`` environment protocol, which is scoped to the single git
+    process: it is never written to the repo's config (as a credentialed clone
+    URL would be) and never appears in argv (as an authenticated push URL
+    does). The header is scoped to github.com so it can't ride along on a
+    redirect to another host.
+    """
+    if not token:
+        return None
+    basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.https://github.com/.extraHeader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: Basic {basic}",
+    }
+
+
+async def run_git(
+    args: list[str], cwd: str | None = None, token: str | None = None
+) -> tuple[int, str, str]:
+    """Run a git command. *token*, when given, authenticates this call only."""
     logger.debug("git %s (cwd=%s)", " ".join(args), cwd or os.getcwd())
     started = time.monotonic()
+    auth = _auth_env(token)
     proc = await asyncio.create_subprocess_exec(
         "git",
         *args,
         cwd=cwd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env={**os.environ, **auth} if auth else None,
     )
     stdout, stderr = await proc.communicate()
     rc = proc.returncode if proc.returncode is not None else -1
@@ -42,8 +72,44 @@ async def run_git(args: list[str], cwd: str | None = None) -> tuple[int, str, st
     return rc, stdout.decode(errors="replace"), stderr.decode(errors="replace")
 
 
+async def scrub_remote_credentials(repo_path: str) -> bool:
+    """Rewrite ``origin`` to a credential-free URL if it carries inline userinfo.
+
+    Clones made before credentials moved to a per-invocation header persisted
+    ``https://<token>@github.com/…`` in ``.git/config``. Those clones keep using
+    that one token for every later fetch no matter who the fetch is for, so the
+    URL is rewritten in place the first time we touch such a repo. Returns True
+    when a rewrite happened.
+    """
+    # `config --get` returns the literal stored value; `remote get-url` would
+    # apply any insteadOf rewrite, and writing that back would replace the
+    # canonical URL with a rewritten one.
+    rc, url, _ = await run_git(["config", "--get", "remote.origin.url"], cwd=repo_path)
+    if rc != 0:
+        return False
+    url = url.strip()
+    if not _CREDENTIALED_URL_RE.match(url):
+        return False
+    clean = _CREDENTIALED_URL_RE.sub(r"\1", url)
+    rc, _, _ = await run_git(["remote", "set-url", "origin", clean], cwd=repo_path)
+    if rc == 0:
+        # Log the cleaned URL only — the original one contains the credential.
+        logger.warning(
+            "Removed embedded credentials from origin URL of %s (now %s)", repo_path, clean
+        )
+        return True
+    return False
+
+
 async def ensure_repo(repos_dir: str, repo_full: str, token: str | None = None) -> str | None:
-    """Clone repo if absent, otherwise fast-forward to origin/HEAD. Returns local path."""
+    """Clone repo if absent, otherwise fast-forward to origin/HEAD. Returns local path.
+
+    *token* authenticates this call only. It is deliberately NOT baked into the
+    ``origin`` URL: a persisted credential is used by every later fetch on this
+    shared clone regardless of which user the fetch is for, so the first caller's
+    token would silently serve everyone else's tasks — and outlive its own
+    validity.
+    """
     parts = repo_full.split("/", 1)
     if len(parts) != 2:
         logger.error("ensure_repo: malformed repo name %r", repo_full)
@@ -51,32 +117,31 @@ async def ensure_repo(repos_dir: str, repo_full: str, token: str | None = None) 
     owner, name = parts
     local_path = os.path.join(repos_dir, owner, name)
 
-    remote_url = (
-        f"https://{token}@github.com/{repo_full}.git"
-        if token
-        else f"https://github.com/{repo_full}.git"
-    )
+    remote_url = f"https://github.com/{repo_full}.git"
 
     if not os.path.exists(os.path.join(local_path, ".git")):
         logger.info("Cloning %s into %s", repo_full, local_path)
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
-        rc, _, _ = await run_git(["clone", remote_url, local_path])
+        rc, _, _ = await run_git(["clone", remote_url, local_path], token=token)
         if rc != 0:
             logger.error("Clone failed for %s (rc=%d)", repo_full, rc)
             return None
         logger.info("Clone done: %s", repo_full)
     else:
+        await scrub_remote_credentials(local_path)
         logger.info("Fetching latest for %s at %s", repo_full, local_path)
-        await run_git(["fetch", "origin"], cwd=local_path)
+        await run_git(["fetch", "origin"], cwd=local_path, token=token)
         await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
 
     return local_path
 
 
-async def create_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
+async def create_worktree(
+    repo_path: str, wt_path: str, branch: str, token: str | None = None
+) -> bool:
     logger.info("Creating worktree at %s on branch %s (from %s)", wt_path, branch, repo_path)
     os.makedirs(os.path.dirname(wt_path), exist_ok=True)
-    await run_git(["fetch", "origin"], cwd=repo_path)
+    await run_git(["fetch", "origin"], cwd=repo_path, token=token)
     rc, _, _ = await run_git(
         ["worktree", "add", "-b", branch, wt_path, "origin/HEAD"],
         cwd=repo_path,
@@ -86,7 +151,9 @@ async def create_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
     return rc == 0
 
 
-async def attach_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
+async def attach_worktree(
+    repo_path: str, wt_path: str, branch: str, token: str | None = None
+) -> bool:
     """Create a worktree that checks out an *existing* branch.
 
     Used when continuing a task on a branch the original worker already
@@ -98,7 +165,7 @@ async def attach_worktree(repo_path: str, wt_path: str, branch: str) -> bool:
         "Attaching worktree at %s to existing branch %s (from %s)", wt_path, branch, repo_path
     )
     os.makedirs(os.path.dirname(wt_path), exist_ok=True)
-    await run_git(["fetch", "origin", branch], cwd=repo_path)
+    await run_git(["fetch", "origin", branch], cwd=repo_path, token=token)
     # Prefer attaching to the local branch ref if it exists; otherwise fall
     # back to creating a tracking branch from origin/<branch>.
     rc, _, _ = await run_git(["worktree", "add", wt_path, branch], cwd=repo_path)
@@ -166,7 +233,7 @@ async def get_pr_head_branch(repo_full: str, pr_number: int | str) -> str | None
 
 
 async def checkout_pr_worktree(
-    repo_path: str, wt_path: str, pr_number: int | str, repo_full: str
+    repo_path: str, wt_path: str, pr_number: int | str, repo_full: str, token: str | None = None
 ) -> bool:
     """Create a worktree checked out to an existing PR's branch via ``gh pr checkout``.
 
@@ -179,7 +246,7 @@ async def checkout_pr_worktree(
     logger.info("Checking out PR #%s (%s) into worktree %s", pr_number, repo_full, wt_path)
     if parent := os.path.dirname(wt_path):
         os.makedirs(parent, exist_ok=True)
-    await run_git(["fetch", "origin"], cwd=repo_path)
+    await run_git(["fetch", "origin"], cwd=repo_path, token=token)
     rc, _, _ = await run_git(["worktree", "add", "--detach", wt_path, "origin/HEAD"], cwd=repo_path)
     if rc != 0:
         logger.error("Detached worktree add failed at %s (rc=%d)", wt_path, rc)
@@ -226,7 +293,8 @@ async def pull_repos(
         if not os.path.exists(os.path.join(local_path, ".git")):
             logger.debug("pull_repos: %s not cloned yet — will clone on demand", repo_full)
             continue
-        rc, _, err = await run_git(["fetch", "origin"], cwd=local_path)
+        await scrub_remote_credentials(local_path)
+        rc, _, err = await run_git(["fetch", "origin"], cwd=local_path, token=token)
         await run_git(["merge", "--ff-only", "origin/HEAD"], cwd=local_path)
         if rc == 0:
             logger.info("pull_repos: pulled %s", repo_full)

--- a/worker/pioneer_worker/worker.py
+++ b/worker/pioneer_worker/worker.py
@@ -77,6 +77,20 @@ WORKTREE_SWEEP_INTERVAL_SECONDS = 60 * 60
 # list current if new repos are added or permissions change without a restart.
 REPO_REFRESH_INTERVAL_SECONDS = 20 * 60
 
+# Env vars that mean "claude has a way to authenticate". A direct key, an OAuth
+# token, a proxy auth token, or a gateway flag that makes claude authenticate
+# through the cloud provider's own credentials instead (this deployment runs
+# claude on Bedrock, so the flag alone is a valid configuration). A tool with
+# none of these and no logged-in CLI is dropped from the available list rather
+# than launched per-task and failed.
+_CLAUDE_CREDENTIAL_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+)
+
 
 class Agent:
     """An agent owned by a Worker.
@@ -466,10 +480,10 @@ class Worker:
         """
         env = self._env_for_tool(name)
         if name == "claude":
-            if env.get("ANTHROPIC_API_KEY") or env.get("CLAUDE_CODE_OAUTH_TOKEN"):
+            if any(env.get(k) for k in _CLAUDE_CREDENTIAL_KEYS):
                 return True
             # Fall back to a locally logged-in CLI (dev machines / keychain).
-            return await self._claude_is_authenticated()
+            return await self._claude_is_authenticated(env)
         if name == "codex":
             if env.get("OPENAI_API_KEY") or self.cfg.openai_api_key:
                 return True
@@ -540,7 +554,7 @@ class Worker:
             "pi": self.cfg.pi_path,
         }
         cred_hint = {
-            "claude": "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN",
+            "claude": " or ".join(_CLAUDE_CREDENTIAL_KEYS),
             "codex": "OPENAI_API_KEY",
         }
         candidates = self.cfg.tools if self.cfg.tools is not None else list(tool_paths)
@@ -570,7 +584,7 @@ class Worker:
         self._available_tools = tools
         logger.info("Available tools: %s", tools or ["(none)"])
 
-    async def _claude_is_authenticated(self) -> bool:
+    async def _claude_is_authenticated(self, env: dict[str, str] | None = None) -> bool:
         """Return True if `claude auth status --json` reports loggedIn=true.
 
         Works on macOS keychain and Linux. The exit code alone is unreliable
@@ -578,6 +592,11 @@ class Worker:
         false``), so we parse the JSON. A timeout guards against macOS keychain
         access prompts that can hang the subprocess indefinitely when invoked
         without a controlling TTY.
+
+        *env* is claude's scoped environment (see _env_for_tool). Passing it
+        matters: the codex and pi probes already do, and without it a per-tool
+        override that configures claude's auth is invisible to the probe, so a
+        correctly configured tool reads as unauthenticated and gets dropped.
         """
         import json as _json
 
@@ -589,6 +608,7 @@ class Worker:
                 "--json",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
+                env=env if env is not None else self._env_for_tool("claude"),
             )
         except FileNotFoundError as exc:
             logger.warning("claude binary not found at %r: %s", self.cfg.claude_path, exc)
@@ -879,6 +899,51 @@ class Worker:
                     await self._emit_agent_state(slot)
 
         return _emit_task
+
+    async def _inject_worker_message(self, text: str, task_id: str | None) -> None:
+        """Write *text* to the stdin of the agent running *task_id*.
+
+        A worker runs up to ``max_agents`` tasks concurrently, so "the running
+        agent" is ambiguous. With a task id we target exactly that agent. Without
+        one we deliver only when a single agent is running — picking arbitrarily
+        would inject one task's instructions into an unrelated task's session,
+        which is worse than not delivering at all.
+        """
+        running = [s for s in self.agents if s.current_claude]
+        if task_id:
+            target = next((s for s in running if s.current_task_id == task_id), None)
+            if target is None:
+                logger.info(
+                    "worker-message for task %s: no agent running it here (running=%s); dropping",
+                    task_id,
+                    [s.current_task_id for s in running] or "none",
+                )
+                return
+        elif len(running) == 1:
+            target = running[0]
+        elif not running:
+            logger.debug("worker-message: no agent running; dropping")
+            return
+        else:
+            tasks = ", ".join(str(s.current_task_id) for s in running)
+            logger.warning(
+                "worker-message without a taskId while %d agents are running (%s); dropping",
+                len(running),
+                tasks,
+            )
+            await self._emit(
+                f"Message not delivered — {len(running)} tasks are running ({tasks}). "
+                "Send it to a specific task."
+            )
+            return
+
+        delivered = await target.current_claude.send_message(text)
+        if delivered:
+            await self._emit(f"Injected into {target.current_task_id}: {text[:80]}")
+        else:
+            logger.warning(
+                "Failed to inject message into %s (stdin closed?)", target.current_task_id
+            )
 
     async def _emit_agent_state(self, slot: Agent) -> None:
         """Broadcast the slot's full identity + runtime state.
@@ -1291,15 +1356,7 @@ class Worker:
                     continue
                 text = msg.get("message", "")
                 if text:
-                    active = next((s for s in self.agents if s.current_claude), None)
-                    if active:
-                        delivered = await active.current_claude.send_message(text)
-                        if delivered:
-                            await self._emit(f"Injected: {text[:80]}")
-                        else:
-                            logger.warning("Failed to inject message (stdin closed?)")
-                    else:
-                        logger.debug("worker-message: no claude running; dropping")
+                    await self._inject_worker_message(text, msg.get("taskId"))
 
             elif mtype == "worker-outdated":
                 if msg.get("workerId") not in (None, self.cfg.worker_id):
@@ -1328,8 +1385,10 @@ class Worker:
                     task_id,
                     instructions[:80],
                 )
-                # Drop the cached known-id so the puller doesn't reject the
-                # re-queued task as a duplicate after a worker restart.
+                # Remember the id so the idle puller doesn't queue this task a
+                # second time alongside the copy we're about to enqueue (it is
+                # already known unless this worker restarted since the original
+                # assignment).
                 self._known_task_ids.add(task_id)
                 await self.task_queue.put(
                     {
@@ -1917,7 +1976,7 @@ class Worker:
                 if is_followup or is_review:
                     # Pull latest so we don't clobber commits pushed since the
                     # last follow-up or by other workers.
-                    await git_ops.run_git(["fetch", "origin", branch], cwd=wt_path)
+                    await git_ops.run_git(["fetch", "origin", branch], cwd=wt_path, token=token)
                     await git_ops.run_git(["reset", "--hard", f"origin/{branch}"], cwd=wt_path)
                 worktree_entries.append((repo_full, repo_path, wt_path))
                 if primary_wt is None:
@@ -1929,7 +1988,7 @@ class Worker:
                 # new worktree starts at the latest remote commit — no separate pull needed.
                 # Pull latest so we don't clobber commits pushed since the last follow-up
                 # or by other workers.
-                ok = await git_ops.attach_worktree(repo_path, wt_path, branch)
+                ok = await git_ops.attach_worktree(repo_path, wt_path, branch, token)
                 if not ok:
                     # Branch never reached origin (e.g. original task failed before push).
                     # Fall back to creating a fresh branch so the follow-up can still run.
@@ -1944,7 +2003,7 @@ class Worker:
                         f"Branch not found on origin; creating fresh branch {branch[:50]}",
                         level=LEVEL_WORKER,
                     )
-                    ok = await git_ops.create_worktree(repo_path, wt_path, branch)
+                    ok = await git_ops.create_worktree(repo_path, wt_path, branch, token)
             elif is_review and pr_repo and repo_full.lower() == pr_repo.lower():
                 # Check out the PR's own branch via `gh pr checkout` instead of
                 # `git checkout -b` — review tasks read an existing PR, they
@@ -1957,7 +2016,9 @@ class Worker:
                     repo_full,
                     wt_path,
                 )
-                ok = await git_ops.checkout_pr_worktree(repo_path, wt_path, pr_number, repo_full)
+                ok = await git_ops.checkout_pr_worktree(
+                    repo_path, wt_path, pr_number, repo_full, token
+                )
             else:
                 if is_review:
                     logger.warning(
@@ -1968,7 +2029,7 @@ class Worker:
                         pr_repo,
                     )
                 logger.info("Task %s: creating worktree %s on branch %s", task_id, wt_path, branch)
-                ok = await git_ops.create_worktree(repo_path, wt_path, branch)
+                ok = await git_ops.create_worktree(repo_path, wt_path, branch, token)
             if ok:
                 logger.info("Task %s: worktree ready at %s", task_id, wt_path)
                 await emit(f"Worktree ready: {repo_name}", level=LEVEL_WORKER)
@@ -1984,6 +2045,13 @@ class Worker:
             await emit("✗ No worktrees — aborting.", level=LEVEL_WORKER)
             await self._task_update(task_id, agent=agent, state="failed", finishedAt=_now_iso())
             await self._set_state("error", agent)
+            # Return the slot to idle like every other abort path. An agent left
+            # in "error" is invisible to the backend's follow-up routing (it
+            # selects on state == "idle"), and the only thing that would clear
+            # the state is another task — which it can no longer be given. One
+            # repo that reliably fails to clone would otherwise retire the
+            # worker's slots one at a time.
+            await self._set_state("idle", agent)
             return
 
         await self._task_update(task_id, agent=agent, branch=branch, worktreePath=primary_wt)

--- a/worker/tests/test_agent_recovery.py
+++ b/worker/tests/test_agent_recovery.py
@@ -1,0 +1,73 @@
+"""An abort must return the agent slot to idle.
+
+The backend routes follow-ups only to agents whose state is ``idle``
+(``_select_followup_worker``), and the only thing that clears an agent's state
+is running another task. So an agent left in ``error`` can never be handed the
+work that would clear it: one repo that reliably fails to clone would retire the
+worker's slots one at a time until it looks online but is unroutable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_cfg(**kwargs) -> Config:
+    return Config(
+        backend_url="ws://localhost:8000",
+        guild_id="test-guild",
+        worker_id="w-test01",
+        max_agents=1,
+        pull_interval=3600.0,
+        **kwargs,
+    )
+
+
+def _states_sent(worker: Worker) -> list[str]:
+    return [
+        m.args[0]["state"]
+        for m in worker._send.await_args_list
+        if m.args and m.args[0].get("type") == "agent-state"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_worktree_failure_returns_the_slot_to_idle(tmp_path):
+    worker = Worker(_make_cfg(work_dir=str(tmp_path), repos=["org/myrepo"]))
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+
+    task = {"id": "t-noclone", "description": "do something", "name": "do something"}
+
+    with (
+        # Clone fails, so no worktree is ever created for the task.
+        patch("pioneer_worker.worker.git_ops.ensure_repo", new=AsyncMock(return_value=None)),
+        patch("pioneer_worker.worker.Worker._task_github_token", new=AsyncMock(return_value=None)),
+    ):
+        await worker._execute_task(task, worker.agents[0])
+
+    states = _states_sent(worker)
+    assert "error" in states, states
+    assert states[-1] == "idle", states
+    assert worker.agents[0].state == "idle"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_tool_returns_the_slot_to_idle(tmp_path):
+    """The sibling abort path, pinned so the two stay consistent."""
+    worker = Worker(_make_cfg(work_dir=str(tmp_path), repos=["org/myrepo"]))
+    worker._send = AsyncMock()
+    worker._task_update = AsyncMock()
+    worker._available_tools = ["pi"]
+
+    task = {"id": "t-notool", "description": "x", "name": "x", "tool": "claude"}
+
+    with patch("pioneer_worker.worker.Worker._task_github_token", new=AsyncMock(return_value=None)):
+        await worker._execute_task(task, worker.agents[0])
+
+    assert _states_sent(worker)[-1] == "idle"
+    assert worker.agents[0].state == "idle"

--- a/worker/tests/test_claude_runner.py
+++ b/worker/tests/test_claude_runner.py
@@ -415,8 +415,12 @@ class _FakeProc:
         self.stdout = _FakeStream(stdout_lines)
         self.stderr = _FakeStream([])
         self.stdin = None
+        # Real asyncio Processes always expose this; run_claude_auto's reaper
+        # reads it to decide whether the child still needs killing.
+        self.returncode: int | None = None
 
     async def wait(self) -> int:
+        self.returncode = 0
         return 0
 
 

--- a/worker/tests/test_followup_branch_reuse.py
+++ b/worker/tests/test_followup_branch_reuse.py
@@ -75,7 +75,7 @@ async def test_followup_ws_path_uses_existing_branch():
 
     attached_branches: list[str] = []
 
-    async def fake_attach(repo_path: str, wt_path: str, branch: str) -> bool:
+    async def fake_attach(repo_path: str, wt_path: str, branch: str, token=None) -> bool:
         attached_branches.append(branch)
         return True
 
@@ -145,7 +145,7 @@ async def test_followup_rest_path_uses_existing_branch():
 
     attached_branches: list[str] = []
 
-    async def fake_attach(repo_path: str, wt_path: str, branch: str) -> bool:
+    async def fake_attach(repo_path: str, wt_path: str, branch: str, token=None) -> bool:
         attached_branches.append(branch)
         return True
 
@@ -196,7 +196,7 @@ async def test_new_task_still_generates_fresh_branch():
 
     created_branches: list[str] = []
 
-    async def fake_create(repo_path: str, wt_path: str, branch: str) -> bool:
+    async def fake_create(repo_path: str, wt_path: str, branch: str, token=None) -> bool:
         created_branches.append(branch)
         return True
 
@@ -252,7 +252,7 @@ async def test_new_task_branch_contains_full_task_id_not_truncated():
 
     created_branches: list[str] = []
 
-    async def fake_create(repo_path: str, wt_path: str, branch: str) -> bool:
+    async def fake_create(repo_path: str, wt_path: str, branch: str, token=None) -> bool:
         created_branches.append(branch)
         return True
 

--- a/worker/tests/test_git_credentials.py
+++ b/worker/tests/test_git_credentials.py
@@ -1,0 +1,137 @@
+"""Credentials must authenticate a single git call, never persist in a clone.
+
+A token baked into ``remote.origin.url`` is reused by every later fetch on that
+shared clone regardless of which user the fetch is for, so the first caller's
+token silently serves everyone else's tasks and keeps being used after it stops
+being valid. These tests pin the invariant and the migration path for clones
+made before it held.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pioneer_worker import git_ops  # noqa: E402
+
+
+def _git(*args: str, cwd: str | None = None) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _make_origin(tmp_path: Path) -> str:
+    """A real bare repo with one commit, usable as an origin for clones."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(origin)], check=True)
+    src = tmp_path / "src"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(src)], check=True)
+    for k, v in (("user.email", "t@example.com"), ("user.name", "T")):
+        _git("config", k, v, cwd=str(src))
+    (src / "README.md").write_text("hi\n")
+    _git("add", "-A", cwd=str(src))
+    _git("commit", "-qm", "init", cwd=str(src))
+    _git("push", "-q", str(origin), "main", cwd=str(src))
+    _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=str(origin))
+    return str(origin)
+
+
+async def test_auth_env_carries_token_out_of_argv_and_config():
+    env = git_ops._auth_env("ghp_secret123")
+    assert env is not None
+    # The token rides in a git config value delivered by environment, so it is
+    # not in the command line and not written to any repo's config file.
+    assert env["GIT_CONFIG_COUNT"] == "1"
+    assert env["GIT_CONFIG_KEY_0"].startswith("http.https://github.com/")
+    expected = base64.b64encode(b"x-access-token:ghp_secret123").decode()
+    assert env["GIT_CONFIG_VALUE_0"] == f"Authorization: Basic {expected}"
+    assert git_ops._auth_env(None) is None
+    assert git_ops._auth_env("") is None
+
+
+async def test_run_git_passes_token_only_to_that_invocation(tmp_path):
+    captured: dict = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["argv"] = args
+        captured["env"] = kwargs.get("env")
+
+        class _P:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        return _P()
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await git_ops.run_git(["fetch", "origin"], cwd=str(tmp_path), token="ghp_secret123")
+    assert "ghp_secret123" not in " ".join(str(a) for a in captured["argv"])
+    assert captured["env"]["GIT_CONFIG_COUNT"] == "1"
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await git_ops.run_git(["status"], cwd=str(tmp_path))
+    # No token — no config injection, so the process just inherits the parent env.
+    assert captured["env"] is None
+
+
+async def test_clone_does_not_persist_the_token_in_git_config(tmp_path):
+    origin = _make_origin(tmp_path)
+    repos_dir = tmp_path / "repos"
+
+    # ensure_repo builds a github.com URL, so point the clone at the local origin
+    # by intercepting the URL while leaving the token handling under test.
+    real_run_git = git_ops.run_git
+
+    async def run_git(args, cwd=None, token=None):
+        args = [origin if a.startswith("https://github.com/") else a for a in args]
+        return await real_run_git(args, cwd=cwd, token=token)
+
+    with patch.object(git_ops, "run_git", side_effect=run_git):
+        path = await git_ops.ensure_repo(str(repos_dir), "owner/repo", token="ghp_secret123")
+
+    assert path is not None
+    config = (Path(path) / ".git" / "config").read_text()
+    assert "ghp_secret123" not in config
+    assert _git("config", "--get", "remote.origin.url", cwd=path) == origin
+
+
+async def test_existing_clone_with_an_embedded_token_is_scrubbed(tmp_path):
+    origin = _make_origin(tmp_path)
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", origin, str(clone)], check=True)
+    # Simulate a clone made by the old credentialed-URL code path.
+    _git(
+        "remote",
+        "set-url",
+        "origin",
+        "https://ghp_old_token@github.com/owner/repo.git",
+        cwd=str(clone),
+    )
+
+    assert await git_ops.scrub_remote_credentials(str(clone)) is True
+
+    url = _git("config", "--get", "remote.origin.url", cwd=str(clone))
+    assert url == "https://github.com/owner/repo.git"
+    assert "ghp_old_token" not in (clone / ".git" / "config").read_text()
+    # Idempotent: a clean URL is left exactly as it is.
+    assert await git_ops.scrub_remote_credentials(str(clone)) is False
+    assert _git("config", "--get", "remote.origin.url", cwd=str(clone)) == url
+
+
+async def test_scrub_leaves_ssh_and_local_remotes_alone(tmp_path):
+    origin = _make_origin(tmp_path)
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", origin, str(clone)], check=True)
+    _git("remote", "set-url", "origin", "git@github.com:owner/repo.git", cwd=str(clone))
+    assert await git_ops.scrub_remote_credentials(str(clone)) is False
+    assert _git("config", "--get", "remote.origin.url", cwd=str(clone)) == (
+        "git@github.com:owner/repo.git"
+    )

--- a/worker/tests/test_org_clone.py
+++ b/worker/tests/test_org_clone.py
@@ -336,7 +336,7 @@ async def test_pull_repos_updates_already_cloned_repo(tmp_path):
 
     git_calls: list[list[str]] = []
 
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, token=None):
         git_calls.append(args)
         return 0, "", ""
 
@@ -366,7 +366,7 @@ async def test_pull_repos_skips_uncloned_but_pulls_cloned(tmp_path):
         ensure_calls.append(repo_full)
         return None
 
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, token=None):
         git_calls.append(args)
         return 0, "", ""
 

--- a/worker/tests/test_review_phase_guard.py
+++ b/worker/tests/test_review_phase_guard.py
@@ -253,7 +253,9 @@ async def test_review_phase_checks_out_pr_branch_via_gh(caplog: pytest.LogCaptur
 
     expected_wt_path = os.path.join(tmp, "test-guild", "w-test01", "t-revcheckout", "repo")
     mock_get_branch.assert_awaited_once_with("owner/repo", 42)
-    mock_checkout.assert_awaited_once_with("/tmp/fake-repo", expected_wt_path, 42, "owner/repo")
+    mock_checkout.assert_awaited_once_with(
+        "/tmp/fake-repo", expected_wt_path, 42, "owner/repo", None
+    )
     mock_create_worktree.assert_not_called()
     mock_push.assert_not_called()
 
@@ -315,5 +317,5 @@ async def test_review_prefers_pr_number_over_issue_number():
 
     expected_wt_path = os.path.join(tmp, "test-guild", "w-test01", "t-revpr", "repo")
     mock_get_branch.assert_awaited_once_with("owner/repo", 99)
-    mock_co.assert_awaited_once_with("/tmp/fake-repo", expected_wt_path, 99, "owner/repo")
+    mock_co.assert_awaited_once_with("/tmp/fake-repo", expected_wt_path, 99, "owner/repo", None)
     mock_create_worktree.assert_not_called()

--- a/worker/tests/test_worker_message_targeting.py
+++ b/worker/tests/test_worker_message_targeting.py
@@ -1,0 +1,99 @@
+"""A mid-task message must reach the agent running the task it was meant for.
+
+A worker runs up to ``max_agents`` tasks at once, so "the running agent" is
+ambiguous. Delivering to an arbitrary one injects a task's instructions into an
+unrelated task's session, which is worse than not delivering at all.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pioneer_worker.config import Config
+from pioneer_worker.worker import Worker
+
+
+def _make_worker(slots: int) -> Worker:
+    worker = Worker(
+        Config(
+            backend_url="ws://localhost:8000",
+            guild_id="test-guild",
+            worker_id="w-test01",
+            max_agents=slots,
+            pull_interval=3600.0,
+        )
+    )
+    worker._send = AsyncMock()
+    return worker
+
+
+def _running(worker: Worker, idx: int, task_id: str) -> AsyncMock:
+    proc = AsyncMock()
+    proc.send_message = AsyncMock(return_value=True)
+    worker.agents[idx].current_claude = proc
+    worker.agents[idx].current_task_id = task_id
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_message_goes_to_the_agent_running_the_named_task():
+    worker = _make_worker(3)
+    first = _running(worker, 0, "t-aaa")
+    second = _running(worker, 1, "t-bbb")
+    third = _running(worker, 2, "t-ccc")
+
+    await worker._inject_worker_message("focus on the migration", "t-bbb")
+
+    second.send_message.assert_awaited_once_with("focus on the migration")
+    first.send_message.assert_not_awaited()
+    third.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_message_for_a_task_running_elsewhere_is_dropped():
+    worker = _make_worker(2)
+    first = _running(worker, 0, "t-aaa")
+    second = _running(worker, 1, "t-bbb")
+
+    await worker._inject_worker_message("hello", "t-not-here")
+
+    first.send_message.assert_not_awaited()
+    second.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_untargeted_message_is_delivered_when_only_one_agent_runs():
+    worker = _make_worker(4)
+    only = _running(worker, 2, "t-aaa")
+
+    await worker._inject_worker_message("carry on", None)
+
+    only.send_message.assert_awaited_once_with("carry on")
+
+
+@pytest.mark.asyncio
+async def test_untargeted_message_is_dropped_when_several_agents_run():
+    worker = _make_worker(2)
+    first = _running(worker, 0, "t-aaa")
+    second = _running(worker, 1, "t-bbb")
+
+    await worker._inject_worker_message("ambiguous", None)
+
+    first.send_message.assert_not_awaited()
+    second.send_message.assert_not_awaited()
+    # The operator is told why, and which tasks were candidates.
+    lines = [
+        m.args[0]["line"]
+        for m in worker._send.await_args_list
+        if m.args and m.args[0].get("type") == "terminal-output"
+    ]
+    assert any("not delivered" in line and "t-aaa" in line and "t-bbb" in line for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_message_with_no_agent_running_is_a_no_op():
+    worker = _make_worker(2)
+    await worker._inject_worker_message("nobody home", None)
+    await worker._inject_worker_message("nobody home", "t-aaa")
+    assert worker._send.await_count == 0


### PR DESCRIPTION
Fixes from an audit of `worker/`. Branches off `main`, so it's independent of the launch-worker/spawn work on `claude/launch-worker-sizing-vars-1jozux` — no shared files.

## 1. Credentials were baked into every clone

`ensure_repo` cloned from `https://<token>@github.com/…`, and git stores that URL verbatim as `remote.origin.url`. Two consequences:

- **The `token` argument was dead after the first clone.** Every later call takes the fetch branch, which uses the persisted URL. So #1074 ("clone/fetch with the triggering user's token, not the App token") only ever applied to a repo's *first* clone. For repos in `cfg.repos` — cloned at startup with the App token — every subsequent fetch still used the App token the fix was meant to replace.
- **Cross-user reuse and stale credentials.** For a lazily-cloned org repo, whichever user's task cloned it first had their personal OAuth token written to disk in plaintext and used for every other member's fetches, until it expired — after which fetches failed persistently with no self-heal.

This also contradicted the invariant `push_branch` documents ("a stale clone-time token can never be reused"): the push path was fixed, the clone path wasn't.

Credentials now travel as an `http.extraHeader` passed through git's `GIT_CONFIG_*` environment protocol — scoped to a single git process and to github.com, so it is neither written to the repo config nor placed in argv (where the push path puts it). Every fetch that relied on the persisted credential now takes the token explicitly: `create_worktree`, `attach_worktree`, `checkout_pr_worktree`, the worktree-reuse fetch, and `pull_repos`.

Existing clones are repaired in place — `scrub_remote_credentials` rewrites a credentialed origin URL the first time the worker touches the repo, which also clears the stale token currently breaking their fetches. It reads the raw `config --get` value rather than `remote get-url`, so an `insteadOf` rewrite can't be written back over the canonical URL.

## 2. A worktree failure retired the agent slot

The "no worktrees — aborting" path set the agent to `error` and returned, without the `idle` its three sibling abort paths send. `_select_followup_worker` routes only to agents whose state is `idle`, and the only thing that clears the state is running another task — which the agent could no longer be given. One repo that reliably fails to clone would take the worker's slots one at a time until it looked online but was unroutable.

## 3. Mid-task messages went to an arbitrary agent

`worker-message` carried no task id, so the worker delivered to the first agent with a live subprocess. With the default 4 concurrent agents that is usually not the task the message was about — it injected one task's instructions into another's session. `taskId` now travels end to end (WS type → foreman tool → REST body → worker). Without one the worker delivers only when exactly one agent is running, and otherwise reports why instead of guessing. The endpoint now returns `"sent"` rather than `"delivered"`, since delivery is the worker's call.

## Also

- Reap the claude subprocess when an exception escapes the streaming loop (a stdout line past the 16 MiB limit, or a WS send that gave up) instead of leaving it running against the worktree.
- Pass claude's scoped env to its auth probe, as the codex and pi probes already do, and recognise the gateway/proxy auth vars alongside `ANTHROPIC_API_KEY` — a Bedrock-configured claude was being dropped as uncredentialed.
- Floor `max_agents` at 1; `0` produced a worker that connects, announces no agents, and silently never runs anything.

## Deliberately not included

`_known_task_ids` and `_cancelled_tasks` grow without bound. It's a few hundred KB on a worker that has run thousands of tasks, and bounding them needs an LRU rather than a one-liner, so it seemed better left out of a fix-focused PR.

## Testing

```
cd worker  && python -m pytest        # 326 passed (3 new files, 12 new tests)
cd backend && python -m pytest        # 1239 passed, 3 skipped
cd frontend && npm test && npm run type-check   # 128 passed
ruff check . && ruff format --check .
```

The two behavioural fixes are pinned by tests verified to fail without them: `test_worktree_failure_returns_the_slot_to_idle` and the message-targeting suite. `test_git_credentials.py` clones a real local repo and asserts no token reaches `.git/config`, plus the scrub path for clones made before this change.

Existing test doubles for `run_git` / `create_worktree` / `attach_worktree` / `checkout_pr_worktree` were updated for the new `token` parameter, and `_FakeProc` gained the `returncode` a real `asyncio.subprocess.Process` always has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC98gfnZwH4z73kYmA7b8w